### PR TITLE
feat: add OpenRouter as LLM provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 data
 data/
 .claude/
+reference_repos/

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
   "files": {
-    "ignore": ["**/data/**", "**/dist/**"]
+    "ignore": ["**/data/**", "**/dist/**", "**/reference_repos/**"]
   },
   "organizeImports": { "enabled": true },
   "linter": {

--- a/packages/server/src/agent/llm-env.test.ts
+++ b/packages/server/src/agent/llm-env.test.ts
@@ -63,6 +63,7 @@ describe("applyLlmEnvFromSettings", () => {
         aws_access_key_id: null,
         aws_secret_access_key: null,
         aws_region: null,
+        openrouter_api_key: null,
       },
       logger as never,
     );
@@ -90,6 +91,7 @@ describe("applyLlmEnvFromSettings", () => {
         aws_access_key_id: null,
         aws_secret_access_key: null,
         aws_region: null,
+        openrouter_api_key: null,
       },
       logger as never,
     );
@@ -113,6 +115,7 @@ describe("applyLlmEnvFromSettings", () => {
         aws_access_key_id: "AKIA...",
         aws_secret_access_key: "secret",
         aws_region: "us-west-2",
+        openrouter_api_key: null,
       },
       logger as never,
     );
@@ -140,6 +143,7 @@ describe("applyLlmEnvFromSettings", () => {
         aws_access_key_id: "",
         aws_secret_access_key: "secret",
         aws_region: "us-west-2",
+        openrouter_api_key: null,
       },
       logger as never,
     );
@@ -156,6 +160,62 @@ describe("applyLlmEnvFromSettings", () => {
     );
   });
 
+  it("configures openrouter and clears bedrock/anthropic routing env", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-existing";
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_ACCESS_KEY_ID = "aws-access";
+    process.env.AWS_SECRET_ACCESS_KEY = "aws-secret";
+    process.env.AWS_REGION = "us-east-1";
+    const logger = { warn: vi.fn(), info: vi.fn() };
+
+    applyLlmEnvFromSettings(
+      {
+        llm_provider: "openrouter",
+        anthropic_api_key: null,
+        aws_access_key_id: null,
+        aws_secret_access_key: null,
+        aws_region: null,
+        openrouter_api_key: "sk-or-test-key",
+      },
+      logger as never,
+    );
+
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://openrouter.ai/api");
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("sk-or-test-key");
+    expect(process.env.ANTHROPIC_API_KEY).toBe("");
+    expect(process.env.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+    expect(process.env.AWS_ACCESS_KEY_ID).toBeUndefined();
+    expect(process.env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+    expect(process.env.AWS_REGION).toBeUndefined();
+    expect(logger.info).toHaveBeenCalledWith(
+      { llmProvider: "openrouter", source: "db" },
+      "Configured LLM provider from DB settings",
+    );
+  });
+
+  it("preserves env for incomplete openrouter settings", () => {
+    process.env.ANTHROPIC_API_KEY = "existing-key";
+    const logger = { warn: vi.fn(), info: vi.fn() };
+
+    applyLlmEnvFromSettings(
+      {
+        llm_provider: "openrouter",
+        anthropic_api_key: null,
+        aws_access_key_id: null,
+        aws_secret_access_key: null,
+        aws_region: null,
+        openrouter_api_key: null,
+      },
+      logger as never,
+    );
+
+    expect(process.env.ANTHROPIC_API_KEY).toBe("existing-key");
+    expect(logger.warn).toHaveBeenCalledWith(
+      { llmProvider: "openrouter", hasOpenrouterKey: false },
+      "Incomplete LLM settings in DB; preserving existing environment-based LLM config",
+    );
+  });
+
   it("warns and leaves env untouched for unsupported providers", () => {
     process.env.ANTHROPIC_API_KEY = "existing-key";
     const logger = { warn: vi.fn(), info: vi.fn() };
@@ -167,13 +227,14 @@ describe("applyLlmEnvFromSettings", () => {
         aws_access_key_id: null,
         aws_secret_access_key: null,
         aws_region: null,
+        openrouter_api_key: null,
       },
       logger as never,
     );
 
     expect(process.env.ANTHROPIC_API_KEY).toBe("existing-key");
     expect(logger.warn).toHaveBeenCalledWith(
-      { llmProvider: "vertex", supportedProviders: ["anthropic", "bedrock"] },
+      { llmProvider: "vertex", supportedProviders: ["anthropic", "bedrock", "openrouter"] },
       "Unsupported LLM provider in DB; preserving existing environment-based LLM config",
     );
   });

--- a/packages/server/src/agent/llm-env.ts
+++ b/packages/server/src/agent/llm-env.ts
@@ -3,7 +3,12 @@ import type { Logger } from "../logger";
 
 type LlmSettings = Pick<
   SettingsTable,
-  "llm_provider" | "anthropic_api_key" | "aws_access_key_id" | "aws_secret_access_key" | "aws_region"
+  | "llm_provider"
+  | "anthropic_api_key"
+  | "aws_access_key_id"
+  | "aws_secret_access_key"
+  | "aws_region"
+  | "openrouter_api_key"
 >;
 
 function unsetEnv(...keys: string[]) {
@@ -68,10 +73,28 @@ export function applyLlmEnvFromSettings(settings: LlmSettings | null, logger?: L
     return;
   }
 
+  if (settings.llm_provider === "openrouter") {
+    if (!settings.openrouter_api_key) {
+      logger?.warn(
+        { llmProvider: settings.llm_provider, hasOpenrouterKey: false },
+        "Incomplete LLM settings in DB; preserving existing environment-based LLM config",
+      );
+      return;
+    }
+
+    clearProviderRoutingEnv();
+    unsetEnv("ANTHROPIC_API_KEY", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION");
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    process.env.ANTHROPIC_AUTH_TOKEN = settings.openrouter_api_key;
+    process.env.ANTHROPIC_API_KEY = "";
+    logger?.info({ llmProvider: "openrouter", source: "db" }, "Configured LLM provider from DB settings");
+    return;
+  }
+
   logger?.warn(
     {
       llmProvider: settings.llm_provider,
-      supportedProviders: ["anthropic", "bedrock"],
+      supportedProviders: ["anthropic", "bedrock", "openrouter"],
     },
     "Unsupported LLM provider in DB; preserving existing environment-based LLM config",
   );

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -56,6 +56,10 @@ const llmSchema = z.discriminatedUnion("provider", [
     awsSecretAccessKey: z.string().min(1, "AWS Secret Access Key is required"),
     awsRegion: z.string().min(1, "AWS Region is required"),
   }),
+  z.object({
+    provider: z.literal("openrouter"),
+    apiKey: z.string().min(1, "API key is required"),
+  }),
 ]);
 
 async function verifyAnthropicApiKey(apiKey: string): Promise<void> {
@@ -68,6 +72,30 @@ async function verifyAnthropicApiKey(apiKey: string): Promise<void> {
     },
     body: JSON.stringify({
       model: "claude-haiku-4-5",
+      max_tokens: 1,
+      messages: [{ role: "user", content: "Ping" }],
+    }),
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("invalid_auth");
+  }
+
+  if (!response.ok) {
+    throw new Error("verification_failed");
+  }
+}
+
+async function verifyOpenRouterApiKey(apiKey: string): Promise<void> {
+  const response = await fetch("https://openrouter.ai/api/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "anthropic/claude-haiku-4-5",
       max_tokens: 1,
       messages: [{ role: "user", content: "Ping" }],
     }),
@@ -101,7 +129,8 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
     const hasBedrock =
       row?.llm_provider === "bedrock" &&
       Boolean(row?.aws_access_key_id?.trim() && row?.aws_secret_access_key?.trim() && row?.aws_region?.trim());
-    const hasLlm = Boolean(hasAnthropic || hasBedrock);
+    const hasOpenRouter = row?.llm_provider === "openrouter" && Boolean(row?.openrouter_api_key?.trim());
+    const hasLlm = Boolean(hasAnthropic || hasBedrock || hasOpenRouter);
     const isCompleted = Boolean(row?.onboarding_completed_at);
     const currentStep = isCompleted ? 5 : hasLlm ? 5 : hasSlack ? 4 : hasIdentity ? 3 : hasAdmin ? 2 : 0;
     return c.json({
@@ -112,7 +141,14 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       botName: row?.bot_name ?? "Sketch",
       slackConnected: hasSlack,
       llmConnected: hasLlm,
-      llmProvider: row?.llm_provider === "bedrock" ? "bedrock" : row?.llm_provider === "anthropic" ? "anthropic" : null,
+      llmProvider:
+        row?.llm_provider === "bedrock"
+          ? "bedrock"
+          : row?.llm_provider === "anthropic"
+            ? "anthropic"
+            : row?.llm_provider === "openrouter"
+              ? "openrouter"
+              : null,
     });
   });
 
@@ -268,6 +304,22 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       }
     }
 
+    if (parsed.data.provider === "openrouter") {
+      try {
+        await verifyOpenRouterApiKey(parsed.data.apiKey.trim());
+      } catch {
+        return c.json(
+          {
+            error: {
+              code: "INVALID_LLM_SETTINGS",
+              message: "Invalid LLM credentials. Check your API key and try again.",
+            },
+          },
+          400,
+        );
+      }
+    }
+
     return c.json({ success: true });
   });
 
@@ -294,6 +346,16 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
         awsAccessKeyId: null,
         awsSecretAccessKey: null,
         awsRegion: null,
+        openrouterApiKey: null,
+      });
+    } else if (parsed.data.provider === "openrouter") {
+      await settings.update({
+        llmProvider: "openrouter",
+        openrouterApiKey: parsed.data.apiKey.trim(),
+        anthropicApiKey: null,
+        awsAccessKeyId: null,
+        awsSecretAccessKey: null,
+        awsRegion: null,
       });
     } else {
       await settings.update({
@@ -302,6 +364,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
         awsAccessKeyId: parsed.data.awsAccessKeyId.trim(),
         awsSecretAccessKey: parsed.data.awsSecretAccessKey.trim(),
         awsRegion: parsed.data.awsRegion.trim(),
+        openrouterApiKey: null,
       });
     }
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -19,6 +19,7 @@ import * as m012 from "./migrations/012-chat-sessions";
 import * as m013 from "./migrations/013-scheduled-tasks";
 import * as m014 from "./migrations/014-chat-sessions-thread-key-sentinel";
 import * as m015 from "./migrations/015-whatsapp-groups";
+import * as m016 from "./migrations/016-settings-openrouter";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>): Promise<void> {
@@ -42,6 +43,7 @@ export async function runMigrations(db: Kysely<DB>): Promise<void> {
           "013-scheduled-tasks": m013,
           "014-chat-sessions-thread-key-sentinel": m014,
           "015-whatsapp-groups": m015,
+          "016-settings-openrouter": m016,
         };
       },
     },

--- a/packages/server/src/db/migrations/016-settings-openrouter.ts
+++ b/packages/server/src/db/migrations/016-settings-openrouter.ts
@@ -1,0 +1,9 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("settings").addColumn("openrouter_api_key", "text").execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("settings").dropColumn("openrouter_api_key").execute();
+}

--- a/packages/server/src/db/repositories/settings.ts
+++ b/packages/server/src/db/repositories/settings.ts
@@ -37,6 +37,7 @@ export function createSettingsRepository(db: Kysely<DB>) {
         awsAccessKeyId: string | null;
         awsSecretAccessKey: string | null;
         awsRegion: string | null;
+        openrouterApiKey: string | null;
         jwtSecret: string;
         smtpHost: string | null;
         smtpPort: number | null;
@@ -59,6 +60,7 @@ export function createSettingsRepository(db: Kysely<DB>) {
       if (data.awsAccessKeyId !== undefined) updates.aws_access_key_id = data.awsAccessKeyId;
       if (data.awsSecretAccessKey !== undefined) updates.aws_secret_access_key = data.awsSecretAccessKey;
       if (data.awsRegion !== undefined) updates.aws_region = data.awsRegion;
+      if (data.openrouterApiKey !== undefined) updates.openrouter_api_key = data.openrouterApiKey;
       if (data.smtpHost !== undefined) updates.smtp_host = data.smtpHost;
       if (data.smtpPort !== undefined) updates.smtp_port = data.smtpPort;
       if (data.smtpUser !== undefined) updates.smtp_user = data.smtpUser;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -50,6 +50,7 @@ export interface SettingsTable {
   aws_access_key_id: string | null;
   aws_secret_access_key: string | null;
   aws_region: string | null;
+  openrouter_api_key: string | null;
   jwt_secret: string | null;
   smtp_host: string | null;
   smtp_port: number | null;

--- a/packages/web/src/components/onboarding/step-completion.tsx
+++ b/packages/web/src/components/onboarding/step-completion.tsx
@@ -9,7 +9,7 @@ interface OnboardingData {
   slackWorkspace?: string;
   whatsappConnected: boolean;
   whatsappPhone?: string;
-  llmProvider: "anthropic" | "bedrock";
+  llmProvider: "anthropic" | "bedrock" | "openrouter";
 }
 
 interface StepCompletionProps {
@@ -40,7 +40,12 @@ export function StepCompletion({ data, onGoToDashboard, isFinishing }: StepCompl
     },
     {
       label: "LLM",
-      value: data.llmProvider === "anthropic" ? "Anthropic (Sonnet)" : "AWS Bedrock (Sonnet)",
+      value:
+        data.llmProvider === "anthropic"
+          ? "Anthropic (Sonnet)"
+          : data.llmProvider === "openrouter"
+            ? "OpenRouter (Sonnet)"
+            : "AWS Bedrock (Sonnet)",
       connected: true,
     },
   ] as const;

--- a/packages/web/src/components/onboarding/step-configure-llm.tsx
+++ b/packages/web/src/components/onboarding/step-configure-llm.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type Provider = "anthropic" | "bedrock";
+type Provider = "anthropic" | "bedrock" | "openrouter";
 
 interface StepConfigureLLMProps {
   initialProvider?: Provider;
@@ -25,6 +25,7 @@ const bedrockRegions = ["us-east-1", "us-west-2", "eu-west-1", "eu-west-3", "ap-
 export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: StepConfigureLLMProps) {
   const [provider, setProvider] = useState<Provider>(initialProvider ?? "anthropic");
   const [apiKey, setApiKey] = useState("");
+  const [openrouterKey, setOpenrouterKey] = useState("");
   const [awsAccessKey, setAwsAccessKey] = useState("");
   const [awsSecretKey, setAwsSecretKey] = useState("");
   const [awsRegion, setAwsRegion] = useState("us-east-1");
@@ -41,12 +42,24 @@ export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: 
   const canConnect =
     provider === "anthropic"
       ? apiKey.trim().length > 0
-      : awsAccessKey.trim().length > 0 && awsSecretKey.trim().length > 0 && awsRegion.trim().length > 0;
+      : provider === "openrouter"
+        ? openrouterKey.trim().length > 0
+        : awsAccessKey.trim().length > 0 && awsSecretKey.trim().length > 0 && awsRegion.trim().length > 0;
+
+  const providerLabel =
+    provider === "anthropic" ? "Anthropic" : provider === "openrouter" ? "OpenRouter" : "AWS Bedrock";
 
   const llmMutation = useMutation({
     mutationFn: async () => {
       if (provider === "anthropic") {
         const payload = { provider: "anthropic" as const, apiKey: apiKey.trim() };
+        await api.setup.verifyLlm(payload);
+        await api.setup.llm(payload);
+        return;
+      }
+
+      if (provider === "openrouter") {
+        const payload = { provider: "openrouter" as const, apiKey: openrouterKey.trim() };
         await api.setup.verifyLlm(payload);
         await api.setup.llm(payload);
         return;
@@ -64,9 +77,10 @@ export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: 
     onSuccess: () => {
       setIsConnected(true);
       setApiKey("");
+      setOpenrouterKey("");
       setAwsAccessKey("");
       setAwsSecretKey("");
-      toast.success(`Connected to ${provider === "anthropic" ? "Anthropic" : "AWS Bedrock"}, using Claude Sonnet.`);
+      toast.success(`Connected to ${providerLabel}, using Claude Sonnet.`);
     },
     onError: (err: Error) => {
       setError(err.message);
@@ -98,9 +112,7 @@ export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: 
                 <span className="text-sm font-semibold text-success">✓</span>
               </div>
               <div>
-                <p className="text-sm font-medium">
-                  Connected to {provider === "anthropic" ? "Anthropic" : "AWS Bedrock"}
-                </p>
+                <p className="text-sm font-medium">Connected to {providerLabel}</p>
                 <p className="text-xs text-muted-foreground">Using Claude Sonnet</p>
               </div>
             </div>
@@ -111,7 +123,7 @@ export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: 
         </div>
       ) : (
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             <button
               type="button"
               onClick={() => {
@@ -130,9 +142,9 @@ export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: 
                   <title>Anthropic logo</title>
                   <path d="M13.827 3.52h3.603L24 20.48h-3.603l-6.57-16.96zm-7.258 0h3.604L16.742 20.48h-3.603L6.569 3.52zM0 20.48h3.604L10.174 3.52H6.569L0 20.48z" />
                 </svg>
-                <span className="text-sm font-medium">Anthropic (Direct)</span>
+                <span className="text-sm font-medium">Anthropic</span>
               </div>
-              <p className="text-xs text-muted-foreground">Use your Anthropic API key directly</p>
+              <p className="text-xs text-muted-foreground">Direct API key</p>
             </button>
             <button
               type="button"
@@ -154,7 +166,29 @@ export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: 
                 </svg>
                 <span className="text-sm font-medium">AWS Bedrock</span>
               </div>
-              <p className="text-xs text-muted-foreground">Use Claude through your AWS account</p>
+              <p className="text-xs text-muted-foreground">Through your AWS account</p>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setProvider("openrouter");
+                setError("");
+              }}
+              className={cn(
+                "rounded-lg border p-4 text-left transition-all",
+                provider === "openrouter"
+                  ? "border-primary bg-primary/5 ring-1 ring-primary/20"
+                  : "border-border bg-card hover:border-muted-foreground/30",
+              )}
+            >
+              <div className="mb-1.5 flex items-center gap-2">
+                <svg className="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false">
+                  <title>OpenRouter logo</title>
+                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+                </svg>
+                <span className="text-sm font-medium">OpenRouter</span>
+              </div>
+              <p className="text-xs text-muted-foreground">Route through OpenRouter</p>
             </button>
           </div>
 
@@ -170,6 +204,21 @@ export function StepConfigureLLM({ initialProvider, initialConnected, onNext }: 
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}
                   placeholder="sk-ant-..."
+                  disabled={isVerifying}
+                  className="font-mono text-xs"
+                />
+              </div>
+            ) : provider === "openrouter" ? (
+              <div className="space-y-1.5">
+                <Label htmlFor="openrouterKey" className="text-xs">
+                  API Key
+                </Label>
+                <Input
+                  id="openrouterKey"
+                  type="password"
+                  value={openrouterKey}
+                  onChange={(e) => setOpenrouterKey(e.target.value)}
+                  placeholder="sk-or-..."
                   disabled={isVerifying}
                   className="font-mono text-xs"
                 />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -82,7 +82,7 @@ export interface SetupStatus {
   botName: string;
   slackConnected: boolean;
   llmConnected: boolean;
-  llmProvider: "anthropic" | "bedrock" | null;
+  llmProvider: "anthropic" | "bedrock" | "openrouter" | null;
 }
 
 export interface SessionResponse {
@@ -115,7 +115,8 @@ export const api = {
     verifyLlm(
       data:
         | { provider: "anthropic"; apiKey: string }
-        | { provider: "bedrock"; awsAccessKeyId: string; awsSecretAccessKey: string; awsRegion: string },
+        | { provider: "bedrock"; awsAccessKeyId: string; awsSecretAccessKey: string; awsRegion: string }
+        | { provider: "openrouter"; apiKey: string },
     ) {
       return request<{ success: boolean }>("/api/setup/llm/verify", {
         method: "POST",
@@ -143,7 +144,8 @@ export const api = {
     llm(
       data:
         | { provider: "anthropic"; apiKey: string }
-        | { provider: "bedrock"; awsAccessKeyId: string; awsSecretAccessKey: string; awsRegion: string },
+        | { provider: "bedrock"; awsAccessKeyId: string; awsSecretAccessKey: string; awsRegion: string }
+        | { provider: "openrouter"; apiKey: string },
     ) {
       return request<{ success: boolean }>("/api/setup/llm", {
         method: "POST",

--- a/packages/web/src/routes/onboarding.tsx
+++ b/packages/web/src/routes/onboarding.tsx
@@ -70,7 +70,9 @@ export function OnboardingPage({ initialSetupStatus }: { initialSetupStatus?: Se
   const [whatsappConnected, setWhatsappConnected] = useState(false);
   const [whatsappPhone, setWhatsappPhone] = useState<string | undefined>(undefined);
 
-  const [llmProvider, setLlmProvider] = useState<"anthropic" | "bedrock">(setupStatus.llmProvider ?? "anthropic");
+  const [llmProvider, setLlmProvider] = useState<"anthropic" | "bedrock" | "openrouter">(
+    setupStatus.llmProvider ?? "anthropic",
+  );
   const [llmConnected, setLlmConnected] = useState(setupStatus.llmConnected);
 
   const goToStep = (nextStep: number) => {


### PR DESCRIPTION
## Summary

- Adds OpenRouter as a third LLM provider option alongside Anthropic Direct and AWS Bedrock
- OpenRouter proxies to Claude via `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`, with `ANTHROPIC_API_KEY=""` per OpenRouter docs
- DB migration 016 adds `openrouter_api_key` column to settings
- API verification endpoint validates keys against OpenRouter's messages API
- Onboarding UI updated with 3-column provider selector grid and OpenRouter API key input
- All existing tests updated; 2 new test cases for openrouter env configuration

## Test plan

- [x] `pnpm test` — 914 tests pass (812 server + 102 web)
- [x] `tsc --noEmit` — no TypeScript errors
- [x] `biome check` — no lint/format errors
- [x] `pnpm build` — production build succeeds
- [ ] Manual: onboarding flow → select OpenRouter → enter API key → verify → connect
- [ ] Manual: send message via Slack/WhatsApp, confirm agent responds with `llmProvider: "openrouter"` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)