### PR TITLE
Make tool progress operation specific

### DIFF
--- a/packages/server/src/agent/tool-progress.test.ts
+++ b/packages/server/src/agent/tool-progress.test.ts
@@ -3,8 +3,8 @@ import type { ProgressDisplaySettings } from "../progress-settings";
 import type { ProgressEvent } from "./runner";
 import { createProgressRenderer, getProgressTransportStrategy } from "./tool-progress";
 
-function renderEvents(settings: ProgressDisplaySettings, events: ProgressEvent[], random = () => 0) {
-  const renderer = createProgressRenderer(settings, random);
+function renderEvents(settings: ProgressDisplaySettings, events: ProgressEvent[]) {
+  const renderer = createProgressRenderer(settings);
   for (const event of events) {
     renderer.renderEvent(event);
   }
@@ -13,60 +13,19 @@ function renderEvents(settings: ProgressDisplaySettings, events: ProgressEvent[]
 
 describe("createProgressRenderer", () => {
   it("renders technical mode with clipped primary args", () => {
-    const longPath = `src/${"very-long-folder-name/".repeat(3)}index.ts`;
+    const longPath = `src/${"very-long-folder-name/".repeat(5)}index.ts`;
     const { lines } = renderEvents({ toolProgress: "technical", reasoningText: false }, [
       { kind: "tool_use", toolName: "Read", input: { file_path: longPath } },
     ]);
 
-    expect(lines).toEqual([`📖 Read: "${longPath.slice(0, 40)}..."`]);
-  });
-
-  it("renders verbose mode with intermediate text when reasoning text is enabled", () => {
-    const { lines } = renderEvents({ toolProgress: "verbose", reasoningText: true }, [
-      { kind: "intermediate_text", text: "Let me check the config" },
-      { kind: "tool_use", toolName: "Read", input: { file_path: "config.json", recursive: true } },
-    ]);
-
-    expect(lines).toEqual(["💬 Let me check the config", '📖 Read: {"file_path":"config.json","recursive":true}']);
+    expect(lines).toEqual([`📖 Read: "${longPath.slice(0, 80)}..."`]);
   });
 
   it("suppresses intermediate text when reasoning text is off", () => {
-    const { lines } = renderEvents({ toolProgress: "verbose", reasoningText: false }, [
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
       { kind: "intermediate_text", text: "Thinking..." },
     ]);
     expect(lines).toEqual([]);
-  });
-
-  it("reuses the same friendly line for consecutive identical tool calls and dedups the history", () => {
-    const { lines } = renderEvents(
-      { toolProgress: "friendly", reasoningText: false },
-      [
-        { kind: "tool_use", toolName: "Edit", input: {} },
-        { kind: "tool_use", toolName: "Edit", input: {} },
-        { kind: "tool_use", toolName: "Edit", input: {} },
-      ],
-      () => 0,
-    );
-
-    expect(lines).toEqual(["🔧 Tweaking things (x3)"]);
-  });
-
-  it("concise mode keeps only the latest tool line", () => {
-    const renderer = createProgressRenderer({ toolProgress: "concise", reasoningText: false }, () => 0);
-
-    renderer.renderEvent({ kind: "tool_use", toolName: "Read", input: {} });
-    expect(renderer.getLines()).toEqual(["📖 Flipping through some pages"]);
-
-    renderer.renderEvent({ kind: "tool_use", toolName: "Bash", input: {} });
-    expect(renderer.getLines()).toEqual(["🚀 Running commands"]);
-  });
-
-  it("concise mode replaces with reasoning text when enabled", () => {
-    const renderer = createProgressRenderer({ toolProgress: "concise", reasoningText: true }, () => 0);
-
-    renderer.renderEvent({ kind: "tool_use", toolName: "Read", input: {} });
-    renderer.renderEvent({ kind: "intermediate_text", text: "Checking config" });
-    expect(renderer.getLines()).toEqual(["💬 Checking config"]);
   });
 
   it("renders reasoning-only updates when tool progress is off", () => {
@@ -79,18 +38,101 @@ describe("createProgressRenderer", () => {
   it("renders nothing when both tool progress and reasoning text are off", () => {
     const { lines } = renderEvents({ toolProgress: "off", reasoningText: false }, [
       { kind: "intermediate_text", text: "Checking config" },
-      { kind: "tool_use", toolName: "Read", input: {} },
+      { kind: "tool_use", toolName: "Read", input: { file_path: "a.ts" } },
     ]);
     expect(lines).toEqual([]);
   });
 
-  it("uses the fallback friendly pool for unknown tools", () => {
-    const { lines } = renderEvents(
-      { toolProgress: "friendly", reasoningText: false },
-      [{ kind: "tool_use", toolName: "SomeMcpTool", input: {} }],
-      () => 0,
-    );
-    expect(lines).toEqual(["⚙️ Working on it"]);
+  it("renders friendly file operations with targets", () => {
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+      { kind: "tool_use", toolName: "Read", input: { file_path: "src/index.ts" } },
+      { kind: "tool_use", toolName: "Write", input: { file_path: "notes.md" } },
+      { kind: "tool_use", toolName: "Edit", input: { file_path: "src/index.ts" } },
+    ]);
+
+    expect(lines).toEqual(['📖 Reading "src/index.ts"', '✍️ Creating "notes.md"', '🔧 Editing "src/index.ts"']);
+  });
+
+  it("renders friendly search and shell operations with targets", () => {
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+      { kind: "tool_use", toolName: "Glob", input: { pattern: "**/*.ts" } },
+      { kind: "tool_use", toolName: "Grep", input: { pattern: "TOOL_PROGRESS_OPTIONS" } },
+      { kind: "tool_use", toolName: "Bash", input: { command: "pnpm test" } },
+    ]);
+
+    expect(lines).toEqual([
+      '📂 Finding files matching "**/*.ts"',
+      '🔎 Searching for "TOOL_PROGRESS_OPTIONS"',
+      '💻 Running "pnpm test"',
+    ]);
+  });
+
+  it("collapses repeated identical friendly operations", () => {
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+      { kind: "tool_use", toolName: "Edit", input: { file_path: "a.ts" } },
+      { kind: "tool_use", toolName: "Edit", input: { file_path: "a.ts" } },
+      { kind: "tool_use", toolName: "Edit", input: { file_path: "a.ts" } },
+    ]);
+
+    expect(lines).toEqual(['🔧 Editing "a.ts" (x3)']);
+  });
+
+  it("renders Canvas CLI Bash calls as Canvas actions in friendly mode", () => {
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+      {
+        kind: "tool_use",
+        toolName: "Bash",
+        input: {
+          command:
+            '$CANVAS_CLI direct-execute-action --component-key slack-send-message --configured-props \'{"text":"hi"}\' --output json',
+        },
+      },
+    ]);
+
+    expect(lines).toEqual(['🧩 Canvas action: "slack-send-message"']);
+  });
+
+  it("renders quoted Canvas CLI Bash calls as Canvas actions in technical mode", () => {
+    const { lines } = renderEvents({ toolProgress: "technical", reasoningText: false }, [
+      {
+        kind: "tool_use",
+        toolName: "Bash",
+        input: {
+          command:
+            "sh -c '\"$CANVAS_CLI\" direct-execute-action --component-key slack-send-message --output json' | jq .",
+        },
+      },
+    ]);
+
+    expect(lines).toEqual(['🧩 Canvas: "direct-execute-action slack-send-message"']);
+  });
+
+  it("renders Canvas web commands with the operation target", () => {
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+      {
+        kind: "tool_use",
+        toolName: "Bash",
+        input: {
+          command: '$CANVAS_CLI direct-execute-web-search --query "TypeScript best practices" --limit 5 --output json',
+        },
+      },
+    ]);
+
+    expect(lines).toEqual(['🧩 Canvas web search: "TypeScript best practices"']);
+  });
+
+  it("renders a clear fallback for unknown tools with safe available input", () => {
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+      { kind: "tool_use", toolName: "mcp__google_drive__list_files", input: { folder: "root" } },
+    ]);
+    expect(lines).toEqual(['⚙️ Using list_files: "root"']);
+  });
+
+  it("does not include unsafe fallback input fields", () => {
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+      { kind: "tool_use", toolName: "UnknownTool", input: { apiKey: "secret", message: "hello" } },
+    ]);
+    expect(lines).toEqual(["⚙️ Using UnknownTool"]);
   });
 
   it("strips the mcp__<server>__ prefix when picking the friendly pool", () => {
@@ -141,18 +183,13 @@ describe("createProgressRenderer", () => {
 });
 
 describe("getProgressTransportStrategy", () => {
-  it("returns replace only for concise", () => {
-    expect(getProgressTransportStrategy({ toolProgress: "concise", reasoningText: false })).toBe("replace");
-  });
-
   it("returns none when both settings disable live progress", () => {
     expect(getProgressTransportStrategy({ toolProgress: "off", reasoningText: false })).toBe("none");
   });
 
-  it("returns accumulate for reasoning-only and accumulate styles", () => {
+  it("returns accumulate for reasoning-only and enabled tool-progress modes", () => {
     expect(getProgressTransportStrategy({ toolProgress: "off", reasoningText: true })).toBe("accumulate");
     expect(getProgressTransportStrategy({ toolProgress: "friendly", reasoningText: false })).toBe("accumulate");
     expect(getProgressTransportStrategy({ toolProgress: "technical", reasoningText: true })).toBe("accumulate");
-    expect(getProgressTransportStrategy({ toolProgress: "verbose", reasoningText: false })).toBe("accumulate");
   });
 });

--- a/packages/server/src/agent/tool-progress.test.ts
+++ b/packages/server/src/agent/tool-progress.test.ts
@@ -18,7 +18,7 @@ describe("createProgressRenderer", () => {
       { kind: "tool_use", toolName: "Read", input: { file_path: longPath } },
     ]);
 
-    expect(lines).toEqual([`📖 Read: "${longPath.slice(0, 80)}..."`]);
+    expect(lines).toEqual([`📖 Read: "${longPath.slice(0, 40)}..."`]);
   });
 
   it("suppresses intermediate text when reasoning text is off", () => {
@@ -44,27 +44,48 @@ describe("createProgressRenderer", () => {
   });
 
   it("renders friendly file operations with targets", () => {
+    expect(
+      renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+        { kind: "tool_use", toolName: "Read", input: { file_path: "src/index.ts" } },
+      ]).lines,
+    ).toEqual(['📖 Reading "src/index.ts"']);
+    expect(
+      renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+        { kind: "tool_use", toolName: "Write", input: { file_path: "notes.md" } },
+      ]).lines,
+    ).toEqual(['✍️ Creating "notes.md"']);
+    expect(
+      renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+        { kind: "tool_use", toolName: "Edit", input: { file_path: "src/index.ts" } },
+      ]).lines,
+    ).toEqual(['🔧 Editing "src/index.ts"']);
+  });
+
+  it("replaces the previous friendly line with the latest operation", () => {
     const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
       { kind: "tool_use", toolName: "Read", input: { file_path: "src/index.ts" } },
-      { kind: "tool_use", toolName: "Write", input: { file_path: "notes.md" } },
       { kind: "tool_use", toolName: "Edit", input: { file_path: "src/index.ts" } },
     ]);
 
-    expect(lines).toEqual(['📖 Reading "src/index.ts"', '✍️ Creating "notes.md"', '🔧 Editing "src/index.ts"']);
+    expect(lines).toEqual(['🔧 Editing "src/index.ts"']);
   });
 
   it("renders friendly search and shell operations with targets", () => {
-    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
-      { kind: "tool_use", toolName: "Glob", input: { pattern: "**/*.ts" } },
-      { kind: "tool_use", toolName: "Grep", input: { pattern: "TOOL_PROGRESS_OPTIONS" } },
-      { kind: "tool_use", toolName: "Bash", input: { command: "pnpm test" } },
-    ]);
-
-    expect(lines).toEqual([
-      '📂 Finding files matching "**/*.ts"',
-      '🔎 Searching for "TOOL_PROGRESS_OPTIONS"',
-      '💻 Running "pnpm test"',
-    ]);
+    expect(
+      renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+        { kind: "tool_use", toolName: "Glob", input: { pattern: "**/*.ts" } },
+      ]).lines,
+    ).toEqual(['📂 Finding files matching "**/*.ts"']);
+    expect(
+      renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+        { kind: "tool_use", toolName: "Grep", input: { pattern: "TOOL_PROGRESS_OPTIONS" } },
+      ]).lines,
+    ).toEqual(['🔎 Searching for "TOOL_PROGRESS_OPTIONS"']);
+    expect(
+      renderEvents({ toolProgress: "friendly", reasoningText: false }, [
+        { kind: "tool_use", toolName: "Bash", input: { command: "pnpm test" } },
+      ]).lines,
+    ).toEqual(['💻 Running "pnpm test"']);
   });
 
   it("collapses repeated identical friendly operations", () => {
@@ -135,50 +156,18 @@ describe("createProgressRenderer", () => {
     expect(lines).toEqual(["⚙️ Using UnknownTool"]);
   });
 
-  it("strips the mcp__<server>__ prefix when picking the friendly pool", () => {
-    const { lines } = renderEvents(
-      { toolProgress: "friendly", reasoningText: false },
-      [{ kind: "tool_use", toolName: "mcp__sketch__SendFileToChat", input: { file_path: "a.ts" } }],
-      () => 0,
-    );
-    expect(lines).toEqual(["📦 Wrapping up a file for you"]);
-  });
-
-  it("strips the mcp__<server>__ prefix in technical mode and renders the bare name with primary arg", () => {
+  it("strips the mcp__<server>__ prefix in technical output", () => {
     const { lines } = renderEvents({ toolProgress: "technical", reasoningText: false }, [
       { kind: "tool_use", toolName: "mcp__sketch__SendFileToChat", input: { file_path: "a.ts" } },
     ]);
     expect(lines).toEqual(['📎 SendFileToChat: "a.ts"']);
-  });
-
-  it("strips the mcp__<server>__ prefix in verbose mode and renders the bare name with full input", () => {
-    const { lines } = renderEvents({ toolProgress: "verbose", reasoningText: false }, [
-      { kind: "tool_use", toolName: "mcp__sketch__SendFileToChat", input: { file_path: "a.ts" } },
-    ]);
-    expect(lines).toEqual(['📎 SendFileToChat: {"file_path":"a.ts"}']);
   });
 
   it("strips the mcp__<server>__ prefix when the server segment contains underscores", () => {
-    const { lines } = renderEvents({ toolProgress: "technical", reasoningText: false }, [
+    const { lines } = renderEvents({ toolProgress: "friendly", reasoningText: false }, [
       { kind: "tool_use", toolName: "mcp__plugin_pipedream__SendFileToChat", input: { file_path: "a.ts" } },
     ]);
-    expect(lines).toEqual(['📎 SendFileToChat: "a.ts"']);
-  });
-
-  it("strips the mcp__<server>__ prefix only up to the first __ so underscores in the tool name survive", () => {
-    const { lines } = renderEvents({ toolProgress: "verbose", reasoningText: false }, [
-      { kind: "tool_use", toolName: "mcp__google_drive__list_files", input: { folder: "root" } },
-    ]);
-    expect(lines).toEqual(['⚙️ list_files: {"folder":"root"}']);
-  });
-
-  it("strips the mcp__<server>__ prefix in friendly mode for an underscored server", () => {
-    const { lines } = renderEvents(
-      { toolProgress: "friendly", reasoningText: false },
-      [{ kind: "tool_use", toolName: "mcp__plugin_pipedream__SendFileToChat", input: {} }],
-      () => 0,
-    );
-    expect(lines).toEqual(["📦 Wrapping up a file for you"]);
+    expect(lines).toEqual(['📎 Sending file "a.ts"']);
   });
 });
 
@@ -187,9 +176,9 @@ describe("getProgressTransportStrategy", () => {
     expect(getProgressTransportStrategy({ toolProgress: "off", reasoningText: false })).toBe("none");
   });
 
-  it("returns accumulate for reasoning-only and enabled tool-progress modes", () => {
-    expect(getProgressTransportStrategy({ toolProgress: "off", reasoningText: true })).toBe("accumulate");
-    expect(getProgressTransportStrategy({ toolProgress: "friendly", reasoningText: false })).toBe("accumulate");
-    expect(getProgressTransportStrategy({ toolProgress: "technical", reasoningText: true })).toBe("accumulate");
+  it("returns replace for enabled live progress modes", () => {
+    expect(getProgressTransportStrategy({ toolProgress: "off", reasoningText: true })).toBe("replace");
+    expect(getProgressTransportStrategy({ toolProgress: "friendly", reasoningText: false })).toBe("replace");
+    expect(getProgressTransportStrategy({ toolProgress: "technical", reasoningText: true })).toBe("replace");
   });
 });

--- a/packages/server/src/agent/tool-progress.ts
+++ b/packages/server/src/agent/tool-progress.ts
@@ -6,6 +6,17 @@ export interface ProgressRenderer {
   getLines(): string[];
 }
 
+interface FriendlyTargetLine {
+  prefix: string;
+  keys: string[];
+  fallback: string;
+}
+
+interface CanvasInvocation {
+  subcommand: string | null;
+  target: string | null;
+}
+
 const TOOL_EMOJI: Record<string, string> = {
   Read: "📖",
   Write: "✍️",
@@ -13,6 +24,8 @@ const TOOL_EMOJI: Record<string, string> = {
   Bash: "💻",
   Glob: "📂",
   Grep: "🔎",
+  WebSearch: "🌐",
+  WebFetch: "🌐",
   Skill: "📚",
   SendFileToChat: "📎",
   ManageScheduledTasks: "⏰",
@@ -29,146 +42,200 @@ const PRIMARY_ARG: Record<string, string> = {
   Bash: "command",
   Glob: "pattern",
   Grep: "pattern",
+  WebSearch: "query",
+  WebFetch: "url",
   Skill: "skill",
   SendFileToChat: "file_path",
   ManageScheduledTasks: "action",
   SearchEntities: "queries",
 };
 
+const EXTRA_FALLBACK_ARG_KEYS = ["path", "folder"];
+const SAFE_FALLBACK_ARG_KEYS = [
+  ...new Set([...Object.values(PRIMARY_ARG).filter((key) => key !== "command"), ...EXTRA_FALLBACK_ARG_KEYS]),
+];
 const MAX_ARG_LENGTH = 40;
 
-const FRIENDLY_MESSAGES: Record<string, string[]> = {
-  Read: ["📖 Flipping through some pages", "📖 Digging into the files", "📖 Scanning the code", "📖 Having a read"],
-  Write: ["✨ Creating something new", "📝 Drafting a new file", "🛠️ Building from scratch"],
-  Edit: [
-    "🔧 Tweaking things",
-    "✂️ Making some cuts",
-    "🪚 Fixing things up",
-    "🎯 Nailing the fix",
-    "🧩 Putting pieces together",
-  ],
-  Bash: ["🚀 Running commands", "⚡ Crunching away", "🖥️ Talking to the machine", "🔥 Firing things up"],
-  Glob: ["🔍 Hunting for files", "🗺️ Exploring the codebase", "📂 Sifting through folders"],
-  Grep: ["🕵️ On the hunt", "🔎 Searching high and low", "🎪 Looking for clues"],
-  Skill: ["📚 Loading a new trick", "🎓 Brushing up on skills", "🎒 Packing the toolkit"],
-  SendFileToChat: ["📦 Wrapping up a file for you", "🎁 Sending something your way", "📎 Getting that ready for you"],
-  ManageScheduledTasks: ["⏰ Setting up schedules", "📅 Marking the calendar", "🕰️ Planning ahead"],
-  SearchEntities: ["🕵️ Looking things up", "🌐 Scanning the knowledge base", "🔭 Searching far and wide"],
-  GetEntityContext: ["🧠 Gathering some context", "📋 Getting the full picture", "🪞 Pulling up the details"],
-  Fallback: [
-    "⚙️ Working on it",
-    "🧙 Cooking something up",
-    "🔮 Consulting the magic ball",
-    "🤖 Beep boop, working on it",
-  ],
+const FRIENDLY_TARGET_LINES: Record<string, FriendlyTargetLine> = {
+  Read: { prefix: "Reading", keys: ["file_path"], fallback: "Reading a file" },
+  Write: { prefix: "Creating", keys: ["file_path"], fallback: "Creating a file" },
+  Edit: { prefix: "Editing", keys: ["file_path"], fallback: "Editing a file" },
+  Glob: { prefix: "Finding files matching", keys: ["pattern"], fallback: "Finding files" },
+  Grep: { prefix: "Searching for", keys: ["pattern"], fallback: "Searching files" },
+  WebSearch: { prefix: "Searching the web for", keys: ["query"], fallback: "Searching the web" },
+  WebFetch: { prefix: "Fetching", keys: ["url"], fallback: "Fetching a web page" },
+  Skill: { prefix: "Loading skill", keys: ["skill", "name"], fallback: "Loading a skill" },
+  SendFileToChat: { prefix: "Sending file", keys: ["file_path"], fallback: "Sending a file" },
+  ManageScheduledTasks: {
+    prefix: "Managing scheduled tasks:",
+    keys: ["action"],
+    fallback: "Managing scheduled tasks",
+  },
+  SearchEntities: { prefix: "Searching entities for", keys: ["queries"], fallback: "Searching entities" },
+};
+
+const FRIENDLY_STATIC_LINES: Record<string, string> = {
+  GetEntityContext: "Getting entity context",
+};
+
+const CANVAS_FRIENDLY_TARGET_PREFIX: Record<string, string> = {
+  "direct-execute-action": "Canvas action:",
+  "direct-execute-web-search": "Canvas web search:",
+  "direct-execute-web-scrape": "Canvas web scrape:",
+};
+
+const CANVAS_FRIENDLY_FALLBACK: Record<string, string> = {
+  "direct-execute-action": "Running Canvas action",
+  "direct-execute-web-search": "Searching the web with Canvas",
+  "direct-execute-web-scrape": "Scraping a web page with Canvas",
 };
 
 function stripMcpPrefix(toolName: string): string {
   return toolName.replace(/^mcp__.+?__/, "");
 }
 
+function stringifyValue(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string") return value.trim() ? value : null;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    const parts = value.map((entry) => stringifyValue(entry)).filter((entry): entry is string => Boolean(entry));
+    return parts.length > 0 ? parts.join(", ") : null;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function quoteValue(value: string): string {
+  const chars = Array.from(value);
+  const clipped = chars.length > MAX_ARG_LENGTH ? `${chars.slice(0, MAX_ARG_LENGTH).join("")}...` : value;
+  return JSON.stringify(clipped);
+}
+
+function findInputValue(input: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = stringifyValue(input[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function findFallbackInputValue(input: Record<string, unknown>): string | null {
+  return findInputValue(input, SAFE_FALLBACK_ARG_KEYS);
+}
+
+function findCanvasFlag(command: string, flags: string[]): string | null {
+  for (const flag of flags) {
+    const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = command.match(new RegExp(`${escaped}(?:=|\\s+)(?:"([^"]*)"|'([^']*)'|([^\\s|;&]+))`));
+    const value = match?.[1] ?? match?.[2] ?? match?.[3];
+    if (value) return value;
+  }
+  return null;
+}
+
+function parseCanvasInvocation(command: string): CanvasInvocation | null {
+  if (!/\$\{?CANVAS_CLI\}?/.test(command)) return null;
+
+  const normalized = command.replace(/["']?\$\{?CANVAS_CLI\}?["']?/g, "$CANVAS_CLI");
+  const afterCli = normalized.match(/\$CANVAS_CLI\s+([\s\S]+)/)?.[1] ?? "";
+  const segment = afterCli.split(/[|;&\n]/)[0]?.trim() ?? "";
+  const subcommand = segment.match(/^([^\s]+)/)?.[1] ?? null;
+  const target = findCanvasFlag(segment, [
+    "--component-key",
+    "--componentKey",
+    "--query",
+    "--queries",
+    "--q",
+    "--url",
+    "--apps",
+    "--key",
+    "--field-name",
+    "--fieldName",
+    "--search-query",
+    "--searchQuery",
+  ]);
+
+  return subcommand || target ? { subcommand, target } : { subcommand: null, target: null };
+}
+
+function getCanvasFriendlyLine(invocation: CanvasInvocation): string {
+  const target = invocation.target ? quoteValue(invocation.target) : null;
+  if (!invocation.subcommand) return "🧩 Running Canvas";
+
+  const prefix = CANVAS_FRIENDLY_TARGET_PREFIX[invocation.subcommand] ?? `Canvas ${invocation.subcommand}:`;
+  const fallback = CANVAS_FRIENDLY_FALLBACK[invocation.subcommand] ?? `Canvas ${invocation.subcommand}`;
+  return target ? `🧩 ${prefix} ${target}` : `🧩 ${fallback}`;
+}
+
+function getCanvasTechnicalLine(invocation: CanvasInvocation): string {
+  if (!invocation.subcommand) return "🧩 Canvas...";
+  const target = invocation.target ? `${invocation.subcommand} ${invocation.target}` : invocation.subcommand;
+  return `🧩 Canvas: ${quoteValue(target)}`;
+}
+
 function buildTechnicalLine(toolName: string, input: Record<string, unknown>): string {
   const display = stripMcpPrefix(toolName);
   const emoji = TOOL_EMOJI[display] ?? FALLBACK_EMOJI;
-  const argKey = PRIMARY_ARG[display];
 
-  if (argKey) {
-    const rawValue = input[argKey];
-    if (rawValue != null) {
-      const raw = typeof rawValue === "string" ? rawValue : JSON.stringify(rawValue);
-      const clipped = raw.length > MAX_ARG_LENGTH ? `${raw.slice(0, MAX_ARG_LENGTH)}...` : raw;
-      return `${emoji} ${display}: "${clipped}"`;
-    }
+  if (display === "Bash") {
+    const command = findInputValue(input, ["command"]);
+    const canvasInvocation = command ? parseCanvasInvocation(command) : null;
+    if (canvasInvocation) return getCanvasTechnicalLine(canvasInvocation);
   }
 
-  return `${emoji} ${display}...`;
+  const argKey = PRIMARY_ARG[display];
+  const rawValue = argKey ? stringifyValue(input[argKey]) : findFallbackInputValue(input);
+  return rawValue ? `${emoji} ${display}: ${quoteValue(rawValue)}` : `${emoji} ${display}...`;
 }
 
-function buildVerboseLine(toolName: string, input: Record<string, unknown>): string {
+function getFriendlyLine(toolName: string, input: Record<string, unknown>): string {
   const display = stripMcpPrefix(toolName);
   const emoji = TOOL_EMOJI[display] ?? FALLBACK_EMOJI;
-  return Object.keys(input).length > 0 ? `${emoji} ${display}: ${JSON.stringify(input)}` : `${emoji} ${display}`;
-}
 
-function dedup(lines: string[]): string[] {
-  if (lines.length < 2) return [...lines];
-
-  const result = [...lines];
-  const last = result[result.length - 1];
-  if (!last) return result;
-
-  let runStart = result.length - 2;
-  while (runStart >= 0) {
-    const entry = result[runStart];
-    if (!entry) break;
-    const counterMatch = entry.match(/^(.*) \(x(\d+)\)$/);
-    const base = counterMatch ? counterMatch[1] : entry;
-    if (base === last) {
-      runStart--;
-    } else {
-      break;
-    }
-  }
-  runStart++;
-
-  const runLength = result.length - runStart;
-  if (runLength < 2) return result;
-
-  let totalCount = 0;
-  for (let i = runStart; i < result.length; i++) {
-    const entry = result[i];
-    if (!entry) continue;
-    const counterMatch = entry.match(/^(.*) \(x(\d+)\)$/);
-    totalCount += counterMatch ? Number(counterMatch[2]) : 1;
+  if (display === "Bash") {
+    const command = findInputValue(input, ["command"]);
+    const canvasInvocation = command ? parseCanvasInvocation(command) : null;
+    if (canvasInvocation) return getCanvasFriendlyLine(canvasInvocation);
+    return command ? `${emoji} Running ${quoteValue(command)}` : `${emoji} Running a shell command`;
   }
 
-  result.splice(runStart, runLength, `${last} (x${totalCount})`);
-  return result;
-}
+  const targetLine = FRIENDLY_TARGET_LINES[display];
+  if (targetLine) {
+    const value = findInputValue(input, targetLine.keys);
+    return value ? `${emoji} ${targetLine.prefix} ${quoteValue(value)}` : `${emoji} ${targetLine.fallback}`;
+  }
 
-function getFriendlyPool(toolName: string): string[] {
-  return FRIENDLY_MESSAGES[stripMcpPrefix(toolName)] ?? FRIENDLY_MESSAGES.Fallback;
-}
+  const staticLine = FRIENDLY_STATIC_LINES[display];
+  if (staticLine) {
+    return `${emoji} ${staticLine}`;
+  }
 
-function pickFriendlyLine(toolName: string, random: () => number): string {
-  const pool = getFriendlyPool(toolName);
-  const index = Math.floor(random() * pool.length);
-  return pool[index] ?? pool[0] ?? `${FALLBACK_EMOJI} Working on it`;
+  const fallback = findFallbackInputValue(input);
+  return fallback ? `${emoji} Using ${display}: ${quoteValue(fallback)}` : `${emoji} Using ${display}`;
 }
 
 export function getProgressTransportStrategy(settings: ProgressDisplaySettings): "accumulate" | "replace" | "none" {
-  if (settings.toolProgress === "concise") return "replace";
   if (settings.toolProgress === "off" && !settings.reasoningText) return "none";
-  return "accumulate";
+  return "replace";
 }
 
-export function createProgressRenderer(
-  settings: ProgressDisplaySettings,
-  random: () => number = Math.random,
-): ProgressRenderer {
+export function createProgressRenderer(settings: ProgressDisplaySettings): ProgressRenderer {
   const lines: string[] = [];
-  let lastFriendlyToolName: string | null = null;
-  let lastFriendlyLine: string | null = null;
-
-  const getFriendlyLine = (toolName: string) => {
-    if (toolName === lastFriendlyToolName && lastFriendlyLine) {
-      return lastFriendlyLine;
-    }
-
-    const line = pickFriendlyLine(toolName, random);
-    lastFriendlyToolName = toolName;
-    lastFriendlyLine = line;
-    return line;
-  };
-
-  const appendAccumulateLine = (line: string) => {
-    lines.push(line);
-    const deduped = dedup(lines);
-    lines.splice(0, lines.length, ...deduped);
-  };
+  let lastLine: string | null = null;
+  let repeatCount = 0;
 
   const replaceLine = (line: string) => {
     lines.splice(0, lines.length, line);
+  };
+
+  const appendAccumulateLine = (line: string) => {
+    repeatCount = line === lastLine ? repeatCount + 1 : 1;
+    lastLine = line;
+    replaceLine(repeatCount > 1 ? `${line} (x${repeatCount})` : line);
   };
 
   return {
@@ -176,10 +243,6 @@ export function createProgressRenderer(
       if (event.kind === "intermediate_text") {
         if (!settings.reasoningText) return;
         const line = `💬 ${event.text}`;
-        if (settings.toolProgress === "concise") {
-          replaceLine(line);
-          return;
-        }
         appendAccumulateLine(line);
         return;
       }
@@ -191,17 +254,7 @@ export function createProgressRenderer(
         return;
       }
 
-      if (settings.toolProgress === "verbose") {
-        appendAccumulateLine(buildVerboseLine(event.toolName, event.input));
-        return;
-      }
-
-      const friendlyLine = getFriendlyLine(event.toolName);
-      if (settings.toolProgress === "concise") {
-        replaceLine(friendlyLine);
-        return;
-      }
-
+      const friendlyLine = getFriendlyLine(event.toolName, event.input);
       appendAccumulateLine(friendlyLine);
     },
 

--- a/packages/server/src/commands.test.ts
+++ b/packages/server/src/commands.test.ts
@@ -42,9 +42,7 @@ describe("parseSketchCommand", () => {
   it("detects /toolprogress with all supported values", () => {
     expect(parseSketchCommand("/toolprogress off")).toBe("tool_progress_off");
     expect(parseSketchCommand("/toolprogress friendly")).toBe("tool_progress_friendly");
-    expect(parseSketchCommand("/toolprogress concise")).toBe("tool_progress_concise");
     expect(parseSketchCommand("/toolprogress technical")).toBe("tool_progress_technical");
-    expect(parseSketchCommand("/toolprogress verbose")).toBe("tool_progress_verbose");
   });
 
   it("treats /toolprogress without args as query", () => {
@@ -91,7 +89,7 @@ describe("getNewSessionConfirmation", () => {
 
 describe("tool progress helpers", () => {
   it("formats the set confirmation", () => {
-    expect(getToolProgressConfirmation("verbose", false)).toBe("🔍 Tool progress set to verbose.");
+    expect(getToolProgressConfirmation("technical", false)).toBe("🛠️ Tool progress set to technical.");
   });
 
   it("mentions live reasoning when turning tool progress off", () => {
@@ -102,7 +100,7 @@ describe("tool progress helpers", () => {
 
   it("formats the current settings message", () => {
     expect(getToolProgressCurrent({ toolProgress: "friendly", reasoningText: false })).toBe(
-      "🛠️ Tool progress: friendly. 🧠 Reasoning text: off.\nUse /toolprogress off|friendly|concise|technical|verbose",
+      "🛠️ Tool progress: friendly. 🧠 Reasoning text: off.\nUse /toolprogress off|friendly|technical",
     );
   });
 
@@ -119,8 +117,8 @@ describe("reasoning text helpers", () => {
   });
 
   it("formats the current settings message", () => {
-    expect(getReasoningTextCurrent({ toolProgress: "concise", reasoningText: true })).toBe(
-      "🧠 Reasoning text: on. 🛠️ Tool progress: concise.\nUse /reasoningtext on|off",
+    expect(getReasoningTextCurrent({ toolProgress: "friendly", reasoningText: true })).toBe(
+      "🧠 Reasoning text: on. 🛠️ Tool progress: friendly.\nUse /reasoningtext on|off",
     );
   });
 });

--- a/packages/server/src/commands.ts
+++ b/packages/server/src/commands.ts
@@ -25,9 +25,7 @@ export const REASONING_TEXT_OPTIONS = ["on", "off"] as const;
 export const TOOL_PROGRESS_LABELS: Record<ToolProgressCommand, string> = {
   off: "Off",
   friendly: "Friendly",
-  concise: "Concise",
   technical: "Technical",
-  verbose: "Verbose",
 };
 
 export const REASONING_TEXT_LABELS: Record<ReasoningTextCommand, string> = {

--- a/packages/server/src/commands.ts
+++ b/packages/server/src/commands.ts
@@ -1,13 +1,11 @@
-export type ToolProgressCommand = "off" | "friendly" | "concise" | "technical" | "verbose";
+export type ToolProgressCommand = "off" | "friendly" | "technical";
 export type ReasoningTextCommand = "on" | "off";
 
 export type SketchCommand =
   | "new_session"
   | "tool_progress_off"
   | "tool_progress_friendly"
-  | "tool_progress_concise"
   | "tool_progress_technical"
-  | "tool_progress_verbose"
   | "tool_progress_query"
   | "reasoning_text_on"
   | "reasoning_text_off"
@@ -21,7 +19,7 @@ export const NEW_SESSION_CONFIRMATIONS = [
   "New conversation started. 💬",
 ] as const;
 
-export const TOOL_PROGRESS_OPTIONS = ["off", "friendly", "concise", "technical", "verbose"] as const;
+export const TOOL_PROGRESS_OPTIONS = ["off", "friendly", "technical"] as const;
 export const REASONING_TEXT_OPTIONS = ["on", "off"] as const;
 
 export const TOOL_PROGRESS_LABELS: Record<ToolProgressCommand, string> = {
@@ -82,12 +80,8 @@ export function getToolProgressConfirmation(style: ToolProgressCommand, reasonin
         : "🛑 Tool progress turned off.";
     case "friendly":
       return "🪄 Tool progress set to friendly.";
-    case "concise":
-      return "🎯 Tool progress set to concise.";
     case "technical":
       return "🛠️ Tool progress set to technical.";
-    case "verbose":
-      return "🔍 Tool progress set to verbose.";
   }
 }
 

--- a/packages/server/src/db/repositories/channels.test.ts
+++ b/packages/server/src/db/repositories/channels.test.ts
@@ -79,8 +79,8 @@ describe("findById()", () => {
 describe("update()", () => {
   it("updates tool_progress and reasoning_text", async () => {
     const created = await channels.create({ slackChannelId: "C007", name: "ops", type: "public_channel" });
-    const updated = await channels.update(created.id, { toolProgress: "verbose", reasoningText: true });
-    expect(updated.tool_progress).toBe("verbose");
+    const updated = await channels.update(created.id, { toolProgress: "technical", reasoningText: true });
+    expect(updated.tool_progress).toBe("technical");
     expect(updated.reasoning_text).toBe(1);
     expect(updated.name).toBe("ops");
   });

--- a/packages/server/src/db/repositories/users.test.ts
+++ b/packages/server/src/db/repositories/users.test.ts
@@ -232,8 +232,8 @@ describe("update()", () => {
 
   it("updates tool_progress and reasoning_text", async () => {
     const created = await users.create({ name: "Jules", slackUserId: "U017" });
-    const updated = await users.update(created.id, { toolProgress: "concise", reasoningText: true });
-    expect(updated.tool_progress).toBe("concise");
+    const updated = await users.update(created.id, { toolProgress: "technical", reasoningText: true });
+    expect(updated.tool_progress).toBe("technical");
     expect(updated.reasoning_text).toBe(1);
   });
 });

--- a/packages/server/src/db/repositories/whatsapp-groups.test.ts
+++ b/packages/server/src/db/repositories/whatsapp-groups.test.ts
@@ -73,9 +73,9 @@ describe("createWhatsAppGroupRepository", () => {
       updated_at: "2026-03-13T10:00:00.000Z",
     });
 
-    const updated = await repo.updateProgressSettings("123@g.us", { toolProgress: "concise", reasoningText: true });
+    const updated = await repo.updateProgressSettings("123@g.us", { toolProgress: "technical", reasoningText: true });
 
-    expect(updated?.tool_progress).toBe("concise");
+    expect(updated?.tool_progress).toBe("technical");
     expect(updated?.reasoning_text).toBe(1);
     expect(updated?.name).toBe("Founders");
   });

--- a/packages/server/src/progress-settings.test.ts
+++ b/packages/server/src/progress-settings.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveToolProgress } from "./progress-settings";
+
+describe("resolveToolProgress", () => {
+  it("keeps supported values", () => {
+    expect(resolveToolProgress("off")).toBe("off");
+    expect(resolveToolProgress("friendly")).toBe("friendly");
+    expect(resolveToolProgress("technical")).toBe("technical");
+  });
+
+  it("resolves unsupported stored values to the safe default", () => {
+    expect(resolveToolProgress("concise")).toBe("friendly");
+    expect(resolveToolProgress("verbose")).toBe("friendly");
+    expect(resolveToolProgress(null)).toBe("friendly");
+  });
+});

--- a/packages/server/src/slack/adapter.test.ts
+++ b/packages/server/src/slack/adapter.test.ts
@@ -435,12 +435,12 @@ describe("slack/adapter", () => {
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
       const { dm } = getHandlers();
 
-      await dm({ text: "/toolprogress concise", userId: "S1", channelId: "D1", ts: "1", type: "dm" });
+      await dm({ text: "/toolprogress technical", userId: "S1", channelId: "D1", ts: "1", type: "dm" });
       await flush();
 
-      expect(deps.repos.users.update).toHaveBeenCalledWith("u1", { toolProgress: "concise" });
+      expect(deps.repos.users.update).toHaveBeenCalledWith("u1", { toolProgress: "technical" });
       expect(deps.runAgent).not.toHaveBeenCalled();
-      expect(mockBotInstance.postMessage).toHaveBeenCalledWith("D1", "🎯 Tool progress set to concise.");
+      expect(mockBotInstance.postMessage).toHaveBeenCalledWith("D1", "🛠️ Tool progress set to technical.");
     });
 
     it("injects inbox messages into DM context and marks them consumed after success", async () => {
@@ -598,7 +598,7 @@ describe("slack/adapter", () => {
       expect(mockBotInstance.postThreadReply).toHaveBeenCalledWith(
         "C1",
         "1",
-        "🛠️ Tool progress: technical. 🧠 Reasoning text: off.\nUse /toolprogress off|friendly|concise|technical|verbose",
+        "🛠️ Tool progress: technical. 🧠 Reasoning text: off.\nUse /toolprogress off|friendly|technical",
       );
     });
   });
@@ -791,7 +791,6 @@ describe("slack/adapter", () => {
       expect(mockBotInstance.setAssistantStatus).toHaveBeenCalledWith("C1", "1", "💭 Thinking…");
       expect(mockBotInstance.setAssistantStatus).toHaveBeenLastCalledWith("C1", "1", "");
     });
-
     it("applies bound agent overlay when channel.agent_user_id is set", async () => {
       const baseDeps = makeDeps();
       const agentUser = makeUser({
@@ -924,7 +923,7 @@ describe("slack/adapter", () => {
         await dm({ text: "hi", userId: "S1", channelId: "D1", ts: "1", threadTs: "t1", type: "dm" });
         await flush();
 
-        expect(mockBotInstance.setAssistantStatus).toHaveBeenCalledWith("D1", "t1", "📖 Flipping through some pages");
+        expect(mockBotInstance.setAssistantStatus).toHaveBeenCalledWith("D1", "t1", '📖 Reading "a.ts"');
       } finally {
         randomSpy.mockRestore();
       }

--- a/packages/server/src/slack/home.test.ts
+++ b/packages/server/src/slack/home.test.ts
@@ -60,14 +60,14 @@ describe("buildHomeView", () => {
   });
 
   it("wires the tool-progress select with the right action_id, options, and initial value", () => {
-    const view = buildHomeView({ ...baseParams, toolProgress: "concise" });
+    const view = buildHomeView({ ...baseParams, toolProgress: "technical" });
     const select = getSelect(findActionsBlock(view, "home_tool_progress_actions"));
 
     expect(select.type).toBe("static_select");
     expect(select.action_id).toBe(HOME_ACTION_TOOL_PROGRESS);
     expect(select.options.map((o) => o.value)).toEqual([...TOOL_PROGRESS_OPTIONS]);
-    expect(select.initial_option.value).toBe("concise");
-    expect(select.initial_option.text.text).toBe("Concise");
+    expect(select.initial_option.value).toBe("technical");
+    expect(select.initial_option.text.text).toBe("Technical");
   });
 
   it("wires the reasoning-text select with the right action_id, options, and initial value", () => {

--- a/packages/server/src/whatsapp/adapter.test.ts
+++ b/packages/server/src/whatsapp/adapter.test.ts
@@ -537,7 +537,7 @@ describe("whatsapp/adapter", () => {
 
       await handler({
         type: "dm",
-        text: "/toolprogress verbose",
+        text: "/toolprogress technical",
         jid: "1234@s.whatsapp.net",
         messageId: "m1",
         pushName: "Alice",
@@ -546,9 +546,9 @@ describe("whatsapp/adapter", () => {
       });
       await flush();
 
-      expect(deps.repos.users.update).toHaveBeenCalledWith("u1", { toolProgress: "verbose" });
+      expect(deps.repos.users.update).toHaveBeenCalledWith("u1", { toolProgress: "technical" });
       expect(deps.runAgent).not.toHaveBeenCalled();
-      expect(mock.sendText).toHaveBeenCalledWith("1234567890@s.whatsapp.net", "🔍 Tool progress set to verbose.");
+      expect(mock.sendText).toHaveBeenCalledWith("1234567890@s.whatsapp.net", "🛠️ Tool progress set to technical.");
     });
 
     it("injects inbox messages into DM context and marks them consumed after success", async () => {

--- a/packages/server/src/whatsapp/progress-transport.test.ts
+++ b/packages/server/src/whatsapp/progress-transport.test.ts
@@ -99,7 +99,7 @@ describe("createWhatsAppProgressTransport", () => {
     }
   });
 
-  it("replaces the latest concise status in place", async () => {
+  it("replaces the latest status in place", async () => {
     const bot = createMockWhatsApp();
     const transport = createWhatsAppProgressTransport(bot, "jid", "replace");
 
@@ -116,17 +116,17 @@ describe("createWhatsAppProgressTransport", () => {
     const bot = createMockWhatsApp();
     const transport = createWhatsAppProgressTransport(bot, "jid", "accumulate");
 
-    await transport.syncLines(["🔧 Tweaking things"]);
-    await transport.syncLines(["🔧 Tweaking things (x2)"]);
+    await transport.syncLines(['🔧 Editing "a.ts"']);
+    await transport.syncLines(['🔧 Editing "a.ts" (x2)']);
     await vi.advanceTimersByTimeAsync(1_500);
     await transport.flush();
 
     expect(bot.sendText).toHaveBeenCalledTimes(1);
-    expect(bot.sendText).toHaveBeenCalledWith("jid", "🔧 Tweaking things", undefined);
+    expect(bot.sendText).toHaveBeenCalledWith("jid", '🔧 Editing "a.ts"', undefined);
     expect(bot.editText).toHaveBeenCalledWith(
       "jid",
       { remoteJid: "jid", id: "sent-1", fromMe: true },
-      "🔧 Tweaking things (x2)",
+      '🔧 Editing "a.ts" (x2)',
     );
   });
 });


### PR DESCRIPTION
## What

Make tool progress friendlier and more specific while reducing supported progress modes to `off`, `friendly`, and `technical`.

This updates the shared progress renderer so friendly mode reports the actual operation target where available, including file reads/writes/edits, search patterns, shell commands, known Sketch tools, and Canvas CLI activity.

## Why

The previous friendly mode used randomized generic messages, which made live progress less useful. Users could not tell whether Sketch was reading a file, editing a file, searching, running Bash, or calling an integration.

## Notes

- Unsupported stored values such as `concise` and `verbose` resolve to the safe default.
- `$CANVAS_CLI` Bash invocations render as Canvas-specific progress instead of generic Bash progress.
- Unknown tools strip MCP prefixes and show only safe, common input targets when available.
- Slack and WhatsApp continue to use the same shared renderer path.

## Verification

- `pnpm biome check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
