### PR TITLE
fix: standardize tab content width

### DIFF
--- a/packages/ui/src/components/ui/tab-content-container.tsx
+++ b/packages/ui/src/components/ui/tab-content-container.tsx
@@ -3,5 +3,5 @@ import type { ComponentProps } from "react";
 import { cn } from "@sketch/ui/lib/utils";
 
 export function TabContentContainer({ className, ...props }: ComponentProps<"div">) {
-  return <div className={cn("mx-auto w-full max-w-4xl", className)} {...props} />;
+  return <div className={cn("w-full", className)} {...props} />;
 }

--- a/packages/ui/src/components/ui/tab-content-container.tsx
+++ b/packages/ui/src/components/ui/tab-content-container.tsx
@@ -1,0 +1,7 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@sketch/ui/lib/utils";
+
+export function TabContentContainer({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("mx-auto w-full max-w-4xl", className)} {...props} />;
+}

--- a/packages/web/src/components/tab-content-container.test.tsx
+++ b/packages/web/src/components/tab-content-container.test.tsx
@@ -1,0 +1,15 @@
+import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("TabContentContainer", () => {
+  it("fills the page shell instead of applying a second page width", () => {
+    render(<TabContentContainer data-testid="tab-content" />);
+
+    const content = screen.getByTestId("tab-content");
+
+    expect(content).toHaveClass("w-full");
+    expect(content.className).not.toContain("mx-auto");
+    expect(content.className).not.toContain("max-w-4xl");
+  });
+});

--- a/packages/web/src/routes/channels.tsx
+++ b/packages/web/src/routes/channels.tsx
@@ -72,7 +72,7 @@ export function ChannelsPage() {
   const allDisconnected = data?.channels?.every((ch) => ch.connected !== true);
 
   return (
-    <div className="mx-auto max-w-4xl px-10 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <h1 className="text-xl font-semibold text-foreground">Channels</h1>
       <p className="mt-2 text-sm text-muted-foreground">Manage your messaging platform connections.</p>
 

--- a/packages/web/src/routes/connections.tsx
+++ b/packages/web/src/routes/connections.tsx
@@ -56,7 +56,7 @@ function ConnectionsCallback() {
   }, []);
 
   return (
-    <div className="mx-auto max-w-4xl px-10 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <p className="text-sm text-muted-foreground">Connection complete. You can close this window.</p>
     </div>
   );
@@ -124,7 +124,7 @@ function ConnectionsPage() {
   const isLoading = serversQuery.isLoading;
 
   return (
-    <div className="mx-auto max-w-4xl px-10 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div>
         <h1 className="text-xl font-semibold text-foreground">Integrations</h1>
         <p className="mt-2 text-sm text-muted-foreground">Connect apps and tools to extend your workspace.</p>

--- a/packages/web/src/routes/connections.tsx
+++ b/packages/web/src/routes/connections.tsx
@@ -27,6 +27,7 @@ import { api } from "@/lib/api";
 import { PlusIcon } from "@phosphor-icons/react";
 import type { AgentEnvironmentVariableRecord, McpServerRecord } from "@sketch/shared";
 import { TabButton } from "@sketch/ui/components/tab-button";
+import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
@@ -143,7 +144,7 @@ function ConnectionsPage() {
         />
       </div>
 
-      <div className="mt-5 space-y-8">
+      <TabContentContainer className="mt-5 space-y-8">
         {isLoading || (activeTab === "environment" && envVarsQuery.isLoading) ? (
           <LoadingSkeleton />
         ) : activeTab === "applications" ? (
@@ -211,7 +212,7 @@ function ConnectionsPage() {
             onDelete={setDeletingEnvVar}
           />
         )}
-      </div>
+      </TabContentContainer>
 
       <AddMcpDialog open={showAddMcpDialog} onOpenChange={setShowAddMcpDialog} onSuccess={invalidateAll} />
 

--- a/packages/web/src/routes/files/index.tsx
+++ b/packages/web/src/routes/files/index.tsx
@@ -233,7 +233,7 @@ function FilesPage() {
   });
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-bold">Files</h1>

--- a/packages/web/src/routes/files/index.tsx
+++ b/packages/web/src/routes/files/index.tsx
@@ -17,6 +17,7 @@ import type { IntegrationDefinition, IntegrationType } from "@/lib/integrations"
 import { getIntegration } from "@/lib/integrations";
 import { SparkleIcon, SpinnerGapIcon } from "@phosphor-icons/react";
 import { Button } from "@sketch/ui/components/button";
+import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -284,81 +285,83 @@ function FilesPage() {
         </button>
       </div>
 
-      {activeTab === "entities" ? (
-        <EntityExplorer />
-      ) : (
-        <>
-          <ConnectorPicker
-            connectors={connectors}
-            sourceCounts={sourceCounts}
-            totalFiles={totalFiles}
-            localFileCount={localFileCount}
-            sourceFilter={sourceFilter}
-            onSourceFilterChange={setSourceFilter}
-            onConnected={handleConnected}
-            onManageConnector={(def, connector) => setManagingConnector({ definition: def, connector })}
-            forcedConnectIntegration={reconnectTarget}
-            onForcedConnectDone={() => setReconnectTarget(null)}
-          />
-
-          {totalFiles > 0 && (
-            <div className="mt-3 flex items-center justify-between rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs">
-              <div className="flex items-center gap-4 text-muted-foreground">
-                <span>
-                  <SparkleIcon size={12} weight="fill" className="mr-1 inline text-primary" />
-                  {enrichmentStats
-                    ? `${enrichmentStats.total - pendingEnrichment}/${enrichmentStats.total} indexed`
-                    : pendingEnrichment > 0
-                      ? `${pendingEnrichment} file${pendingEnrichment !== 1 ? "s" : ""} need to be indexed`
-                      : "All files indexed"}
-                </span>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-6 gap-1 text-xs"
-                onClick={() => enrichMutation.mutate()}
-                disabled={enrichMutation.isPending || enrichmentActive}
-              >
-                {(enrichMutation.isPending || enrichmentActive) && (
-                  <SpinnerGapIcon size={12} className="animate-spin" />
-                )}
-                {enrichmentActive ? "Indexing..." : "Enrich now"}
-              </Button>
-            </div>
-          )}
-
-          <SearchBar
-            search={search}
-            onSearchChange={setSearch}
-            typeFilter={typeFilter}
-            accessFilter={accessFilter}
-            statusFilter={statusFilter}
-            onTypeChange={setTypeFilter}
-            onAccessChange={setAccessFilter}
-            onStatusChange={setStatusFilter}
-          />
-
-          <div className="mt-4">
-            <FileList
-              isLoading={isLoading}
-              isSearching={isSearching}
-              isInSearchMode={isInSearchMode}
-              isFetchingFiles={isFetchingFiles}
-              filteredFiles={filteredFiles}
-              searchResults={searchResults}
-              debouncedSearch={debouncedSearch}
-              hasAnyFilter={hasAnyFilter}
-              hasMore={hasMore}
-              hasClientOnlyFilter={hasClientOnlyFilter}
-              allFilesCount={allFiles.length}
+      <TabContentContainer>
+        {activeTab === "entities" ? (
+          <EntityExplorer />
+        ) : (
+          <>
+            <ConnectorPicker
+              connectors={connectors}
+              sourceCounts={sourceCounts}
               totalFiles={totalFiles}
-              onView={setViewingFile}
-              onLoadMore={loadMore}
+              localFileCount={localFileCount}
+              sourceFilter={sourceFilter}
+              onSourceFilterChange={setSourceFilter}
+              onConnected={handleConnected}
+              onManageConnector={(def, connector) => setManagingConnector({ definition: def, connector })}
+              forcedConnectIntegration={reconnectTarget}
+              onForcedConnectDone={() => setReconnectTarget(null)}
             />
-          </div>
-        </>
-      )}
+
+            {totalFiles > 0 && (
+              <div className="mt-3 flex items-center justify-between rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs">
+                <div className="flex items-center gap-4 text-muted-foreground">
+                  <span>
+                    <SparkleIcon size={12} weight="fill" className="mr-1 inline text-primary" />
+                    {enrichmentStats
+                      ? `${enrichmentStats.total - pendingEnrichment}/${enrichmentStats.total} indexed`
+                      : pendingEnrichment > 0
+                        ? `${pendingEnrichment} file${pendingEnrichment !== 1 ? "s" : ""} need to be indexed`
+                        : "All files indexed"}
+                  </span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 gap-1 text-xs"
+                  onClick={() => enrichMutation.mutate()}
+                  disabled={enrichMutation.isPending || enrichmentActive}
+                >
+                  {(enrichMutation.isPending || enrichmentActive) && (
+                    <SpinnerGapIcon size={12} className="animate-spin" />
+                  )}
+                  {enrichmentActive ? "Indexing..." : "Enrich now"}
+                </Button>
+              </div>
+            )}
+
+            <SearchBar
+              search={search}
+              onSearchChange={setSearch}
+              typeFilter={typeFilter}
+              accessFilter={accessFilter}
+              statusFilter={statusFilter}
+              onTypeChange={setTypeFilter}
+              onAccessChange={setAccessFilter}
+              onStatusChange={setStatusFilter}
+            />
+
+            <div className="mt-4">
+              <FileList
+                isLoading={isLoading}
+                isSearching={isSearching}
+                isInSearchMode={isInSearchMode}
+                isFetchingFiles={isFetchingFiles}
+                filteredFiles={filteredFiles}
+                searchResults={searchResults}
+                debouncedSearch={debouncedSearch}
+                hasAnyFilter={hasAnyFilter}
+                hasMore={hasMore}
+                hasClientOnlyFilter={hasClientOnlyFilter}
+                allFilesCount={allFiles.length}
+                totalFiles={totalFiles}
+                onView={setViewingFile}
+                onLoadMore={loadMore}
+              />
+            </div>
+          </>
+        )}
+      </TabContentContainer>
 
       <ManageConnectorDialog
         definition={managingConnector?.definition ?? null}

--- a/packages/web/src/routes/scheduled-tasks.tsx
+++ b/packages/web/src/routes/scheduled-tasks.tsx
@@ -207,7 +207,7 @@ export function ScheduledTasksPage() {
   const isAdmin = auth.role === "admin";
 
   return (
-    <div className="mx-auto max-w-4xl px-10 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div>
         <h1 className="text-xl font-semibold text-foreground">Automations</h1>
         <p className="mt-2 text-sm text-muted-foreground">{getSubtitle(auth.role ?? "member")}</p>

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -40,7 +40,7 @@ function SettingsPage() {
 
   if (auth.role !== "admin") {
     return (
-      <div className="mx-auto max-w-4xl px-10 py-8">
+      <div className="mx-auto box-content max-w-4xl px-10 py-8">
         <h1 className="text-xl font-semibold text-foreground">Settings</h1>
         <p className="mt-2 text-sm text-muted-foreground">Admin access is required to manage workspace settings.</p>
       </div>
@@ -48,7 +48,7 @@ function SettingsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-10 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <h1 className="text-xl font-semibold text-foreground">Settings</h1>
       <p className="mt-2 text-sm text-muted-foreground">Manage workspace-level configuration.</p>
 

--- a/packages/web/src/routes/skills.tsx
+++ b/packages/web/src/routes/skills.tsx
@@ -234,7 +234,7 @@ export function SkillsPage() {
   // ── Loading skeleton ───────────────────────────────────────
   if (skillsQuery.isLoading && skills.length === 0) {
     return (
-      <div className="mx-auto max-w-4xl px-10 py-8">
+      <div className="mx-auto box-content max-w-4xl px-10 py-8">
         <div className="flex items-start justify-between">
           <Skeleton className="h-7 w-24" />
           <Skeleton className="h-8 w-32" />
@@ -255,7 +255,7 @@ export function SkillsPage() {
 
   if (skillsQuery.isError && skills.length === 0) {
     return (
-      <div className="mx-auto max-w-4xl px-10 py-8">
+      <div className="mx-auto box-content max-w-4xl px-10 py-8">
         <div>
           <h1 className="text-xl font-semibold text-foreground">Skills</h1>
           <p className="mt-2 text-sm text-muted-foreground">Discover and manage your bot&apos;s capabilities.</p>
@@ -279,7 +279,7 @@ export function SkillsPage() {
   // ── View mode ──────────────────────────────────────────────
   if (mode === "view" && selectedSkill) {
     return (
-      <div className="mx-auto max-w-4xl px-10 py-8">
+      <div className="mx-auto box-content max-w-4xl px-10 py-8">
         <SkillDetailView
           skill={selectedSkill}
           onBack={handleBackToListing}
@@ -300,7 +300,7 @@ export function SkillsPage() {
   // ── Edit / Create mode ─────────────────────────────────────
   if (mode === "edit" || mode === "create") {
     return (
-      <div className="mx-auto max-w-4xl px-10 py-8">
+      <div className="mx-auto box-content max-w-4xl px-10 py-8">
         <SkillDetailEdit
           skill={mode === "edit" && selectedSkill ? selectedSkill : null}
           onBack={handleCancelEdit}
@@ -323,7 +323,7 @@ export function SkillsPage() {
     skills.length === 0 ? "no-skills" : searchQuery.trim() ? "no-results" : "no-skills";
 
   return (
-    <div className="mx-auto max-w-4xl px-10 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>

--- a/packages/web/src/routes/team.test.tsx
+++ b/packages/web/src/routes/team.test.tsx
@@ -27,6 +27,13 @@ afterEach(() => {
 });
 
 describe("TeamPage", () => {
+  it("uses the shared dashboard page width", () => {
+    const { container } = renderWithProviders(<TeamPage />);
+
+    expect(container.firstElementChild).toHaveClass("mx-auto", "box-content", "max-w-4xl", "px-10", "py-8");
+    expect(container.firstElementChild?.className).not.toContain("max-w-[");
+  });
+
   it("renders member list", async () => {
     renderWithProviders(<TeamPage />);
 

--- a/packages/web/src/routes/team.tsx
+++ b/packages/web/src/routes/team.tsx
@@ -21,6 +21,7 @@ import { Button } from "@sketch/ui/components/button";
 import { Card, CardContent } from "@sketch/ui/components/card";
 import { Skeleton } from "@sketch/ui/components/skeleton";
 import { TabButton } from "@sketch/ui/components/tab-button";
+import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@sketch/ui/components/tooltip";
 import { getInitials } from "@sketch/ui/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -77,31 +78,27 @@ export function TeamPage() {
         </div>
       </div>
 
-      <div className="mt-5">
+      <TabContentContainer className="mt-5">
         {activeTab === "list" ? (
-          <div className="mx-auto w-full max-w-4xl">
-            {isLoading ? (
-              <LoadingSkeleton />
-            ) : users.length === 0 ? (
-              <EmptyState onAdd={() => setShowAddDialog(true)} />
-            ) : (
-              <MemberList
-                users={users}
-                auth={auth}
-                onEdit={setEditingUser}
-                onRemove={setRemovingUser}
-                onLink={setLinkingUser}
-              />
-            )}
-          </div>
-        ) : isLoading ? (
-          <div className="mx-auto w-full max-w-4xl">
+          isLoading ? (
             <LoadingSkeleton />
-          </div>
+          ) : users.length === 0 ? (
+            <EmptyState onAdd={() => setShowAddDialog(true)} />
+          ) : (
+            <MemberList
+              users={users}
+              auth={auth}
+              onEdit={setEditingUser}
+              onRemove={setRemovingUser}
+              onLink={setLinkingUser}
+            />
+          )
+        ) : isLoading ? (
+          <LoadingSkeleton />
         ) : (
           <OrgChart users={users} />
         )}
-      </div>
+      </TabContentContainer>
 
       <AddMemberDialog
         open={showAddDialog}

--- a/packages/web/src/routes/team.tsx
+++ b/packages/web/src/routes/team.tsx
@@ -52,26 +52,24 @@ export function TeamPage() {
   const users = data?.users ?? [];
 
   return (
-    <div className="px-10 py-8">
-      <div className="mx-auto max-w-4xl">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-xl font-semibold text-foreground">Team</h1>
-            <p className="mt-2 text-sm text-muted-foreground">Manage your workspace members and roles.</p>
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-1.5 hover:bg-brand-accent/8"
-            onClick={() => setShowAddDialog(true)}
-          >
-            <PlusIcon size={14} weight="bold" />
-            Add member
-          </Button>
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Team</h1>
+          <p className="mt-2 text-sm text-muted-foreground">Manage your workspace members and roles.</p>
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="gap-1.5 hover:bg-brand-accent/8"
+          onClick={() => setShowAddDialog(true)}
+        >
+          <PlusIcon size={14} weight="bold" />
+          Add member
+        </Button>
       </div>
 
-      <div className="mx-auto mt-6 w-full max-w-4xl">
+      <div className="mt-6 w-full">
         <div className="flex items-center gap-6 border-b border-border">
           <TabButton label="List" isActive={activeTab === "list"} onClick={() => setActiveTab("list")} />
           <TabButton label="Chart" isActive={activeTab === "chart"} onClick={() => setActiveTab("chart")} />

--- a/packages/web/src/routes/usage/index.tsx
+++ b/packages/web/src/routes/usage/index.tsx
@@ -18,7 +18,7 @@ function UsagePage() {
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("Month");
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-8">
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div>
         <h1 className="text-[22px] font-medium">Usage</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">Monitor your workspace activity and team adoption.</p>

--- a/packages/web/src/routes/usage/index.tsx
+++ b/packages/web/src/routes/usage/index.tsx
@@ -1,4 +1,5 @@
 import { TabButton } from "@sketch/ui/components/tab-button";
+import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
 import { createRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { dashboardRoute } from "../dashboard";
@@ -28,11 +29,13 @@ function UsagePage() {
         <TabButton label="My usage" isActive={activeTab === "my-usage"} onClick={() => setActiveTab("my-usage")} />
       </div>
 
-      {activeTab === "team" ? (
-        <TeamView timePeriod={timePeriod} onTimePeriodChange={setTimePeriod} />
-      ) : (
-        <PersonalView timePeriod={timePeriod} onTimePeriodChange={setTimePeriod} />
-      )}
+      <TabContentContainer>
+        {activeTab === "team" ? (
+          <TeamView timePeriod={timePeriod} onTimePeriodChange={setTimePeriod} />
+        ) : (
+          <PersonalView timePeriod={timePeriod} onTimePeriodChange={setTimePeriod} />
+        )}
+      </TabContentContainer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Added a shared `TabContentContainer` next to the existing shared tab button.
- Standardized default tab panels on the dominant page width, `max-w-4xl`.
- Wrapped Integrations, Team, Usage, and Files tab content so panels stay equally wide; Team chart no longer bypasses the same content width.

## Width scan
- `max-w-4xl` was the dominant width in the web UI scan: 17 occurrences before this change.

## Videos

<table>
<tr>
 <td> Before </td>
 <td> After </td>
<tr>
 <td>

https://github.com/user-attachments/assets/2305e4a9-c69e-4f9a-bfa1-faa2229c04d1

 </td>

 <td>

https://github.com/user-attachments/assets/cfa6b25e-f62a-4e36-ba58-d919f19cbc11

 </td>
</table>

## Verification
- `pnpm biome check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- pre-push checks passed