### PR TITLE
feat: admin file content bypass setting

### DIFF
--- a/packages/server/src/api/auth-helpers.ts
+++ b/packages/server/src/api/auth-helpers.ts
@@ -43,11 +43,13 @@ export function getFileViewer(c: Context): FileViewer {
 }
 
 /**
- * Same shape as getFileViewer but always isAdmin: false.
- * Use for content-read endpoints (file body, mention contexts) — admin role grants
- * ops access (manage connectors, see metadata) but does NOT confer read access to
- * private contents. The two named call sites make the asymmetry obvious.
+ * Same shape as getFileViewer but admin status is gated by the org-level
+ * `admin_can_read_all_files` setting. By default admin role grants ops access
+ * (manage connectors, see metadata) but does NOT confer read access to private
+ * contents. Orgs that need it can flip the setting on from Settings → Access.
+ * The agent file-content tool stays on email rails regardless of this setting.
  */
 export function getContentViewer(c: Context): FileViewer {
-  return { email: c.get("email") ?? null, isAdmin: false };
+  const bypass = c.get("adminCanReadAllFiles") === true;
+  return { email: c.get("email") ?? null, isAdmin: isAdmin(c) && bypass };
 }

--- a/packages/server/src/api/connectors-authz.test.ts
+++ b/packages/server/src/api/connectors-authz.test.ts
@@ -466,6 +466,81 @@ describe("Connectors API — authorization", () => {
     });
   });
 
+  describe("GET /files/:fileId/content — admin content bypass setting", () => {
+    /**
+     * Insert a file restricted to a scope that does NOT include the admin's email,
+     * so the admin would normally be denied content access. Returns the file id.
+     */
+    async function insertRestrictedFile(): Promise<string> {
+      const cfg = await insertConfig(db, { connectorType: "fireflies", createdBy: memberId });
+      await db
+        .insertInto("access_scopes")
+        .values({
+          id: "scope-restricted",
+          connector_config_id: cfg.id,
+          scope_type: "drive",
+          provider_scope_id: "drive-r",
+        })
+        .execute();
+      await db
+        .insertInto("access_scope_members")
+        .values({ access_scope_id: "scope-restricted", email: OTHER_MEMBER_EMAIL })
+        .execute();
+      const repo = createConnectorRepository(db);
+      const result = await repo.upsertFile({
+        source: "fireflies",
+        providerFileId: `pf-restricted-${Math.random().toString(36).slice(2)}`,
+        providerUrl: null,
+        fileName: "restricted.txt",
+        fileType: "text/plain",
+        contentCategory: "document",
+        content: "secret payload",
+        sourcePath: null,
+        contentHash: null,
+        sourceCreatedAt: null,
+        sourceUpdatedAt: null,
+        connectorConfigId: cfg.id,
+      });
+      await repo.linkConnectorFile(cfg.id, result.id);
+      await db
+        .updateTable("indexed_files")
+        .set({ access_scope_id: "scope-restricted" })
+        .where("id", "=", result.id)
+        .execute();
+      return result.id;
+    }
+
+    it("admin → 403 when admin_can_read_all_files=0 (default)", async () => {
+      const fileId = await insertRestrictedFile();
+      const res = await app.request(`/api/connectors/files/${fileId}/content`, {
+        headers: { Cookie: adminCookie },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("admin → 200 with content when admin_can_read_all_files=1", async () => {
+      const fileId = await insertRestrictedFile();
+      await createSettingsRepository(db).update({ adminCanReadAllFiles: 1 });
+
+      const res = await app.request(`/api/connectors/files/${fileId}/content`, {
+        headers: { Cookie: adminCookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.file?.content).toBe("secret payload");
+    });
+
+    it("member without access → 403 even when admin_can_read_all_files=1", async () => {
+      const fileId = await insertRestrictedFile();
+      await createSettingsRepository(db).update({ adminCanReadAllFiles: 1 });
+
+      const res = await app.request(`/api/connectors/files/${fileId}/content`, {
+        headers: { Cookie: memberCookie },
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
   /**
    * Defense-in-depth: enumerate every gated `/:id/*` route and assert each returns 403
    * for an unauthorized caller. This catches the failure mode where a future route

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -29,7 +29,14 @@ import type { createConnectorRepository } from "../db/repositories/connectors";
 import { createEntityRepository } from "../db/repositories/entities";
 import type { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
-import { denyIfCannotEdit, denyIfCannotRead, denyIfNotAdmin, getFileViewer, isAdmin } from "./auth-helpers";
+import {
+  denyIfCannotEdit,
+  denyIfCannotRead,
+  denyIfNotAdmin,
+  getContentViewer,
+  getFileViewer,
+  isAdmin,
+} from "./auth-helpers";
 
 type ConnectorRepo = ReturnType<typeof createConnectorRepository>;
 type UserRepo = ReturnType<typeof createUserRepository>;
@@ -346,7 +353,11 @@ export function connectorRoutes(
   /** Get full content of a file, including who has access and linked entities. */
   routes.get("/files/:fileId/content", async (c) => {
     const fileId = c.req.param("fileId");
-    const userEmails = await getUserEmails(c);
+    // Admin bypass (admin role + admin_can_read_all_files setting) → undefined
+    // signals trusted bypass to getFileContent; otherwise pass the caller's
+    // resolved emails so the 3-tier RBAC check runs.
+    const contentViewer = getContentViewer(c);
+    const userEmails = contentViewer.isAdmin ? undefined : await getUserEmails(c);
     const exists = await db
       .selectFrom("indexed_files")
       .select(["id", "file_name", "file_type", "source", "source_path", "synced_at", "enrichment_status"])

--- a/packages/server/src/api/middleware.ts
+++ b/packages/server/src/api/middleware.ts
@@ -22,6 +22,8 @@ declare module "hono" {
     sub: string;
     /** Caller's primary email — used by file-access RBAC. Null if the user row has no email. */
     email: string | null;
+    /** Org setting: when true, admins bypass per-file content RBAC for direct HTTP reads. */
+    adminCanReadAllFiles: boolean;
   }
 }
 
@@ -98,12 +100,14 @@ export function createAuthMiddleware(settings: SettingsRepo, opts?: AuthMiddlewa
     let setupComplete = false;
     let hasAdmin = false;
     let jwtSecret: string | null = null;
+    let adminCanReadAllFiles = false;
     try {
       const row = await settings.get();
       setupComplete = Boolean(row?.onboarding_completed_at);
       hasAdmin = opts?.hasLocalAdmin ? await opts.hasLocalAdmin() : Boolean(row?.admin_email);
       jwtSecret = row?.jwt_secret ?? null;
       if (jwtSecret) cachedSecret = jwtSecret;
+      adminCanReadAllFiles = row?.admin_can_read_all_files === 1;
     } catch {
       // DB unavailable — let public paths through, block everything else
     }
@@ -141,6 +145,7 @@ export function createAuthMiddleware(settings: SettingsRepo, opts?: AuthMiddlewa
         c.set("role", "admin");
         c.set("sub", "sketch-api-key");
         c.set("email", null);
+        c.set("adminCanReadAllFiles", adminCanReadAllFiles);
         return next();
       }
     }
@@ -166,6 +171,7 @@ export function createAuthMiddleware(settings: SettingsRepo, opts?: AuthMiddlewa
         c.set("role", toAuthRole(user.authRole));
         c.set("sub", user.id);
         c.set("email", user.email ?? payload.email ?? null);
+        c.set("adminCanReadAllFiles", adminCanReadAllFiles);
         return next();
       }
     }
@@ -199,6 +205,7 @@ export function createAuthMiddleware(settings: SettingsRepo, opts?: AuthMiddlewa
       c.set("sub", payload.sub);
       c.set("email", payload.email ?? null);
     }
+    c.set("adminCanReadAllFiles", adminCanReadAllFiles);
 
     return next();
   };

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -24,6 +24,10 @@ const identityUpdateSchema = z.object({
     .optional(),
 });
 
+const accessUpdateSchema = z.object({
+  adminCanReadAllFiles: z.boolean(),
+});
+
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 
 function generateSketchApiKey(): string {
@@ -141,6 +145,31 @@ export function settingsRoutes(settings: SettingsRepo, db?: Kysely<DB>, logger?:
     });
 
     return c.json({ success: true, message: "Enrichment started" });
+  });
+
+  routes.get("/access", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    const row = await settings.get();
+    return c.json({
+      adminCanReadAllFiles: row?.admin_can_read_all_files === 1,
+    });
+  });
+
+  routes.put("/access", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = accessUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+
+    await settings.update({ adminCanReadAllFiles: parsed.data.adminCanReadAllFiles ? 1 : 0 });
+    return c.json({ adminCanReadAllFiles: parsed.data.adminCanReadAllFiles });
   });
 
   routes.get("/api-key", async (c) => {

--- a/packages/server/src/connectors/search.test.ts
+++ b/packages/server/src/connectors/search.test.ts
@@ -283,13 +283,23 @@ describe("filterAccessibleFileIds — 3-tier RBAC", () => {
     }
   });
 
-  it("returns all files when userEmails is empty (no filtering)", async () => {
+  it("returns all files when userEmails is undefined (trusted bypass)", async () => {
+    const accessible = await filterAccessibleFileIds(db, [
+      "file-unrestricted",
+      "file-scope-a",
+      "file-scope-b",
+      "file-per-file",
+    ]);
+    expect(accessible.size).toBe(4);
+  });
+
+  it("returns empty set when userEmails is [] (fail closed)", async () => {
     const accessible = await filterAccessibleFileIds(
       db,
       ["file-unrestricted", "file-scope-a", "file-scope-b", "file-per-file"],
       [],
     );
-    expect(accessible.size).toBe(4);
+    expect(accessible.size).toBe(0);
   });
 
   it("returns unrestricted files for any user", async () => {
@@ -444,10 +454,15 @@ describe("getFileContent — RBAC", () => {
     }
   });
 
-  it("returns file when no userEmails provided (admin/API without auth)", async () => {
+  it("returns file when userEmails is undefined (trusted bypass)", async () => {
     const file = await getFileContent(db, "file-restricted");
     expect(file).toBeTruthy();
     expect(file?.content).toBe("top secret content");
+  });
+
+  it("returns null when userEmails is [] (fail closed)", async () => {
+    const file = await getFileContent(db, "file-restricted", []);
+    expect(file).toBeNull();
   });
 
   it("returns file when user is in the scope", async () => {

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -158,7 +158,13 @@ export async function searchFiles(db: Kysely<DB>, query: string, opts?: SearchOp
  * Used by the agent when it wants to load a document into conversation context,
  * and by the frontend file detail sheet.
  *
- * Access control: 3-tier model (unrestricted / scope / per-file) via userEmails.
+ * Access control:
+ *   - `userEmails === undefined` → trusted bypass (server/agent boot paths,
+ *     admin bypass when the org setting is on). Returns the file unfiltered.
+ *   - `userEmails === []`        → caller has no resolvable email → fail closed.
+ *     Returns null regardless of the file's access shape. Prevents an unauth'd
+ *     user from inheriting visibility through the empty-array path.
+ *   - `userEmails.length > 0`    → 3-tier check (unrestricted / scope / per-file).
  */
 export async function getFileContent(
   db: Kysely<DB>,
@@ -196,9 +202,10 @@ export async function getFileContent(
 
   if (!file) return null;
 
-  // User-level RBAC: 3-tier access check
-  if (userEmails && userEmails.length > 0) {
-    // Tier 1: unrestricted — no scope and no file_access rows
+  // userEmails === undefined → trusted bypass; userEmails === [] → fail closed.
+  if (userEmails !== undefined) {
+    if (userEmails.length === 0) return null;
+
     const hasScope = file.access_scope_id != null;
     const hasFileAccess = await db
       .selectFrom("file_access")
@@ -254,16 +261,22 @@ export async function getFileContent(
 
 /**
  * Filter a list of indexed file IDs down to only those the user can access.
- * Applies the 3-tier RBAC model (unrestricted / scope-level / per-file).
- * Returns the input set unchanged when userEmails is empty (no filtering).
+ *
+ * Contract mirrors `getFileContent`:
+ *   - `userEmails === undefined` → trusted bypass (server/agent boot, admin
+ *     bypass): returns the input set unchanged.
+ *   - `userEmails === []`        → caller has no resolvable email → fail closed:
+ *     returns an empty set.
+ *   - `userEmails.length > 0`    → 3-tier check (unrestricted / scope / per-file).
  */
 export async function filterAccessibleFileIds(
   db: Kysely<DB>,
   fileIds: string[],
-  userEmails: string[],
+  userEmails?: string[],
 ): Promise<Set<string>> {
   if (fileIds.length === 0) return new Set();
-  if (userEmails.length === 0) return new Set(fileIds);
+  if (userEmails === undefined) return new Set(fileIds);
+  if (userEmails.length === 0) return new Set();
 
   const files = await db
     .selectFrom("indexed_files")

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -68,6 +68,7 @@ import * as m065 from "./migrations/065-entity-domains-reserved-seed";
 import * as m066 from "./migrations/066-entity-review-domain-candidates";
 import * as m067 from "./migrations/067-relation-evidence-fact-link";
 import * as m068 from "./migrations/068-entities-ai-brief";
+import * as m069 from "./migrations/069-admin-can-read-all-files";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>): Promise<void> {
@@ -140,6 +141,7 @@ export async function runMigrations(db: Kysely<DB>): Promise<void> {
           "066-entity-review-domain-candidates": m066,
           "067-relation-evidence-fact-link": m067,
           "068-entities-ai-brief": m068,
+          "069-admin-can-read-all-files": m069,
         };
       },
     },

--- a/packages/server/src/db/migrations/069-admin-can-read-all-files.ts
+++ b/packages/server/src/db/migrations/069-admin-can-read-all-files.ts
@@ -1,0 +1,12 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("settings")
+    .addColumn("admin_can_read_all_files", "integer", (c) => c.notNull().defaultTo(0))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("settings").dropColumn("admin_can_read_all_files").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(64);
+    expect(rows.rows).toHaveLength(65);
   });
 
   it("records migrations with correct names in order", async () => {
@@ -98,6 +98,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[61]).toBe("066-entity-review-domain-candidates");
     expect(names[62]).toBe("067-relation-evidence-fact-link");
     expect(names[63]).toBe("068-entities-ai-brief");
+    expect(names[64]).toBe("069-admin-can-read-all-files");
   });
 
   it("running migrations twice is idempotent", async () => {
@@ -106,7 +107,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(64);
+    expect(rows.rows).toHaveLength(65);
   });
 
   it("creates the users table", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(64);
+    expect(rows.rows).toHaveLength(65);
   });
 
   it("records migrations with the correct names in order", async () => {
@@ -101,6 +101,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[61]).toBe("066-entity-review-domain-candidates");
     expect(names[62]).toBe("067-relation-evidence-fact-link");
     expect(names[63]).toBe("068-entities-ai-brief");
+    expect(names[64]).toBe("069-admin-can-read-all-files");
   });
 
   it("creates the users table", async () => {
@@ -222,7 +223,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(64);
+    expect(rows.rows).toHaveLength(65);
   });
 });
 
@@ -254,6 +255,6 @@ describe("runMigrations — incremental upgrade", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(64);
+    expect(rows.rows).toHaveLength(65);
   });
 });

--- a/packages/server/src/db/repositories/settings.test.ts
+++ b/packages/server/src/db/repositories/settings.test.ts
@@ -82,6 +82,18 @@ describe("Settings repository", () => {
     expect(row?.aws_region).toBe("us-east-1");
   });
 
+  it("update() round-trips admin_can_read_all_files and defaults to 0", async () => {
+    await settings.create({ adminEmail: "a@b.com", adminPasswordHash: "hash" });
+    const initial = await settings.get();
+    expect(initial?.admin_can_read_all_files).toBe(0);
+
+    await settings.update({ adminCanReadAllFiles: 1 });
+    expect((await settings.get())?.admin_can_read_all_files).toBe(1);
+
+    await settings.update({ adminCanReadAllFiles: 0 });
+    expect((await settings.get())?.admin_can_read_all_files).toBe(0);
+  });
+
   it("update() allows clearing Slack and LLM credentials with null values", async () => {
     await settings.create({ adminEmail: "a@b.com", adminPasswordHash: "hash" });
     await settings.update({

--- a/packages/server/src/db/repositories/settings.ts
+++ b/packages/server/src/db/repositories/settings.ts
@@ -140,6 +140,7 @@ export function createSettingsRepository(db: Kysely<DB>, encryptionKey?: string)
         googleOauthClientSecret: string | null;
         geminiApiKey: string | null;
         enrichmentEnabled: number | null;
+        adminCanReadAllFiles: number;
         syncIntervalMinutes: number | null;
         orgContext: string | null;
         sketchApiKey: string | null;
@@ -172,6 +173,7 @@ export function createSettingsRepository(db: Kysely<DB>, encryptionKey?: string)
       if (data.googleOauthClientSecret !== undefined) updates.google_oauth_client_secret = data.googleOauthClientSecret;
       if (data.geminiApiKey !== undefined) updates.gemini_api_key = data.geminiApiKey;
       if (data.enrichmentEnabled !== undefined) updates.enrichment_enabled = data.enrichmentEnabled;
+      if (data.adminCanReadAllFiles !== undefined) updates.admin_can_read_all_files = data.adminCanReadAllFiles;
       if (data.syncIntervalMinutes !== undefined) updates.sync_interval_minutes = data.syncIntervalMinutes;
       if (data.sketchApiKey !== undefined) updates.sketch_api_key = data.sketchApiKey;
       if (data.whatsappFallbackAgentId !== undefined) updates.whatsapp_fallback_agent_id = data.whatsappFallbackAgentId;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -78,6 +78,7 @@ export interface SettingsTable {
   google_oauth_client_secret: string | null;
   gemini_api_key: string | null;
   enrichment_enabled: Generated<number>;
+  admin_can_read_all_files: Generated<number>;
   sync_interval_minutes: Generated<number>;
   org_context: string | null;
   sketch_api_key: string | null;

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -796,6 +796,15 @@ export const api = {
     revokeApiKey() {
       return request<{ success: true }>("/api/settings/api-key", { method: "DELETE" });
     },
+    access() {
+      return request<{ adminCanReadAllFiles: boolean }>("/api/settings/access");
+    },
+    updateAccess(data: { adminCanReadAllFiles: boolean }) {
+      return request<{ adminCanReadAllFiles: boolean }>("/api/settings/access", {
+        method: "PUT",
+        body: JSON.stringify(data),
+      });
+    },
     searchConfig() {
       return request<{ geminiApiKeyConfigured: boolean; enrichmentEnabled: number; syncIntervalMinutes: number }>(
         "/api/settings/search",

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from "@sketch/ui/components/button";
 import { Input } from "@sketch/ui/components/input";
 import { Skeleton } from "@sketch/ui/components/skeleton";
+import { Switch } from "@sketch/ui/components/switch";
 import { Textarea } from "@sketch/ui/components/textarea";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
@@ -55,6 +56,7 @@ function SettingsPage() {
 
       <div className="mt-6 space-y-8">
         <OrgContextSection />
+        <AccessSection />
         <ApiKeySection />
       </div>
     </div>
@@ -144,6 +146,60 @@ function OrgContextSection() {
               Save
             </Button>
           </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AccessSection() {
+  const queryClient = useQueryClient();
+  const accessQuery = useQuery({
+    queryKey: ["settings", "access"],
+    queryFn: () => api.settings.access(),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (value: boolean) => api.settings.updateAccess({ adminCanReadAllFiles: value }),
+    onMutate: async (value) => {
+      await queryClient.cancelQueries({ queryKey: ["settings", "access"] });
+      const previous = queryClient.getQueryData<{ adminCanReadAllFiles: boolean }>(["settings", "access"]);
+      queryClient.setQueryData(["settings", "access"], { adminCanReadAllFiles: value });
+      return { previous };
+    },
+    onError: (err: Error, _value, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(["settings", "access"], ctx.previous);
+      toast.error(err.message);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings", "access"] });
+      toast.success("Saved");
+    },
+  });
+
+  const value = accessQuery.data?.adminCanReadAllFiles ?? false;
+
+  return (
+    <section>
+      <p className="mb-3 text-sm font-medium text-muted-foreground">Access</p>
+      {accessQuery.isLoading ? (
+        <Skeleton className="h-20 rounded-lg" />
+      ) : (
+        <div className="flex items-start justify-between gap-4 rounded-lg border border-border bg-card p-4">
+          <div>
+            <p className="text-sm font-medium">Admins can read all file content</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              When off, admins manage connectors and see file metadata but not file content unless explicitly shared.
+              When on, admins can read any file's content. The agent's file-content tool stays on email rails either
+              way.
+            </p>
+          </div>
+          <Switch
+            checked={value}
+            onCheckedChange={(next) => updateMutation.mutate(next)}
+            disabled={updateMutation.isPending}
+            aria-label="Allow admins to read all file content"
+          />
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- Adds a per-org **Admin can read all files** setting (`settings.admin_can_read_all_files`, default `0`), surfaced via a Switch in the Settings → Access section.
- When enabled, admin viewers see the full content of any indexed file regardless of per-file ACL or scope membership. Default off — current behavior is preserved.
- Tightens the `getFileContent` / `filterAccessibleFileIds` contract: `undefined` = trusted bypass, `[]` = fail closed, `length > 0` = scoped check. Replaces the prior fail-open "empty array = trusted" behavior in preparation for file/entity sharing.
- Backend: middleware reads the flag once per request (piggybacking on the existing settings lookup), attaches `adminCanReadAllFiles` to the request context for all auth paths (API key, managed SSO, local cookie, JWT). `getContentViewer` returns `isAdmin: isAdmin(c) && bypass`. The agent tool path is unaffected — it stays on email-based rails by design (a future PR can introduce a workspace-level toggle if needed).
- Frontend: optimistic Switch with toast on success/error, follows the `OrgContextSection` pattern in the same file.
- Migration `069-admin-can-read-all-files` adds the column.

Plan: `.planning/access/implemented/ADMIN_FILE_BYPASS.md`

## Test plan
- [x] Settings repo round-trip (`packages/server/src/db/repositories/settings.test.ts`)
- [x] `getFileContent` and `filterAccessibleFileIds` contract tests — `undefined` vs `[]` (`packages/server/src/connectors/search.test.ts`)
- [x] API authz: admin GET `/files/:id/content` returns 403 with bypass off, 200 with bypass on; non-admin member without access still 403 with bypass on (`packages/server/src/api/connectors-authz.test.ts`)
- [x] `pnpm typecheck` clean across all 4 workspaces
- [x] `pnpm biome check` clean on all touched files
- [ ] Manual smoke: toggle the Switch in `/settings` as admin → restricted-file content panel becomes accessible; toggle off → reverts to 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)