### PR TITLE
Support Canvas-managed automations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.33.0
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -205,6 +205,7 @@ export function buildSystemContext(params: {
     "## Scheduled Tasks",
     "",
     "Use the ManageScheduledTasks tool when a user asks to do something periodically, on a schedule, or as a reminder. Platform and delivery target are filled in automatically from context. Do not ask the user for these.",
+    "For external app events, prefer a Canvas-managed trigger only when a Canvas skill/MCP is available: use Canvas search_components to find the trigger, then create a workflow with triggerConfig.type='canvas'. If Canvas is not available, use a normal scheduled cron/interval/once trigger instead.",
   );
 
   sections.push(

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -519,6 +519,15 @@ export async function handleManageScheduledTasks(
           );
         }
 
+        const triggerStep = params.steps.find((step) => step.type === "trigger");
+        if (triggerStep?.triggerConfig?.type === "canvas") {
+          updateFields.scheduleType = "external";
+          updateFields.scheduleValue = "canvas";
+          triggerStep.triggerConfig = {
+            ...triggerStep.triggerConfig,
+            status: triggerStep.triggerConfig.status ?? "pending_canvas_setup",
+          };
+        }
         const stepsForDb = stripContentFromSteps(params.steps);
         updateFields.steps = JSON.stringify(stepsForDb);
 

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -104,11 +104,23 @@ const workflowStepSchema = z.object({
   timeout: z.number().optional().describe("Step timeout in seconds. Default: 1800 (30 min)."),
   triggerConfig: z
     .object({
-      type: z.enum(["webhook", "schedule"]),
+      type: z.enum(["webhook", "schedule", "canvas"]),
       scheduleType: z.enum(["cron", "interval", "once"]).optional(),
       scheduleValue: z.string().optional(),
       timezone: z.string().optional(),
+      app: z.string().optional().describe("Source app for Canvas-managed triggers, e.g. 'clickup' or 'linear'."),
+      eventDescription: z.string().optional().describe("Human-readable event description, e.g. 'new issue created'."),
+      componentKey: z.string().optional().describe("Canvas trigger component ID/key found through search_components."),
+      configuredProps: z.record(z.string(), z.unknown()).optional(),
+      status: z.enum(["pending_canvas_setup", "active", "error"]).optional(),
+      canvasWorkflowId: z.string().optional(),
+      canvasTriggerNodeId: z.string().optional(),
+      canvasActionNodeId: z.string().optional(),
+      errorMessage: z.string().optional(),
     })
+    .describe(
+      "Use type 'canvas' for Canvas-managed external triggers. Use it only when a Canvas skill/MCP has selected a trigger component via search_components; otherwise create a normal schedule trigger fallback.",
+    )
     .optional(),
 });
 
@@ -180,7 +192,7 @@ type WorkflowStepInput = z.infer<typeof workflowStepSchema>;
 type ManageScheduledTasksParams = {
   action: "list" | "add" | "update" | "remove" | "pause" | "resume" | "run" | "getRun" | "updateStepContent";
   prompt?: string;
-  schedule_type?: "cron" | "interval" | "once";
+  schedule_type?: "cron" | "interval" | "once" | "external";
   schedule_value?: string;
   timezone?: string;
   session_mode?: "fresh" | "persistent" | "chat";
@@ -282,8 +294,18 @@ export async function handleManageScheduledTasks(
         if (!params.title) {
           return text("Error: title is required when creating a multi-step automation.");
         }
-        if (!params.schedule_type || !params.schedule_value) {
+        const triggerStep = params.steps.find((step) => step.type === "trigger");
+        const isCanvasManagedTrigger = triggerStep?.triggerConfig?.type === "canvas";
+        if (!isCanvasManagedTrigger && (!params.schedule_type || !params.schedule_value)) {
           return text("Error: schedule_type and schedule_value are required for add action.");
+        }
+        if (triggerStep?.triggerConfig?.type === "canvas") {
+          params.schedule_type = "external";
+          params.schedule_value = "canvas";
+          triggerStep.triggerConfig = {
+            ...triggerStep.triggerConfig,
+            status: triggerStep.triggerConfig.status ?? "pending_canvas_setup",
+          };
         }
 
         const brokerError = await ensureBrokerForActionSteps(params.steps);

--- a/packages/server/src/api/scheduled-tasks.test.ts
+++ b/packages/server/src/api/scheduled-tasks.test.ts
@@ -143,6 +143,81 @@ describe("Scheduled Tasks API", () => {
     expect(whatsappTask.canResume).toBe(true);
   });
 
+  it("returns Canvas-managed trigger metadata for external workflows", async () => {
+    await seedAdmin(db);
+    const users = createUserRepository(db);
+    const tasks = createScheduledTaskRepository(db);
+    const member = await users.create({ name: "Alice Member", email: "alice@test.com" });
+
+    await tasks.add({
+      id: "task-canvas",
+      platform: "slack",
+      context_type: "dm",
+      delivery_target: "D123",
+      thread_ts: null,
+      prompt: "Handle ClickUp issues",
+      schedule_type: "external",
+      schedule_value: "canvas",
+      timezone: "UTC",
+      session_mode: "fresh",
+      created_by: member.id,
+      status: "active",
+      next_run_at: null,
+      steps: JSON.stringify([
+        {
+          id: "trigger",
+          type: "trigger",
+          label: "ClickUp issue created",
+          icon: "clickup",
+          position: { x: 0, y: 0 },
+          triggerConfig: {
+            type: "canvas",
+            app: "ClickUp",
+            eventDescription: "new issue created",
+            componentKey: "clickup.issue.created",
+            status: "pending_canvas_setup",
+          },
+        },
+        {
+          id: "agent1",
+          type: "agent",
+          label: "Handle issue",
+          icon: "sketch-ai",
+          position: { x: 0, y: 100 },
+        },
+      ]),
+    });
+
+    const app = createApp(db, config, {
+      scheduler: {
+        pauseTask: vi.fn(),
+        resumeTask: vi.fn(),
+        removeTask: vi.fn(),
+        executeTaskById: vi.fn(),
+      },
+    });
+    const cookie = await loginAdmin(app);
+
+    const res = await app.request("/api/scheduled-tasks", { headers: { Cookie: cookie } });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.tasks[0]).toEqual(
+      expect.objectContaining({
+        id: "task-canvas",
+        scheduleType: "external",
+        scheduleValue: "canvas",
+        scheduleLabel: "Canvas managed: ClickUp - new issue created",
+        nextRunAt: null,
+        triggerConfig: expect.objectContaining({
+          type: "canvas",
+          status: "pending_canvas_setup",
+          componentKey: "clickup.issue.created",
+        }),
+      }),
+    );
+  });
+
   it("members see only their own tasks; admins see all", async () => {
     await seedAdmin(db);
     const users = createUserRepository(db);

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -8,8 +8,10 @@ import { createScheduledTaskRepository } from "../db/repositories/scheduled-task
 import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB, ScheduledTasksTable } from "../db/schema";
+import type { WorkflowStep } from "../workflows/types";
 
 type ScheduledTaskRow = Selectable<ScheduledTasksTable>;
+type WorkflowTriggerConfig = NonNullable<WorkflowStep["triggerConfig"]>;
 
 interface ScheduledTaskMutationDeps {
   pauseTask: (id: string) => Promise<void>;
@@ -25,7 +27,7 @@ interface ScheduledTaskListItem {
   deliveryTarget: string;
   threadTs: string | null;
   prompt: string;
-  scheduleType: "cron" | "interval" | "once";
+  scheduleType: "cron" | "interval" | "once" | "external";
   scheduleValue: string;
   timezone: string;
   sessionMode: "fresh" | "persistent" | "chat";
@@ -45,6 +47,7 @@ interface ScheduledTaskListItem {
   description: string | null;
   steps: string | null;
   stepCount: number;
+  triggerConfig: WorkflowTriggerConfig | null;
   outputTarget: string | null;
   outputPlatform: string | null;
   lastRunStatus: string | null;
@@ -91,7 +94,23 @@ function formatIntervalLabel(rawSeconds: string): string {
   return `Every ${seconds} seconds`;
 }
 
-function formatScheduleLabel(row: ScheduledTaskRow): string {
+function formatCanvasTriggerLabel(triggerConfig: WorkflowTriggerConfig | null): string {
+  if (triggerConfig?.type !== "canvas") return "Canvas managed trigger";
+
+  const app = triggerConfig.app;
+  const event = triggerConfig.eventDescription;
+  if (app && event) return `Canvas managed: ${app} - ${event}`;
+  if (app) return `Canvas managed: ${app}`;
+  if (event) return `Canvas managed: ${event}`;
+  return "Canvas managed trigger";
+}
+
+function formatScheduleLabel(row: ScheduledTaskRow, triggerConfig: WorkflowTriggerConfig | null): string {
+  if (row.schedule_type === "external") {
+    if (row.schedule_value === "canvas") return formatCanvasTriggerLabel(triggerConfig);
+    return "External trigger";
+  }
+
   if (row.schedule_type === "interval") {
     return formatIntervalLabel(row.schedule_value);
   }
@@ -101,6 +120,18 @@ function formatScheduleLabel(row: ScheduledTaskRow): string {
   }
 
   return `Cron: ${row.schedule_value} (${row.timezone})`;
+}
+
+function parseTriggerConfig(stepsValue: string | null): WorkflowTriggerConfig | null {
+  if (!stepsValue) return null;
+  try {
+    const steps = JSON.parse(stepsValue) as WorkflowStep[];
+    if (!Array.isArray(steps)) return null;
+    const triggerStep = steps.find((step) => step?.type === "trigger" && step.triggerConfig);
+    return triggerStep?.triggerConfig ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function getTargetKindLabel(row: ScheduledTaskRow): ScheduledTaskListItem["targetKindLabel"] {
@@ -178,6 +209,7 @@ async function buildTaskListItems(db: Kysely<DB>, rows: ScheduledTaskRow[]): Pro
         stepCount = JSON.parse(row.steps).length;
       } catch {}
     }
+    const triggerConfig = parseTriggerConfig(row.steps);
 
     const rd = runData.get(row.id);
 
@@ -188,7 +220,7 @@ async function buildTaskListItems(db: Kysely<DB>, rows: ScheduledTaskRow[]): Pro
       deliveryTarget: row.delivery_target,
       threadTs: row.thread_ts,
       prompt: row.prompt,
-      scheduleType: row.schedule_type as "cron" | "interval" | "once",
+      scheduleType: row.schedule_type as "cron" | "interval" | "once" | "external",
       scheduleValue: row.schedule_value,
       timezone: row.timezone,
       sessionMode: row.session_mode as "fresh" | "persistent" | "chat",
@@ -200,7 +232,7 @@ async function buildTaskListItems(db: Kysely<DB>, rows: ScheduledTaskRow[]): Pro
       targetLabel,
       targetKindLabel: getTargetKindLabel(row),
       creatorName,
-      scheduleLabel: formatScheduleLabel(row),
+      scheduleLabel: formatScheduleLabel(row, triggerConfig),
       canPause: row.status === "active",
       canResume: row.status === "paused",
       canDelete: true,
@@ -208,6 +240,7 @@ async function buildTaskListItems(db: Kysely<DB>, rows: ScheduledTaskRow[]): Pro
       description: row.description,
       steps: row.steps,
       stepCount,
+      triggerConfig,
       outputTarget: row.output_target,
       outputPlatform: row.output_platform,
       lastRunStatus: rd?.lastRunStatus ?? null,

--- a/packages/server/src/scheduler/service.test.ts
+++ b/packages/server/src/scheduler/service.test.ts
@@ -276,6 +276,29 @@ describe("addTask()", () => {
     const instance = mockCronInstances[mockCronInstances.length - 1];
     expect(instance.pattern).toBe("0 */6 * * *");
   });
+
+  it("stores external trigger tasks without creating a cron instance", async () => {
+    const deps = buildDeps(db);
+    const scheduler = new TaskScheduler(deps as never);
+
+    const task = await scheduler.addTask({
+      platform: "slack",
+      contextType: "dm",
+      deliveryTarget: "U_USER1",
+      prompt: "Run when Canvas fires",
+      scheduleType: "external",
+      scheduleValue: "canvas",
+      createdBy: "U_USER1",
+    });
+
+    expect(task.status).toBe("active");
+    expect(task.nextRunAt).toBeNull();
+    expect(cronCallCount).toBe(0);
+
+    const dbRow = await repo.getById(task.id);
+    expect(dbRow?.schedule_type).toBe("external");
+    expect(dbRow?.schedule_value).toBe("canvas");
+  });
 });
 
 describe("removeTask()", () => {

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -97,6 +97,12 @@ export class TaskScheduler {
       this.cronInstances.delete(task.id);
     }
 
+    if (task.schedule_type === "external") {
+      await this.repo.update(task.id, { next_run_at: null });
+      this.deps.logger.debug({ taskId: task.id }, "TaskScheduler: external trigger task has no local schedule");
+      return;
+    }
+
     if (task.schedule_type === "once") {
       const runAt = parseOnceSchedule(task.schedule_value, task.timezone || "UTC");
       if (runAt.getTime() <= Date.now()) {
@@ -248,7 +254,7 @@ export class TaskScheduler {
     deliveryTarget: string;
     threadTs?: string | null;
     prompt: string;
-    scheduleType: "cron" | "interval" | "once";
+    scheduleType: "cron" | "interval" | "once" | "external";
     scheduleValue: string;
     timezone?: string;
     sessionMode?: "fresh" | "persistent" | "chat";
@@ -377,7 +383,7 @@ export class TaskScheduler {
       deliveryTarget: row.delivery_target,
       threadTs: row.thread_ts,
       prompt: row.prompt,
-      scheduleType: row.schedule_type as "cron" | "interval" | "once",
+      scheduleType: row.schedule_type as "cron" | "interval" | "once" | "external",
       scheduleValue: row.schedule_value,
       timezone: row.timezone,
       sessionMode: row.session_mode as "fresh" | "persistent" | "chat",

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -361,6 +361,57 @@ describe("handleManageScheduledTasks — add", () => {
     expect(agentStep.agentPrompt).toBeUndefined();
   });
 
+  it("creates Canvas-managed trigger workflows without requiring a local schedule", async () => {
+    const localRepo = makeMockStepContentRepo();
+    const scheduler = makeMockScheduler({ addTask: vi.fn().mockResolvedValue(makeTask({ id: "wf-canvas" })) });
+    const result = await handleManageScheduledTasks(
+      {
+        action: "add",
+        title: "New ClickUp issues",
+        steps: [
+          {
+            id: "trigger",
+            type: "trigger",
+            label: "ClickUp issue created",
+            icon: "clickup",
+            position: { x: 0, y: 0 },
+            triggerConfig: {
+              type: "canvas",
+              app: "clickup",
+              eventDescription: "new issue created",
+              componentKey: "clickup.issue.created",
+            },
+          },
+          {
+            id: "agent1",
+            type: "agent",
+            label: "Handle issue",
+            icon: "sketch-ai",
+            position: { x: 0, y: 100 },
+            agentPrompt: "Handle the incoming issue.",
+          },
+        ],
+      },
+      { scheduler, stepContentRepo: localRepo, taskContext: dmContext },
+    );
+
+    expect(result.content[0].text).toContain("Automation created:");
+    expect(scheduler.addTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduleType: "external",
+        scheduleValue: "canvas",
+      }),
+    );
+    const addTaskCall = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const stepsJson = JSON.parse(addTaskCall.steps);
+    expect(stepsJson[0].triggerConfig).toEqual(
+      expect.objectContaining({
+        type: "canvas",
+        status: "pending_canvas_setup",
+      }),
+    );
+  });
+
   it("fails loudly when multi-step workflow is created without stepContentRepo", async () => {
     const scheduler = makeMockScheduler();
     const result = await handleManageScheduledTasks(

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -566,6 +566,56 @@ describe("handleManageScheduledTasks — update", () => {
     });
   });
 
+  it("normalizes schedule fields when updating steps to a Canvas-managed trigger", async () => {
+    const scheduler = makeMockScheduler();
+    await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "task-1",
+        steps: [
+          {
+            id: "trigger",
+            type: "trigger",
+            label: "Linear issue created",
+            icon: "linear",
+            position: { x: 0, y: 0 },
+            triggerConfig: {
+              type: "canvas",
+              app: "linear",
+              eventDescription: "new issue created",
+              componentKey: "linear.issue.created",
+            },
+          },
+          {
+            id: "agent1",
+            type: "agent",
+            label: "Handle issue",
+            icon: "sketch-ai",
+            position: { x: 0, y: 100 },
+            agentPrompt: "Handle the issue.",
+          },
+        ],
+      },
+      { scheduler, stepContentRepo, taskContext: dmContext },
+    );
+
+    expect(scheduler.updateTask).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        scheduleType: "external",
+        scheduleValue: "canvas",
+      }),
+    );
+    const updateFields = (scheduler.updateTask as ReturnType<typeof vi.fn>).mock.calls[0][1] as { steps: string };
+    const stepsJson = JSON.parse(updateFields.steps);
+    expect(stepsJson[0].triggerConfig).toEqual(
+      expect.objectContaining({
+        type: "canvas",
+        status: "pending_canvas_setup",
+      }),
+    );
+  });
+
   it("returns updated task in response", async () => {
     const task = makeTask({ prompt: "Updated" });
     const scheduler = makeMockScheduler({ updateTask: vi.fn().mockResolvedValue(task) });

--- a/packages/server/src/scheduler/types.ts
+++ b/packages/server/src/scheduler/types.ts
@@ -14,7 +14,7 @@ export interface ScheduledTask {
   deliveryTarget: string;
   threadTs: string | null;
   prompt: string;
-  scheduleType: "cron" | "interval" | "once";
+  scheduleType: "cron" | "interval" | "once" | "external";
   scheduleValue: string;
   timezone: string;
   sessionMode: "fresh" | "persistent" | "chat";

--- a/packages/server/src/workflows/types.ts
+++ b/packages/server/src/workflows/types.ts
@@ -27,10 +27,19 @@ export interface WorkflowStep {
 
   /** Trigger step config. */
   triggerConfig?: {
-    type: "webhook" | "schedule";
+    type: "webhook" | "schedule" | "canvas";
     scheduleType?: "cron" | "interval" | "once";
     scheduleValue?: string;
     timezone?: string;
+    app?: string;
+    eventDescription?: string;
+    componentKey?: string;
+    configuredProps?: Record<string, unknown>;
+    status?: "pending_canvas_setup" | "active" | "error";
+    canvasWorkflowId?: string;
+    canvasTriggerNodeId?: string;
+    canvasActionNodeId?: string;
+    errorMessage?: string;
   };
 }
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -56,7 +56,7 @@ export interface ScheduledTaskListItem {
   deliveryTarget: string;
   threadTs: string | null;
   prompt: string;
-  scheduleType: "cron" | "interval" | "once";
+  scheduleType: "cron" | "interval" | "once" | "external";
   scheduleValue: string;
   timezone: string;
   sessionMode: "fresh" | "persistent" | "chat";
@@ -76,10 +76,27 @@ export interface ScheduledTaskListItem {
   description: string | null;
   steps: string | null;
   stepCount: number;
+  triggerConfig: WorkflowTriggerConfig | null;
   outputTarget: string | null;
   outputPlatform: string | null;
   lastRunStatus: string | null;
   runCount: number;
+}
+
+export interface WorkflowTriggerConfig {
+  type: "webhook" | "schedule" | "canvas";
+  scheduleType?: "cron" | "interval" | "once";
+  scheduleValue?: string;
+  timezone?: string;
+  app?: string;
+  eventDescription?: string;
+  componentKey?: string;
+  configuredProps?: Record<string, unknown>;
+  status?: "pending_canvas_setup" | "active" | "error";
+  canvasWorkflowId?: string;
+  canvasTriggerNodeId?: string;
+  canvasActionNodeId?: string;
+  errorMessage?: string;
 }
 
 export interface AutomationRunItem {

--- a/packages/web/src/routes/scheduled-tasks.test.tsx
+++ b/packages/web/src/routes/scheduled-tasks.test.tsx
@@ -56,6 +56,7 @@ function buildTask(overrides: Partial<ScheduledTaskListItem> = {}): ScheduledTas
     description: null,
     steps: null,
     stepCount: 0,
+    triggerConfig: null,
     outputTarget: null,
     outputPlatform: null,
     lastRunStatus: null,
@@ -216,6 +217,46 @@ describe("ScheduledTasksPage", () => {
     });
     expect(screen.getByText("UTC")).toBeInTheDocument();
     expect(screen.getByText("Session mode")).toBeInTheDocument();
+  });
+
+  it("shows Canvas-managed trigger state in task rows and details", async () => {
+    installTaskHandlers([
+      buildTask({
+        id: "task-canvas",
+        prompt: "Handle ClickUp issues",
+        scheduleType: "external",
+        scheduleValue: "canvas",
+        scheduleLabel: "Canvas managed: ClickUp - new issue created",
+        nextRunAt: null,
+        lastRunAt: null,
+        triggerConfig: {
+          type: "canvas",
+          app: "ClickUp",
+          eventDescription: "new issue created",
+          componentKey: "clickup.issue.created",
+          status: "pending_canvas_setup",
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderWithProviders(<ScheduledTasksPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Handle ClickUp issues")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Canvas")).toBeInTheDocument();
+    expect(screen.getByText("Trigger · Canvas · ClickUp · new issue created")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Show details for Handle ClickUp issues/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Trigger")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Trigger-based")).toBeInTheDocument();
+    expect(screen.getByText("Canvas · ClickUp · new issue created")).toBeInTheDocument();
+    expect(screen.queryByText("Pending setup")).not.toBeInTheDocument();
   });
 
   it("pauses an active task via the dropdown menu", async () => {

--- a/packages/web/src/routes/scheduled-tasks.tsx
+++ b/packages/web/src/routes/scheduled-tasks.tsx
@@ -108,6 +108,32 @@ function isMultiStep(task: ScheduledTaskListItem): boolean {
   return task.stepCount > 2;
 }
 
+function isCanvasManaged(task: ScheduledTaskListItem): boolean {
+  return task.triggerConfig?.type === "canvas" || (task.scheduleType === "external" && task.scheduleValue === "canvas");
+}
+
+function getTriggerDetail(task: ScheduledTaskListItem): string {
+  if (isCanvasManaged(task)) {
+    const config = task.triggerConfig;
+    const parts = ["Canvas"];
+    if (config?.app) parts.push(config.app);
+    if (config?.eventDescription) parts.push(config.eventDescription);
+    return parts.join(" · ");
+  }
+
+  return `${task.scheduleType} · ${task.scheduleValue}`;
+}
+
+function getTaskScheduleLabel(task: ScheduledTaskListItem): string {
+  if (!isCanvasManaged(task)) return task.scheduleLabel;
+
+  const config = task.triggerConfig;
+  const parts = ["Trigger", "Canvas"];
+  if (config?.app) parts.push(config.app);
+  if (config?.eventDescription) parts.push(config.eventDescription);
+  return parts.join(" · ");
+}
+
 function getStepSummary(task: ScheduledTaskListItem): string | null {
   if (!task.steps) return null;
   try {
@@ -279,6 +305,7 @@ function TaskRow({
   onTrigger: () => void;
 }) {
   const multi = isMultiStep(task);
+  const canvasManaged = isCanvasManaged(task);
   const displayName = task.title ?? task.prompt;
   const stepSummary = multi ? getStepSummary(task) : null;
   const lastRunLabel = formatRelativeTime(task.lastRunAt);
@@ -311,7 +338,7 @@ function TaskRow({
             {stepSummary ? <p className="mt-0.5 truncate text-xs text-muted-foreground">{stepSummary}</p> : null}
 
             <p className="mt-0.5 truncate text-xs text-muted-foreground">
-              {task.scheduleLabel}
+              {getTaskScheduleLabel(task)}
               {lastRunLabel ? (
                 <>
                   <span className="mx-1.5">&middot;</span>
@@ -333,7 +360,10 @@ function TaskRow({
           </div>
         </button>
 
-        <TaskStatusBadge status={task.status} />
+        <div className="flex shrink-0 items-center gap-2">
+          {canvasManaged ? <CanvasManagedBadge triggerConfig={task.triggerConfig} /> : null}
+          <TaskStatusBadge status={task.status} />
+        </div>
 
         <button
           type="button"
@@ -395,6 +425,7 @@ function TaskRow({
 function TaskExpandedDetail({ task, isAdmin }: { task: ScheduledTaskListItem; isAdmin: boolean }) {
   const multi = isMultiStep(task);
   const targetLabel = task.targetLabel || task.deliveryTarget;
+  const canvasManaged = isCanvasManaged(task);
 
   return (
     <div className="border-t border-border bg-muted/20 px-4 py-4 space-y-4">
@@ -404,10 +435,11 @@ function TaskExpandedDetail({ task, isAdmin }: { task: ScheduledTaskListItem; is
 
       <dl className="grid gap-4 text-sm sm:grid-cols-2">
         <DetailItem label="Target" value={`${task.targetKindLabel} \u00b7 ${targetLabel}`} />
-        <DetailItem label="Schedule" value={`${task.scheduleType} \u00b7 ${task.scheduleValue}`} />
-        <DetailItem label="Timezone" value={task.timezone} />
+        <DetailItem label="Type" value={canvasManaged ? "Trigger-based" : "Scheduled"} />
+        <DetailItem label={canvasManaged ? "Trigger" : "Schedule"} value={getTriggerDetail(task)} />
+        {canvasManaged ? null : <DetailItem label="Timezone" value={task.timezone} />}
         <DetailItem label="Session mode" value={formatSessionMode(task.sessionMode)} />
-        <DetailItem label="Next run" value={formatDateTime(task.nextRunAt)} />
+        {canvasManaged ? null : <DetailItem label="Next run" value={formatDateTime(task.nextRunAt)} />}
         <DetailItem label="Last run" value={formatDateTime(task.lastRunAt)} />
         <DetailItem label="Created" value={formatDateTime(task.createdAt)} />
         {isAdmin ? <DetailItem label="Created by" value={task.creatorName ?? task.createdBy ?? "Unknown"} /> : null}
@@ -426,7 +458,7 @@ function StepsList({ task }: { task: ScheduledTaskListItem }) {
 
   if (!task.steps) return null;
 
-  let steps: Array<{ id: string; type: string; label: string }>;
+  let steps: Array<{ id: string; type: string; label: string; triggerConfig?: ScheduledTaskListItem["triggerConfig"] }>;
   try {
     steps = JSON.parse(task.steps);
   } catch {
@@ -759,6 +791,31 @@ function TaskStatusBadge({ status }: { status: ScheduledTaskListItem["status"] }
   return (
     <Badge variant="outline" className="shrink-0">
       Completed
+    </Badge>
+  );
+}
+
+function CanvasManagedBadge({ triggerConfig }: { triggerConfig: ScheduledTaskListItem["triggerConfig"] }) {
+  const status = triggerConfig?.status;
+  if (status === "active") {
+    return (
+      <Badge variant="outline" className="shrink-0 border-blue-500/30 text-blue-700 dark:text-blue-300">
+        Canvas
+      </Badge>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <Badge variant="outline" className="shrink-0 border-destructive/30 text-destructive">
+        Canvas error
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="outline" className="shrink-0">
+      Canvas
     </Badge>
   );
 }


### PR DESCRIPTION
## What changed

- Represent Canvas-managed external app triggers inside existing `scheduled_tasks` workflows.
- Add external trigger scheduling behavior so Canvas-managed automations do not get local cron jobs or next-run timestamps.
- Extend scheduled task APIs and workflow types to return Canvas trigger metadata.
- Update the Automations UI to show trigger-based Canvas tasks with a `Canvas` badge and without schedule-only pending/setup copy.
- Add server and web tests for Canvas-managed trigger creation, API serialization, scheduler behavior, and UI rendering.

## Why

Sketch needs to stage workflows for external app events now, while Canvas-side trigger workflow creation lands later. This lets users see Canvas-managed trigger automations in Sketch without requiring a webhook or local cron fallback.

## Validation

- `pnpm biome check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Pre-push hook reran lint, typecheck, test, and build successfully.

## Migrations

No database migrations. The change reuses the existing `scheduled_tasks` schema and stores Canvas trigger metadata in existing workflow JSON fields.