### PR TITLE
feat: add agent environment variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ sketch/
 - pino for structured JSON logging — never log message content
 - zod + dotenv for config validation (`import "dotenv/config"`, .env at repo root)
 - Kysely migrations run at app startup (static imports, not FileMigrationProvider)
+- Database code must stay compatible with both SQLite and Postgres. When writing queries, repository methods, migrations, constraints, or database error handling, prefer portable Kysely patterns; if dialect-specific behavior is unavoidable, handle both dialects and add coverage for the difference.
 - No inline comments. Use docstrings to explain decisions when the code isn't self-evident.
 - Vitest for testing
 - Run `pnpm dev` from repo root — tsx watches `packages/server/src/index.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ sketch/
 - pino for structured JSON logging — never log message content
 - zod + dotenv for config validation (`import "dotenv/config"`, .env at repo root)
 - Kysely migrations run at app startup (static imports, not FileMigrationProvider)
+- Database code must stay compatible with both SQLite and Postgres. When writing queries, repository methods, migrations, constraints, or database error handling, prefer portable Kysely patterns; if dialect-specific behavior is unavoidable, handle both dialects and add coverage for the difference.
 - No inline comments. Use docstrings to explain decisions when the code isn't self-evident.
 - Vitest for testing
 - Run `pnpm dev` from repo root — tsx watches `packages/server/src/index.ts`

--- a/packages/server/src/agent/environment.test.ts
+++ b/packages/server/src/agent/environment.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isReservedAgentEnvName, removeReservedAgentEnv } from "./environment";
+
+describe("agent environment helpers", () => {
+  it("identifies runtime-reserved names", () => {
+    expect(isReservedAgentEnvName("CLAUDE_CODE_USE_BEDROCK")).toBe(true);
+    expect(isReservedAgentEnvName("ANTHROPIC_API_KEY")).toBe(true);
+    expect(isReservedAgentEnvName("OPENAI_API_KEY")).toBe(true);
+    expect(isReservedAgentEnvName("AWS_ACCESS_KEY_ID")).toBe(true);
+    expect(isReservedAgentEnvName("TEST_ENV_VALUE")).toBe(false);
+  });
+
+  it("removes reserved names before runtime injection", () => {
+    expect(
+      removeReservedAgentEnv({
+        ANTHROPIC_API_KEY: "sk-test",
+        AWS_ACCESS_KEY_ID: "aws-test",
+        TEST_ENV_VALUE: "visible",
+      }),
+    ).toEqual({
+      TEST_ENV_VALUE: "visible",
+    });
+  });
+});

--- a/packages/server/src/agent/environment.ts
+++ b/packages/server/src/agent/environment.ts
@@ -1,0 +1,7 @@
+import { isReservedAgentEnvName } from "@sketch/shared";
+
+export { isReservedAgentEnvName };
+
+export function removeReservedAgentEnv(env: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(env).filter(([name]) => !isReservedAgentEnvName(name)));
+}

--- a/packages/server/src/agent/runner.test.ts
+++ b/packages/server/src/agent/runner.test.ts
@@ -12,6 +12,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 }));
 
 vi.mock("./sessions", () => ({
+  deleteSessionId: vi.fn().mockResolvedValue(undefined),
   getSessionId: vi.fn().mockResolvedValue(undefined),
   saveSessionId: vi.fn().mockResolvedValue(undefined),
 }));
@@ -167,6 +168,72 @@ function makeRichResultMessage(overrides?: Record<string, unknown>) {
 }
 
 describe("runAgent", () => {
+  it("clears a stale resumed session and retries once fresh before producing output", async () => {
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    const sessions = await import("./sessions");
+    const capturedResume: Array<string | undefined> = [];
+    vi.mocked(sessions.getSessionId).mockResolvedValueOnce("sess-stale");
+    vi.mocked(query)
+      .mockImplementationOnce(((args: unknown) => {
+        const callArgs = args as { options: { resume?: string } };
+        capturedResume.push(callArgs.options.resume);
+        return (async function* () {
+          yield { type: "system", subtype: "init", session_id: "sess-stale" };
+          throw new Error("Claude Code process exited with code 1");
+        })();
+      }) as unknown as typeof query)
+      .mockImplementationOnce(((args: unknown) => {
+        const callArgs = args as { options: { resume?: string } };
+        capturedResume.push(callArgs.options.resume);
+        return (async function* () {
+          yield { type: "system", subtype: "init", session_id: "sess-fresh" };
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "Recovered" }] },
+          };
+          yield makeRichResultMessage({ session_id: "sess-fresh" });
+        })();
+      }) as unknown as typeof query);
+
+    const result = await runAgent(makeBaseParams());
+
+    expect(capturedResume).toEqual(["sess-stale", undefined]);
+    expect(sessions.deleteSessionId).toHaveBeenCalledWith(expect.anything(), "u-test", undefined);
+    expect(sessions.saveSessionId).toHaveBeenCalledWith(expect.anything(), "u-test", "sess-fresh", undefined);
+    expect(result.isResumedSession).toBe(false);
+    expect(result.trace.finalText).toBe("Recovered");
+  });
+
+  it("passes user env vars through the SDK process env", async () => {
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    let capturedEnv: Record<string, string | undefined> = {};
+
+    vi.mocked(query).mockImplementation(((args: unknown) => {
+      const callArgs = args as {
+        options: {
+          env: Record<string, string | undefined>;
+        };
+      };
+      capturedEnv = callArgs.options.env;
+      return (async function* () {
+        yield { type: "system", subtype: "init", session_id: "sess-bash-env" };
+        yield { type: "result", session_id: "sess-bash-env", total_cost_usd: 0 };
+      })();
+    }) as unknown as typeof query);
+
+    await runAgent(
+      makeBaseParams({
+        agentEnv: {
+          TEST_REGION: "us-east-1",
+          GH_TOKEN: "token'with-quote",
+        },
+      }),
+    );
+
+    expect(capturedEnv.TEST_REGION).toBe("us-east-1");
+    expect(capturedEnv.GH_TOKEN).toBe("token'with-quote");
+  });
+
   it("uses custom string systemPrompt (not preset) with no per-user content", async () => {
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
     const capturedOptions: unknown[] = [];

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -27,7 +27,7 @@ import type { TaskScheduler } from "../scheduler/service";
 import type { TaskContext } from "../scheduler/types";
 import { createCanUseTool } from "./permissions";
 import { buildSystemContext } from "./prompt";
-import { getSessionId, saveSessionId } from "./sessions";
+import { deleteSessionId, getSessionId, saveSessionId } from "./sessions";
 import { UploadCollector, createSketchMcpServer } from "./sketch-tools";
 
 export interface ToolCallRecord {
@@ -149,6 +149,7 @@ export interface RunAgentParams {
     groupDescription?: string;
   };
   enqueueMessage?: (params: { requesterUserId: string; message: string }) => Promise<void>;
+  agentEnv?: Record<string, string>;
 }
 
 /**
@@ -214,6 +215,7 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
 
   const attachments = params.attachments ?? [];
   const hasImages = attachments.some((a) => isImageAttachment(a));
+  let usedExistingSession = existingSessionId !== undefined;
 
   let prompt: string | AsyncIterable<SDKUserMessage>;
 
@@ -312,15 +314,19 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
     }
   };
 
-  try {
+  const executeSdkRun = async (resumeSessionId: string | undefined) => {
     const run = query({
       prompt,
       options: {
         maxTurns: params.maxTurns ?? 100,
         ...(params.model ? { model: params.model } : {}),
         cwd: workspaceDir,
-        resume: existingSessionId,
-        env: { ...process.env, ...integrationAccess.envVars },
+        resume: resumeSessionId,
+        env: {
+          ...process.env,
+          ...integrationAccess.envVars,
+          ...params.agentEnv,
+        },
         systemPrompt: systemAppend,
         tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill"],
         permissionMode: "default" as const,
@@ -416,6 +422,39 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
         model = modelKeys.length > 0 ? modelKeys[0] : null;
       }
     }
+  };
+
+  try {
+    let resumeSessionId = existingSessionId;
+    let retriedFreshAfterResumeFailure = false;
+    while (true) {
+      try {
+        await executeSdkRun(resumeSessionId);
+        break;
+      } catch (err) {
+        if (
+          !resumeSessionId ||
+          retriedFreshAfterResumeFailure ||
+          toolCalls.length > 0 ||
+          progressEvents.length > 0 ||
+          currentTextSuffix.length > 0 ||
+          typeof prompt !== "string" ||
+          !isRecoverableResumeFailure(err)
+        ) {
+          throw err;
+        }
+
+        logger.warn(
+          { err, workspaceKey: params.workspaceKey, threadKey: params.threadTs },
+          "Agent resumed session failed before producing output; retrying with a fresh session",
+        );
+        await deleteSessionId(params.db, params.workspaceKey, params.threadTs);
+        resumeSessionId = undefined;
+        usedExistingSession = false;
+        sessionId = "";
+        retriedFreshAfterResumeFailure = true;
+      }
+    }
 
     if (sessionId && !isFresh) {
       await saveSessionId(params.db, params.workspaceKey, sessionId, params.threadTs);
@@ -461,7 +500,7 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
     webSearchRequests,
     webFetchRequests,
     model,
-    isResumedSession: existingSessionId !== undefined,
+    isResumedSession: usedExistingSession,
     totalAttachments: attachments.length,
     imageCount: images.length,
     nonImageCount: nonImages.length,
@@ -474,4 +513,8 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
       finalText,
     },
   };
+}
+
+function isRecoverableResumeFailure(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("Claude Code process exited with code");
 }

--- a/packages/server/src/api/agent-environment.test.ts
+++ b/packages/server/src/api/agent-environment.test.ts
@@ -1,0 +1,192 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hashPassword } from "../auth/password";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import { isUniqueConstraintError } from "./agent-environment";
+
+const ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const PASSWORD = "testpassword123";
+const ADMIN_EMAIL = "admin@test.com";
+const MEMBER_EMAIL = "member@test.com";
+const OTHER_EMAIL = "other@test.com";
+
+async function seedUsers(db: Kysely<DB>) {
+  const settings = createSettingsRepository(db, ENCRYPTION_KEY);
+  const users = createUserRepository(db);
+  const hash = await hashPassword(PASSWORD);
+  await settings.create();
+  await users.create({
+    name: "admin",
+    email: ADMIN_EMAIL,
+    emailVerified: true,
+    passwordHash: hash,
+    authRole: "admin",
+  });
+  await users.create({
+    name: "member",
+    email: MEMBER_EMAIL,
+    emailVerified: true,
+    passwordHash: hash,
+    authRole: "member",
+  });
+  await users.create({
+    name: "other",
+    email: OTHER_EMAIL,
+    emailVerified: true,
+    passwordHash: hash,
+    authRole: "member",
+  });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+}
+
+async function login(app: ReturnType<typeof createApp>, email: string): Promise<string> {
+  const res = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  });
+  return res.headers.get("set-cookie") ?? "";
+}
+
+describe("Agent environment variables API", () => {
+  let db: Kysely<DB>;
+  let app: ReturnType<typeof createApp>;
+  let memberCookie: string;
+  let otherCookie: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUsers(db);
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), { logger: createTestLogger() });
+    memberCookie = await login(app, MEMBER_EMAIL);
+    otherCookie = await login(app, OTHER_EMAIL);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("returns non-secret values for copy and hides secret values", async () => {
+    const nonSecret = await app.request("/api/agent-environment-variables", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: memberCookie },
+      body: JSON.stringify({ name: "TEST_REGION", value: "us-east-1", isSecret: false }),
+    });
+    expect(nonSecret.status).toBe(201);
+    expect((await nonSecret.json()).variable).toMatchObject({
+      name: "TEST_REGION",
+      value: "us-east-1",
+      isSecret: false,
+    });
+
+    const secret = await app.request("/api/agent-environment-variables", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: memberCookie },
+      body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_secret", isSecret: true }),
+    });
+    expect(secret.status).toBe(201);
+    expect((await secret.json()).variable).toMatchObject({ name: "GH_TOKEN", value: null, isSecret: true });
+
+    const list = await app.request("/api/agent-environment-variables", {
+      headers: { Cookie: memberCookie },
+    });
+    expect(list.status).toBe(200);
+    expect((await list.json()).variables).toEqual([
+      expect.objectContaining({ name: "GH_TOKEN", value: null, isSecret: true }),
+      expect.objectContaining({ name: "TEST_REGION", value: "us-east-1", isSecret: false }),
+    ]);
+  });
+
+  it("encrypts values at rest", async () => {
+    await app.request("/api/agent-environment-variables", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: memberCookie },
+      body: JSON.stringify({ name: "BACKEND_API_URL", value: "https://api.test", isSecret: false }),
+    });
+
+    const row = await db
+      .selectFrom("agent_environment_variables")
+      .select("value")
+      .where("name", "=", "BACKEND_API_URL")
+      .executeTakeFirstOrThrow();
+    expect(row.value.startsWith("enc:")).toBe(true);
+  });
+
+  it("returns conflict for duplicate variable names", async () => {
+    const body = JSON.stringify({ name: "TEST_REGION", value: "us-east-1", isSecret: false });
+
+    const first = await app.request("/api/agent-environment-variables", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: memberCookie },
+      body,
+    });
+    expect(first.status).toBe(201);
+
+    const duplicate = await app.request("/api/agent-environment-variables", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: memberCookie },
+      body,
+    });
+    expect(duplicate.status).toBe(409);
+    expect((await duplicate.json()).error.code).toBe("CONFLICT");
+  });
+
+  it("scopes variables to the authenticated user", async () => {
+    const create = await app.request("/api/agent-environment-variables", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: memberCookie },
+      body: JSON.stringify({ name: "TEST_REGION", value: "us-east-1", isSecret: false }),
+    });
+    const created = await create.json();
+
+    const otherList = await app.request("/api/agent-environment-variables", {
+      headers: { Cookie: otherCookie },
+    });
+    expect((await otherList.json()).variables).toEqual([]);
+
+    const otherDelete = await app.request(`/api/agent-environment-variables/${created.variable.id}`, {
+      method: "DELETE",
+      headers: { Cookie: otherCookie },
+    });
+    expect(otherDelete.status).toBe(404);
+  });
+
+  it.each([
+    "ANTHROPIC_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CONFIG_DIR",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+  ])("rejects reserved name %s", async (name) => {
+    const res = await app.request("/api/agent-environment-variables", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: memberCookie },
+      body: JSON.stringify({ name, value: "reserved-value", isSecret: true }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toContain("reserved");
+  });
+});
+
+describe("isUniqueConstraintError", () => {
+  it("detects SQLite and Postgres unique constraint errors", () => {
+    const postgresError = Object.assign(new Error("duplicate key value violates unique constraint"), {
+      code: "23505",
+    });
+    const wrappedPostgresError = Object.assign(new Error("wrapped error"), { cause: postgresError });
+
+    expect(
+      isUniqueConstraintError(
+        new Error("UNIQUE constraint failed: agent_environment_variables.user_id, agent_environment_variables.name"),
+      ),
+    ).toBe(true);
+    expect(isUniqueConstraintError(postgresError)).toBe(true);
+    expect(isUniqueConstraintError(wrappedPostgresError)).toBe(true);
+    expect(isUniqueConstraintError(new Error("other database error"))).toBe(false);
+  });
+});

--- a/packages/server/src/api/agent-environment.ts
+++ b/packages/server/src/api/agent-environment.ts
@@ -1,0 +1,91 @@
+import { isReservedAgentEnvName } from "@sketch/shared";
+import { Hono } from "hono";
+import { z } from "zod";
+import type { createAgentEnvironmentVariableRepository } from "../db/repositories/agent-environment-variables";
+
+type AgentEnvironmentRepo = ReturnType<typeof createAgentEnvironmentVariableRepository>;
+
+const envNameSchema = z
+  .string()
+  .regex(/^[A-Za-z_][A-Za-z0-9_]*$/, "Use letters, numbers, and underscores. Start with a letter or underscore.");
+
+const createVariableSchema = z.object({
+  name: envNameSchema,
+  value: z.string(),
+  isSecret: z.boolean(),
+});
+
+const updateVariableSchema = z.object({
+  value: z.string(),
+});
+
+function validationError(message: string) {
+  return { error: { code: "VALIDATION_ERROR", message } };
+}
+
+export function isUniqueConstraintError(err: unknown): boolean {
+  if (err instanceof Error && err.message.includes("UNIQUE constraint failed")) return true;
+  if (!err || typeof err !== "object") return false;
+  const { code, cause } = err as { code?: unknown; cause?: unknown };
+  if (code === "23505") return true;
+  return isUniqueConstraintError(cause);
+}
+
+export function agentEnvironmentRoutes(envVars: AgentEnvironmentRepo) {
+  const routes = new Hono();
+
+  routes.get("/", async (c) => {
+    const userId = c.get("sub");
+    return c.json({ variables: await envVars.list(userId) });
+  });
+
+  routes.post("/", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = createVariableSchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json(validationError(message), 400);
+    }
+    if (isReservedAgentEnvName(parsed.data.name)) {
+      return c.json(validationError("This environment variable name is reserved by Sketch."), 400);
+    }
+
+    try {
+      const variable = await envVars.create(c.get("sub"), parsed.data);
+      return c.json({ variable }, 201);
+    } catch (err) {
+      if (isUniqueConstraintError(err)) {
+        return c.json(
+          { error: { code: "CONFLICT", message: "An environment variable with this name already exists." } },
+          409,
+        );
+      }
+      throw err;
+    }
+  });
+
+  routes.patch("/:id", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = updateVariableSchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json(validationError(message), 400);
+    }
+
+    const variable = await envVars.updateValue(c.req.param("id"), c.get("sub"), parsed.data.value);
+    if (!variable) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Environment variable not found" } }, 404);
+    }
+    return c.json({ variable });
+  });
+
+  routes.delete("/:id", async (c) => {
+    const removed = await envVars.remove(c.req.param("id"), c.get("sub"));
+    if (!removed) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Environment variable not found" } }, 404);
+    }
+    return c.json({ success: true });
+  });
+
+  return routes;
+}

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import { serve } from "@hono/node-server";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import type { Kysely } from "kysely";
+import { removeReservedAgentEnv } from "./agent/environment";
 import { applyLlmEnvFromSettings } from "./agent/llm-env";
 import { type AgentResult, runAgent } from "./agent/runner";
 import type { McpServerConfig, RunAgentParams } from "./agent/runner";
@@ -14,6 +15,7 @@ import type { Config } from "./config";
 import { startSyncScheduler } from "./connectors/sync";
 import { createDatabase } from "./db/index";
 import { runMigrations } from "./db/migrate";
+import { createAgentEnvironmentVariableRepository } from "./db/repositories/agent-environment-variables";
 import { createAgentRunsRepo } from "./db/repositories/agent-runs";
 import { createAutomationRunsRepository } from "./db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "./db/repositories/automation-step-content";
@@ -94,6 +96,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const users = createUserRepository(db);
   const channels = createChannelRepository(db);
   const settingsRepo = createSettingsRepository(db, config.ENCRYPTION_KEY);
+  const agentEnvironmentVariables = createAgentEnvironmentVariableRepository(db, config.ENCRYPTION_KEY);
   await runManagedSeed(config, settingsRepo, users);
   const mcpServersRepo = createMcpServerRepository(db);
   const whatsappGroupsRepo = createWhatsAppGroupRepository(db);
@@ -111,7 +114,18 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const trackedRunAgent = async (params: RunAgentParams): Promise<AgentResult> => {
     const runId = randomUUID();
     const span = tracer.startSpan("chat sketch");
-    const enrichedParams = { ...params };
+    const shouldInjectAgentEnv = params.contextType === "dm" && !!params.currentUserId;
+    const agentEnv = shouldInjectAgentEnv
+      ? removeReservedAgentEnv(await agentEnvironmentVariables.listForRuntime(params.currentUserId as string))
+      : undefined;
+    const enrichedParams = {
+      ...params,
+      ...(agentEnv && Object.keys(agentEnv).length > 0
+        ? {
+            agentEnv,
+          }
+        : {}),
+    };
     setAgentRunAttributes(span, enrichedParams, runId);
 
     try {

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -45,6 +45,7 @@ import * as m038 from "./migrations/038-sync-interval";
 import * as m039 from "./migrations/039-drop-outreach-messages";
 import * as m040 from "./migrations/040-user-auth-role";
 import * as m041 from "./migrations/041-per-user-fireflies";
+import * as m042 from "./migrations/042-agent-environment-variables";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>): Promise<void> {
@@ -94,6 +95,7 @@ export async function runMigrations(db: Kysely<DB>): Promise<void> {
           "039-drop-outreach-messages": m039,
           "040-user-auth-role": m040,
           "041-per-user-fireflies": m041,
+          "042-agent-environment-variables": m042,
         };
       },
     },

--- a/packages/server/src/db/migrations/042-agent-environment-variables.ts
+++ b/packages/server/src/db/migrations/042-agent-environment-variables.ts
@@ -1,0 +1,25 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("agent_environment_variables")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("user_id", "text", (col) => col.notNull().references("users.id").onDelete("cascade"))
+    .addColumn("name", "text", (col) => col.notNull())
+    .addColumn("value", "text", (col) => col.notNull())
+    .addColumn("is_secret", "integer", (col) => col.notNull().defaultTo(1))
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createIndex("idx_agent_environment_variables_user_name")
+    .on("agent_environment_variables")
+    .columns(["user_id", "name"])
+    .unique()
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("agent_environment_variables").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.test.ts
@@ -36,11 +36,11 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(rows.rows.length).toBeGreaterThan(0);
   }, 30000);
 
-  it("records all 41 migration entries in kysely_migration", async () => {
+  it("records all 42 migration entries in kysely_migration", async () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(41);
+    expect(rows.rows).toHaveLength(42);
   });
 
   it("records migrations with correct names in order", async () => {
@@ -75,6 +75,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[38]).toBe("039-drop-outreach-messages");
     expect(names[39]).toBe("040-user-auth-role");
     expect(names[40]).toBe("041-per-user-fireflies");
+    expect(names[41]).toBe("042-agent-environment-variables");
   });
 
   it("running migrations twice is idempotent", async () => {
@@ -83,7 +84,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(41);
+    expect(rows.rows).toHaveLength(42);
   });
 
   it("creates the users table", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -33,14 +33,14 @@ describe("runMigrations — full sequence", () => {
     await expect(runMigrations(db)).resolves.not.toThrow();
   });
 
-  it("records all 41 migration entries in the kysely_migration table", async () => {
+  it("records all 42 migration entries in the kysely_migration table", async () => {
     await runMigrations(db);
 
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(41);
+    expect(rows.rows).toHaveLength(42);
   });
 
   it("records migrations with the correct names in order", async () => {
@@ -78,6 +78,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[38]).toBe("039-drop-outreach-messages");
     expect(names[39]).toBe("040-user-auth-role");
     expect(names[40]).toBe("041-per-user-fireflies");
+    expect(names[41]).toBe("042-agent-environment-variables");
   });
 
   it("creates the users table", async () => {
@@ -183,8 +184,8 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    // Still exactly 41, not 82
-    expect(rows.rows).toHaveLength(41);
+    // Still exactly 42, not 84
+    expect(rows.rows).toHaveLength(42);
   });
 });
 
@@ -206,7 +207,7 @@ describe("runMigrations — incremental upgrade", () => {
 
     await db.insertInto("users").values({ id: "existing-user", name: "Alice" }).execute();
 
-    // Running again should be a no-op (all 41 already applied)
+    // Running again should be a no-op (all 42 already applied)
     await runMigrations(db);
 
     const users = await db.selectFrom("users").selectAll().execute();
@@ -216,6 +217,6 @@ describe("runMigrations — incremental upgrade", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(41);
+    expect(rows.rows).toHaveLength(42);
   });
 });

--- a/packages/server/src/db/repositories/agent-environment-variables.ts
+++ b/packages/server/src/db/repositories/agent-environment-variables.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "node:crypto";
+import { type Kysely, sql } from "kysely";
+import { decrypt, encrypt } from "../../auth/encryption";
+import type { DB } from "../schema";
+
+export interface AgentEnvironmentVariableInput {
+  name: string;
+  value: string;
+  isSecret: boolean;
+}
+
+export interface AgentEnvironmentVariableRecord {
+  id: string;
+  name: string;
+  value: string | null;
+  isSecret: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function decryptAgentEnvValue(value: string, encryptionKey?: string): string {
+  if (value.startsWith("enc:")) {
+    if (!encryptionKey) {
+      throw new Error("Encrypted agent environment variable found but ENCRYPTION_KEY is not set");
+    }
+    return decrypt(value, encryptionKey);
+  }
+  return value;
+}
+
+function serialize(
+  row: {
+    id: string;
+    name: string;
+    value: string;
+    is_secret: number;
+    created_at: string;
+    updated_at: string;
+  },
+  encryptionKey?: string,
+): AgentEnvironmentVariableRecord {
+  const isSecret = row.is_secret === 1;
+  return {
+    id: row.id,
+    name: row.name,
+    value: isSecret ? null : decryptAgentEnvValue(row.value, encryptionKey),
+    isSecret,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function encodeValue(value: string, encryptionKey?: string): string {
+  return encryptionKey ? encrypt(value, encryptionKey) : value;
+}
+
+export function createAgentEnvironmentVariableRepository(db: Kysely<DB>, encryptionKey?: string) {
+  return {
+    async list(userId: string): Promise<AgentEnvironmentVariableRecord[]> {
+      const rows = await db
+        .selectFrom("agent_environment_variables")
+        .selectAll()
+        .where("user_id", "=", userId)
+        .orderBy("name", "asc")
+        .execute();
+      return rows.map((row) => serialize(row, encryptionKey));
+    },
+
+    async listForRuntime(userId: string): Promise<Record<string, string>> {
+      const rows = await db
+        .selectFrom("agent_environment_variables")
+        .select(["name", "value"])
+        .where("user_id", "=", userId)
+        .orderBy("name", "asc")
+        .execute();
+      return Object.fromEntries(rows.map((row) => [row.name, decryptAgentEnvValue(row.value, encryptionKey)]));
+    },
+
+    async create(userId: string, data: AgentEnvironmentVariableInput): Promise<AgentEnvironmentVariableRecord> {
+      const id = randomUUID();
+      await db
+        .insertInto("agent_environment_variables")
+        .values({
+          id,
+          user_id: userId,
+          name: data.name,
+          value: encodeValue(data.value, encryptionKey),
+          is_secret: data.isSecret ? 1 : 0,
+        })
+        .execute();
+      const row = await db
+        .selectFrom("agent_environment_variables")
+        .selectAll()
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .executeTakeFirstOrThrow();
+      return serialize(row, encryptionKey);
+    },
+
+    async updateValue(id: string, userId: string, value: string): Promise<AgentEnvironmentVariableRecord | null> {
+      await db
+        .updateTable("agent_environment_variables")
+        .set({ value: encodeValue(value, encryptionKey), updated_at: sql`CURRENT_TIMESTAMP` })
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .execute();
+      const row = await db
+        .selectFrom("agent_environment_variables")
+        .selectAll()
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .executeTakeFirst();
+      return row ? serialize(row, encryptionKey) : null;
+    },
+
+    async remove(id: string, userId: string): Promise<boolean> {
+      const result = await db
+        .deleteFrom("agent_environment_variables")
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .executeTakeFirst();
+      return Number(result.numDeletedRows) > 0;
+    },
+  };
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -203,6 +203,16 @@ export interface MagicLinkTokensTable {
   created_at: Generated<string>;
 }
 
+export interface AgentEnvironmentVariablesTable {
+  id: string;
+  user_id: string;
+  name: string;
+  value: string;
+  is_secret: Generated<number>;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
 export interface McpServersTable {
   id: string;
   type: string | null;
@@ -380,6 +390,7 @@ export interface DB {
   file_access: FileAccessTable;
   email_verification_tokens: EmailVerificationTokensTable;
   magic_link_tokens: MagicLinkTokensTable;
+  agent_environment_variables: AgentEnvironmentVariablesTable;
   mcp_servers: McpServersTable;
   chat_sessions: ChatSessionsTable;
   scheduled_tasks: ScheduledTasksTable;

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -10,6 +10,7 @@ import { getCookie } from "hono/cookie";
 import { streamSSE } from "hono/streaming";
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
+import { agentEnvironmentRoutes } from "./api/agent-environment";
 import { type MagicLinkSender, authRoutes } from "./api/auth";
 import { channelRoutes } from "./api/channels";
 import { connectorRoutes } from "./api/connectors";
@@ -32,6 +33,7 @@ import { userRoutes } from "./api/users";
 import { whatsappRoutes } from "./api/whatsapp";
 import { createWorkspaceApi } from "./api/workspace";
 import type { Config } from "./config";
+import { createAgentEnvironmentVariableRepository } from "./db/repositories/agent-environment-variables";
 import { createConnectorRepository } from "./db/repositories/connectors";
 import { createInboxMessagesRepository } from "./db/repositories/inbox-messages";
 import { createMcpServerRepository } from "./db/repositories/mcp-servers";
@@ -63,6 +65,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   const users = createUserRepository(db);
   const inboxMessages = createInboxMessagesRepository(db);
   const connectors = createConnectorRepository(db);
+  const agentEnvVars = createAgentEnvironmentVariableRepository(db, config.ENCRYPTION_KEY);
   const mcpServers = createMcpServerRepository(db);
   const logger = deps?.logger ?? (console as unknown as Logger);
 
@@ -174,6 +177,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   app.route("/api/settings", settingsRoutes(settings, db, deps?.logger));
   app.route("/api/skills", skillsRoutes(config));
   app.route("/api/users", userRoutes(users, { settings, db, logger, config }));
+  app.route("/api/agent-environment-variables", agentEnvironmentRoutes(agentEnvVars));
   app.route("/api/mcp-servers", mcpServerRoutes(mcpServers, users));
   app.route("/api/workspace", createWorkspaceApi({ config }));
   if (deps?.scheduler) {

--- a/packages/shared/src/agent-environment.ts
+++ b/packages/shared/src/agent-environment.ts
@@ -1,0 +1,42 @@
+export interface AgentEnvironmentVariableRecord {
+  id: string;
+  name: string;
+  value: string | null;
+  isSecret: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const RESERVED_AGENT_ENV_EXACT = new Set([
+  "NODE_OPTIONS",
+  "HOME",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "DATA_DIR",
+  "SQLITE_PATH",
+  "DATABASE_URL",
+  "ENCRYPTION_KEY",
+  "SYSTEM_SECRET",
+  "MANAGED_AUTH_SECRET",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_MODEL",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+]);
+
+const RESERVED_AGENT_ENV_PREFIXES = [
+  "ANTHROPIC_",
+  "AWS_",
+  "CANVAS_",
+  "CLAUDE_",
+  "GOOGLE_",
+  "OPENAI_",
+  "SKETCH_",
+  "VERTEX_",
+];
+
+export function isReservedAgentEnvName(name: string): boolean {
+  return RESERVED_AGENT_ENV_EXACT.has(name) || RESERVED_AGENT_ENV_PREFIXES.some((prefix) => name.startsWith(prefix));
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./agent-environment";
 export * from "./llm-provider";
 export * from "./mcp-servers";
 export * from "./skills";

--- a/packages/web/src/components/connections/environment-variables-section.tsx
+++ b/packages/web/src/components/connections/environment-variables-section.tsx
@@ -1,0 +1,471 @@
+import { api } from "@/lib/api";
+import {
+  CopySimpleIcon,
+  EyeIcon,
+  EyeSlashIcon,
+  LockIcon,
+  PencilSimpleIcon,
+  PlusIcon,
+  SpinnerGapIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+import { type AgentEnvironmentVariableRecord, isReservedAgentEnvName } from "@sketch/shared";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@sketch/ui/components/alert-dialog";
+import { Button } from "@sketch/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@sketch/ui/components/dialog";
+import { Input } from "@sketch/ui/components/input";
+import { Label } from "@sketch/ui/components/label";
+import { Switch } from "@sketch/ui/components/switch";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+
+const MASKED_VALUE = "••••••••••••••••";
+
+export function EnvironmentVariablesSection({
+  variables,
+  onAdd,
+  onEdit,
+  onDelete,
+}: {
+  variables: AgentEnvironmentVariableRecord[];
+  onAdd: () => void;
+  onEdit: (variable: AgentEnvironmentVariableRecord) => void;
+  onDelete: (variable: AgentEnvironmentVariableRecord) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <p className="text-sm font-medium text-muted-foreground">Environment variables</p>
+        <Button variant="ghost" size="sm" className="gap-1.5 hover:bg-brand-accent/8" onClick={onAdd}>
+          <PlusIcon size={14} weight="bold" />
+          New variable
+        </Button>
+      </div>
+
+      {variables.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-brand-accent/[0.04] px-6 pt-8 pb-10 text-center">
+          <div className="flex size-12 items-center justify-center rounded-full border border-brand-accent bg-white">
+            <LockIcon size={24} className="text-[#8B7A00]" />
+          </div>
+          <p className="mt-3 text-sm font-medium">No environment variables</p>
+          <p className="mt-1.5 max-w-sm text-sm text-muted-foreground">
+            Add credentials and config for Bash commands run by Sketch.
+          </p>
+          <Button variant="ghost" size="sm" className="mt-4 gap-1.5 hover:bg-brand-accent/8" onClick={onAdd}>
+            <PlusIcon size={14} weight="bold" />
+            New variable
+          </Button>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <div className="grid grid-cols-[minmax(160px,0.8fr)_minmax(0,1.4fr)] gap-4 border-b border-border px-4 py-2 text-xs font-medium text-muted-foreground">
+            <span>Key</span>
+            <span>Value</span>
+          </div>
+          {variables.map((variable, i) => (
+            <EnvironmentVariableRow
+              key={variable.id}
+              variable={variable}
+              isLast={i === variables.length - 1}
+              onEdit={() => onEdit(variable)}
+              onDelete={() => onDelete(variable)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EnvironmentVariableRow({
+  variable,
+  isLast,
+  onEdit,
+  onDelete,
+}: {
+  variable: AgentEnvironmentVariableRecord;
+  isLast: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const value = variable.value ?? "";
+
+  const handleCopy = async () => {
+    try {
+      await copyTextToClipboard(value);
+      setCopied(true);
+      toast.success("Value copied");
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Unable to copy value");
+    }
+  };
+
+  return (
+    <div
+      className={`grid grid-cols-[minmax(160px,0.8fr)_minmax(0,1.4fr)] items-center gap-4 px-4 py-3 ${
+        isLast ? "" : "border-b border-border"
+      }`}
+    >
+      <span className="truncate font-mono text-sm font-medium text-muted-foreground">{variable.name}</span>
+
+      <div className="flex h-9 min-w-0 items-center gap-2 rounded-md border border-border bg-muted/40 px-3 text-left transition-colors hover:bg-muted">
+        {variable.isSecret ? (
+          <span className="flex min-w-0 flex-1 items-center gap-2 text-sm font-medium text-muted-foreground">
+            <LockIcon size={15} weight="fill" />
+            Secret
+          </span>
+        ) : (
+          <span className="min-w-0 flex-1 truncate font-mono text-sm text-muted-foreground">
+            {revealed ? value : MASKED_VALUE}
+          </span>
+        )}
+        <span className="flex items-center gap-1 text-muted-foreground">
+          {!variable.isSecret && (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setRevealed((current) => !current);
+                }}
+                aria-label={revealed ? `Hide ${variable.name}` : `Reveal ${variable.name}`}
+              >
+                {revealed ? <EyeSlashIcon size={14} /> : <EyeIcon size={14} />}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCopy();
+                }}
+                aria-label={`Copy ${variable.name}`}
+              >
+                {copied ? <span className="text-[10px] font-medium">OK</span> : <CopySimpleIcon size={14} />}
+              </Button>
+            </>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit();
+            }}
+            aria-label={`Edit ${variable.name}`}
+          >
+            <PencilSimpleIcon size={14} />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="hover:text-destructive"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            aria-label={`Delete ${variable.name}`}
+          >
+            <TrashIcon size={14} />
+          </Button>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+async function copyTextToClipboard(value: string): Promise<void> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      await navigator.clipboard.writeText(value);
+      return;
+    }
+  } catch {}
+
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    const copied = document.execCommand("copy");
+    if (!copied) throw new Error("Copy command failed");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export function AddEnvironmentVariableDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [isSecret, setIsSecret] = useState(true);
+  const trimmedName = name.trim();
+  const isReservedName = isReservedAgentEnvName(trimmedName);
+
+  const addMutation = useMutation({
+    mutationFn: () => api.agentEnvironmentVariables.create({ name: trimmedName, value, isSecret }),
+    onSuccess: () => {
+      toast.success("Environment variable saved");
+      resetAndClose();
+      onSuccess();
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const resetAndClose = () => {
+    setName("");
+    setValue("");
+    setIsSecret(true);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) resetAndClose();
+        else onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add environment variable</DialogTitle>
+          <DialogDescription>Available to Sketch agent Bash commands in your DMs.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="env-var-name">Name</Label>
+            <Input
+              id="env-var-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="BACKEND_API_URL"
+              disabled={addMutation.isPending}
+              className="font-mono text-xs"
+              aria-invalid={isReservedName}
+            />
+            {isReservedName && (
+              <p className="text-xs text-destructive">This environment variable name is reserved by Sketch.</p>
+            )}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="env-var-value">Value</Label>
+            <Input
+              id="env-var-value"
+              type={isSecret ? "password" : "text"}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              disabled={addMutation.isPending}
+              className="font-mono text-xs"
+            />
+          </div>
+          <div className="flex items-start justify-between gap-4 rounded-md border border-border bg-muted/30 px-3 py-3">
+            <div>
+              <p className="text-sm font-medium">Secret value</p>
+              <p className="mt-1 text-xs text-muted-foreground">Secret values cannot be revealed or copied later.</p>
+            </div>
+            <Switch checked={isSecret} onCheckedChange={setIsSecret} disabled={addMutation.isPending} />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={addMutation.isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={() => addMutation.mutate()}
+            disabled={!trimmedName || isReservedName || addMutation.isPending}
+          >
+            {addMutation.isPending ? (
+              <>
+                <SpinnerGapIcon size={14} className="animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save variable"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function EditEnvironmentVariableDialog({
+  variable,
+  onOpenChange,
+  onSuccess,
+}: {
+  variable: AgentEnvironmentVariableRecord | null;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}) {
+  const [value, setValue] = useState("");
+  const [lastVariableId, setLastVariableId] = useState<string | null>(null);
+  if (variable && variable.id !== lastVariableId) {
+    setValue("");
+    setLastVariableId(variable.id);
+  }
+  if (!variable && lastVariableId) {
+    setLastVariableId(null);
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: () => api.agentEnvironmentVariables.update(variable?.id ?? "", { value }),
+    onSuccess: () => {
+      toast.success("Environment variable updated");
+      onOpenChange(false);
+      onSuccess();
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  return (
+    <Dialog open={!!variable} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit environment variable</DialogTitle>
+          <DialogDescription>Replace the value for this variable.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-env-var-name">Name</Label>
+            <Input
+              id="edit-env-var-name"
+              value={variable?.name ?? ""}
+              disabled
+              readOnly
+              className="font-mono text-xs"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-env-var-value">New value</Label>
+            <Input
+              id="edit-env-var-value"
+              type={variable?.isSecret ? "password" : "text"}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="Enter a new value"
+              disabled={updateMutation.isPending}
+              className="font-mono text-xs"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            The variable name and secret setting cannot be changed after creation.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={updateMutation.isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button onClick={() => updateMutation.mutate()} disabled={!value || updateMutation.isPending}>
+            {updateMutation.isPending ? (
+              <>
+                <SpinnerGapIcon size={14} className="animate-spin" />
+                Updating...
+              </>
+            ) : (
+              "Update value"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function DeleteEnvironmentVariableDialog({
+  variable,
+  onOpenChange,
+  onSuccess,
+}: {
+  variable: AgentEnvironmentVariableRecord | null;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}) {
+  const deleteMutation = useMutation({
+    mutationFn: () => api.agentEnvironmentVariables.remove(variable?.id ?? ""),
+    onSuccess: () => {
+      toast.success("Environment variable deleted");
+      onOpenChange(false);
+      onSuccess();
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  return (
+    <AlertDialog open={!!variable} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {variable?.name}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Sketch will stop injecting this variable into your DM Bash commands.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={() => deleteMutation.mutate()}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? (
+              <>
+                <SpinnerGapIcon size={14} className="animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              "Delete"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5,6 +5,7 @@
 
 import type { SkillCategory } from "@/lib/skills-data";
 import type {
+  AgentEnvironmentVariableRecord,
   FileMetadata,
   IntegrationApp,
   IntegrationConnection,
@@ -883,6 +884,32 @@ export const api = {
       return request<void>(`/api/mcp-servers/${providerId}/connections/${connectionId}`, {
         method: "DELETE",
       });
+    },
+  },
+  agentEnvironmentVariables: {
+    async list() {
+      const res = await request<{ variables: AgentEnvironmentVariableRecord[] }>("/api/agent-environment-variables");
+      return res.variables;
+    },
+    async create(data: { name: string; value: string; isSecret: boolean }) {
+      const res = await request<{ variable: AgentEnvironmentVariableRecord }>("/api/agent-environment-variables", {
+        method: "POST",
+        body: JSON.stringify(data),
+      });
+      return res.variable;
+    },
+    async update(id: string, data: { value: string }) {
+      const res = await request<{ variable: AgentEnvironmentVariableRecord }>(
+        `/api/agent-environment-variables/${id}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify(data),
+        },
+      );
+      return res.variable;
+    },
+    remove(id: string) {
+      return request<{ success: true }>(`/api/agent-environment-variables/${id}`, { method: "DELETE" });
     },
   },
   entities: {

--- a/packages/web/src/routes/connections.tsx
+++ b/packages/web/src/routes/connections.tsx
@@ -13,13 +13,19 @@ import { AddMcpDialog } from "@/components/connections/add-mcp-dialog";
 import { AddProviderDialog, ProviderSelectorDialog } from "@/components/connections/add-provider-dialog";
 import { EditMcpDialog } from "@/components/connections/edit-mcp-dialog";
 import { EditProviderDialog } from "@/components/connections/edit-provider-dialog";
+import {
+  AddEnvironmentVariableDialog,
+  DeleteEnvironmentVariableDialog,
+  EditEnvironmentVariableDialog,
+  EnvironmentVariablesSection,
+} from "@/components/connections/environment-variables-section";
 import { IntegrationsSection } from "@/components/connections/integrations-section";
 import { McpServersSection } from "@/components/connections/mcp-servers-section";
 import { RemoveMcpDialog } from "@/components/connections/remove-mcp-dialog";
 import { LoadingSkeleton } from "@/components/connections/shared";
 import { api } from "@/lib/api";
 import { PlusIcon } from "@phosphor-icons/react";
-import type { McpServerRecord } from "@sketch/shared";
+import type { AgentEnvironmentVariableRecord, McpServerRecord } from "@sketch/shared";
 import { TabButton } from "@sketch/ui/components/tab-button";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
@@ -59,7 +65,7 @@ function ConnectionsCallback() {
 // Tab button
 // ---------------------------------------------------------------------------
 
-type IntegrationsTab = "applications" | "mcps";
+type IntegrationsTab = "applications" | "mcps" | "environment";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -70,7 +76,8 @@ function ConnectionsPage() {
   const [activeTab, setActiveTab] = useState<IntegrationsTab>(() => {
     if (typeof window === "undefined") return "applications";
     const tab = new URLSearchParams(window.location.search).get("tab");
-    return tab === "mcps" ? "mcps" : "applications";
+    if (tab === "mcps" || tab === "environment") return tab;
+    return "applications";
   });
 
   const serversQuery = useQuery({
@@ -89,10 +96,20 @@ function ConnectionsPage() {
 
   const connections = connectionsQuery.data ?? [];
 
+  const envVarsQuery = useQuery({
+    queryKey: ["agent-environment-variables"],
+    queryFn: () => api.agentEnvironmentVariables.list(),
+    enabled: activeTab === "environment",
+  });
+  const envVars = envVarsQuery.data ?? [];
+
   const [showAddMcpDialog, setShowAddMcpDialog] = useState(false);
   const [editingServer, setEditingServer] = useState<McpServerRecord | null>(null);
   const [editingProvider, setEditingProvider] = useState<McpServerRecord | null>(null);
   const [removingServer, setRemovingServer] = useState<McpServerRecord | null>(null);
+  const [showAddEnvDialog, setShowAddEnvDialog] = useState(false);
+  const [editingEnvVar, setEditingEnvVar] = useState<AgentEnvironmentVariableRecord | null>(null);
+  const [deletingEnvVar, setDeletingEnvVar] = useState<AgentEnvironmentVariableRecord | null>(null);
   const [showAddIntegrationDialog, setShowAddIntegrationDialog] = useState(false);
   const [showProviderSelector, setShowProviderSelector] = useState(false);
   const [showAddProvider, setShowAddProvider] = useState(false);
@@ -100,6 +117,7 @@ function ConnectionsPage() {
   const invalidateAll = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["mcp-servers"] });
     queryClient.invalidateQueries({ queryKey: ["connections"] });
+    queryClient.invalidateQueries({ queryKey: ["agent-environment-variables"] });
   }, [queryClient]);
 
   const isLoading = serversQuery.isLoading;
@@ -118,10 +136,15 @@ function ConnectionsPage() {
           onClick={() => setActiveTab("applications")}
         />
         <TabButton label="MCPs" isActive={activeTab === "mcps"} onClick={() => setActiveTab("mcps")} />
+        <TabButton
+          label="Environment"
+          isActive={activeTab === "environment"}
+          onClick={() => setActiveTab("environment")}
+        />
       </div>
 
       <div className="mt-5 space-y-8">
-        {isLoading ? (
+        {isLoading || (activeTab === "environment" && envVarsQuery.isLoading) ? (
           <LoadingSkeleton />
         ) : activeTab === "applications" ? (
           <>
@@ -155,7 +178,7 @@ function ConnectionsPage() {
               </>
             )}
           </>
-        ) : (
+        ) : activeTab === "mcps" ? (
           <McpServersSection
             servers={servers}
             onAdd={() => setShowAddMcpDialog(true)}
@@ -179,6 +202,13 @@ function ConnectionsPage() {
                 toast.error(err instanceof Error ? err.message : "Connection test failed");
               }
             }}
+          />
+        ) : (
+          <EnvironmentVariablesSection
+            variables={envVars}
+            onAdd={() => setShowAddEnvDialog(true)}
+            onEdit={setEditingEnvVar}
+            onDelete={setDeletingEnvVar}
           />
         )}
       </div>
@@ -211,6 +241,24 @@ function ConnectionsPage() {
       <RemoveMcpDialog
         server={removingServer}
         onOpenChange={(open) => !open && setRemovingServer(null)}
+        onSuccess={invalidateAll}
+      />
+
+      <AddEnvironmentVariableDialog
+        open={showAddEnvDialog}
+        onOpenChange={setShowAddEnvDialog}
+        onSuccess={invalidateAll}
+      />
+
+      <EditEnvironmentVariableDialog
+        variable={editingEnvVar}
+        onOpenChange={(open) => !open && setEditingEnvVar(null)}
+        onSuccess={invalidateAll}
+      />
+
+      <DeleteEnvironmentVariableDialog
+        variable={deletingEnvVar}
+        onOpenChange={(open) => !open && setDeletingEnvVar(null)}
         onSuccess={invalidateAll}
       />
 


### PR DESCRIPTION
## Summary

- Add a user-scoped Environment tab under Integrations for managing agent environment variables.
- Store values encrypted at rest, hide secret values after save, and allow reveal/copy only for non-secret values.
- Inject non-reserved user env vars into DM agent runs through Claude Agent SDK `options.env`.
- Add shared reserved-key validation across frontend and backend, including `AWS_*` for v1 because Bedrock provider auth uses ambient AWS env vars.

## Scope

- Applies only to Slack DM agent runs for the invoking user.
- Shared Slack channels and WhatsApp groups remain out of scope.

## Validation

- `pnpm biome check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Local Slack/browser testing confirmed the agent can read configured env vars.