### PR TITLE
fix: wire teammate tools in shared chats

### DIFF
--- a/packages/server/src/slack/adapter.test.ts
+++ b/packages/server/src/slack/adapter.test.ts
@@ -546,6 +546,21 @@ describe("slack/adapter", () => {
       expect(agentCall.integrationMcpServers).toEqual(mcpServers);
     });
 
+    it("passes teammate messaging deps to agent for channel mentions", async () => {
+      const deps = makeDeps();
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { mention } = getHandlers();
+
+      await mention({ text: "help", userId: "S1", channelId: "C1", ts: "1", type: "channel_mention" });
+      await flush();
+
+      const agentCall = vi.mocked(deps.runAgent).mock.calls[0][0];
+      expect(agentCall.userRepo).toBe(deps.repos.users);
+      expect(agentCall.inboxMessagesRepo).toBe(deps.inboxMessagesRepo);
+      expect(agentCall.currentUserId).toBe("u1");
+      expect(agentCall.sendDm).toBeTypeOf("function");
+    });
+
     it("resets the current thread when a channel mention sends /new", async () => {
       const deps = makeDeps();
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -627,6 +627,9 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
           automationRunsRepo,
           queueManager: queue,
           toolConfig,
+          inboxMessagesRepo,
+          userRepo: repos.users,
+          sendDm: sendDmViaSlack,
         });
 
         await flushSlackProgressTransport(progressTransport, logger, {

--- a/packages/server/src/whatsapp/adapter.test.ts
+++ b/packages/server/src/whatsapp/adapter.test.ts
@@ -746,6 +746,32 @@ describe("whatsapp/adapter", () => {
       expect(agentCall.integrationMcpServers).toEqual(mcpServers);
     });
 
+    it("passes teammate messaging deps to agent for group mentions", async () => {
+      const deps = makeDeps();
+      const { mock, getHandler } = createMockWhatsApp();
+      wireWhatsAppHandlers(mock as never, deps);
+      const handler = getHandler();
+
+      await handler({
+        type: "group",
+        text: "@bot help",
+        jid: "group@g.us",
+        messageId: "m1",
+        pushName: "Alice",
+        rawMessage: {},
+        isMentioned: true,
+        senderJid: "5555@s.whatsapp.net",
+        senderPhone: "+5555",
+      });
+      await flush();
+
+      const agentCall = vi.mocked(deps.runAgent).mock.calls[0][0];
+      expect(agentCall.userRepo).toBe(deps.repos.users);
+      expect(agentCall.inboxMessagesRepo).toBe(deps.inboxMessagesRepo);
+      expect(agentCall.currentUserId).toBe("u1");
+      expect(agentCall.sendDm).toBeTypeOf("function");
+    });
+
     it("passes user email to agent for group mentions", async () => {
       const deps = makeDeps();
       const { mock, getHandler } = createMockWhatsApp();

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -540,6 +540,9 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppBot, deps: WhatsAppAdapte
           automationRunsRepo,
           queueManager: queue,
           toolConfig,
+          inboxMessagesRepo,
+          userRepo: repos.users,
+          sendDm: sendDmViaWhatsApp,
         });
 
         await flushWhatsAppProgressTransport(progressTransport, logger, { userId: user?.id, groupJid });


### PR DESCRIPTION
## Summary

This fixes teammate messaging tools in shared-chat entry points.

- pass `userRepo`, `inboxMessagesRepo`, and `sendDm` into the Slack channel mention `runAgent()` path
- pass the same dependencies into the WhatsApp group mention `runAgent()` path
- add regression tests covering both shared-chat adapters

## Root cause

`GetTeamDirectory` and `SendMessageToUser` rely on repositories and DM helpers that were wired for direct-message flows but not for shared-chat mention flows. That meant the tools worked in Slack DMs, but failed from Slack channels with logs showing `userRepo` was false. The same dependency gap existed in WhatsApp group mentions.

## Impact

Agents can now resolve teammates and send follow-up messages from shared chats, not just from DMs.

## Validation

- `pnpm biome check .`
- `pnpm -r typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm exec vitest run src/slack/adapter.test.ts src/whatsapp/adapter.test.ts` (from `packages/server`)
