### PR TITLE
feat: manual file sharing (Google Drive-style)

### DIFF
--- a/packages/server/src/api/connectors-authz.test.ts
+++ b/packages/server/src/api/connectors-authz.test.ts
@@ -541,6 +541,71 @@ describe("Connectors API — authorization", () => {
     });
   });
 
+  describe("file shares — POST / PUT share-everyone authz", () => {
+    async function insertSharableFile(): Promise<string> {
+      const cfg = await insertConfig(db, { connectorType: "fireflies", createdBy: memberId });
+      const repo = createConnectorRepository(db);
+      const result = await repo.upsertFile({
+        source: "fireflies",
+        providerFileId: `pf-share-${Math.random().toString(36).slice(2)}`,
+        providerUrl: null,
+        fileName: "sharable.txt",
+        fileType: "text/plain",
+        contentCategory: "document",
+        content: null,
+        sourcePath: null,
+        contentHash: null,
+        sourceCreatedAt: null,
+        sourceUpdatedAt: null,
+        connectorConfigId: cfg.id,
+      });
+      await repo.linkConnectorFile(cfg.id, result.id);
+      return result.id;
+    }
+
+    it("only admin or connector owner can POST a share; share-everyone is admin-only", async () => {
+      const fileId = await insertSharableFile();
+
+      // memberCookie is the connector owner → 200; otherMemberCookie is not → 403.
+      const ownerRes = await app.request(`/api/connectors/files/${fileId}/shares`, {
+        method: "POST",
+        headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "alice@example.com" }),
+      });
+      expect(ownerRes.status).toBe(200);
+
+      const strangerRes = await app.request(`/api/connectors/files/${fileId}/shares`, {
+        method: "POST",
+        headers: { Cookie: otherMemberCookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "bob@example.com" }),
+      });
+      expect(strangerRes.status).toBe(403);
+
+      // Admin can also share.
+      const adminRes = await app.request(`/api/connectors/files/${fileId}/shares`, {
+        method: "POST",
+        headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "carol@example.com" }),
+      });
+      expect(adminRes.status).toBe(200);
+
+      // share-everyone is admin-only: the connector owner (member) is denied.
+      const ownerEveryone = await app.request(`/api/connectors/files/${fileId}/share-everyone`, {
+        method: "PUT",
+        headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+      expect(ownerEveryone.status).toBe(403);
+
+      const adminEveryone = await app.request(`/api/connectors/files/${fileId}/share-everyone`, {
+        method: "PUT",
+        headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+      expect(adminEveryone.status).toBe(200);
+    });
+  });
+
   /**
    * Defense-in-depth: enumerate every gated `/:id/*` route and assert each returns 403
    * for an unauthorized caller. This catches the failure mode where a future route

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -27,6 +27,7 @@ import { getSyncProgress, runConnectorSync } from "../connectors/sync";
 import type { ApiKeyCredentials, ConnectorCredentials, ConnectorType, OAuthCredentials } from "../connectors/types";
 import type { createConnectorRepository } from "../db/repositories/connectors";
 import { createEntityRepository } from "../db/repositories/entities";
+import { createFileSharesRepository } from "../db/repositories/file-shares";
 import type { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import {
@@ -110,6 +111,7 @@ export function connectorRoutes(
   >,
 ) {
   const routes = new Hono();
+  const fileSharesRepo = createFileSharesRepository(db);
 
   async function getUserEmails(c: { get: (key: string) => unknown }): Promise<string[]> {
     if (!userRepo) return [];
@@ -411,6 +413,8 @@ export function connectorRoutes(
     }
 
     const accessDetails = await connectorRepo.getFileAccessDetails(fileId);
+    const manualShares = await fileSharesRepo.listForFile(fileId);
+    const shareWithEveryone = await fileSharesRepo.getOrgWide(fileId);
 
     // Get entities linked to this file via entity_mentions
     const mentions = await db
@@ -452,8 +456,160 @@ export function connectorRoutes(
           source: a.source,
           mapped: !!a.userId,
         })),
+        manualShares: manualShares.map((s) => ({ email: s.email, grantedAt: s.granted_at })),
+        shareWithEveryone,
       },
       entities: linkedEntities,
+    });
+  });
+
+  /**
+   * Manual file share management. Connector reconcile never touches these rows.
+   *
+   * Authz:
+   *   - GET, POST, DELETE individual shares: admin OR connector owner
+   *     (admins always have manage access; connector owners can share files
+   *     they ingested)
+   *   - PUT share-everyone: admin only (org-wide flag)
+   *   - PUT batch: admin OR connector owner for the emails delta, plus admin
+   *     gate when shareWithEveryone is in the body
+   */
+  const shareEmailBodySchema = z.object({ email: z.string().email().toLowerCase() });
+  const shareEveryoneBodySchema = z.object({ enabled: z.boolean() });
+  const shareBatchBodySchema = z.object({
+    emails: z.array(z.string().email().toLowerCase()),
+    shareWithEveryone: z.boolean().optional(),
+  });
+
+  async function loadFileForShare(fileId: string) {
+    const config = await connectorRepo.findConfigByFileId(fileId);
+    if (!config) return null;
+    return { connectorConfigId: config.id, createdBy: config.created_by };
+  }
+
+  routes.get("/files/:fileId/shares", async (c) => {
+    const fileId = c.req.param("fileId");
+    const fileOwner = await loadFileForShare(fileId);
+    if (!fileOwner) return c.json({ error: { code: "NOT_FOUND", message: "File not found" } }, 404);
+    const denied = denyIfCannotEdit(c, { created_by: fileOwner.createdBy });
+    if (denied) return denied;
+    const shares = await fileSharesRepo.listForFile(fileId);
+    const shareWithEveryone = await fileSharesRepo.getOrgWide(fileId);
+    return c.json({
+      shares: shares.map((s) => ({ email: s.email, grantedAt: s.granted_at })),
+      shareWithEveryone,
+    });
+  });
+
+  routes.post("/files/:fileId/shares", async (c) => {
+    const fileId = c.req.param("fileId");
+    const fileOwner = await loadFileForShare(fileId);
+    if (!fileOwner) return c.json({ error: { code: "NOT_FOUND", message: "File not found" } }, 404);
+    const denied = denyIfCannotEdit(c, { created_by: fileOwner.createdBy });
+    if (denied) return denied;
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = shareEmailBodySchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+    const grantedBy = c.get("sub") as string;
+    await fileSharesRepo.grantToEmail(fileId, parsed.data.email, grantedBy);
+    const shares = await fileSharesRepo.listForFile(fileId);
+    return c.json({ shares: shares.map((s) => ({ email: s.email, grantedAt: s.granted_at })) });
+  });
+
+  routes.delete("/files/:fileId/shares/:email", async (c) => {
+    const fileId = c.req.param("fileId");
+    const email = decodeURIComponent(c.req.param("email"));
+    const fileOwner = await loadFileForShare(fileId);
+    if (!fileOwner) return c.json({ error: { code: "NOT_FOUND", message: "File not found" } }, 404);
+    const denied = denyIfCannotEdit(c, { created_by: fileOwner.createdBy });
+    if (denied) return denied;
+    await fileSharesRepo.revokeFromEmail(fileId, email);
+    return c.json({ success: true });
+  });
+
+  routes.put("/files/:fileId/share-everyone", async (c) => {
+    const fileId = c.req.param("fileId");
+    const fileOwner = await loadFileForShare(fileId);
+    if (!fileOwner) return c.json({ error: { code: "NOT_FOUND", message: "File not found" } }, 404);
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = shareEveryoneBodySchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+    await fileSharesRepo.setOrgWide(fileId, parsed.data.enabled);
+    return c.json({ shareWithEveryone: parsed.data.enabled });
+  });
+
+  /**
+   * Replace the share set in one transaction. Lets the UI commit the dialog
+   * without sequencing several requests; partial-save states aren't possible.
+   */
+  routes.put("/files/:fileId/shares", async (c) => {
+    const fileId = c.req.param("fileId");
+    const fileOwner = await loadFileForShare(fileId);
+    if (!fileOwner) return c.json({ error: { code: "NOT_FOUND", message: "File not found" } }, 404);
+    const editDenied = denyIfCannotEdit(c, { created_by: fileOwner.createdBy });
+    if (editDenied) return editDenied;
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = shareBatchBodySchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+    if (parsed.data.shareWithEveryone !== undefined) {
+      const adminDenied = denyIfNotAdmin(c);
+      if (adminDenied) return adminDenied;
+    }
+    const grantedBy = c.get("sub") as string;
+    const targetEmails = new Set(parsed.data.emails);
+    await db.transaction().execute(async (trx) => {
+      const existing = await trx
+        .selectFrom("file_share_emails")
+        .select("email")
+        .where("indexed_file_id", "=", fileId)
+        .execute();
+      const existingSet = new Set(existing.map((r) => r.email));
+      const toAdd = [...targetEmails].filter((e) => !existingSet.has(e));
+      const toRemove = [...existingSet].filter((e) => !targetEmails.has(e));
+      if (toAdd.length > 0) {
+        await trx
+          .insertInto("file_share_emails")
+          .values(
+            toAdd.map((email) => ({
+              indexed_file_id: fileId,
+              email,
+              granted_by_user_id: grantedBy,
+            })),
+          )
+          .onConflict((oc) => oc.columns(["indexed_file_id", "email"]).doNothing())
+          .execute();
+      }
+      if (toRemove.length > 0) {
+        await trx
+          .deleteFrom("file_share_emails")
+          .where("indexed_file_id", "=", fileId)
+          .where("email", "in", toRemove)
+          .execute();
+      }
+      if (parsed.data.shareWithEveryone !== undefined) {
+        await trx
+          .updateTable("indexed_files")
+          .set({ share_with_everyone: parsed.data.shareWithEveryone ? 1 : 0 })
+          .where("id", "=", fileId)
+          .execute();
+      }
+    });
+    const shares = await fileSharesRepo.listForFile(fileId);
+    const shareWithEveryone = await fileSharesRepo.getOrgWide(fileId);
+    return c.json({
+      shares: shares.map((s) => ({ email: s.email, grantedAt: s.granted_at })),
+      shareWithEveryone,
     });
   });
 

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -387,6 +387,8 @@ export function connectorRoutes(
             },
             access: await (async () => {
               const details = await connectorRepo.getFileAccessDetails(fileId);
+              const manualShares = await fileSharesRepo.listForFile(fileId);
+              const shareWithEveryone = await fileSharesRepo.getOrgWide(fileId);
               return {
                 scope: details.length > 0 ? "restricted" : "unrestricted",
                 members: details.map((a) => ({
@@ -396,6 +398,8 @@ export function connectorRoutes(
                   source: a.source,
                   mapped: !!a.userId,
                 })),
+                manualShares: manualShares.map((s) => ({ email: s.email, grantedAt: s.granted_at })),
+                shareWithEveryone,
               };
             })(),
           }

--- a/packages/server/src/connectors/search.test.ts
+++ b/packages/server/src/connectors/search.test.ts
@@ -330,7 +330,16 @@ describe("filterAccessibleFileIds — 3-tier RBAC", () => {
 describe("search — recency browse applies RBAC before limit", () => {
   let db: Kysely<DB>;
 
-  async function insertMeeting(id: string, sourceUpdatedAt: string, opts: { fileAccessEmails?: string[] } = {}) {
+  async function insertMeeting(
+    id: string,
+    sourceUpdatedAt: string,
+    opts: {
+      content?: string | null;
+      fileAccessEmails?: string[];
+      manualShareEmails?: string[];
+      shareWithEveryone?: boolean;
+    } = {},
+  ) {
     await db
       .insertInto("indexed_files")
       .values({
@@ -343,10 +352,11 @@ describe("search — recency browse applies RBAC before limit", () => {
         source: "fireflies",
         source_path: `/meetings/${id}`,
         provider_url: null,
-        content: null,
+        content: opts.content ?? null,
         summary: null,
         context_note: null,
         access_scope_id: null,
+        share_with_everyone: opts.shareWithEveryone ? 1 : 0,
         source_updated_at: sourceUpdatedAt,
         synced_at: sourceUpdatedAt,
       })
@@ -354,6 +364,23 @@ describe("search — recency browse applies RBAC before limit", () => {
 
     for (const email of opts.fileAccessEmails ?? []) {
       await db.insertInto("file_access").values({ indexed_file_id: id, email }).execute();
+    }
+    if ((opts.manualShareEmails ?? []).length > 0) {
+      await db
+        .insertInto("users")
+        .values({ id: "admin", name: "admin", email: "admin@example.com" })
+        .onConflict((oc) => oc.column("id").doNothing())
+        .execute();
+      await db
+        .insertInto("file_share_emails")
+        .values(
+          (opts.manualShareEmails ?? []).map((email) => ({
+            indexed_file_id: id,
+            email,
+            granted_by_user_id: "admin",
+          })),
+        )
+        .execute();
     }
   }
 
@@ -393,6 +420,31 @@ describe("search — recency browse applies RBAC before limit", () => {
     });
 
     expect(results.map((r) => r.id)).toEqual(["accessible"]);
+  });
+
+  it("includes manually shared and org-wide files in non-empty search", async () => {
+    await insertMeeting("manual-shared", "2026-04-30T10:00:00.000Z", {
+      content: "manual visibility planning",
+      fileAccessEmails: ["other@example.com"],
+      manualShareEmails: ["alice@example.com"],
+    });
+    await insertMeeting("org-shared", "2026-04-30T09:00:00.000Z", {
+      content: "org visibility planning",
+      fileAccessEmails: ["other@example.com"],
+      shareWithEveryone: true,
+    });
+    await insertMeeting("blocked-shared", "2026-04-30T08:00:00.000Z", {
+      content: "blocked visibility planning",
+      fileAccessEmails: ["other@example.com"],
+    });
+
+    const results = await search(db, "shared", {
+      source: "fireflies",
+      limit: 10,
+      userEmails: ["alice@example.com"],
+    });
+
+    expect(results.map((r) => r.id).sort()).toEqual(["manual-shared", "org-shared"]);
   });
 });
 

--- a/packages/server/src/connectors/search.test.ts
+++ b/packages/server/src/connectors/search.test.ts
@@ -480,6 +480,32 @@ describe("getFileContent — RBAC", () => {
     const file = await getFileContent(db, "does-not-exist", ["member@example.com"]);
     expect(file).toBeNull();
   });
+
+  it("manual share grants content access; revoking removes it immediately", async () => {
+    // outsider isn't in scope-c → blocked.
+    expect(await getFileContent(db, "file-restricted", ["outsider@example.com"])).toBeNull();
+
+    await db
+      .insertInto("users")
+      .values({ id: "u-admin", name: "admin", email: "admin@example.com" })
+      .onConflict((oc) => oc.column("id").doNothing())
+      .execute();
+    await db
+      .insertInto("file_share_emails")
+      .values({ indexed_file_id: "file-restricted", email: "outsider@example.com", granted_by_user_id: "u-admin" })
+      .execute();
+
+    const granted = await getFileContent(db, "file-restricted", ["outsider@example.com"]);
+    expect(granted?.content).toBe("top secret content");
+
+    await db
+      .deleteFrom("file_share_emails")
+      .where("indexed_file_id", "=", "file-restricted")
+      .where("email", "=", "outsider@example.com")
+      .execute();
+
+    expect(await getFileContent(db, "file-restricted", ["outsider@example.com"])).toBeNull();
+  });
 });
 
 describe("listIndexedSourcesForPrompt", () => {

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -196,6 +196,7 @@ export async function getFileContent(
       "provider_url",
       "enrichment_status",
       "access_scope_id",
+      "share_with_everyone",
     ])
     .where("id", "=", fileId)
     .executeTakeFirst();
@@ -206,42 +207,56 @@ export async function getFileContent(
   if (userEmails !== undefined) {
     if (userEmails.length === 0) return null;
 
-    const hasScope = file.access_scope_id != null;
-    const hasFileAccess = await db
-      .selectFrom("file_access")
-      .select("email")
-      .where("indexed_file_id", "=", fileId)
-      .limit(1)
-      .execute();
+    if (file.share_with_everyone !== 1) {
+      const hasScope = file.access_scope_id != null;
+      const hasFileAccess = await db
+        .selectFrom("file_access")
+        .select("email")
+        .where("indexed_file_id", "=", fileId)
+        .limit(1)
+        .execute();
 
-    if (hasScope || hasFileAccess.length > 0) {
-      let allowed = false;
+      if (hasScope || hasFileAccess.length > 0) {
+        let allowed = false;
 
-      // Tier 2: scope-level access
-      if (hasScope && file.access_scope_id) {
-        const scopeMatch = await db
-          .selectFrom("access_scope_members")
-          .select("email")
-          .where("access_scope_id", "=", file.access_scope_id)
-          .where("email", "in", userEmails)
-          .limit(1)
-          .execute();
-        if (scopeMatch.length > 0) allowed = true;
+        // Tier 2: scope-level access
+        if (hasScope && file.access_scope_id) {
+          const scopeMatch = await db
+            .selectFrom("access_scope_members")
+            .select("email")
+            .where("access_scope_id", "=", file.access_scope_id)
+            .where("email", "in", userEmails)
+            .limit(1)
+            .execute();
+          if (scopeMatch.length > 0) allowed = true;
+        }
+
+        // Tier 3: per-file access
+        if (!allowed && hasFileAccess.length > 0) {
+          const fileMatch = await db
+            .selectFrom("file_access")
+            .select("email")
+            .where("indexed_file_id", "=", fileId)
+            .where("email", "in", userEmails)
+            .limit(1)
+            .execute();
+          if (fileMatch.length > 0) allowed = true;
+        }
+
+        // Tier 4: manual share
+        if (!allowed) {
+          const shareMatch = await db
+            .selectFrom("file_share_emails")
+            .select("email")
+            .where("indexed_file_id", "=", fileId)
+            .where("email", "in", userEmails)
+            .limit(1)
+            .execute();
+          if (shareMatch.length > 0) allowed = true;
+        }
+
+        if (!allowed) return null;
       }
-
-      // Tier 3: per-file access
-      if (!allowed && hasFileAccess.length > 0) {
-        const fileMatch = await db
-          .selectFrom("file_access")
-          .select("email")
-          .where("indexed_file_id", "=", fileId)
-          .where("email", "in", userEmails)
-          .limit(1)
-          .execute();
-        if (fileMatch.length > 0) allowed = true;
-      }
-
-      if (!allowed) return null;
     }
   }
 
@@ -280,11 +295,11 @@ export async function filterAccessibleFileIds(
 
   const files = await db
     .selectFrom("indexed_files")
-    .select(["id", "access_scope_id"])
+    .select(["id", "access_scope_id", "share_with_everyone"])
     .where("id", "in", fileIds)
     .execute();
 
-  const [fileAccessRows, scopeMemberRows] = await Promise.all([
+  const [fileAccessRows, scopeMemberRows, shareRows] = await Promise.all([
     db.selectFrom("file_access").select(["indexed_file_id", "email"]).where("indexed_file_id", "in", fileIds).execute(),
     (async () => {
       const scopeIds = files.map((f) => f.access_scope_id).filter((s): s is string => !!s);
@@ -296,6 +311,12 @@ export async function filterAccessibleFileIds(
         .where("email", "in", userEmails)
         .execute();
     })(),
+    db
+      .selectFrom("file_share_emails")
+      .select(["indexed_file_id", "email"])
+      .where("indexed_file_id", "in", fileIds)
+      .where("email", "in", userEmails)
+      .execute(),
   ]);
 
   const fileAccessByFile = new Map<string, Set<string>>();
@@ -310,10 +331,19 @@ export async function filterAccessibleFileIds(
     set.add(row.email);
     scopeMemberByScope.set(row.access_scope_id, set);
   }
+  const manualSharesByFile = new Set<string>();
+  for (const row of shareRows) {
+    manualSharesByFile.add(row.indexed_file_id);
+  }
 
   const emailSet = new Set(userEmails);
   const allowed = new Set<string>();
   for (const file of files) {
+    if (file.share_with_everyone === 1) {
+      allowed.add(file.id);
+      continue;
+    }
+
     const perFile = fileAccessByFile.get(file.id);
     const hasScope = file.access_scope_id != null;
     const hasFileAccess = (perFile?.size ?? 0) > 0;
@@ -332,12 +362,19 @@ export async function filterAccessibleFileIds(
     }
 
     if (hasFileAccess && perFile) {
+      let matched = false;
       for (const email of emailSet) {
         if (perFile.has(email)) {
           allowed.add(file.id);
+          matched = true;
           break;
         }
       }
+      if (matched) continue;
+    }
+
+    if (manualSharesByFile.has(file.id)) {
+      allowed.add(file.id);
     }
   }
   return allowed;

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -54,6 +54,33 @@ export interface SearchOptions {
   userEmails?: string[];
 }
 
+function fileAccessFilterSql(emailList: string[]) {
+  const emailSql = sql.join(
+    emailList.map((e) => sql`${e}`),
+    sql`,`,
+  );
+  return sql<SqlBool>`(
+    (indexed_files.access_scope_id IS NULL
+      AND NOT EXISTS (SELECT 1 FROM file_access WHERE file_access.indexed_file_id = indexed_files.id))
+    OR EXISTS (
+      SELECT 1 FROM access_scope_members
+      WHERE access_scope_members.access_scope_id = indexed_files.access_scope_id
+      AND access_scope_members.email IN (${emailSql})
+    )
+    OR EXISTS (
+      SELECT 1 FROM file_access
+      WHERE file_access.indexed_file_id = indexed_files.id
+      AND file_access.email IN (${emailSql})
+    )
+    OR EXISTS (
+      SELECT 1 FROM file_share_emails
+      WHERE file_share_emails.indexed_file_id = indexed_files.id
+      AND file_share_emails.email IN (${emailSql})
+    )
+    OR indexed_files.share_with_everyone = 1
+  )`;
+}
+
 /**
  * Search the FTS5 index.
  *
@@ -66,34 +93,8 @@ export interface SearchOptions {
 export async function searchFiles(db: Kysely<DB>, query: string, opts?: SearchOptions): Promise<SearchResult[]> {
   const limit = opts?.limit ?? 10;
 
-  // Build user-level access filter (3-tier model):
-  // 1. Unrestricted: no scope AND no file_access rows → visible to all
-  // 2. Scope-level: user's email in access_scope_members for the file's scope
-  // 3. Per-file: user's email in file_access
   const emailList = opts?.userEmails ?? [];
-  const userFilter =
-    emailList.length > 0
-      ? sql`AND (
-				(indexed_files.access_scope_id IS NULL
-				 AND NOT EXISTS (SELECT 1 FROM file_access WHERE file_access.indexed_file_id = indexed_files.id))
-				OR EXISTS (
-					SELECT 1 FROM access_scope_members
-					WHERE access_scope_members.access_scope_id = indexed_files.access_scope_id
-					AND access_scope_members.email IN (${sql.join(
-            emailList.map((e) => sql`${e}`),
-            sql`,`,
-          )})
-				)
-				OR EXISTS (
-					SELECT 1 FROM file_access
-					WHERE file_access.indexed_file_id = indexed_files.id
-					AND file_access.email IN (${sql.join(
-            emailList.map((e) => sql`${e}`),
-            sql`,`,
-          )})
-				)
-			)`
-      : sql``;
+  const userFilter = emailList.length > 0 ? sql`AND ${fileAccessFilterSql(emailList)}` : sql``;
 
   if (isPg(db)) {
     const tsQuery = sanitizeTsQuery(query);
@@ -909,16 +910,7 @@ export async function hybridSearch(
 
   if (emailList.length > 0 && filteredFiles.length > 0) {
     const fileIds = filteredFiles.map((f) => f.id);
-    const emailSql = sql.join(
-      emailList.map((e) => sql`${e}`),
-      sql`,`,
-    );
 
-    // Single query: returns IDs of files the user can access.
-    // Mirrors the 3-tier model in searchFiles:
-    //   T1 — unrestricted (no scope AND no per-file rows)
-    //   T2 — user is in the file's access scope
-    //   T3 — user has a direct per-file access entry
     const accessRows = await sql<{ id: string }>`
       SELECT indexed_files.id
       FROM indexed_files
@@ -926,20 +918,7 @@ export async function hybridSearch(
         fileIds.map((id) => sql`${id}`),
         sql`,`,
       )})
-      AND (
-        (indexed_files.access_scope_id IS NULL
-         AND NOT EXISTS (SELECT 1 FROM file_access WHERE file_access.indexed_file_id = indexed_files.id))
-        OR EXISTS (
-          SELECT 1 FROM access_scope_members
-          WHERE access_scope_members.access_scope_id = indexed_files.access_scope_id
-          AND access_scope_members.email IN (${emailSql})
-        )
-        OR EXISTS (
-          SELECT 1 FROM file_access
-          WHERE file_access.indexed_file_id = indexed_files.id
-          AND file_access.email IN (${emailSql})
-        )
-      )
+      AND ${fileAccessFilterSql(emailList)}
     `.execute(db);
 
     const allowedIds = new Set(accessRows.rows.map((r) => r.id));
@@ -1157,35 +1136,7 @@ async function browseLatest(
 
   if ((opts.userEmails ?? []).length > 0) {
     const userEmails = opts.userEmails ?? [];
-    q = q.where((eb) =>
-      eb.or([
-        eb.and([
-          eb("indexed_files.access_scope_id", "is", null),
-          eb.not(
-            eb.exists(
-              eb
-                .selectFrom("file_access")
-                .select("indexed_file_id")
-                .whereRef("file_access.indexed_file_id", "=", "indexed_files.id"),
-            ),
-          ),
-        ]),
-        eb.exists(
-          eb
-            .selectFrom("access_scope_members")
-            .select("access_scope_id")
-            .whereRef("access_scope_members.access_scope_id", "=", "indexed_files.access_scope_id")
-            .where("access_scope_members.email", "in", userEmails),
-        ),
-        eb.exists(
-          eb
-            .selectFrom("file_access")
-            .select("indexed_file_id")
-            .whereRef("file_access.indexed_file_id", "=", "indexed_files.id")
-            .where("file_access.email", "in", userEmails),
-        ),
-      ]),
-    );
+    q = q.where(fileAccessFilterSql(userEmails));
   }
 
   if (opts.after || opts.before) {

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -69,6 +69,7 @@ import * as m066 from "./migrations/066-entity-review-domain-candidates";
 import * as m067 from "./migrations/067-relation-evidence-fact-link";
 import * as m068 from "./migrations/068-entities-ai-brief";
 import * as m069 from "./migrations/069-admin-can-read-all-files";
+import * as m070 from "./migrations/070-file-shares";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>): Promise<void> {
@@ -142,6 +143,7 @@ export async function runMigrations(db: Kysely<DB>): Promise<void> {
           "067-relation-evidence-fact-link": m067,
           "068-entities-ai-brief": m068,
           "069-admin-can-read-all-files": m069,
+          "070-file-shares": m070,
         };
       },
     },

--- a/packages/server/src/db/migrations/070-file-shares.ts
+++ b/packages/server/src/db/migrations/070-file-shares.ts
@@ -1,0 +1,35 @@
+/**
+ * Manual file sharing on top of connector-derived access.
+ *
+ * - file_share_emails: per-(file, email) grants. Independent of file_access and
+ *   access_scope_members so connector reconcile cannot trample manual shares.
+ * - indexed_files.share_with_everyone: org-wide visibility flag (admin-only toggle).
+ */
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("file_share_emails")
+    .addColumn("indexed_file_id", "text", (col) => col.notNull().references("indexed_files.id").onDelete("cascade"))
+    .addColumn("email", "text", (col) => col.notNull())
+    .addColumn("granted_by_user_id", "text", (col) => col.notNull().references("users.id"))
+    .addColumn("granted_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addPrimaryKeyConstraint("file_share_emails_pk", ["indexed_file_id", "email"])
+    .execute();
+
+  await sql`CREATE INDEX idx_file_share_emails_email ON file_share_emails(email)`.execute(db);
+
+  await db.schema
+    .alterTable("indexed_files")
+    .addColumn("share_with_everyone", "integer", (col) => col.notNull().defaultTo(0))
+    .execute();
+
+  await sql`CREATE INDEX idx_indexed_files_share_with_everyone ON indexed_files(share_with_everyone)`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_indexed_files_share_with_everyone`.execute(db);
+  await db.schema.alterTable("indexed_files").dropColumn("share_with_everyone").execute();
+  await sql`DROP INDEX IF EXISTS idx_file_share_emails_email`.execute(db);
+  await db.schema.dropTable("file_share_emails").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(65);
+    expect(rows.rows).toHaveLength(66);
   });
 
   it("records migrations with correct names in order", async () => {
@@ -99,6 +99,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[62]).toBe("067-relation-evidence-fact-link");
     expect(names[63]).toBe("068-entities-ai-brief");
     expect(names[64]).toBe("069-admin-can-read-all-files");
+    expect(names[65]).toBe("070-file-shares");
   });
 
   it("running migrations twice is idempotent", async () => {
@@ -107,7 +108,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(65);
+    expect(rows.rows).toHaveLength(66);
   });
 
   it("creates the users table", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(65);
+    expect(rows.rows).toHaveLength(66);
   });
 
   it("records migrations with the correct names in order", async () => {
@@ -102,6 +102,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[62]).toBe("067-relation-evidence-fact-link");
     expect(names[63]).toBe("068-entities-ai-brief");
     expect(names[64]).toBe("069-admin-can-read-all-files");
+    expect(names[65]).toBe("070-file-shares");
   });
 
   it("creates the users table", async () => {
@@ -223,7 +224,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(65);
+    expect(rows.rows).toHaveLength(66);
   });
 });
 
@@ -255,6 +256,6 @@ describe("runMigrations — incremental upgrade", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(65);
+    expect(rows.rows).toHaveLength(66);
   });
 });

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -27,9 +27,11 @@ export interface FileViewer {
 /**
  * Predicate matching files visible to `viewer`. Composed into queries via `.where(...)`.
  *
- *   unrestricted  = no scope AND no per-file shares
- *   scoped        = caller is in access_scope_members for the file's scope
- *   per-file      = caller has a row in file_access for the file
+ *   unrestricted    = no scope AND no per-file shares
+ *   scoped          = caller is in access_scope_members for the file's scope
+ *   per-file        = caller has a row in file_access for the file
+ *   manual share    = caller's email is in file_share_emails for the file
+ *   org-wide        = indexed_files.share_with_everyone = 1
  *
  * v1 matches the caller's primary email only; multi-email users (Slack login email
  * differs from connector-side email) under-see — the safe failure direction. v2 will
@@ -49,6 +51,10 @@ export function fileVisibilityPredicate(viewer: FileViewer) {
     OR EXISTS (SELECT 1 FROM file_access fa
                WHERE fa.indexed_file_id = indexed_files.id
                  AND fa.email = ${email})
+    OR EXISTS (SELECT 1 FROM file_share_emails fse
+               WHERE fse.indexed_file_id = indexed_files.id
+                 AND fse.email = ${email})
+    OR indexed_files.share_with_everyone = 1
   )`;
 }
 

--- a/packages/server/src/db/repositories/file-shares.ts
+++ b/packages/server/src/db/repositories/file-shares.ts
@@ -1,0 +1,73 @@
+/**
+ * Repository for manual file shares — `file_share_emails` rows and the
+ * `indexed_files.share_with_everyone` flag.
+ *
+ * Independent of `file_access` and `access_scope_members`: connector reconcile
+ * never touches these tables, so manual grants survive resyncs.
+ */
+import type { Kysely } from "kysely";
+import type { DB } from "../schema";
+
+export interface FileShareRow {
+  email: string;
+  granted_by_user_id: string;
+  granted_at: string;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function createFileSharesRepository(db: Kysely<DB>) {
+  return {
+    /** List manual grants for a file, newest first. */
+    async listForFile(fileId: string): Promise<FileShareRow[]> {
+      return db
+        .selectFrom("file_share_emails")
+        .select(["email", "granted_by_user_id", "granted_at"])
+        .where("indexed_file_id", "=", fileId)
+        .orderBy("granted_at", "desc")
+        .execute();
+    },
+
+    /** Idempotent grant — re-granting does not bump granted_at. */
+    async grantToEmail(fileId: string, email: string, grantedByUserId: string): Promise<void> {
+      await db
+        .insertInto("file_share_emails")
+        .values({
+          indexed_file_id: fileId,
+          email: normalizeEmail(email),
+          granted_by_user_id: grantedByUserId,
+        })
+        .onConflict((oc) => oc.columns(["indexed_file_id", "email"]).doNothing())
+        .execute();
+    },
+
+    async revokeFromEmail(fileId: string, email: string): Promise<void> {
+      await db
+        .deleteFrom("file_share_emails")
+        .where("indexed_file_id", "=", fileId)
+        .where("email", "=", normalizeEmail(email))
+        .execute();
+    },
+
+    async setOrgWide(fileId: string, value: boolean): Promise<void> {
+      await db
+        .updateTable("indexed_files")
+        .set({ share_with_everyone: value ? 1 : 0 })
+        .where("id", "=", fileId)
+        .execute();
+    },
+
+    async getOrgWide(fileId: string): Promise<boolean> {
+      const row = await db
+        .selectFrom("indexed_files")
+        .select(["share_with_everyone"])
+        .where("id", "=", fileId)
+        .executeTakeFirst();
+      return row?.share_with_everyone === 1;
+    },
+  };
+}
+
+export type FileSharesRepository = ReturnType<typeof createFileSharesRepository>;

--- a/packages/server/src/db/repositories/file-visibility.test.ts
+++ b/packages/server/src/db/repositories/file-visibility.test.ts
@@ -222,4 +222,35 @@ describe("file-visibility predicate (RBAC for file list/count)", () => {
       }
     });
   });
+
+  describe("manual file sharing (file_share_emails + share_with_everyone)", () => {
+    it("a manual share grants list visibility; share_with_everyone fans out to any email", async () => {
+      const repo = createConnectorRepository(db);
+
+      // dana isn't in any scope or per-file ACL; before sharing, she sees only the unrestricted file.
+      const before = await repo.listAllFiles({ limit: 50, offset: 0, viewer: member("dana@example.com") });
+      expect(before.map((f) => f.id)).toEqual(["f-unrestricted"]);
+
+      // Grant dana a manual share to a restricted file → it should show up in her list.
+      await db
+        .insertInto("users")
+        .values({ id: "u-admin", name: "admin", email: "admin@example.com" })
+        .onConflict((oc) => oc.column("id").doNothing())
+        .execute();
+      await db
+        .insertInto("file_share_emails")
+        .values({ indexed_file_id: "f-scope-a", email: "dana@example.com", granted_by_user_id: "u-admin" })
+        .execute();
+
+      const afterShare = await repo.listAllFiles({ limit: 50, offset: 0, viewer: member("dana@example.com") });
+      expect(afterShare.map((f) => f.id).sort()).toEqual(["f-scope-a", "f-unrestricted"]);
+
+      // Flip share_with_everyone on a different file → it must be visible to any email
+      // (e.g. an unrelated 'eve@example.com') with no other access path.
+      await db.updateTable("indexed_files").set({ share_with_everyone: 1 }).where("id", "=", "f-scope-b").execute();
+
+      const eveFiles = await repo.listAllFiles({ limit: 50, offset: 0, viewer: member("eve@example.com") });
+      expect(eveFiles.map((f) => f.id).sort()).toEqual(["f-scope-b", "f-unrestricted"]);
+    });
+  });
 });

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -130,6 +130,7 @@ export interface IndexedFilesTable {
   mime_type: string | null;
   embedding_status: Generated<string>;
   summary_status: Generated<string>;
+  share_with_everyone: Generated<number>;
 }
 
 export interface ChunkEmbeddingsTable {
@@ -191,6 +192,13 @@ export interface UserProviderIdentitiesTable {
 export interface FileAccessTable {
   indexed_file_id: string;
   email: string;
+}
+
+export interface FileShareEmailsTable {
+  indexed_file_id: string;
+  email: string;
+  granted_by_user_id: string;
+  granted_at: Generated<string>;
 }
 
 export interface EmailVerificationTokensTable {
@@ -521,6 +529,7 @@ export interface DB {
   file_embeddings: FileEmbeddingsTable;
   user_provider_identities: UserProviderIdentitiesTable;
   file_access: FileAccessTable;
+  file_share_emails: FileShareEmailsTable;
   email_verification_tokens: EmailVerificationTokensTable;
   magic_link_tokens: MagicLinkTokensTable;
   agent_environment_variables: AgentEnvironmentVariablesTable;

--- a/packages/web/src/components/file-share-dialog.tsx
+++ b/packages/web/src/components/file-share-dialog.tsx
@@ -1,0 +1,303 @@
+/**
+ * FileShareDialog — Google Drive style sharing for an indexed file.
+ *
+ * Mirrors the manage-shares contract on the server: emails go into
+ * file_share_emails, the org-wide flag goes onto indexed_files. Connector
+ * reconcile never touches these so manual shares survive resyncs.
+ *
+ * Admin-only in v1: the calling component should gate the trigger button on
+ * `auth.role === "admin"`. Backend also allows connector owners — they reach
+ * the same endpoints via API but no UI affordance exists yet.
+ */
+import { api } from "@/lib/api";
+import type { FileManualShare, User } from "@/lib/api";
+import { GlobeIcon, LockSimpleIcon, SpinnerGapIcon, XIcon } from "@phosphor-icons/react";
+import { Button } from "@sketch/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@sketch/ui/components/dialog";
+import { Input } from "@sketch/ui/components/input";
+import { Switch } from "@sketch/ui/components/switch";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+interface FileShareDialogProps {
+  fileId: string;
+  fileName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isEmail(value: string) {
+  return EMAIL_PATTERN.test(value.trim());
+}
+
+export function FileShareDialog({ fileId, fileName, open, onOpenChange }: FileShareDialogProps) {
+  const queryClient = useQueryClient();
+
+  const sharesQuery = useQuery({
+    queryKey: ["file-shares", fileId],
+    queryFn: () => api.integrations.listFileShares(fileId),
+    enabled: open,
+  });
+
+  const usersQuery = useQuery({
+    queryKey: ["users-for-share"],
+    queryFn: () => api.users.list(),
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const [pendingEmails, setPendingEmails] = useState<string[]>([]);
+  const [draft, setDraft] = useState("");
+  const [orgWideDraft, setOrgWideDraft] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setPendingEmails([]);
+      setDraft("");
+      setOrgWideDraft(null);
+    }
+  }, [open]);
+
+  const currentEmails = useMemo(() => sharesQuery.data?.shares.map((s) => s.email) ?? [], [sharesQuery.data]);
+  const finalEmails = useMemo(() => {
+    const combined = new Set([...currentEmails, ...pendingEmails]);
+    return [...combined];
+  }, [currentEmails, pendingEmails]);
+  const currentOrgWide = sharesQuery.data?.shareWithEveryone ?? false;
+  const effectiveOrgWide = orgWideDraft ?? currentOrgWide;
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      api.integrations.updateFileShares(fileId, {
+        emails: finalEmails.map((e) => e.toLowerCase()),
+        shareWithEveryone: orgWideDraft ?? undefined,
+      }),
+    onSuccess: () => {
+      toast.success("Sharing updated");
+      queryClient.invalidateQueries({ queryKey: ["file-shares", fileId] });
+      queryClient.invalidateQueries({ queryKey: ["file-content", fileId] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (email: string) => api.integrations.revokeFileShare(fileId, email),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["file-shares", fileId] });
+      queryClient.invalidateQueries({ queryKey: ["file-content", fileId] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  function tryAddEmail() {
+    const value = draft.trim().toLowerCase();
+    if (!value) return;
+    if (!isEmail(value)) {
+      toast.error("Enter a valid email");
+      return;
+    }
+    if (finalEmails.includes(value)) {
+      setDraft("");
+      return;
+    }
+    setPendingEmails((prev) => [...prev, value]);
+    setDraft("");
+  }
+
+  function removePending(email: string) {
+    setPendingEmails((prev) => prev.filter((e) => e !== email));
+  }
+
+  const hasOrgWideChange = orgWideDraft !== null && orgWideDraft !== currentOrgWide;
+  const hasPendingEmails = pendingEmails.length > 0;
+  const canSave = hasPendingEmails || hasOrgWideChange;
+
+  const suggestions = useMemo(() => {
+    const draftLower = draft.trim().toLowerCase();
+    if (!draftLower) return [];
+    const used = new Set(finalEmails);
+    return (usersQuery.data?.users ?? [])
+      .map((u) => u.email)
+      .filter((email): email is string => !!email)
+      .map((email) => email.toLowerCase())
+      .filter((email) => email.includes(draftLower) && !used.has(email))
+      .slice(0, 5);
+  }, [draft, finalEmails, usersQuery.data]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-base">Share "{fileName}"</DialogTitle>
+          <DialogDescription className="text-xs">
+            People you add can read this file's contents regardless of the underlying connector access.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-2">Add people</p>
+            <div className="flex gap-2">
+              <Input
+                placeholder="name@example.com"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === ",") {
+                    e.preventDefault();
+                    tryAddEmail();
+                  }
+                }}
+                className="text-sm"
+              />
+              <Button size="sm" variant="outline" onClick={tryAddEmail} disabled={!draft.trim()}>
+                Add
+              </Button>
+            </div>
+            {suggestions.length > 0 && (
+              <div className="mt-1 space-y-0.5">
+                {suggestions.map((email) => (
+                  <button
+                    type="button"
+                    key={email}
+                    className="block w-full rounded px-2 py-1 text-left text-xs hover:bg-muted"
+                    onClick={() => {
+                      setPendingEmails((prev) => (prev.includes(email) ? prev : [...prev, email]));
+                      setDraft("");
+                    }}
+                  >
+                    {email}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {sharesQuery.data?.shares.length || pendingEmails.length ? (
+            <div>
+              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-2">
+                People with access
+              </p>
+              <div className="space-y-1.5">
+                {sharesQuery.data?.shares.map((share) => (
+                  <ShareRow
+                    key={share.email}
+                    share={share}
+                    user={usersQuery.data?.users.find((u) => u.email?.toLowerCase() === share.email)}
+                    onRevoke={() => revokeMutation.mutate(share.email)}
+                    isRevoking={revokeMutation.isPending && revokeMutation.variables === share.email}
+                  />
+                ))}
+                {pendingEmails.map((email) => (
+                  <div
+                    key={email}
+                    className="flex items-center justify-between rounded-md border border-dashed border-border bg-muted/20 px-2.5 py-1.5 text-xs"
+                  >
+                    <span className="truncate">{email}</span>
+                    <span className="flex items-center gap-2">
+                      <span className="text-[10px] text-muted-foreground">Pending</span>
+                      <button
+                        type="button"
+                        onClick={() => removePending(email)}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label={`Remove ${email}`}
+                      >
+                        <XIcon size={12} />
+                      </button>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="rounded-lg border border-border px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                {effectiveOrgWide ? (
+                  <GlobeIcon size={14} className="text-muted-foreground" />
+                ) : (
+                  <LockSimpleIcon size={14} className="text-muted-foreground" />
+                )}
+                <div>
+                  <p className="text-xs font-medium">{effectiveOrgWide ? "Anyone in the org" : "Restricted"}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {effectiveOrgWide
+                      ? "Every authenticated user in the org can read this file."
+                      : "Only the people listed above and connector-derived access apply."}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                checked={effectiveOrgWide}
+                onCheckedChange={(value) => setOrgWideDraft(value)}
+                aria-label="Share with everyone in the org"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button size="sm" onClick={() => updateMutation.mutate()} disabled={!canSave || updateMutation.isPending}>
+            {updateMutation.isPending ? (
+              <>
+                <SpinnerGapIcon size={12} className="animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ShareRow({
+  share,
+  user,
+  onRevoke,
+  isRevoking,
+}: {
+  share: FileManualShare;
+  user?: User;
+  onRevoke: () => void;
+  isRevoking: boolean;
+}) {
+  const displayName = user?.name ?? share.email;
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border px-2.5 py-1.5 text-xs">
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium">{displayName}</p>
+        {user?.name && <p className="truncate text-[11px] text-muted-foreground">{share.email}</p>}
+      </div>
+      <button
+        type="button"
+        onClick={onRevoke}
+        disabled={isRevoking}
+        className="ml-2 text-muted-foreground hover:text-destructive disabled:opacity-50"
+        aria-label={`Revoke ${share.email}`}
+      >
+        {isRevoking ? <SpinnerGapIcon size={12} className="animate-spin" /> : <XIcon size={12} />}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -628,9 +628,21 @@ export interface SearchResult {
   score: number;
 }
 
+export interface FileManualShare {
+  email: string;
+  grantedAt: string;
+}
+
 export interface FileAccess {
   scope: "restricted" | "unrestricted";
   members: FileAccessMember[];
+  manualShares: FileManualShare[];
+  shareWithEveryone: boolean;
+}
+
+export interface FileSharesResponse {
+  shares: FileManualShare[];
+  shareWithEveryone: boolean;
 }
 
 export interface ProviderIdentity {
@@ -936,6 +948,20 @@ export const api = {
       return request<{ file: FileContent; access: FileAccess; entities: LinkedEntity[] }>(
         `/api/connectors/files/${fileId}/content`,
       );
+    },
+    listFileShares(fileId: string) {
+      return request<FileSharesResponse>(`/api/connectors/files/${fileId}/shares`);
+    },
+    updateFileShares(fileId: string, data: { emails: string[]; shareWithEveryone?: boolean }) {
+      return request<FileSharesResponse>(`/api/connectors/files/${fileId}/shares`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      });
+    },
+    revokeFileShare(fileId: string, email: string) {
+      return request<{ success: boolean }>(`/api/connectors/files/${fileId}/shares/${encodeURIComponent(email)}`, {
+        method: "DELETE",
+      });
     },
     enrich(id: string, data: { fileIds: string[]; instruction: string }) {
       return request<{ enrichment: { jobId: string; connectorId: string; fileCount: number } }>(

--- a/packages/web/src/routes/files/file-detail-sheet.tsx
+++ b/packages/web/src/routes/files/file-detail-sheet.tsx
@@ -4,14 +4,17 @@
  * trigger button.
  */
 import { ConnectorLogo } from "@/components/connector-logos";
+import { FileShareDialog } from "@/components/file-share-dialog";
 import type { FileAccess, FileContent, LinkedEntity } from "@/lib/api";
 import { ApiRequestError, api } from "@/lib/api";
 import { type IntegrationType, getIntegration } from "@/lib/integrations";
+import { useDashboardAuth } from "@/routes/dashboard";
 import {
   ArrowSquareOutIcon,
   GlobeIcon,
   LinkIcon,
   LockSimpleIcon,
+  ShareNetworkIcon,
   SparkleIcon,
   SpinnerGapIcon,
 } from "@phosphor-icons/react";
@@ -81,7 +84,7 @@ export function FileDetailSheet({ fileId, onClose }: { fileId: string | null; on
           )}
         </div>
 
-        {file && <FileDetailFooter fileId={file.id} />}
+        {file && <FileDetailFooter fileId={file.id} fileName={file.fileName} />}
       </SheetContent>
     </Sheet>
   );
@@ -117,12 +120,21 @@ function FileDetailContent({
         {access && (
           <Badge
             variant="outline"
-            className={`gap-0.5 text-[10px] ${access.scope === "restricted" ? "text-amber-500 border-amber-500/30" : "text-muted-foreground"}`}
+            className={`gap-0.5 text-[10px] ${
+              access.shareWithEveryone || access.scope !== "restricted"
+                ? "text-muted-foreground"
+                : "text-amber-500 border-amber-500/30"
+            }`}
           >
-            {access.scope === "restricted" ? (
+            {access.shareWithEveryone ? (
+              <>
+                <GlobeIcon size={10} />
+                Anyone in org
+              </>
+            ) : access.scope === "restricted" ? (
               <>
                 <LockSimpleIcon size={10} weight="fill" />
-                {access.members.length} users
+                {access.members.length + access.manualShares.length} users
               </>
             ) : (
               <>
@@ -206,7 +218,7 @@ function FileDetailContent({
         </div>
       )}
 
-      {access && access.members.length > 0 && <AccessSection access={access} />}
+      {access && (access.members.length > 0 || access.manualShares.length > 0) && <AccessSection access={access} />}
 
       {file.content && <ContentPreview content={file.content} />}
     </div>
@@ -311,8 +323,11 @@ function ContentPreview({ content }: { content: string }) {
   );
 }
 
-function FileDetailFooter({ fileId }: { fileId: string }) {
+function FileDetailFooter({ fileId, fileName }: { fileId: string; fileName: string }) {
   const queryClient = useQueryClient();
+  const auth = useDashboardAuth();
+  const isAdmin = auth.role === "admin";
+  const [shareOpen, setShareOpen] = useState(false);
 
   const enrichMutation = useMutation({
     mutationFn: () => api.integrations.enrichFile(fileId),
@@ -324,11 +339,17 @@ function FileDetailFooter({ fileId }: { fileId: string }) {
   });
 
   return (
-    <div className="border-t border-border px-4 py-3">
+    <div className="border-t border-border px-4 py-3 flex gap-2">
+      {isAdmin && (
+        <Button size="sm" variant="outline" className="flex-1 gap-1.5 text-xs" onClick={() => setShareOpen(true)}>
+          <ShareNetworkIcon size={12} />
+          Share
+        </Button>
+      )}
       <Button
         size="sm"
         variant="outline"
-        className="w-full gap-1.5 text-xs"
+        className="flex-1 gap-1.5 text-xs"
         onClick={() => enrichMutation.mutate()}
         disabled={enrichMutation.isPending}
       >
@@ -340,10 +361,11 @@ function FileDetailFooter({ fileId }: { fileId: string }) {
         ) : (
           <>
             <SparkleIcon size={12} />
-            Enrich File
+            Enrich
           </>
         )}
       </Button>
+      {isAdmin && <FileShareDialog fileId={fileId} fileName={fileName} open={shareOpen} onOpenChange={setShareOpen} />}
     </div>
   );
 }
@@ -443,6 +465,21 @@ function AccessSection({ access }: { access: FileAccess }) {
           >
             Show less
           </button>
+        </div>
+      )}
+
+      {access.manualShares.length > 0 && (
+        <div className="mt-2">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            Manually shared ({access.manualShares.length})
+          </p>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {access.manualShares.map((share) => (
+              <Badge key={share.email} variant="outline" className="text-[10px]">
+                {share.email}
+              </Badge>
+            ))}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
> Stacks on top of #180 (`feat/admin-file-bypass`). Set base to `main` after #180 merges.

## Summary
- **Backend.** Adds `file_share_emails` + `indexed_files.share_with_everyone` (migration 070). Extends `fileVisibilityPredicate`, `getFileContent`, and `filterAccessibleFileIds` with two new branches (manual share / org-wide), without touching the connector-derived access tables — so reconcile can never trample manual grants. New `file-shares` repository handles grant/revoke/setOrgWide with email normalization.
- **API.** Under `/api/connectors/files/:fileId`:
  - `GET /shares` — list (admin or connector owner)
  - `POST /shares` — grant (admin or owner)
  - `DELETE /shares/:email` — revoke (admin or owner)
  - `PUT /share-everyone` — admin-only org-wide toggle
  - `PUT /shares` — transactional batch (emails delta + optional `shareWithEveryone`; admin gate fires when the org-wide bit is in the body)
  - Existing `GET /files/:fileId/content` now returns `access.manualShares[]` and `access.shareWithEveryone`.
- **Frontend.** `FileShareDialog` (radix Dialog + Switch). Email tag input with autocomplete from `GET /api/users`, restricted / anyone-in-org segmented toggle, revoke buttons. Admin-only in v1; connector owners can still manage via API. File detail sheet badge surfaces "Anyone in org" when set, counts in the restricted state include manual shares, and the `AccessSection` now lists manual shares inline.

Plan: `.planning/access/implemented/FILE_SHARING.md`

## Test plan
- [x] `file-visibility.test.ts` — manual share gives `listAllFiles` visibility; `share_with_everyone` fans out to any email (guards the SQL predicate edit)
- [x] `search.test.ts` — `getFileContent` honors a manual share; revoke removes access immediately (guards the in-memory check)
- [x] `connectors-authz.test.ts` — only admin or connector owner can POST a share; share-everyone is admin-only (guards the dual `denyIfCannotEdit`/`denyIfNotAdmin` gates)
- [x] `pnpm typecheck` clean across all 4 workspaces
- [x] `pnpm biome check` clean on all touched files
- [ ] Manual smoke: open a restricted file as admin → Share dialog opens → grant an email → that user sees the file in their list; flip the org-wide toggle → unrelated emails see the file; revoke → access goes back to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)