### PR TITLE
Fix scheduled prompt automation runtime and run-now queueing

### DIFF
--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -134,6 +134,7 @@ export interface RunAgentParams {
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };
+  activeQueueKey?: string;
   toolConfig?: { BASE_URL?: string; PORT: number };
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   userRepo?: {
@@ -295,6 +296,7 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
     stepContentRepo: params.stepContentRepo,
     automationRunsRepo: params.automationRunsRepo,
     queueManager: params.queueManager,
+    activeQueueKey: params.activeQueueKey,
     toolConfig: params.toolConfig,
     inboxMessagesRepo: params.inboxMessagesRepo,
     userRepo: params.userRepo,

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -29,8 +29,9 @@ import type { createInboxMessagesRepository } from "../db/repositories/inbox-mes
 import type { DB, UsersTable } from "../db/schema";
 import type { IntegrationProvider } from "../integrations/types";
 import { parseOnceSchedule } from "../scheduler/parse-once";
+import { getActiveTaskContextQueueKey, getScheduledTaskQueueKey } from "../scheduler/queue-key";
 import type { TaskScheduler } from "../scheduler/service";
-import type { TaskContext } from "../scheduler/types";
+import type { ScheduledTask, TaskContext } from "../scheduler/types";
 import type { WorkflowStep } from "../workflows/types";
 
 type SelectableUser = Selectable<UsersTable>;
@@ -75,6 +76,7 @@ export interface SketchMcpDeps {
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   userRepo?: SearchableUserRepo;
   currentUserId?: string;
+  activeQueueKey?: string;
   sendDm?: (params: { userId: string; platform: string; message: string }) => Promise<{
     channelId: string;
     messageRef: string;
@@ -216,6 +218,7 @@ export interface ManageScheduledTasksDeps {
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   loadIntegrationProvider?: () => Promise<IntegrationProvider | null>;
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };
+  activeQueueKey?: string;
   config?: { BASE_URL?: string; PORT: number };
 }
 
@@ -272,11 +275,13 @@ export async function handleManageScheduledTasks(
   // existence leaks. Admin bypass is deliberately not offered here; admins use the
   // web UI for tenant-wide ops. Matches the HTTP layer's same-behavior guarantee.
   const OWNERSHIP_GUARDED_ACTIONS = ["update", "remove", "pause", "resume", "run", "getRun", "updateStepContent"];
+  let guardedTask: ScheduledTask | null = null;
   if (task_id && OWNERSHIP_GUARDED_ACTIONS.includes(action)) {
     const task = await deps.scheduler.getTaskById(task_id);
     if (!ctx.createdBy || !task || task.createdBy !== ctx.createdBy) {
       return text("Error: task not found.");
     }
+    guardedTask = task;
   }
 
   switch (action) {
@@ -334,6 +339,7 @@ export async function handleManageScheduledTasks(
             type: "agent",
             label: params.prompt.slice(0, 80),
             icon: "sketch-ai",
+            agentMode: "sketch",
             agentPrompt: params.prompt,
             position: { x: 0, y: 100 },
           },
@@ -607,6 +613,16 @@ export async function handleManageScheduledTasks(
         return text("Error: task_id is required for run action.");
       }
       try {
+        const activeQueueKey = deps.activeQueueKey ?? getActiveTaskContextQueueKey(ctx);
+        if (
+          guardedTask?.status === "active" &&
+          activeQueueKey &&
+          getScheduledTaskQueueKey(guardedTask) === activeQueueKey
+        ) {
+          await deps.scheduler.enqueueTaskById(task_id);
+          return text(`Automation ${task_id} queued to run after this chat turn completes.`);
+        }
+
         const result = await deps.scheduler.executeTaskById(task_id);
         if (!result) {
           const latestRun = deps.automationRunsRepo ? await deps.automationRunsRepo.getLatest(task_id) : undefined;
@@ -1080,6 +1096,7 @@ export function createSketchMcpServer(deps: SketchMcpDeps) {
           automationRunsRepo: deps.automationRunsRepo,
           loadIntegrationProvider: deps.loadIntegrationProvider,
           queueManager: deps.queueManager,
+          activeQueueKey: deps.activeQueueKey,
           config: deps.toolConfig,
         });
       },

--- a/packages/server/src/scheduler/queue-key.ts
+++ b/packages/server/src/scheduler/queue-key.ts
@@ -1,0 +1,39 @@
+import type { ScheduledTaskRow } from "../db/repositories/scheduled-tasks";
+import type { ScheduledTask, TaskContext } from "./types";
+
+export function getScheduledTaskRowQueueKey(task: ScheduledTaskRow): string {
+  if (task.session_mode === "chat") {
+    const userId = task.created_by ?? task.delivery_target;
+    if (task.context_type === "dm") return userId;
+    if (task.platform === "slack" && task.context_type === "channel") {
+      return task.thread_ts ? `${task.delivery_target}:${task.thread_ts}` : task.delivery_target;
+    }
+    return `wa-group-${task.delivery_target}`;
+  }
+
+  return `task-${task.id}`;
+}
+
+export function getScheduledTaskQueueKey(task: ScheduledTask): string {
+  if (task.sessionMode === "chat") {
+    const userId = task.createdBy ?? task.deliveryTarget;
+    if (task.contextType === "dm") return userId;
+    if (task.platform === "slack" && task.contextType === "channel") {
+      return task.threadTs ? `${task.deliveryTarget}:${task.threadTs}` : task.deliveryTarget;
+    }
+    return `wa-group-${task.deliveryTarget}`;
+  }
+
+  return `task-${task.id}`;
+}
+
+export function getActiveTaskContextQueueKey(ctx: TaskContext): string | null {
+  if (ctx.contextType === "dm") return ctx.createdBy ?? ctx.deliveryTarget;
+  if (ctx.platform === "slack" && ctx.contextType === "channel") {
+    return ctx.threadTs ? `${ctx.deliveryTarget}:${ctx.threadTs}` : null;
+  }
+  if (ctx.platform === "whatsapp" && ctx.contextType === "group") {
+    return `wa-group-${ctx.deliveryTarget}`;
+  }
+  return null;
+}

--- a/packages/server/src/scheduler/service.test.ts
+++ b/packages/server/src/scheduler/service.test.ts
@@ -784,6 +784,24 @@ describe("executeTask() queue key derivation", () => {
 
     expect(getQueueSpy).toHaveBeenCalledWith(`task-${row.id}`);
   });
+
+  it("uses the active WhatsApp group queue key for chat mode", async () => {
+    const queueManager = new QueueManager();
+    const getQueueSpy = vi.spyOn(queueManager, "getQueue");
+    const deps = buildDeps(db, { queueManager });
+    const scheduler = new TaskScheduler(deps as never);
+
+    const row = await repo.add({
+      ...baseTaskFields,
+      platform: "whatsapp",
+      context_type: "group",
+      delivery_target: "987654321@g.us",
+      session_mode: "chat",
+    });
+    await scheduler.executeTask(row as ScheduledTaskRow);
+
+    expect(getQueueSpy).toHaveBeenCalledWith("wa-group-987654321@g.us");
+  });
 });
 
 describe("executeTaskById() queueing", () => {
@@ -870,6 +888,33 @@ describe("executeTaskById() queueing", () => {
     releaseScheduledRun?.();
     await expect(manualRun).resolves.toBeNull();
     expect(callCount).toBe(1);
+  });
+
+  it("enqueueTaskById validates then returns without waiting for execution", async () => {
+    const { executeAutomation } = await import("../workflows/runtime");
+    const executeAutomationMock = vi.mocked(executeAutomation);
+    let releaseRun: (() => void) | undefined;
+    let callCount = 0;
+
+    executeAutomationMock.mockImplementation(async (params: ExecuteAutomationParams) => {
+      lastExecuteAutomationParams = params;
+      callCount += 1;
+      await new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      return { runId: "run-1", status: "completed", finalOutput: null, stepOutputs: {} };
+    });
+
+    const deps = buildDeps(db);
+    const scheduler = new TaskScheduler(deps as never);
+    const row = await repo.add({ ...baseTaskFields, session_mode: "chat" });
+
+    await scheduler.enqueueTaskById(row.id);
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(callCount).toBe(1);
+
+    releaseRun?.();
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
   });
 });
 

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -36,6 +36,7 @@ import type { SlackBot } from "../slack/bot";
 import type { WhatsAppBot } from "../whatsapp/bot";
 import { type AutomationExecutionResult, executeAutomation } from "../workflows/runtime";
 import { parseOnceSchedule } from "./parse-once";
+import { getScheduledTaskRowQueueKey } from "./queue-key";
 import type { ScheduledTask } from "./types";
 
 export interface TaskSchedulerDeps {
@@ -275,16 +276,7 @@ export class TaskScheduler {
   }
 
   private getQueueKey(task: ScheduledTaskRow): string {
-    if (task.session_mode === "chat") {
-      const userId = task.created_by ?? task.delivery_target;
-      if (task.context_type === "dm") return userId;
-      if (task.platform === "slack" && task.context_type === "channel") {
-        return task.thread_ts ? `${task.delivery_target}:${task.thread_ts}` : task.delivery_target;
-      }
-      return `wa-group-${task.delivery_target.replace("@g.us", "")}`;
-    }
-
-    return `task-${task.id}`;
+    return getScheduledTaskRowQueueKey(task);
   }
 
   async addTask(params: {
@@ -346,6 +338,17 @@ export class TaskScheduler {
     if (row.status === "completed" && row.schedule_type === "once") return null;
     if (row.status !== "active") throw new Error(`Task ${id} is not active`);
     return this.enqueueTaskRun(row, () => this.getRunnableTask(id, true));
+  }
+
+  async enqueueTaskById(id: string): Promise<void> {
+    const row = await this.repo.getById(id);
+    if (!row) throw new Error(`Task ${id} not found`);
+    if (row.status === "completed" && row.schedule_type === "once") return;
+    if (row.status !== "active") throw new Error(`Task ${id} is not active`);
+
+    this.enqueueTaskRun(row, () => this.getRunnableTask(id, true)).catch((err) => {
+      this.deps.logger.error({ err, taskId: id }, "Automation background execution failed");
+    });
   }
 
   async getTaskById(id: string): Promise<ScheduledTask | null> {

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -50,6 +50,7 @@ function makeMockScheduler(overrides: Partial<TaskScheduler> = {}): TaskSchedule
     pauseTask: vi.fn().mockResolvedValue(undefined),
     resumeTask: vi.fn().mockResolvedValue(undefined),
     executeTaskById: vi.fn().mockResolvedValue(undefined),
+    enqueueTaskById: vi.fn().mockResolvedValue(undefined),
     start: vi.fn(),
     stop: vi.fn(),
     scheduleTask: vi.fn(),
@@ -302,6 +303,20 @@ describe("handleManageScheduledTasks — add", () => {
       { scheduler, stepContentRepo, taskContext: channelThreadContext },
     );
     expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ threadTs: "1234567890.123456" }));
+  });
+
+  it("creates simple prompt automations as Sketch-mode agent steps", async () => {
+    const scheduler = makeMockScheduler();
+    await handleManageScheduledTasks(
+      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
+      { scheduler, stepContentRepo, taskContext: dmContext },
+    );
+
+    const addTaskCall = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const stepsJson = JSON.parse(addTaskCall.steps);
+    expect(stepsJson.find((step: { id: string }) => step.id === "step1")).toEqual(
+      expect.objectContaining({ type: "agent", agentMode: "sketch" }),
+    );
   });
 
   it("returns created task in response", async () => {
@@ -712,6 +727,7 @@ describe("handleManageScheduledTasks — run", () => {
       stepOutputs: { step1: { output: { ok: true }, status: "completed", duration_ms: 12 } },
     };
     const scheduler = makeMockScheduler({
+      getTaskById: vi.fn().mockResolvedValue(makeTask({ sessionMode: "fresh" })),
       executeTaskById: vi.fn().mockResolvedValue(runResult),
     });
 
@@ -726,8 +742,39 @@ describe("handleManageScheduledTasks — run", () => {
     expect(result.content[0].text).toContain('"ok": true');
   });
 
+  it("queues same-conversation runs instead of awaiting the current queue", async () => {
+    const scheduler = makeMockScheduler({
+      getTaskById: vi.fn().mockResolvedValue(
+        makeTask({
+          contextType: "channel",
+          deliveryTarget: "C456",
+          threadTs: "1234567890.123456",
+          sessionMode: "chat",
+          createdBy: "U123",
+        }),
+      ),
+      executeTaskById: vi.fn(),
+      enqueueTaskById: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await handleManageScheduledTasks(
+      { action: "run", task_id: "task-1" },
+      {
+        scheduler,
+        stepContentRepo,
+        taskContext: channelThreadContext,
+        activeQueueKey: "C456:1234567890.123456",
+      },
+    );
+
+    expect(scheduler.enqueueTaskById).toHaveBeenCalledWith("task-1");
+    expect(scheduler.executeTaskById).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain("queued to run after this chat turn completes");
+  });
+
   it("returns the latest run when a completed once task is run again", async () => {
     const scheduler = makeMockScheduler({
+      getTaskById: vi.fn().mockResolvedValue(makeTask({ scheduleType: "once", status: "completed" })),
       executeTaskById: vi.fn().mockResolvedValue(null),
     });
     const automationRunsRepo = {

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -337,7 +337,8 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
       }
       throw err;
     }
-    const userQueue = queue.getQueue(user.id);
+    const activeQueueKey = user.id;
+    const userQueue = queue.getQueue(activeQueueKey);
 
     userQueue.enqueue(async () => {
       logger.info({ slackUserId: message.userId, channelId: message.channelId }, "Processing message");
@@ -457,6 +458,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
           stepContentRepo,
           automationRunsRepo,
           queueManager: queue,
+          activeQueueKey,
           toolConfig,
           inboxMessagesRepo,
           userRepo: repos.users,
@@ -530,7 +532,8 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
   // Channel mention handler
   slackBot.onChannelMention(async (message) => {
     const threadTs = message.threadTs ?? message.ts;
-    const mentionQueue = queue.getQueue(`${message.channelId}:${threadTs}`);
+    const activeQueueKey = `${message.channelId}:${threadTs}`;
+    const mentionQueue = queue.getQueue(activeQueueKey);
 
     mentionQueue.enqueue(async () => {
       logger.info({ slackUserId: message.userId, channelId: message.channelId }, "Processing channel mention");
@@ -725,6 +728,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
           stepContentRepo,
           automationRunsRepo,
           queueManager: queue,
+          activeQueueKey,
           toolConfig,
           inboxMessagesRepo,
           userRepo: repos.users,

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -210,7 +210,8 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppBot, deps: WhatsAppAdapte
         }
       }
 
-      const userQueue = queue.getQueue(user.id);
+      const activeQueueKey = user.id;
+      const userQueue = queue.getQueue(activeQueueKey);
 
       userQueue.enqueue(async () => {
         const command = parseSketchCommand(message.text);
@@ -362,6 +363,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppBot, deps: WhatsAppAdapte
             stepContentRepo,
             automationRunsRepo,
             queueManager: queue,
+            activeQueueKey,
             toolConfig,
             inboxMessagesRepo,
             userRepo: repos.users,
@@ -423,7 +425,8 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppBot, deps: WhatsAppAdapte
     const userName = user?.name ?? message.pushName;
 
     const groupJid = message.jid;
-    const groupQueue = queue.getQueue(`wa-group-${groupJid}`);
+    const activeQueueKey = `wa-group-${groupJid}`;
+    const groupQueue = queue.getQueue(activeQueueKey);
 
     groupQueue.enqueue(async () => {
       const command = parseSketchCommand(message.text);
@@ -615,6 +618,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppBot, deps: WhatsAppAdapte
           stepContentRepo,
           automationRunsRepo,
           queueManager: queue,
+          activeQueueKey,
           toolConfig,
           inboxMessagesRepo,
           userRepo: repos.users,

--- a/packages/server/src/workflows/runtime.test.ts
+++ b/packages/server/src/workflows/runtime.test.ts
@@ -161,6 +161,41 @@ function makeStepContent(rows: Array<{ stepId: string; content: string }>) {
 }
 
 describe("executeAutomation agent steps", () => {
+  it("defaults scheduled agent steps without an explicit mode to the Sketch runtime", async () => {
+    const runAgent = vi.fn().mockResolvedValue({
+      pendingUploads: [],
+      toolCalls: [],
+      trace: { finalText: "sketch result" },
+    });
+    const params = makeParams({
+      runAgent,
+      task: makeTask({
+        steps: JSON.stringify([
+          { id: "trigger", type: "trigger", label: "Schedule", icon: "clock", position: { x: 0, y: 0 } },
+          {
+            id: "step1",
+            type: "agent",
+            label: "Summarize Linear issues",
+            icon: "sketch-ai",
+            position: { x: 0, y: 100 },
+          },
+        ]),
+      }),
+    });
+
+    await executeAutomation(params as never);
+
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(runAgent.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        contextType: "scheduled_task",
+        currentUserId: "user-1",
+        sessionMode: "fresh",
+      }),
+    );
+    expect(params.sendMessage).toHaveBeenCalledWith("sketch result");
+  });
+
   it("routes sketch-mode agent steps through runAgent with workflow context", async () => {
     const runAgent = vi.fn().mockResolvedValue({
       pendingUploads: [],

--- a/packages/server/src/workflows/runtime.ts
+++ b/packages/server/src/workflows/runtime.ts
@@ -114,7 +114,14 @@ export async function executeAutomation(params: ExecuteAutomationParams): Promis
   } else {
     steps = [
       { id: "trigger", type: "trigger", label: "Schedule", icon: "clock", position: { x: 0, y: 0 } },
-      { id: "step1", type: "agent", label: task.prompt, icon: "sketch-ai", position: { x: 0, y: 100 } },
+      {
+        id: "step1",
+        type: "agent",
+        label: task.prompt,
+        icon: "sketch-ai",
+        position: { x: 0, y: 100 },
+        agentMode: "sketch",
+      },
     ];
   }
 
@@ -585,7 +592,7 @@ interface AgentStepParams {
 async function executeAgentStep(params: AgentStepParams): Promise<unknown> {
   const { prompt, step, input, logger, workspaceDir, outputPlatform } = params;
 
-  if (step.agentMode === "sketch") {
+  if (step.agentMode !== "light") {
     return executeSketchAgentStep(params);
   }
 


### PR DESCRIPTION
## What & Why

Fixes SKE-104 and SKE-105.

Scheduled prompt automations now run through the full Sketch runtime by default, so cron jobs can use the same runtime capabilities as normal agent turns, including shared agent environment variables.

Manual `run` requests from the same conversation queue now enqueue the automation behind the active chat turn instead of awaiting execution inside that same queue. That avoids the deadlock/hang pattern where the agent asks to run the automation immediately as a test and never returns.

## How

- Default scheduled agent steps to `agentMode: "sketch"` and treat legacy agent steps with no explicit mode as Sketch runtime steps.
- Pass the active Slack/WhatsApp queue key into the Sketch tools layer.
- Add a shared scheduled-task queue-key helper and `TaskScheduler.enqueueTaskById()` for non-blocking same-queue manual runs.
- Keep completed one-off automation behavior on the existing synchronous `executeTaskById()` path.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Local e2e harness: created a Slack channel-thread prompt cron with a shared env var, invoked `run` from the same active queue, verified it queued instead of blocking, and verified scheduled `runAgent` received `sessionMode: "fresh"` plus the shared env var.
