### PR TITLE
fix(enrichment): close chunk_embeddings UNIQUE-violation race

### DIFF
--- a/packages/server/src/connectors/enrichment-pg.test.ts
+++ b/packages/server/src/connectors/enrichment-pg.test.ts
@@ -115,6 +115,36 @@ describe("chunk_embeddings on Postgres", () => {
 
     expect(rows.rows).toHaveLength(0);
   });
+
+  it("upserts chunk_embeddings with ON CONFLICT DO UPDATE (idempotent re-insert)", async () => {
+    // Production code does this on every embedding insert so a concurrent
+    // enrichment run (e.g. scheduled + manual) for the same file no longer
+    // throws `UNIQUE constraint failed on chunk_embeddings primary key`.
+    const fileId = randomUUID();
+    await seedFile(db, fileId);
+
+    const chunkId = randomUUID();
+    await db
+      .insertInto("document_chunks")
+      .values({ id: chunkId, indexed_file_id: fileId, chunk_index: 0, content: "hello", token_count: 1 })
+      .execute();
+
+    const vec1 = makeVector(EMBEDDING_DIMENSIONS, { 0: 0.1 });
+    const vec2 = makeVector(EMBEDDING_DIMENSIONS, { 0: 0.9 });
+
+    await sql`INSERT INTO chunk_embeddings (chunk_id, embedding) VALUES (${chunkId}, ${vec1}::vector)`.execute(db);
+    await sql`
+      INSERT INTO chunk_embeddings (chunk_id, embedding)
+      VALUES (${chunkId}, ${vec2}::vector)
+      ON CONFLICT (chunk_id) DO UPDATE SET embedding = EXCLUDED.embedding
+    `.execute(db);
+
+    const rows = await sql<{ chunk_id: string }>`
+      SELECT chunk_id FROM chunk_embeddings WHERE chunk_id = ${chunkId}
+    `.execute(db);
+
+    expect(rows.rows).toHaveLength(1);
+  });
 });
 
 describe("file_embeddings on Postgres", () => {

--- a/packages/server/src/connectors/enrichment.test.ts
+++ b/packages/server/src/connectors/enrichment.test.ts
@@ -164,3 +164,106 @@ describe("runEnrichment — batch chunk insert", () => {
     }
   });
 });
+
+/**
+ * Scheduled enrichment must not claim files already in `processing` — that path
+ * lets two concurrent runs both "claim" the same file (status stays `processing`,
+ * `numUpdatedRows` is 1 for both) and race on chunk_embeddings inserts. Manual
+ * fileIds reruns are the explicit-override escape hatch.
+ */
+describe("runEnrichment — claim semantics", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    try {
+      await db.destroy();
+    } catch {
+      // already destroyed
+    }
+  });
+
+  async function setStatus(fileId: string, status: "pending" | "failed" | "processing" | "done"): Promise<void> {
+    await db.updateTable("indexed_files").set({ embedding_status: status }).where("id", "=", fileId).execute();
+  }
+
+  async function getStatus(fileId: string): Promise<string | undefined> {
+    const row = await db
+      .selectFrom("indexed_files")
+      .select("embedding_status")
+      .where("id", "=", fileId)
+      .executeTakeFirst();
+    return row?.embedding_status ?? undefined;
+  }
+
+  it("scheduled run does NOT pick up files in `processing` status", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, "some content here");
+    await setStatus(fileId, "processing");
+
+    const result = await runEnrichment({ db, logger: createTestLogger(), embeddingProvider: null });
+
+    // The file should be untouched: not in pendingFiles, so neither processed nor skipped.
+    expect(result.filesProcessed).toBe(0);
+    expect(result.filesFailed).toBe(0);
+    expect(result.filesSkipped).toBe(0);
+    expect(await getStatus(fileId)).toBe("processing");
+  });
+
+  it("scheduled run picks up `pending` files", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, "some content here");
+    await setStatus(fileId, "pending");
+
+    const result = await runEnrichment({ db, logger: createTestLogger(), embeddingProvider: null });
+
+    expect(result.filesProcessed).toBe(1);
+    expect(await getStatus(fileId)).toBe("done");
+  });
+
+  it("scheduled run picks up `failed` files (retry)", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, "some content here");
+    await setStatus(fileId, "failed");
+
+    const result = await runEnrichment({ db, logger: createTestLogger(), embeddingProvider: null });
+
+    expect(result.filesProcessed).toBe(1);
+    expect(await getStatus(fileId)).toBe("done");
+  });
+
+  it("explicit fileIds rerun DOES claim a file in `processing` (manual override)", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, "some content here");
+    await setStatus(fileId, "processing");
+
+    const result = await runEnrichment({
+      db,
+      logger: createTestLogger(),
+      embeddingProvider: null,
+      fileIds: [fileId],
+    });
+
+    expect(result.filesProcessed).toBe(1);
+    expect(await getStatus(fileId)).toBe("done");
+  });
+
+  it("explicit fileIds rerun DOES claim a file in `done` (manual override)", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, "some content here");
+    await setStatus(fileId, "done");
+
+    const result = await runEnrichment({
+      db,
+      logger: createTestLogger(),
+      embeddingProvider: null,
+      fileIds: [fileId],
+    });
+
+    expect(result.filesProcessed).toBe(1);
+    expect(await getStatus(fileId)).toBe("done");
+  });
+});

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -146,7 +146,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
   } else {
     query = query.where((eb) =>
       eb.or([
-        eb("embedding_status", "in", ["pending", "failed", "processing"]),
+        eb("embedding_status", "in", ["pending", "failed"]),
         eb.and([eb("embedding_status", "=", "done"), eb("summary_status", "in", ["pending", "failed"])]),
       ]),
     );
@@ -227,10 +227,13 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
         continue;
       }
 
-      // Full enrichment: optimistic lock, chunk, embed, summarize
-      const claimableStatuses = deps.fileIds
-        ? ["pending", "failed", "processing", "done"]
-        : ["pending", "failed", "processing"];
+      // Full enrichment: optimistic lock, chunk, embed, summarize.
+      // Scheduled runs only claim pending/failed — never `processing`, since
+      // that would let two concurrent runs (e.g. scheduled + manual trigger)
+      // both "claim" the same file and race on chunk_embeddings inserts.
+      // Stuck `processing` rows are recovered by `recoverStaleEnrichments`.
+      // Explicit fileIds reruns can claim any status (manual override).
+      const claimableStatuses = deps.fileIds ? ["pending", "failed", "processing", "done"] : ["pending", "failed"];
       const claimResult = await db
         .updateTable("indexed_files")
         .set({ embedding_status: "processing" })
@@ -398,20 +401,21 @@ async function enrichTextDocument(
 
       const isPostgres = isPg(db);
 
+      const pairs = storedChunks
+        .map((chunk, i) => ({ chunk, embedding: embeddings[i] }))
+        .filter((p): p is { chunk: (typeof storedChunks)[number]; embedding: number[] } => !!p.embedding);
+
       await Promise.all(
-        storedChunks
-          .filter((_, i) => !!embeddings[i])
-          .map((chunk, i) =>
-            isPostgres
-              ? sql`INSERT INTO chunk_embeddings (chunk_id, embedding) VALUES (${chunk.id}, ${JSON.stringify(embeddings[i])}::vector)`.execute(
-                  db,
-                )
-              : sql`INSERT INTO chunk_embeddings (chunk_id, embedding) VALUES (${chunk.id}, ${JSON.stringify(embeddings[i])})`.execute(
-                  db,
-                ),
-          ),
+        pairs.map(({ chunk, embedding }) =>
+          isPostgres
+            ? sql`INSERT INTO chunk_embeddings (chunk_id, embedding)
+                  VALUES (${chunk.id}, ${JSON.stringify(embedding)}::vector)
+                  ON CONFLICT (chunk_id) DO UPDATE SET embedding = EXCLUDED.embedding`.execute(db)
+            : sql`INSERT OR REPLACE INTO chunk_embeddings (chunk_id, embedding)
+                  VALUES (${chunk.id}, ${JSON.stringify(embedding)})`.execute(db),
+        ),
       );
-      logger.info({ fileId: file.id, chunks: storedChunks.length }, "Embeddings created");
+      logger.info({ fileId: file.id, chunks: pairs.length }, "Embeddings created");
     } catch (err) {
       logger.warn({ err, fileId: file.id }, "Embedding failed, entity linking still saved");
     }

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -442,6 +442,13 @@ export interface SyncSchedulerDeps {
  */
 export async function runAllSyncs(db: Kysely<DB>, logger: Logger, deps?: SyncSchedulerDeps): Promise<void> {
   const repo = createConnectorRepository(db);
+
+  // Scheduled enrichment now only claims `pending`/`failed` files (so two
+  // concurrent runs can't both claim the same file and race on chunk inserts).
+  // Reset stale `processing` rows here so a crashed run is recovered within
+  // one tick instead of waiting for restart.
+  await recoverStaleEnrichments(db, logger);
+
   const configs = await repo.findSyncableConfigs();
 
   logger.info({ connectorCount: configs.length }, "Starting scheduled sync run");


### PR DESCRIPTION
## Summary

While running enrichment we hit:

```
SqliteError: UNIQUE constraint failed on chunk_embeddings primary key
  at enrichTextDocument (enrichment.ts)
```

Caught as a warning, so it looks harmless — but the entire chunk-embedding batch is aborted on the first PK collision and the file is then marked `embedding_status = 'done'`. Net result: file is silently absent from vector search.

### Root cause

Two enrichment runs (scheduled + manual trigger, or two manual triggers) can both pass the optimistic claim because `processing` was in `claimableStatuses` for scheduled runs. They interleave at long `await`s (e.g. Gemini calls inside `smartEnrichFile`) and end up writing to overlapping `chunk_id`s. Beyond the visible PK collision, there's a quieter sibling: Run A's `SELECT storedChunks` can land after Run B's `clearFileChunks` + insert, so Run A writes A's content embeddings under B's `chunk_id`s — misaligned vectors, no error logged.

### Fixes (three layers)

1. **Idempotent `chunk_embeddings` INSERT.** SQLite gets `INSERT OR REPLACE`; Postgres gets `ON CONFLICT (chunk_id) DO UPDATE SET embedding = EXCLUDED.embedding`. Mirrors what `file_embeddings` already does in `smart-enrichment.ts`.
2. **Off-by-filter bug fix.** `.filter((_, i) => !!embeddings[i]).map((chunk, i) => ... embeddings[i])` used the post-filter index, silently mis-attaching embeddings to chunks once any embedding was null. Now pairs `{chunk, embedding}` before filtering.
3. **Race closure.** Drop `processing` from scheduled `claimableStatuses` and from the scheduled `pendingFiles` query — manual `fileIds` reruns keep the override (`pending|failed|processing|done`) as the explicit escape hatch. Call `recoverStaleEnrichments` at the top of every `runAllSyncs` tick so a crashed run's `processing` row is freed within one interval instead of waiting for restart.

### Tests

- `enrichment.test.ts` — claim semantics:
  - scheduled run does NOT pick up `processing`
  - scheduled run picks up `pending` / `failed`
  - explicit fileIds rerun DOES claim `processing` / `done`
- `enrichment-pg.test.ts` — `chunk_embeddings ON CONFLICT DO UPDATE` is idempotent.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (1415 passing)
- [x] `pnpm biome check` on changed files
- [ ] Re-run enrichment in dev with parallel manual trigger; confirm no `UNIQUE constraint failed` warnings and chunk embeddings are saved end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)