### PR TITLE
fix: stabilize dialog layout

### DIFF
--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -48,7 +48,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className,
         )}
         {...props}

--- a/packages/web/src/components/team/add-member-dialog.tsx
+++ b/packages/web/src/components/team/add-member-dialog.tsx
@@ -144,7 +144,7 @@ export function AddMemberDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
+        <div className="max-h-[50vh] space-y-4 overflow-y-auto py-2 pr-1">
           <div className="flex rounded-md border border-border">
             <button
               type="button"

--- a/packages/web/src/components/team/edit-member-dialog.tsx
+++ b/packages/web/src/components/team/edit-member-dialog.tsx
@@ -191,7 +191,7 @@ export function EditMemberDialog({
           <DialogDescription>Update this member's details.</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
+        <div className="max-h-[50vh] space-y-4 overflow-y-auto py-2 pr-1">
           <div>
             {isAgent ? (
               <Badge variant="secondary">

--- a/packages/web/src/routes/team.test.tsx
+++ b/packages/web/src/routes/team.test.tsx
@@ -172,6 +172,46 @@ describe("TeamPage", () => {
         expect(screen.getByText("This email or number is already linked to another member")).toBeInTheDocument();
       });
     });
+
+    it("uses the same capped form viewport when the dialog opens", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<TeamPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Add member/i }));
+
+      const dialog = await screen.findByRole("dialog");
+      const formBody = within(dialog).getByRole("button", { name: "Human" }).parentElement?.parentElement;
+
+      expect(dialog).not.toHaveClass("data-[state=open]:zoom-in-95");
+      expect(dialog).not.toHaveClass("data-[state=closed]:zoom-out-95");
+      expect(formBody).toHaveClass("max-h-[50vh]");
+      expect(formBody).toHaveClass("overflow-y-auto");
+    });
+
+    it("keeps the agent form in the same capped scroll viewport inside the dialog", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<TeamPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Add member/i }));
+
+      const dialog = await screen.findByRole("dialog");
+      await user.click(within(dialog).getByRole("button", { name: "Agent" }));
+
+      const formBody = within(dialog).getByRole("button", { name: "Human" }).parentElement?.parentElement;
+
+      expect(dialog).not.toHaveClass("overflow-hidden");
+      expect(formBody).toHaveClass("max-h-[50vh]");
+      expect(formBody).toHaveClass("overflow-y-auto");
+      expect(within(dialog).getByRole("button", { name: "Add agent" })).toBeInTheDocument();
+    });
   });
 
   it("shows 'You' badge when userId matches a member", async () => {


### PR DESCRIPTION
## Summary
- remove the shared dialog zoom animation that caused repeated open-time layout shifts
- keep add/edit member dialogs stable across Human/Agent tab changes by using the same capped internal form viewport for both variants
- add regression coverage for the human and agent add-member dialog layouts

## Validation
- `pnpm biome check packages/web/src/components/team/add-member-dialog.tsx packages/web/src/components/team/edit-member-dialog.tsx packages/web/src/routes/team.test.tsx`
- `pnpm --filter @sketch/web exec vitest run src/routes/team.test.tsx`
- pre-push hook reran `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` successfully
