### PR TITLE
test: enhance createDbAuthState tests for credential verification

### DIFF
--- a/packages/server/src/whatsapp/auth-store.test.ts
+++ b/packages/server/src/whatsapp/auth-store.test.ts
@@ -84,8 +84,13 @@ describe("createDbAuthState", () => {
     await state.keys.set({ "pre-key": { "1": { data: "test" } as never } });
     await clearCreds();
 
+    const credsRows = await db.selectFrom("whatsapp_creds").selectAll().execute();
+    const keyRows = await db.selectFrom("whatsapp_keys").selectAll().execute();
+    expect(credsRows).toEqual([]);
+    expect(keyRows).toEqual([]);
+
     const { state: state2 } = await createDbAuthState(db);
-    expect(state2.creds.registrationId).not.toBe(state.creds.registrationId);
+    expect(state2.creds).toBeDefined();
     const result = await state2.keys.get("pre-key", ["1"]);
     expect(result["1"]).toBeUndefined();
   });


### PR DESCRIPTION
## What Changed

Updated the WhatsApp auth store test to remove a flaky assertion after `clearCreds()`.

Instead of asserting that a newly generated `registrationId` must differ from the previous one, the test now verifies that `clearCreds()` actually deletes all persisted rows from `whatsapp_creds` and `whatsapp_keys`, then confirms a fresh auth state can still be created with no leftover keys.

## Why

The previous test relied on `registrationId` randomness for correctness. Baileys generates `registrationId` from a small random range, so two fresh auth states can legitimately receive the same value. That made the test nondeterministic and capable of failing in CI even when the implementation was correct.

This change makes the test validate the real contract of `clearCreds()`: persisted credentials and keys are removed.

## How to Test

1. Run `pnpm --filter @sketch/server test -- src/whatsapp/auth-store.test.ts`
2. Confirm `createDbAuthState > clearCreds removes all creds and keys` passes consistently.
3. Optionally run the full server test suite with `pnpm --filter @sketch/server test` to verify there are no regressions.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm build` succeeds