### PR TITLE
fix(dev): vite proxy follows PORT, prompt time formatter pinned to en-US

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ DATA_DIR=./data
 # SKETCH_CONFIG_DIR=/data/.sketch
 PORT=3000
 LOG_LEVEL=info          # debug | info | warn | error
+# In dev, the Vite server proxies /api to http://localhost:${PORT} by default.
+# Override the full target if your API runs elsewhere (e.g. a remote host):
+# VITE_API_PROXY_TARGET=http://localhost:3000
 
 # Public-facing base URL (required for OAuth redirects)
 # e.g. https://sketch.yourcompany.com — no trailing slash

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -216,7 +216,7 @@ export function buildSketchContext(params: SketchContextParams): string {
 
   const tz = params.timezone || "UTC";
   const now = new Date();
-  const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  const dateFormatter = new Intl.DateTimeFormat("en-US", {
     timeZone: tz,
     weekday: "long",
     year: "numeric",
@@ -226,7 +226,7 @@ export function buildSketchContext(params: SketchContextParams): string {
     minute: "2-digit",
     hour12: true,
   });
-  const tzFormatter = new Intl.DateTimeFormat(undefined, {
+  const tzFormatter = new Intl.DateTimeFormat("en-US", {
     timeZone: tz,
     timeZoneName: "short",
   });

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,30 +1,37 @@
 import { resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      "@": resolve(import.meta.dirname, "src"),
-      "@sketch/shared": resolve(import.meta.dirname, "../shared/src/index.ts"),
-      "@sketch/ui/components": resolve(import.meta.dirname, "../ui/src/components/ui"),
-      "@sketch/ui/hooks": resolve(import.meta.dirname, "../ui/src/hooks"),
-      "@sketch/ui/lib": resolve(import.meta.dirname, "../ui/src/lib"),
-      "@sketch/ui": resolve(import.meta.dirname, "../ui/src"),
-      "@ui/components/ui": resolve(import.meta.dirname, "../ui/src/components/ui"),
-      "@ui/hooks": resolve(import.meta.dirname, "../ui/src/hooks"),
-      "@ui/lib": resolve(import.meta.dirname, "../ui/src/lib"),
-      "@ui": resolve(import.meta.dirname, "../ui/src"),
-    },
-  },
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:3000",
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  // Load .env from the repo root so the dev proxy can follow the server's PORT
+  // (the server's .env lives at the monorepo root, not in packages/web).
+  const env = loadEnv(mode, resolve(import.meta.dirname, "../.."), "");
+  const apiProxyTarget = env.VITE_API_PROXY_TARGET ?? `http://localhost:${env.PORT ?? "3000"}`;
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        "@": resolve(import.meta.dirname, "src"),
+        "@sketch/shared": resolve(import.meta.dirname, "../shared/src/index.ts"),
+        "@sketch/ui/components": resolve(import.meta.dirname, "../ui/src/components/ui"),
+        "@sketch/ui/hooks": resolve(import.meta.dirname, "../ui/src/hooks"),
+        "@sketch/ui/lib": resolve(import.meta.dirname, "../ui/src/lib"),
+        "@sketch/ui": resolve(import.meta.dirname, "../ui/src"),
+        "@ui/components/ui": resolve(import.meta.dirname, "../ui/src/components/ui"),
+        "@ui/hooks": resolve(import.meta.dirname, "../ui/src/hooks"),
+        "@ui/lib": resolve(import.meta.dirname, "../ui/src/lib"),
+        "@ui": resolve(import.meta.dirname, "../ui/src"),
       },
     },
-  },
+    server: {
+      proxy: {
+        "/api": {
+          target: apiProxyTarget,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- **Vite dev proxy**: was hard-coded to `http://localhost:3000`, so overriding the server's `PORT` (e.g. when 3000 is taken by another local service like Canvas) silently broke the frontend — every API call still hit 3000. Switched to `loadEnv` against the repo root so the proxy auto-follows `PORT`, with `VITE_API_PROXY_TARGET` as an explicit override for non-default hosts.
- **Flaky timezone test**: `prompt.test.ts` asserted on `GMT+5:30` for `Asia/Kolkata`, but `Intl.DateTimeFormat(undefined, ...)` uses the host locale — so the test (and the agent's `<time>` prompt) produced `IST` on en-IN machines and `GMT+5:30` on en-US. Pinned both formatters to `en-US` so the agent prompt is deterministic regardless of where the server runs.

## Test plan
- [x] `pnpm --filter @sketch/server test` — 1290/1290 passing
- [x] `pnpm build` — succeeds (ran via pre-push hook)
- [x] Manual: `pnpm dev` with `PORT=3002` set in `.env` — Vite proxy now targets `localhost:3002`, frontend loads correctly while another service holds port 3000
- [x] Reviewer: confirm `<time>` prompt rendering still looks reasonable (en-US format: e.g. "Wednesday, April 15, 2026 at 12:23 PM GMT+5:30 (Asia/Kolkata)")

🤖 Generated with [Claude Code](https://claude.com/claude-code)