### PR TITLE
feat: ephemeral credential wrappers for integration CLIs

### DIFF
--- a/packages/server/src/agent/permissions.test.ts
+++ b/packages/server/src/agent/permissions.test.ts
@@ -203,6 +203,110 @@ describe("createCanUseTool", () => {
     });
   });
 
+  describe("credential wrapper isolation (layer 3)", () => {
+    const WRAPPER = "/tmp/sketch-int-canvas-run123.sh";
+
+    describe("blocked — read-style Bash commands targeting wrapper files", () => {
+      it.each([
+        ["cat", `cat ${WRAPPER}`],
+        ["head with flags", `head -n 5 ${WRAPPER}`],
+        ["tail", `tail ${WRAPPER}`],
+        ["less", `less ${WRAPPER}`],
+        ["bat", `bat ${WRAPPER}`],
+        ["xxd", `xxd ${WRAPPER}`],
+        ["od", `od -c ${WRAPPER}`],
+        ["hexdump", `hexdump -C ${WRAPPER}`],
+        ["strings", `strings ${WRAPPER}`],
+        ["file", `file ${WRAPPER}`],
+        ["grep for secrets", `grep SECRET ${WRAPPER}`],
+        ["awk", `awk '{print}' ${WRAPPER}`],
+        ["sed", `sed -n 1p ${WRAPPER}`],
+        ["cp to workspace (exfil)", `cp ${WRAPPER} ${WORKSPACE}/stolen.sh`],
+        ["mv to workspace (exfil)", `mv ${WRAPPER} ${WORKSPACE}/stolen.sh`],
+        ["cat with input redirection", `cat < ${WRAPPER}`],
+        ["base64 encode", `base64 ${WRAPPER}`],
+        ["vi open", `vi ${WRAPPER}`],
+        ["chained after &&", `echo foo && cat ${WRAPPER}`],
+        ["chained after ||", `false || cat ${WRAPPER}`],
+        ["chained after ;", `echo foo; cat ${WRAPPER}`],
+        ["bash -c wrapping", `bash -c "cat ${WRAPPER}"`],
+      ])("denies: %s", async (_name, command) => {
+        const result = await canUseTool("Bash", { command });
+        expectDeny(result);
+        expect(result.message).toContain("cannot read integration credential files");
+      });
+    });
+
+    describe("allowed — execution with downstream output truncation (the key fix)", () => {
+      it("allows wrapper execution piped to head for output truncation", async () => {
+        const result = await canUseTool("Bash", { command: `${WRAPPER} action list | head -c 2000` });
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("allows wrapper execution piped to tail", async () => {
+        const result = await canUseTool("Bash", { command: `${WRAPPER} action list | tail -n 20` });
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("allows wrapper execution piped to jq", async () => {
+        const result = await canUseTool("Bash", { command: `${WRAPPER} action list | jq .result` });
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("allows wrapper execution piped to grep (filter wrapper OUTPUT, not read wrapper FILE)", async () => {
+        const result = await canUseTool("Bash", { command: `${WRAPPER} action list | grep canvas` });
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("allows direct wrapper execution without any read command", async () => {
+        const result = await canUseTool("Bash", { command: `${WRAPPER} action list` });
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("allows sh invocation of the wrapper (sh is not a read command)", async () => {
+        const result = await canUseTool("Bash", { command: `sh ${WRAPPER} action list` });
+        expect(result.behavior).toBe("allow");
+      });
+    });
+
+    describe("allowed — unrelated commands that happen to contain 'sketch-int-' or a read command", () => {
+      it("allows env | grep CANVAS (grep, but no /sketch-int- path)", async () => {
+        const result = await canUseTool("Bash", { command: "env | grep CANVAS" });
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("allows cat of a non-wrapper /tmp file", async () => {
+        const result = await canUseTool("Bash", { command: "cat /tmp/other.txt" });
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("allows head of a workspace file", async () => {
+        const result = await canUseTool("Bash", { command: `head ${WORKSPACE}/notes.md` });
+        expect(result.behavior).toBe("allow");
+      });
+    });
+
+    describe("layer 2 still covers file-tool reads of wrapper paths (no separate layer 3 needed for file tools)", () => {
+      it("denies Read tool with wrapper path (via layer 2 workspace boundary, not layer 3)", async () => {
+        const result = await canUseTool("Read", { file_path: WRAPPER });
+        expectDeny(result);
+        expect(result.message).toContain("outside your workspace");
+      });
+
+      it("denies Glob with wrapper path", async () => {
+        const result = await canUseTool("Glob", { path: WRAPPER });
+        expectDeny(result);
+        expect(result.message).toContain("outside your workspace");
+      });
+
+      it("denies Grep with wrapper path", async () => {
+        const result = await canUseTool("Grep", { path: WRAPPER });
+        expectDeny(result);
+        expect(result.message).toContain("outside your workspace");
+      });
+    });
+  });
+
   describe("edge cases", () => {
     it("allows WebSearch with no path validation", async () => {
       const result = await canUseTool("WebSearch", { query: "vitest testing" });

--- a/packages/server/src/agent/permissions.ts
+++ b/packages/server/src/agent/permissions.ts
@@ -4,9 +4,14 @@
  *
  * Four security layers:
  * 1. Tool allowlist — only permitted tools can execute
- * 2. File path validation — file tools restricted to workspace + ~/.claude (read-write)
- * 3. Credential wrapper isolation — block reading /tmp/sketch-int-* wrapper files
- * 4. Bash path validation — commands blocked if they reference absolute paths outside workspace/~/.claude
+ * 2. File path validation — file tools restricted to workspace + ~/.claude (read-write).
+ *    Layer 2 also implicitly covers file-tool reads of /tmp/sketch-int-* (wrapper files
+ *    live outside the workspace and outside ~/.claude, so they're denied here).
+ * 3. Credential wrapper Bash isolation — block Bash read-style commands whose target
+ *    path contains /sketch-int- (e.g. `cat /tmp/sketch-int-canvas-xxx.sh`), while
+ *    allowing execution with downstream output truncation (e.g. `$CANVAS_CLI | head`).
+ * 4. Bash path validation — commands blocked if they reference absolute paths outside
+ *    workspace/~/.claude.
  */
 import { resolve } from "node:path";
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
@@ -17,6 +22,27 @@ export const PERMITTED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep",
 export const FILE_TOOLS = ["Read", "Edit", "Write", "Glob", "Grep"];
 
 export const READ_ONLY_FILE_TOOLS = ["Read", "Glob", "Grep"];
+
+/**
+ * Matches Bash commands that attempt to read a credential wrapper file with a
+ * read-style tool. The key constraint is `[^|;&]*` between the read command
+ * name and `/sketch-int-`: it ensures the wrapper path is on the SAME side of
+ * any command separator as the read command.
+ *
+ * Blocks: `cat /tmp/sketch-int-canvas-xxx.sh`, `head -n 5 /tmp/sketch-int-...`,
+ *         `grep SECRET /tmp/sketch-int-...`, `foo && cat /tmp/sketch-int-...`,
+ *         `xxd /tmp/sketch-int-...`, `cat < /tmp/sketch-int-...`.
+ * Allows: `$CANVAS_CLI action list | head -c 2000` (head is after the pipe —
+ *         it's truncating wrapper OUTPUT, not reading the wrapper FILE),
+ *         `sh /tmp/sketch-int-...` (executing the wrapper — `sh` isn't in the
+ *         read-command list), `env | grep CANVAS` (no /sketch-int- path).
+ *
+ * Known gaps accepted as out-of-scope for this layer:
+ * - Glob expansion: `cat /tmp/*int*.sh` won't match (no literal /sketch-int-).
+ * - `echo "cat /tmp/sketch-int-..."`: false positive, just printing a string.
+ */
+const WRAPPER_READ_RE =
+  /\b(cat|head|tail|less|more|bat|xxd|od|hexdump|strings|file|stat|awk|sed|grep|dd|tac|nl|rev|cp|mv|cmp|diff|base64|vi|vim|nano|emacs|ed)\b[^|;&]*\/sketch-int-/;
 
 /**
  * Returns true when filePath is exactly dir or a child of dir.
@@ -52,17 +78,12 @@ export function createCanUseTool(absWorkspace: string, logger: Logger, claudeDir
       }
     }
 
-    // Layer 3: block reading credential wrapper files
-    if (FILE_TOOLS.includes(toolName)) {
-      const rawPath = (input.file_path as string) || (input.path as string) || "";
-      if (rawPath.includes("/tmp/sketch-int-")) {
-        logger.warn({ toolName, rawPath }, "Blocked read of integration credential wrapper");
-        return { behavior: "deny", message: "Access denied: cannot read integration credential files" };
-      }
-    }
+    // Layer 3: block Bash read-style commands targeting credential wrapper files.
+    // (FILE_TOOLS reads of /tmp/sketch-int-* are already denied by Layer 2 because
+    // the wrapper files live outside the workspace and outside ~/.claude.)
     if (toolName === "Bash") {
       const command = (input.command as string) || "";
-      if (/sketch-int-/.test(command) && /cat |head |tail |less |more |bat |vi |vim |nano /.test(command)) {
+      if (WRAPPER_READ_RE.test(command)) {
         logger.warn({ toolName, command }, "Blocked bash read of integration credential wrapper");
         return { behavior: "deny", message: "Access denied: cannot read integration credential files" };
       }

--- a/packages/server/src/agent/permissions.ts
+++ b/packages/server/src/agent/permissions.ts
@@ -2,10 +2,11 @@
  * Workspace isolation via canUseTool — factory function that creates the
  * permission callback for the Claude Agent SDK's query().
  *
- * Three security layers:
+ * Four security layers:
  * 1. Tool allowlist — only permitted tools can execute
  * 2. File path validation — file tools restricted to workspace + ~/.claude (read-write)
- * 3. Bash path validation — commands blocked if they reference absolute paths outside workspace/~/.claude
+ * 3. Credential wrapper isolation — block reading /tmp/sketch-int-* wrapper files
+ * 4. Bash path validation — commands blocked if they reference absolute paths outside workspace/~/.claude
  */
 import { resolve } from "node:path";
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
@@ -51,7 +52,23 @@ export function createCanUseTool(absWorkspace: string, logger: Logger, claudeDir
       }
     }
 
-    // Layer 3: bash path validation
+    // Layer 3: block reading credential wrapper files
+    if (FILE_TOOLS.includes(toolName)) {
+      const rawPath = (input.file_path as string) || (input.path as string) || "";
+      if (rawPath.includes("/tmp/sketch-int-")) {
+        logger.warn({ toolName, rawPath }, "Blocked read of integration credential wrapper");
+        return { behavior: "deny", message: "Access denied: cannot read integration credential files" };
+      }
+    }
+    if (toolName === "Bash") {
+      const command = (input.command as string) || "";
+      if (/sketch-int-/.test(command) && /cat |head |tail |less |more |bat |vi |vim |nano /.test(command)) {
+        logger.warn({ toolName, command }, "Blocked bash read of integration credential wrapper");
+        return { behavior: "deny", message: "Access denied: cannot read integration credential files" };
+      }
+    }
+
+    // Layer 4: bash path validation
     if (toolName === "Bash") {
       const command = (input.command as string) || "";
       const hasAbsolutePath = /(?:^|\s)\/(?!dev\/null|tmp\/)/.test(command);

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -14,6 +14,7 @@ import type { createOutreachRepository } from "../db/repositories/outreach";
 import type { DB, UsersTable } from "../db/schema";
 import type { Attachment } from "../files";
 import { buildMultimodalContent, formatAttachmentsForPrompt, isImageAttachment } from "../files";
+import { type WrapperResult, cleanupWrappers, resolveIntegrationWrappers } from "../integrations/wrapper";
 import type { Logger } from "../logger";
 import type { TaskScheduler } from "../scheduler/service";
 import type { TaskContext } from "../scheduler/types";
@@ -233,6 +234,34 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
     return baseCanUseTool(toolName, input);
   };
 
+  // Generate ephemeral credential wrappers for skill-mode integrations.
+  // Sets env vars (just paths, no credentials) on process.env before query() spawns
+  // the subprocess. The subprocess captures a snapshot of env at spawn time.
+  // JS single-threaded execution guarantees no interleaving between env set and spawn.
+  let wrapperResult: WrapperResult = { envVars: {}, wrapperPaths: [] };
+  if (params.findIntegrationProvider) {
+    wrapperResult = await resolveIntegrationWrappers({
+      runId: existingSessionId ?? crypto.randomUUID().slice(0, 8),
+      userEmail: params.userEmail ?? null,
+      findIntegrationProvider: params.findIntegrationProvider,
+      logger,
+    });
+    for (const [key, value] of Object.entries(wrapperResult.envVars)) {
+      process.env[key] = value;
+    }
+    logger.info(
+      {
+        wrapperEnvKeys: Object.keys(wrapperResult.envVars),
+        wrapperPaths: wrapperResult.wrapperPaths,
+        hasCanvasCli: !!process.env.CANVAS_CLI,
+        hasCanvasApiKey: !!process.env.CANVAS_API_KEY_MCP,
+        hasCanvasUserEmail: !!process.env.CANVAS_USER_EMAIL,
+        userEmail: params.userEmail,
+      },
+      "Integration wrappers resolved",
+    );
+  }
+
   const run = query({
     prompt,
     options: {
@@ -344,6 +373,9 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
   if (sessionId && !isFresh) {
     await saveSessionId(params.db, params.workspaceKey, sessionId, params.threadTs);
   }
+
+  // Clean up ephemeral credential wrappers
+  cleanupWrappers(wrapperResult);
 
   const pendingUploads = uploadCollector.drain();
   logger.info({ userId: userName, sessionId, costUsd, pendingUploads: pendingUploads.length }, "Agent run completed");

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -235,9 +235,10 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
   };
 
   // Generate ephemeral credential wrappers for skill-mode integrations.
-  // Sets env vars (just paths, no credentials) on process.env before query() spawns
-  // the subprocess. The subprocess captures a snapshot of env at spawn time.
-  // JS single-threaded execution guarantees no interleaving between env set and spawn.
+  // The wrapper env vars (just paths, no credentials) are passed to the agent
+  // subprocess via the SDK's per-call `options.env` — never mutated onto
+  // process.env — so concurrent runAgent calls in the same Node process cannot
+  // interleave and leak one user's wrapper path to another user's subprocess.
   let wrapperResult: WrapperResult = { envVars: {}, wrapperPaths: [] };
   if (params.findIntegrationProvider) {
     wrapperResult = await resolveIntegrationWrappers({
@@ -246,20 +247,17 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
       findIntegrationProvider: params.findIntegrationProvider,
       logger,
     });
-    for (const [key, value] of Object.entries(wrapperResult.envVars)) {
-      process.env[key] = value;
-    }
     logger.info(
       {
         wrapperEnvKeys: Object.keys(wrapperResult.envVars),
         wrapperPaths: wrapperResult.wrapperPaths,
-        hasCanvasCli: !!process.env.CANVAS_CLI,
-        hasCanvasApiKey: !!process.env.CANVAS_API_KEY_MCP,
-        hasCanvasUserEmail: !!process.env.CANVAS_USER_EMAIL,
-        userEmail: params.userEmail,
+        hasCanvasCli: !!wrapperResult.envVars.CANVAS_CLI,
+        hasCanvasApiKey: !!wrapperResult.envVars.CANVAS_API_KEY_MCP,
+        hasCanvasUserEmail: !!wrapperResult.envVars.CANVAS_USER_EMAIL,
       },
       "Integration wrappers resolved",
     );
+    logger.debug({ userEmail: params.userEmail }, "Integration wrappers resolved (user context)");
   }
 
   const run = query({
@@ -268,6 +266,7 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
       maxTurns: 100,
       cwd: workspaceDir,
       resume: existingSessionId,
+      env: { ...process.env, ...wrapperResult.envVars },
       systemPrompt: {
         type: "preset" as const,
         preset: "claude_code" as const,

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -435,7 +435,7 @@ export function createSketchMcpServer(deps: SketchMcpDeps) {
 
     tool(
       "getProviderConfig",
-      "Get the configured integration provider credentials (API key and type). Call this once when you need to use a provider-backed skill like Canvas. Returns null if no provider is configured.",
+      "Check if an integration provider is configured. Credentials and user scoping are injected automatically into integration CLI wrappers at runtime — never set API keys or email addresses manually.",
       {},
       async () => {
         if (!deps.findIntegrationProvider) {
@@ -451,25 +451,17 @@ export function createSketchMcpServer(deps: SketchMcpDeps) {
           };
         }
 
-        try {
-          const parsed = JSON.parse(provider.credentials) as Record<string, string>;
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({
-                  configured: true,
-                  type: provider.type,
-                  apiKey: parsed.apiKey,
-                }),
-              },
-            ],
-          };
-        } catch {
-          return {
-            content: [{ type: "text" as const, text: JSON.stringify({ configured: false }) }],
-          };
-        }
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                configured: true,
+                type: provider.type,
+              }),
+            },
+          ],
+        };
       },
     ),
 

--- a/packages/server/src/integrations/wrapper.ts
+++ b/packages/server/src/integrations/wrapper.ts
@@ -54,11 +54,11 @@ export async function resolveIntegrationWrappers(params: {
     wrapperPaths.push(wrapperPath);
     envVars.CANVAS_CLI = wrapperPath;
 
-    // Do NOT set CANVAS_API_KEY_MCP or CANVAS_USER_EMAIL on process.env.
+    // Do NOT expose CANVAS_API_KEY_MCP or CANVAS_USER_EMAIL to the agent subprocess.
     // The Canvas CLI embeds an MCP server manifest — if the SDK finds these env vars,
     // it auto-registers Canvas as an MCP server (exposing the API key to the agent).
-    // By keeping them only inside the wrapper, the SDK's MCP registration fails silently
-    // and the agent uses Canvas via $CANVAS_CLI (Bash) only.
+    // By keeping them only inside the wrapper script, the SDK's MCP registration fails
+    // silently and the agent uses Canvas via $CANVAS_CLI (Bash) only.
 
     logger.debug({ wrapperPath }, "Integration wrapper: created for canvas");
   }
@@ -88,15 +88,14 @@ exec node "${config.cliPath}" "$@"
 }
 
 /**
- * Clean up wrapper files and remove env vars from process.env.
+ * Clean up ephemeral wrapper files after an agent run completes.
+ * The env vars are scoped to the SDK subprocess via options.env — nothing
+ * to clean up in the parent process.
  */
 export function cleanupWrappers(result: WrapperResult): void {
   for (const wrapperPath of result.wrapperPaths) {
     try {
       unlinkSync(wrapperPath);
     } catch {}
-  }
-  for (const key of Object.keys(result.envVars)) {
-    delete process.env[key];
   }
 }

--- a/packages/server/src/integrations/wrapper.ts
+++ b/packages/server/src/integrations/wrapper.ts
@@ -1,0 +1,102 @@
+/**
+ * Ephemeral credential wrapper for integration CLIs.
+ *
+ * Generates a per-agent-run shell script that embeds credentials and delegates
+ * to the real CLI. The agent only sees an env var pointing to the wrapper path
+ * (e.g. $CANVAS_CLI) — never the API key or user email.
+ *
+ * The wrapper is deleted after the agent run completes.
+ */
+import { chmodSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Kysely } from "kysely";
+import type { DB } from "../db/schema";
+import type { Logger } from "../logger";
+
+interface SkillModeProvider {
+  type: string;
+  credentials: string;
+}
+
+export interface WrapperResult {
+  envVars: Record<string, string>;
+  wrapperPaths: string[];
+}
+
+/**
+ * Resolve integration wrappers for all skill-mode providers.
+ * Returns env vars to set on the agent subprocess (just paths, no credentials)
+ * and wrapper file paths for cleanup.
+ */
+export async function resolveIntegrationWrappers(params: {
+  runId: string;
+  userEmail: string | null;
+  findIntegrationProvider: () => Promise<SkillModeProvider | null>;
+  logger: Logger;
+}): Promise<WrapperResult> {
+  const { runId, userEmail, logger } = params;
+  const envVars: Record<string, string> = {};
+  const wrapperPaths: string[] = [];
+
+  const provider = await params.findIntegrationProvider();
+  if (!provider) return { envVars, wrapperPaths };
+
+  if (provider.type === "canvas") {
+    const creds = JSON.parse(provider.credentials) as Record<string, string>;
+    const cliPath = join(homedir(), ".claude", "skills", "canvas", "canvas-cli.js");
+
+    const wrapperEnv: Record<string, string> = {};
+    if (creds.apiKey) wrapperEnv.CANVAS_API_KEY_MCP = creds.apiKey;
+    if (userEmail) wrapperEnv.CANVAS_USER_EMAIL = userEmail;
+
+    const wrapperPath = generateWrapper({ runId, slug: "canvas", cliPath, envVars: wrapperEnv });
+    wrapperPaths.push(wrapperPath);
+    envVars.CANVAS_CLI = wrapperPath;
+
+    // Do NOT set CANVAS_API_KEY_MCP or CANVAS_USER_EMAIL on process.env.
+    // The Canvas CLI embeds an MCP server manifest — if the SDK finds these env vars,
+    // it auto-registers Canvas as an MCP server (exposing the API key to the agent).
+    // By keeping them only inside the wrapper, the SDK's MCP registration fails silently
+    // and the agent uses Canvas via $CANVAS_CLI (Bash) only.
+
+    logger.debug({ wrapperPath }, "Integration wrapper: created for canvas");
+  }
+
+  return { envVars, wrapperPaths };
+}
+
+function generateWrapper(config: {
+  runId: string;
+  slug: string;
+  cliPath: string;
+  envVars: Record<string, string>;
+}): string {
+  const wrapperPath = join("/tmp", `sketch-int-${config.slug}-${config.runId}.sh`);
+  const envLines = Object.entries(config.envVars)
+    .map(([k, v]) => `${k}="${v.replace(/"/g, '\\"')}" \\`)
+    .join("\n");
+
+  const content = `#!/bin/bash
+${envLines}
+exec node "${config.cliPath}" "$@"
+`;
+
+  writeFileSync(wrapperPath, content);
+  chmodSync(wrapperPath, 0o700);
+  return wrapperPath;
+}
+
+/**
+ * Clean up wrapper files and remove env vars from process.env.
+ */
+export function cleanupWrappers(result: WrapperResult): void {
+  for (const wrapperPath of result.wrapperPaths) {
+    try {
+      unlinkSync(wrapperPath);
+    } catch {}
+  }
+  for (const key of Object.keys(result.envVars)) {
+    delete process.env[key];
+  }
+}

--- a/packages/server/src/skills/sync.test.ts
+++ b/packages/server/src/skills/sync.test.ts
@@ -86,12 +86,13 @@ describe("syncFeaturedSkills", () => {
     expect(execSync).not.toHaveBeenCalledWith(expect.stringContaining("git clone"), expect.anything());
   });
 
-  it("copies skill dirs based on manifest entries", async () => {
+  it("copies skill dirs based on manifest entries when destinations do not exist", async () => {
     vi.mocked(existsSync).mockImplementation((p) => {
       const s = String(p);
       if (s === SKILLS_CACHE) return true;
       if (s.endsWith("manifest.json")) return true;
-      if (s.includes("skills/skill-a") || s.includes("skills/skill-b")) return true;
+      // Sources (inside SKILLS_CACHE) exist, destinations (inside SKILLS_TARGET) do not.
+      if (s.startsWith(SKILLS_CACHE) && (s.includes("skills/skill-a") || s.includes("skills/skill-b"))) return true;
       return false;
     });
     vi.mocked(readFileSync).mockReturnValue(MANIFEST_WITH_SKILLS);
@@ -103,6 +104,46 @@ describe("syncFeaturedSkills", () => {
     expect(cpSync).toHaveBeenCalledWith(join(SKILLS_CACHE, "skills/skill-a"), join(SKILLS_TARGET, "skill-a"), {
       recursive: true,
     });
+    expect(cpSync).toHaveBeenCalledWith(join(SKILLS_CACHE, "skills/skill-b"), join(SKILLS_TARGET, "skill-b"), {
+      recursive: true,
+    });
+  });
+
+  it("skips copy when destination dir already exists (preserves local edits)", async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s === SKILLS_CACHE) return true;
+      if (s.endsWith("manifest.json")) return true;
+      // Both source and destination exist — destination should be preserved.
+      if (s.includes("skills/skill-a") || s.includes("skills/skill-b")) return true;
+      return false;
+    });
+    vi.mocked(readFileSync).mockReturnValue(MANIFEST_WITH_SKILLS);
+
+    const logger = makeLogger();
+    await syncFeaturedSkills(fakeConfig, logger as never);
+
+    expect(cpSync).not.toHaveBeenCalled();
+  });
+
+  it("copies only skills whose destinations do not exist (partial preservation)", async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s === SKILLS_CACHE) return true;
+      if (s.endsWith("manifest.json")) return true;
+      // skill-a destination already exists (preserve), skill-b destination does not (copy).
+      if (s === join(SKILLS_TARGET, "skill-a")) return true;
+      if (s === join(SKILLS_TARGET, "skill-b")) return false;
+      // Both sources exist.
+      if (s.startsWith(SKILLS_CACHE) && (s.includes("skills/skill-a") || s.includes("skills/skill-b"))) return true;
+      return false;
+    });
+    vi.mocked(readFileSync).mockReturnValue(MANIFEST_WITH_SKILLS);
+
+    const logger = makeLogger();
+    await syncFeaturedSkills(fakeConfig, logger as never);
+
+    expect(cpSync).toHaveBeenCalledTimes(1);
     expect(cpSync).toHaveBeenCalledWith(join(SKILLS_CACHE, "skills/skill-b"), join(SKILLS_TARGET, "skill-b"), {
       recursive: true,
     });

--- a/packages/server/src/skills/sync.ts
+++ b/packages/server/src/skills/sync.ts
@@ -33,15 +33,22 @@ export async function syncFeaturedSkills(config: Config, logger: Logger): Promis
     const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
     mkdirSync(skillsTarget, { recursive: true });
 
+    let copied = 0;
+    let skipped = 0;
     for (const [id, skill] of Object.entries<{ path: string }>(manifest.skills)) {
       const src = join(skillsCache, skill.path);
       const dest = join(skillsTarget, id);
+      if (existsSync(dest)) {
+        skipped++;
+        continue;
+      }
       if (existsSync(src)) {
         cpSync(src, dest, { recursive: true });
+        copied++;
       }
     }
 
-    logger.info({ count: Object.keys(manifest.skills).length }, "Synced featured skills");
+    logger.info({ copied, skipped, total: Object.keys(manifest.skills).length }, "Synced featured skills");
   } catch (err) {
     logger.warn({ err }, "Failed to sync featured skills, continuing with existing skills");
   }


### PR DESCRIPTION
## Summary

Introduces ephemeral, per-run credential wrappers for integration CLIs (Canvas today, any future provider tomorrow), so the agent never sees API keys in plaintext. Bundles a concurrency safety fix caught during review, tightened workspace isolation for wrapper file reads, and a quality-of-life fix that stops server restarts from clobbering hand-edited skill files.

## Changes

### Feature — ephemeral credential wrappers (`92103c5`)
- New `packages/server/src/integrations/wrapper.ts`: generates a one-shot wrapper script at `/tmp/sketch-int-{slug}-{runId}.sh` per agent run, with credentials (`CANVAS_API_KEY_MCP`, `CANVAS_USER_EMAIL`) baked into the script as `exec` env assignments — NOT set on `process.env`, NOT returned to the agent.
- Agent sees only `$CANVAS_CLI` as the path to execute; the API key is never exposed in tool output, logs, or prompts.
- `getProviderConfig` MCP tool updated: returns `{configured, type}` only — no `apiKey` field — and the tool description tells the agent credentials are injected automatically and should never be set manually.
- Workspace isolation (`canUseTool`) gains a new Layer 3 to block Bash read-style commands targeting `/tmp/sketch-int-*` wrapper files.

### Fix — env var scope / concurrency (`4e4543a`)
- Pass wrapper env vars to the SDK subprocess via the per-call `options.env` parameter instead of mutating `process.env`.
- Closes a cross-user credential leak: the original implementation assumed set-then-spawn was atomic (true on single-threaded JS) but `cleanupWrappers()` runs after the async query loop, leaving a window where concurrent `runAgent()` calls can stomp each other's env vars on the shared `process.env`. Worst case: a subprocess inherits another user's wrapper path and runs with their credentials.
- Each `runAgent()` call now gets its own isolated env map. Logging and cleanup operate on the local `wrapperResult.envVars` instead of reading/writing `process.env`.

### Fix — Layer 3 regex tightening (`7877b4f`)
- Original Layer 3 flat-ANDed `/sketch-int-/` with a read-command substring. This false-positive'd on legitimate commands like `$CANVAS_CLI action list | head -c 2000` — the `head` is truncating wrapper OUTPUT, not reading the wrapper FILE — and left agents with no reliable way to bound large tool responses.
- New regex does a structural check: matches a read-style command followed (on the same side of any command separator) by a `/sketch-int-` path. `cat /tmp/sketch-int-...` is blocked; `... | head` is allowed because `head` sits after the pipe.
- Expanded the blocked-command list to cover exfiltration paths (`cp`/`mv`/`base64`/`xxd`/`hexdump`/`strings`/`dd`/...) in addition to the original `cat`/`head`/`tail`/`less`/`more`/`bat`/editors set.
- Dropped the redundant FILE_TOOLS check — Layer 2 already denies file-tool access to `/tmp/sketch-int-*` (outside workspace and outside `~/.claude`).
- Adds 31 test assertions across 4 sub-groups: blocked reads, allowed piped execution, allowed unrelated commands, Layer 2 coverage.

### QoL — skill sync preserves local edits (`ad5459d`)
- `syncFeaturedSkills` no longer `cpSync`-overwrites existing skill directories under `$CLAUDE_CONFIG_DIR/skills/` on every server startup. Fixes a silent revert of hand-edited `~/.claude/skills/canvas/SKILL.md` that was happening once per restart because of the `canvasxai/sketch-skills` repo sync.
- To force a re-sync of a specific skill: `rm -rf ~/.claude/skills/<id>` and restart. Log line now reports `copied`/`skipped`/`total`.

### Tests — skill sync coverage (`3b70699`)
- Fixes an existing test's `existsSync` mock that was too broad (matched both source and destination paths); narrows to source-only.
- Adds two new tests: "skips copy when destination dir already exists" and "copies only skills whose destinations do not exist" (partial preservation).

## Test plan

- [x] `pnpm biome check` — clean (851 files)
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm -r test` — 1274/1274 passing (pre-push hook verified)
- [x] `pnpm build` — server 552 kB, web, ui all clean
- [ ] Manual: verify Canvas skill invocation still works end-to-end through Slack and WhatsApp
  - `$CANVAS_CLI action list | head -c 2000` should run
  - `cat /tmp/sketch-int-canvas-*.sh` should be denied with "cannot read integration credential files"
  - `env | grep CANVAS` should not appear in logs / tool responses
- [ ] Manual: verify concurrent agent runs on two channels don't interleave wrapper paths (check `wrapperPaths` in structured logs)

## Out of scope for this PR

- Generalizing the wrapper to non-Canvas providers (today it has a hardcoded `provider.type === "canvas"` branch). Follow-up when a second provider lands.
- Glob-expansion attacks against Layer 3 (e.g. `cat /tmp/*int*.sh`): not caught by the literal-string regex, and accepted as out of scope for the current threat model (well-meaning agent, not sophisticated adversary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)