### PR TITLE
refactor: simplify OAuth handling in AddIntegrationDialog

### DIFF
--- a/packages/web/src/components/connections/add-integration-dialog.tsx
+++ b/packages/web/src/components/connections/add-integration-dialog.tsx
@@ -19,8 +19,6 @@ import type { IntegrationApp } from "@sketch/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-type OAuthResultMessage = { type: "oauth-result"; status: "success" };
-
 type AddIntegrationStep =
   | { kind: "search" }
   | { kind: "oauth"; app: IntegrationApp }
@@ -52,11 +50,11 @@ export function AddIntegrationDialog({
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const oauthWindowRef = useRef<Window | null>(null);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
-  const oauthCleanupRef = useRef<(() => void) | null>(null);
+  const cancelledRef = useRef(false);
 
   useEffect(() => {
     return () => {
-      oauthCleanupRef.current?.();
+      cancelledRef.current = true;
       if (pollIntervalRef.current) {
         clearInterval(pollIntervalRef.current);
       }
@@ -121,8 +119,7 @@ export function AddIntegrationDialog({
   }, [hasMore, isLoadingApps, search, endCursor, step.kind, loadApps]);
 
   const resetAndClose = () => {
-    oauthCleanupRef.current?.();
-    oauthCleanupRef.current = null;
+    cancelledRef.current = true;
     if (pollIntervalRef.current) {
       clearInterval(pollIntervalRef.current);
       pollIntervalRef.current = undefined;
@@ -154,35 +151,34 @@ export function AddIntegrationDialog({
       }
 
       oauthWindowRef.current = popup;
-      let oauthResolved = false;
+      cancelledRef.current = false;
 
-      const cleanup = () => {
-        window.removeEventListener("message", onMessage);
-        if (pollIntervalRef.current) {
-          clearInterval(pollIntervalRef.current);
-          pollIntervalRef.current = undefined;
+      const verifyConnection = async () => {
+        try {
+          const connections = await api.mcpServers.listConnections(providerId);
+          const connected = connections.some((c) => c.appId === app.id);
+          if (cancelledRef.current) return;
+          if (connected) {
+            toast.success("App connected successfully!");
+            onSuccess();
+            resetAndClose();
+          } else {
+            toast.error("App connection cancelled");
+            setStep({ kind: "oauth_cancelled", app });
+          }
+        } catch {
+          if (cancelledRef.current) return;
+          toast.error("Could not verify connection status");
+          setStep({ kind: "oauth_cancelled", app });
         }
       };
 
-      const onMessage = (e: MessageEvent<OAuthResultMessage>) => {
-        if (e.origin !== window.location.origin || e.data?.type !== "oauth-result") return;
-        oauthResolved = true;
-        cleanup();
-        oauthWindowRef.current = null;
-        toast.success("App connected successfully!");
-        onSuccess();
-        resetAndClose();
-      };
-
-      window.addEventListener("message", onMessage);
-      oauthCleanupRef.current = cleanup;
-
       pollIntervalRef.current = setInterval(() => {
-        if (popup.closed && !oauthResolved) {
-          cleanup();
+        if (popup.closed) {
+          clearInterval(pollIntervalRef.current);
+          pollIntervalRef.current = undefined;
           oauthWindowRef.current = null;
-          toast.error("App connection cancelled");
-          setStep({ kind: "oauth_cancelled", app });
+          verifyConnection();
         }
       }, 500);
     } catch (err) {

--- a/packages/web/src/routes/connections.tsx
+++ b/packages/web/src/routes/connections.tsx
@@ -45,7 +45,6 @@ export const connectionsCallbackRoute = createRoute({
 
 function ConnectionsCallback() {
   useEffect(() => {
-    window.opener?.postMessage({ type: "oauth-result", status: "success" }, window.location.origin);
     window.close();
   }, []);
 


### PR DESCRIPTION
## What Changed

Removed the OAuth result message listener and replaced it with a cancellation flag to manage the connection verification process. This change improves the clarity of the integration flow and ensures proper cleanup of resources when the dialog is closed. 

Additionally, the connection verification logic has been streamlined to handle success and cancellation scenarios more effectively.

## Why

Previous fix was flaky in production enviornments. 

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm build` succeeds
