### PR TITLE
fix: normalize stale schedule trigger metadata on scheduled tasks

### DIFF
--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -31,6 +31,7 @@ import type { IntegrationProvider } from "../integrations/types";
 import { parseOnceSchedule } from "../scheduler/parse-once";
 import { getActiveTaskContextQueueKey, getScheduledTaskQueueKey } from "../scheduler/queue-key";
 import type { TaskScheduler } from "../scheduler/service";
+import { normalizeScheduleTriggerSteps, normalizeScheduleTriggerStepsJson } from "../scheduler/trigger-metadata";
 import type { ScheduledTask, TaskContext } from "../scheduler/types";
 import type { WorkflowStep } from "../workflows/types";
 
@@ -224,6 +225,10 @@ export interface ManageScheduledTasksDeps {
 
 function stripContentFromSteps(steps: WorkflowStepInput[]): WorkflowStep[] {
   return steps.map(({ script: _s, agentPrompt: _a, apps: _apps, ...step }) => step as WorkflowStep);
+}
+
+function isLocalScheduleType(value: unknown): value is "cron" | "interval" | "once" {
+  return value === "cron" || value === "interval" || value === "once";
 }
 
 /**
@@ -434,7 +439,14 @@ export async function handleManageScheduledTasks(
       const title = params.title as string;
       const scheduleType = params.schedule_type as NonNullable<typeof params.schedule_type>;
       const scheduleValue = params.schedule_value as string;
-      const stepsForDb = stripContentFromSteps(steps);
+      let stepsForDb = stripContentFromSteps(steps);
+      if (isLocalScheduleType(scheduleType)) {
+        stepsForDb = normalizeScheduleTriggerSteps(stepsForDb, {
+          scheduleType,
+          scheduleValue,
+          timezone: resolvedTimezone,
+        });
+      }
 
       // Guard against silently dropping step content if the repo wasn't plumbed
       // through. Runs after input validation so user-input errors surface first.
@@ -538,7 +550,15 @@ export async function handleManageScheduledTasks(
             status: triggerStep.triggerConfig.status ?? "pending_canvas_setup",
           };
         }
-        const stepsForDb = stripContentFromSteps(params.steps);
+        let stepsForDb = stripContentFromSteps(params.steps);
+        if (triggerStep?.triggerConfig?.type !== "canvas") {
+          const scheduleType = updateFields.scheduleType ?? guardedTask?.scheduleType;
+          const scheduleValue = updateFields.scheduleValue ?? guardedTask?.scheduleValue;
+          const timezone = updateFields.timezone ?? guardedTask?.timezone;
+          if (isLocalScheduleType(scheduleType) && scheduleValue && timezone) {
+            stepsForDb = normalizeScheduleTriggerSteps(stepsForDb, { scheduleType, scheduleValue, timezone });
+          }
+        }
         updateFields.steps = JSON.stringify(stepsForDb);
 
         // Sync step content
@@ -569,6 +589,21 @@ export async function handleManageScheduledTasks(
       }
 
       if (params.edges !== undefined) updateFields.edges = JSON.stringify(params.edges);
+
+      const scheduleChanged =
+        params.schedule_type !== undefined || params.schedule_value !== undefined || params.timezone !== undefined;
+      if (!params.steps && scheduleChanged && guardedTask?.steps) {
+        const scheduleType = updateFields.scheduleType ?? guardedTask.scheduleType;
+        const scheduleValue = updateFields.scheduleValue ?? guardedTask.scheduleValue;
+        const timezone = updateFields.timezone ?? guardedTask.timezone;
+        if (isLocalScheduleType(scheduleType) && scheduleValue && timezone) {
+          updateFields.steps = normalizeScheduleTriggerStepsJson(guardedTask.steps, {
+            scheduleType,
+            scheduleValue,
+            timezone,
+          });
+        }
+      }
 
       const updated = await deps.scheduler.updateTask(task_id, updateFields);
       if (!updated) {

--- a/packages/server/src/api/scheduled-tasks.test.ts
+++ b/packages/server/src/api/scheduled-tasks.test.ts
@@ -218,6 +218,79 @@ describe("Scheduled Tasks API", () => {
     );
   });
 
+  it("returns schedule trigger metadata from canonical schedule columns", async () => {
+    await seedAdmin(db);
+    const users = createUserRepository(db);
+    const tasks = createScheduledTaskRepository(db);
+    const member = await users.create({ name: "Alice Member", email: "alice@test.com" });
+
+    await tasks.add({
+      id: "task-stale-trigger",
+      platform: "slack",
+      context_type: "dm",
+      delivery_target: "D123",
+      thread_ts: null,
+      prompt: "Check inbox",
+      schedule_type: "cron",
+      schedule_value: "*/10 * * * *",
+      timezone: "UTC",
+      session_mode: "fresh",
+      created_by: member.id,
+      status: "active",
+      next_run_at: null,
+      steps: JSON.stringify([
+        {
+          id: "trigger",
+          type: "trigger",
+          label: "Every 5 minutes",
+          icon: "clock",
+          position: { x: 0, y: 0 },
+          triggerConfig: {
+            type: "schedule",
+            scheduleType: "cron",
+            scheduleValue: "*/5 * * * *",
+            timezone: "UTC",
+          },
+        },
+        {
+          id: "agent1",
+          type: "agent",
+          label: "Check inbox",
+          icon: "sketch-ai",
+          position: { x: 0, y: 100 },
+        },
+      ]),
+    });
+
+    const app = createApp(db, config, {
+      scheduler: {
+        pauseTask: vi.fn(),
+        resumeTask: vi.fn(),
+        removeTask: vi.fn(),
+        executeTaskById: vi.fn(),
+      },
+    });
+    const cookie = await loginAdmin(app);
+
+    const res = await app.request("/api/scheduled-tasks", { headers: { Cookie: cookie } });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const task = body.tasks[0];
+    const steps = JSON.parse(task.steps);
+    expect(task.scheduleValue).toBe("*/10 * * * *");
+    expect(task.triggerConfig).toEqual(
+      expect.objectContaining({
+        type: "schedule",
+        scheduleType: "cron",
+        scheduleValue: "*/10 * * * *",
+        timezone: "UTC",
+      }),
+    );
+    expect(steps[0].label).toBe("Every 10 minutes");
+    expect(steps[0].triggerConfig.scheduleValue).toBe("*/10 * * * *");
+  });
+
   it("members see only their own tasks; admins see all", async () => {
     await seedAdmin(db);
     const users = createUserRepository(db);

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -8,6 +8,7 @@ import { createScheduledTaskRepository } from "../db/repositories/scheduled-task
 import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB, ScheduledTasksTable } from "../db/schema";
+import { formatIntervalScheduleLabel, normalizeScheduleTriggerStepsJson } from "../scheduler/trigger-metadata";
 import type { WorkflowStep } from "../workflows/types";
 
 type ScheduledTaskRow = Selectable<ScheduledTasksTable>;
@@ -72,28 +73,6 @@ function formatDateTime(value: string, timezone: string): string {
   }).format(date);
 }
 
-function formatIntervalLabel(rawSeconds: string): string {
-  const seconds = Number.parseInt(rawSeconds, 10);
-  if (!Number.isFinite(seconds) || seconds <= 0) {
-    return `Every ${rawSeconds} seconds`;
-  }
-
-  const units: Array<{ seconds: number; label: string }> = [
-    { seconds: 86_400, label: "day" },
-    { seconds: 3_600, label: "hour" },
-    { seconds: 60, label: "minute" },
-  ];
-
-  for (const unit of units) {
-    if (seconds % unit.seconds === 0) {
-      const count = seconds / unit.seconds;
-      return `Every ${count} ${unit.label}${count === 1 ? "" : "s"}`;
-    }
-  }
-
-  return `Every ${seconds} seconds`;
-}
-
 function formatCanvasTriggerLabel(triggerConfig: WorkflowTriggerConfig | null): string {
   if (triggerConfig?.type !== "canvas") return "Canvas managed trigger";
 
@@ -112,7 +91,7 @@ function formatScheduleLabel(row: ScheduledTaskRow, triggerConfig: WorkflowTrigg
   }
 
   if (row.schedule_type === "interval") {
-    return formatIntervalLabel(row.schedule_value);
+    return formatIntervalScheduleLabel(row.schedule_value);
   }
 
   if (row.schedule_type === "once") {
@@ -132,6 +111,10 @@ function parseTriggerConfig(stepsValue: string | null): WorkflowTriggerConfig | 
   } catch {
     return null;
   }
+}
+
+function isLocalScheduleType(value: string): value is "cron" | "interval" | "once" {
+  return value === "cron" || value === "interval" || value === "once";
 }
 
 function getTargetKindLabel(row: ScheduledTaskRow): ScheduledTaskListItem["targetKindLabel"] {
@@ -203,13 +186,21 @@ async function buildTaskListItems(db: Kysely<DB>, rows: ScheduledTaskRow[]): Pro
       targetLabel = groupNames.get(row.delivery_target) ?? row.delivery_target;
     }
 
+    const normalizedSteps = isLocalScheduleType(row.schedule_type)
+      ? normalizeScheduleTriggerStepsJson(row.steps, {
+          scheduleType: row.schedule_type,
+          scheduleValue: row.schedule_value,
+          timezone: row.timezone,
+        })
+      : row.steps;
+
     let stepCount = 0;
-    if (row.steps) {
+    if (normalizedSteps) {
       try {
-        stepCount = JSON.parse(row.steps).length;
+        stepCount = JSON.parse(normalizedSteps).length;
       } catch {}
     }
-    const triggerConfig = parseTriggerConfig(row.steps);
+    const triggerConfig = parseTriggerConfig(normalizedSteps ?? null);
 
     const rd = runData.get(row.id);
 
@@ -238,7 +229,7 @@ async function buildTaskListItems(db: Kysely<DB>, rows: ScheduledTaskRow[]): Pro
       canDelete: true,
       title: row.title,
       description: row.description,
-      steps: row.steps,
+      steps: normalizedSteps ?? null,
       stepCount,
       triggerConfig,
       outputTarget: row.output_target,

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -581,6 +581,57 @@ describe("handleManageScheduledTasks — update", () => {
     });
   });
 
+  it("syncs stored schedule trigger metadata when only schedule fields are updated", async () => {
+    const scheduler = makeMockScheduler({
+      getTaskById: vi.fn().mockResolvedValue(
+        makeTask({
+          scheduleType: "cron",
+          scheduleValue: "*/5 * * * *",
+          timezone: "UTC",
+          steps: JSON.stringify([
+            {
+              id: "trigger",
+              type: "trigger",
+              label: "Every 5 minutes",
+              icon: "clock",
+              position: { x: 0, y: 0 },
+              triggerConfig: {
+                type: "schedule",
+                scheduleType: "cron",
+                scheduleValue: "*/5 * * * *",
+                timezone: "UTC",
+              },
+            },
+            {
+              id: "agent1",
+              type: "agent",
+              label: "Check inbox",
+              icon: "sketch-ai",
+              position: { x: 0, y: 100 },
+            },
+          ]),
+        }),
+      ),
+    });
+
+    await handleManageScheduledTasks(
+      { action: "update", task_id: "task-1", schedule_value: "*/10 * * * *" },
+      { scheduler, stepContentRepo, taskContext: dmContext },
+    );
+
+    const updateFields = (scheduler.updateTask as ReturnType<typeof vi.fn>).mock.calls[0][1] as { steps: string };
+    const stepsJson = JSON.parse(updateFields.steps);
+    expect(stepsJson[0].label).toBe("Every 10 minutes");
+    expect(stepsJson[0].triggerConfig).toEqual(
+      expect.objectContaining({
+        type: "schedule",
+        scheduleType: "cron",
+        scheduleValue: "*/10 * * * *",
+        timezone: "UTC",
+      }),
+    );
+  });
+
   it("normalizes schedule fields when updating steps to a Canvas-managed trigger", async () => {
     const scheduler = makeMockScheduler();
     await handleManageScheduledTasks(

--- a/packages/server/src/scheduler/trigger-metadata.ts
+++ b/packages/server/src/scheduler/trigger-metadata.ts
@@ -1,0 +1,101 @@
+import type { WorkflowStep } from "../workflows/types";
+
+type ScheduleType = "cron" | "interval" | "once" | "external";
+type LocalScheduleType = Exclude<ScheduleType, "external">;
+
+export function formatIntervalScheduleLabel(rawSeconds: string): string {
+  const seconds = Number.parseInt(rawSeconds, 10);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return `Every ${rawSeconds} seconds`;
+  }
+
+  const units: Array<{ seconds: number; label: string }> = [
+    { seconds: 86_400, label: "day" },
+    { seconds: 3_600, label: "hour" },
+    { seconds: 60, label: "minute" },
+  ];
+
+  for (const unit of units) {
+    if (seconds % unit.seconds === 0) {
+      const count = seconds / unit.seconds;
+      return `Every ${count} ${unit.label}${count === 1 ? "" : "s"}`;
+    }
+  }
+
+  return `Every ${seconds} seconds`;
+}
+
+export function formatScheduleTriggerLabel(params: {
+  scheduleType: ScheduleType;
+  scheduleValue: string;
+  timezone: string;
+}): string {
+  if (params.scheduleType === "interval") {
+    return formatIntervalScheduleLabel(params.scheduleValue);
+  }
+
+  if (params.scheduleType === "once") {
+    return `Once at ${params.scheduleValue}`;
+  }
+
+  if (params.scheduleType === "cron") {
+    const parts = params.scheduleValue.trim().split(/\s+/);
+    if (parts.length === 5 && /^\*\/\d+$/.test(parts[0]) && parts.slice(1).every((part) => part === "*")) {
+      const minutes = Number.parseInt(parts[0].slice(2), 10);
+      if (Number.isFinite(minutes) && minutes > 0) {
+        return `Every ${minutes} minute${minutes === 1 ? "" : "s"}`;
+      }
+    }
+
+    return `Cron: ${params.scheduleValue} (${params.timezone})`;
+  }
+
+  return "External trigger";
+}
+
+export function normalizeScheduleTriggerSteps(
+  steps: WorkflowStep[],
+  params: {
+    scheduleType: LocalScheduleType;
+    scheduleValue: string;
+    timezone: string;
+  },
+): WorkflowStep[] {
+  let updated = false;
+  const next = steps.map((step) => {
+    if (step.type !== "trigger" || step.triggerConfig?.type !== "schedule") return step;
+    updated = true;
+    return {
+      ...step,
+      label: formatScheduleTriggerLabel(params),
+      triggerConfig: {
+        ...step.triggerConfig,
+        scheduleType: params.scheduleType,
+        scheduleValue: params.scheduleValue,
+        timezone: params.timezone,
+      },
+    };
+  });
+
+  return updated ? next : steps;
+}
+
+export function normalizeScheduleTriggerStepsJson(
+  stepsValue: string | null | undefined,
+  params: {
+    scheduleType: LocalScheduleType;
+    scheduleValue: string;
+    timezone: string;
+  },
+): string | null | undefined {
+  if (!stepsValue) return stepsValue;
+
+  try {
+    const parsed = JSON.parse(stepsValue) as WorkflowStep[];
+    if (!Array.isArray(parsed)) return stepsValue;
+    const normalized = normalizeScheduleTriggerSteps(parsed, params);
+    return normalized === parsed ? stepsValue : JSON.stringify(normalized);
+  } catch {
+    return stepsValue;
+  }
+}


### PR DESCRIPTION
When a schedule's interval, cron expression, or timezone was updated, the stored trigger step label and triggerConfig in the steps JSON were not refreshed. This caused the listing UI to show stale labels — e.g. "Every 5 minutes" after changing the cron to "*/10 * * * *".

**Changes:**
- Extracted shared `formatScheduleTriggerLabel` / `normalizeScheduleTriggerSteps` into `trigger-metadata.ts` (deduplicated an inline `formatIntervalLabel` in the API)
- Normalize trigger metadata on tool-based task creation and update (`sketch-tools.ts`)
- Normalize trigger metadata when listing tasks (`scheduled-tasks.ts` API endpoint)
- Fixed cron minute-field regex (`/^\*\/\d+$/`) to not mislabel mixed expressions like `*/15,10 * * * *` as "Every 15 minutes"

**How to test:**
1. Create a scheduled task with cron `*/5 * * * *` → label shows "Every 5 minutes"
2. Update the task to `*/10 * * * *` (no steps change) → label updates to "Every 10 minutes"
3. Create with `*/15,10 * * * *` → label shows "Cron: */15,10 * * * * (UTC)" instead of incorrectly "Every 15 minutes"
