### PR TITLE
fix(whatsapp): disable fireInitQueries to silence Baileys boot error

### DIFF
--- a/packages/server/src/whatsapp/bot.ts
+++ b/packages/server/src/whatsapp/bot.ts
@@ -164,6 +164,7 @@ export class WhatsAppBot {
       logger: this.logger as unknown as Parameters<typeof makeWASocket>[0]["logger"],
       printQRInTerminal: false,
       syncFullHistory: false,
+      fireInitQueries: false,
       markOnlineOnConnect: false,
     });
     this.activeSocketGeneration += 1;
@@ -380,6 +381,7 @@ export class WhatsAppBot {
       logger: this.logger as unknown as Parameters<typeof makeWASocket>[0]["logger"],
       printQRInTerminal: false,
       syncFullHistory: false,
+      fireInitQueries: false,
       markOnlineOnConnect: false,
       cachedGroupMetadata: async (jid) => {
         const cached = this.groupMetaCache.get(jid);


### PR DESCRIPTION
## Summary

Disables Baileys' \`executeInitQueries\` via \`fireInitQueries: false\` on both \`makeWASocket\` call sites in \`whatsapp/bot.ts\`. This is the documented Baileys escape hatch.

## Problem

Every server startup (and every WhatsApp socket reconnect) logs:

\`\`\`
[server] ERROR: unexpected error in 'init queries'
    err: {
      "message": "bad-request",
      "data": 400,
      "isBoom": true,
      ...
    }
    at executeInitQueries (baileys/Socket/chats.ts:1018:3)
\`\`\`

The init-query batch fires protocol requests for blocklist, privacy settings, \`abt\` config, etc. after the WebSocket handshake. One or more return \`400 bad-request\` against the current WhatsApp server build.

## Why disabling is safe here

The socket is already authenticated and usable once \`connection.update\` fires \`"open"\`. Init queries populate ambient protocol state (blocklists, privacy settings) that the bot doesn't read or write — we only need send/receive and group metadata, both of which work fine without them.

## Test plan

- [ ] Restart server — confirm the \`'init queries'\` error no longer appears in logs
- [ ] Send a WhatsApp DM to the bot — confirm it responds
- [ ] @mention the bot in a WhatsApp group — confirm it responds
- [ ] Trigger a socket reconnect (restart the bot without re-pairing) — confirm no init-query error on reconnect path

🤖 Generated with [Claude Code](https://claude.com/claude-code)