### PR TITLE
feat: entity sharing (Google Drive-style)

### DIFF
--- a/packages/server/src/agent/tools/search.ts
+++ b/packages/server/src/agent/tools/search.ts
@@ -284,23 +284,21 @@ Use this after SearchEntities to dive deeper into a specific entity. The respons
 
         const requestedLimit = limit ?? 20;
         const userEmails = await resolveUserEmails(deps);
+        if (userEmails.length === 0) {
+          return { content: [{ type: "text" as const, text: "No mentions found for this entity." }] };
+        }
         const rawMentions = await entityRepo.getMentionsForEntity(entityId, {
-          limit: userEmails.length > 0 ? Math.max(requestedLimit * 5, 100) : requestedLimit,
+          limit: Math.max(requestedLimit * 5, 100),
           since,
         });
 
-        const accessibleIds =
-          userEmails.length > 0
-            ? await filterAccessibleFileIds(
-                deps.db,
-                rawMentions.map((m) => m.indexed_file_id),
-                userEmails,
-              )
-            : null;
+        const accessibleIds = await filterAccessibleFileIds(
+          deps.db,
+          rawMentions.map((m) => m.indexed_file_id),
+          userEmails,
+        );
 
-        const mentions = (
-          accessibleIds ? rawMentions.filter((m) => accessibleIds.has(m.indexed_file_id)) : rawMentions
-        ).slice(0, requestedLimit);
+        const mentions = rawMentions.filter((m) => accessibleIds.has(m.indexed_file_id)).slice(0, requestedLimit);
 
         const lines: string[] = [];
         const aliases = entity.aliases ? (JSON.parse(entity.aliases) as string[]) : [];

--- a/packages/server/src/api/connectors-authz.test.ts
+++ b/packages/server/src/api/connectors-authz.test.ts
@@ -520,7 +520,7 @@ describe("Connectors API — authorization", () => {
 
     it("admin → 200 with content when admin_can_read_all_files=1", async () => {
       const fileId = await insertRestrictedFile();
-      await createSettingsRepository(db).update({ adminCanReadAllFiles: 1 });
+      await createSettingsRepository(db).update({ adminCanReadAllFiles: true });
 
       const res = await app.request(`/api/connectors/files/${fileId}/content`, {
         headers: { Cookie: adminCookie },
@@ -532,7 +532,7 @@ describe("Connectors API — authorization", () => {
 
     it("member without access → 403 even when admin_can_read_all_files=1", async () => {
       const fileId = await insertRestrictedFile();
-      await createSettingsRepository(db).update({ adminCanReadAllFiles: 1 });
+      await createSettingsRepository(db).update({ adminCanReadAllFiles: true });
 
       const res = await app.request(`/api/connectors/files/${fileId}/content`, {
         headers: { Cookie: memberCookie },

--- a/packages/server/src/api/entities.test.ts
+++ b/packages/server/src/api/entities.test.ts
@@ -1472,6 +1472,87 @@ describe("Entity drawer routes", () => {
     expect(body.entity.profile.summary.activity).not.toContain("Bob Restricted");
   });
 
+  it("GET /api/entities/:id/mentions gates snippets with admin_can_read_all_files", async () => {
+    await seedEntity("e1", "Sarah", "person");
+
+    const scopeId = "scope-mentions-restricted";
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "cfg-mentions-scope",
+        connector_type: "google_drive",
+        auth_type: "oauth",
+        credentials: "{}",
+        created_by: adminId,
+      })
+      .onConflict((oc) => oc.column("id").doNothing())
+      .execute();
+    await db
+      .insertInto("access_scopes")
+      .values({
+        id: scopeId,
+        connector_config_id: "cfg-mentions-scope",
+        scope_type: "shared_drive",
+        provider_scope_id: "mentions-sd",
+        label: "Mentions Restricted",
+      })
+      .execute();
+
+    await seedFile("f-public");
+    await seedFile("f-restricted", scopeId);
+    const now = new Date().toISOString();
+    await db
+      .insertInto("entity_mentions")
+      .values([
+        {
+          id: "m-public",
+          entity_id: "e1",
+          indexed_file_id: "f-public",
+          chunk_index: 0,
+          context_snippet: "public snippet",
+          confidence: "EXTRACTED",
+          source: "google_drive",
+          relation: "mentioned",
+          mentioned_at: now,
+        },
+        {
+          id: "m-restricted",
+          entity_id: "e1",
+          indexed_file_id: "f-restricted",
+          chunk_index: 0,
+          context_snippet: "restricted snippet",
+          confidence: "EXTRACTED",
+          source: "google_drive",
+          relation: "mentioned",
+          mentioned_at: now,
+        },
+      ])
+      .execute();
+
+    const offRes = await app.request("/api/entities/e1/mentions", { headers: { Cookie: adminCookie } });
+    expect(offRes.status).toBe(200);
+    const offBody = (await offRes.json()) as {
+      mentions: Array<{ contextSnippet: string }>;
+      hiddenCount: number;
+      total: number;
+    };
+    expect(offBody.mentions.map((m) => m.contextSnippet)).toEqual(["public snippet"]);
+    expect(offBody.total).toBe(1);
+    expect(offBody.hiddenCount).toBe(1);
+
+    await createSettingsRepository(db).update({ adminCanReadAllFiles: true });
+    const onRes = await app.request("/api/entities/e1/mentions", { headers: { Cookie: adminCookie } });
+    expect(onRes.status).toBe(200);
+    const onBody = (await onRes.json()) as {
+      mentions: Array<{ contextSnippet: string }>;
+      hiddenCount: number;
+      total: number;
+    };
+    expect(onBody.mentions.map((m) => m.contextSnippet).sort()).toEqual(["public snippet", "restricted snippet"]);
+    expect(onBody.total).toBe(2);
+    expect(onBody.hiddenCount).toBe(0);
+  });
+
   it("GET /api/entities/:id/relations partitions outgoing/incoming and pins AMBIGUOUS first", async () => {
     await seedEntity("e1", "Sarah", "person");
     await seedEntity("e2", "Atlas", "project");
@@ -1535,6 +1616,20 @@ describe("Entity drawer routes", () => {
     await seedEvidence("ev-1", "r1", "f-public");
     await seedEvidence("ev-2", "r1", "f-restricted-1");
     await seedEvidence("ev-3", "r1", "f-restricted-2");
+    await db
+      .insertInto("entity_mentions")
+      .values({
+        id: "m-evidence-visible",
+        entity_id: "e1",
+        indexed_file_id: "f-public",
+        chunk_index: 0,
+        context_snippet: "Sarah in public evidence",
+        confidence: "EXTRACTED",
+        source: "google_drive",
+        relation: "mentioned",
+        mentioned_at: new Date().toISOString(),
+      })
+      .execute();
 
     const res = await app.request("/api/entities/e1/relations/r1/evidence", { headers: { Cookie: memberCookie } });
     expect(res.status).toBe(200);

--- a/packages/server/src/api/entities/profile-routes.ts
+++ b/packages/server/src/api/entities/profile-routes.ts
@@ -1,16 +1,18 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
+import { z } from "zod";
 import { type FileViewer, fileVisibilityPredicate } from "../../db/repositories/connectors";
-import { createEntityRepository } from "../../db/repositories/entities";
+import { createEntityRepository, entityVisibilityPredicate } from "../../db/repositories/entities";
 import {
   type RelationListEntry,
   createEntityRelationshipsRepository,
 } from "../../db/repositories/entity-relationships";
+import { createEntitySharesRepository } from "../../db/repositories/entity-shares";
 import { createEntityTimelineRepository } from "../../db/repositories/entity-timeline";
 import type { DB } from "../../db/schema";
 import { type EntityProfileFacts, SYSTEM_SOURCE_TYPES, mapSourceTypeToEntityType } from "../../entities/profile-facts";
-import { denyIfNotAdmin, getFileViewer } from "../auth-helpers";
+import { denyIfNotAdmin, getContentViewer, getFileViewer } from "../auth-helpers";
 import type { EntityRoutesDeps } from "./types";
 
 function countByType(rows: RelationListEntry[]): Record<string, number> {
@@ -25,13 +27,17 @@ function countByType(rows: RelationListEntry[]): Record<string, number> {
  * Loads the structured facts shape the drawer Summary block consumes.
  * Returns null when the entity doesn't exist.
  */
-async function loadEntityFactsForId(db: Kysely<DB>, entityId: string): Promise<EntityProfileFacts | null> {
+async function loadEntityFactsForId(
+  db: Kysely<DB>,
+  entityId: string,
+  viewer: FileViewer,
+): Promise<EntityProfileFacts | null> {
   const repo = createEntityRepository(db);
   const relRepo = createEntityRelationshipsRepository(db);
-  const entity = await repo.getEntity(entityId);
+  const entity = await repo.getEntity(entityId, viewer);
   if (!entity) return null;
   const [aggregates, relations] = await Promise.all([
-    repo.getEntityProfileAggregates(entity.id),
+    repo.getEntityProfileAggregates(entity.id, viewer),
     relRepo.listRelationsForEntity(entity.id, { limit: 50 }),
   ]);
   const parsedMetadata = entity.metadata ? (JSON.parse(entity.metadata) as Record<string, unknown>) : null;
@@ -235,6 +241,7 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
   const repo = createEntityRepository(db);
   const relRepo = createEntityRelationshipsRepository(db);
   const timelineRepo = createEntityTimelineRepository(db);
+  const sharesRepo = createEntitySharesRepository(db);
   const { config } = deps;
 
   const RELATIONS_LIMIT = 200;
@@ -299,20 +306,38 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
     const includeSystem = c.req.query("includeSystem") === "true";
     const includeArchived = c.req.query("includeArchived") === "true";
     const systemTypes = [...SYSTEM_SOURCE_TYPES];
+    const viewer = getFileViewer(c);
+
+    // For non-admin viewers, the mention_count and last_mention_at subqueries
+    // must only count mentions in files the viewer can actually see —
+    // otherwise an entity row that's visible (via manual share, etc.) leaks
+    // activity from hidden files.
+    const mentionCountSql = viewer.isAdmin
+      ? sql<number>`(SELECT count(*) FROM entity_mentions WHERE entity_mentions.entity_id = entities.id)`
+      : sql<number>`(SELECT count(*) FROM entity_mentions
+                     INNER JOIN indexed_files ON indexed_files.id = entity_mentions.indexed_file_id
+                     WHERE entity_mentions.entity_id = entities.id
+                       AND ${fileVisibilityPredicate(viewer)})`;
+    const lastMentionSql = viewer.isAdmin
+      ? sql<string>`(SELECT COALESCE(indexed_files.source_updated_at, indexed_files.source_created_at, entity_mentions.mentioned_at)
+                     FROM entity_mentions
+                     INNER JOIN indexed_files ON indexed_files.id = entity_mentions.indexed_file_id
+                     WHERE entity_mentions.entity_id = entities.id
+                     ORDER BY COALESCE(indexed_files.source_updated_at, indexed_files.source_created_at, entity_mentions.mentioned_at) DESC
+                     LIMIT 1)`
+      : sql<string>`(SELECT COALESCE(indexed_files.source_updated_at, indexed_files.source_created_at, entity_mentions.mentioned_at)
+                     FROM entity_mentions
+                     INNER JOIN indexed_files ON indexed_files.id = entity_mentions.indexed_file_id
+                     WHERE entity_mentions.entity_id = entities.id
+                       AND ${fileVisibilityPredicate(viewer)}
+                     ORDER BY COALESCE(indexed_files.source_updated_at, indexed_files.source_created_at, entity_mentions.mentioned_at) DESC
+                     LIMIT 1)`;
 
     let query = db
       .selectFrom("entities")
       .selectAll("entities")
-      .select(
-        sql<number>`(SELECT count(*) FROM entity_mentions WHERE entity_mentions.entity_id = entities.id)`.as(
-          "mention_count",
-        ),
-      )
-      .select(
-        sql<string>`(SELECT COALESCE(indexed_files.source_updated_at, indexed_files.source_created_at, entity_mentions.mentioned_at) FROM entity_mentions INNER JOIN indexed_files ON indexed_files.id = entity_mentions.indexed_file_id WHERE entity_mentions.entity_id = entities.id ORDER BY COALESCE(indexed_files.source_updated_at, indexed_files.source_created_at, entity_mentions.mentioned_at) DESC LIMIT 1)`.as(
-          "last_mention_at",
-        ),
-      );
+      .select(mentionCountSql.as("mention_count"))
+      .select(lastMentionSql.as("last_mention_at"));
 
     if (typeFilter && typeFilter.length > 0) {
       query = query.where("entities.source_type", "in", typeFilter);
@@ -341,6 +366,10 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
       query = query.where("entities.source_type", "not in", systemTypes);
     }
 
+    if (!viewer.isAdmin) {
+      query = query.where(entityVisibilityPredicate(viewer));
+    }
+
     if (sort === "mentions") {
       query = query.orderBy("mention_count", "desc");
     } else if (sort === "name") {
@@ -353,19 +382,24 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
 
     const entities = await query.execute();
 
-    let countQuery = db.selectFrom("entities").select(db.fn.count("id").as("total"));
+    let countQuery = db.selectFrom("entities").select(db.fn.count("entities.id").as("total"));
     if (typeFilter && typeFilter.length > 0) {
-      countQuery = countQuery.where("source_type", "in", typeFilter);
+      countQuery = countQuery.where("entities.source_type", "in", typeFilter);
     }
     if (search) {
       const pattern = `%${search}%`;
-      countQuery = countQuery.where((eb) => eb.or([eb("name", "like", pattern), eb("aliases", "like", pattern)]));
+      countQuery = countQuery.where((eb) =>
+        eb.or([eb("entities.name", "like", pattern), eb("entities.aliases", "like", pattern)]),
+      );
     }
     if (!includeArchived) {
-      countQuery = countQuery.where("status", "!=", "archived");
+      countQuery = countQuery.where("entities.status", "!=", "archived");
     }
     if (!typeFilter && !includeSystem && systemTypes.length > 0) {
-      countQuery = countQuery.where("source_type", "not in", systemTypes);
+      countQuery = countQuery.where("entities.source_type", "not in", systemTypes);
+    }
+    if (!viewer.isAdmin) {
+      countQuery = countQuery.where(entityVisibilityPredicate(viewer));
     }
     const countResult = await countQuery.executeTakeFirst();
 
@@ -465,21 +499,27 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
    * not the response shape.
    */
   routes.get("/:id", async (c) => {
-    const entity = await repo.getEntity(c.req.param("id"));
+    const viewer = getFileViewer(c);
+    const entity = await repo.getEntity(c.req.param("id"), viewer);
     if (!entity) {
       return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
     }
 
-    const [sourceRefs, facts] = await Promise.all([
+    const [sourceRefs, facts, manualShares] = await Promise.all([
       db.selectFrom("entity_source_refs").selectAll().where("entity_id", "=", entity.id).execute(),
-      loadEntityFactsForId(db, entity.id),
+      loadEntityFactsForId(db, entity.id, viewer),
+      db
+        .selectFrom("entity_share_emails")
+        .select(["email", "granted_at"])
+        .where("entity_id", "=", entity.id)
+        .orderBy("granted_at", "desc")
+        .execute(),
     ]);
     if (!facts) {
       return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
     }
 
     const parsedAliases = entity.aliases ? (JSON.parse(entity.aliases) as string[]) : [];
-    const viewer = getFileViewer(c);
     const activity = await loadActivityStats(db, entity.id, viewer);
     const summary = buildSummary(facts, activity);
 
@@ -493,6 +533,8 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
         metadata: facts.metadata,
         status: entity.status,
         hotness: entity.hotness,
+        shareWithEveryone: entity.share_with_everyone === 1,
+        manualShares: manualShares.map((s) => ({ email: s.email, grantedAt: s.granted_at })),
         createdAt: entity.created_at,
         updatedAt: entity.updated_at,
         profile: {
@@ -524,7 +566,8 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
     if (!config.EXPERIMENTAL_FLAG) {
       return c.json({ error: { code: "NOT_FOUND", message: "Not found" } }, 404);
     }
-    const entity = await repo.getEntity(c.req.param("id"));
+    const viewer = getFileViewer(c);
+    const entity = await repo.getEntity(c.req.param("id"), viewer);
     if (!entity) {
       return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
     }
@@ -550,7 +593,8 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
     }
     const entityId = c.req.param("id");
     const relationshipId = c.req.param("rid");
-    const entity = await repo.getEntity(entityId);
+    const viewer = getFileViewer(c);
+    const entity = await repo.getEntity(entityId, viewer);
     if (!entity) {
       return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
     }
@@ -558,7 +602,6 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
     if (!relation || (relation.source_entity_id !== entityId && relation.target_entity_id !== entityId)) {
       return c.json({ error: { code: "NOT_FOUND", message: "Relation not found" } }, 404);
     }
-    const viewer = getFileViewer(c);
     const result = await relRepo.listEvidenceForRelation(relationshipId, { limit: EVIDENCE_LIMIT, viewer });
     return c.json(result);
   });
@@ -572,11 +615,11 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
     if (!config.EXPERIMENTAL_FLAG) {
       return c.json({ error: { code: "NOT_FOUND", message: "Not found" } }, 404);
     }
-    const entity = await repo.getEntity(c.req.param("id"));
+    const viewer = getFileViewer(c);
+    const entity = await repo.getEntity(c.req.param("id"), viewer);
     if (!entity) {
       return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
     }
-    const viewer = getFileViewer(c);
     const result = await timelineRepo.listTimelineForEntity(entity.id, { limit: TIMELINE_LIMIT, viewer });
     return c.json(result);
   });
@@ -653,8 +696,9 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
     const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
     const offset = Number(c.req.query("offset")) || 0;
     const viewer = getFileViewer(c);
+    const contentViewer = getContentViewer(c);
 
-    const entity = await repo.getEntity(entityId);
+    const entity = await repo.getEntity(entityId, viewer);
     if (!entity) {
       return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
     }
@@ -692,8 +736,8 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
         since,
       );
     }
-    if (!viewer.isAdmin) {
-      query = query.where(fileVisibilityPredicate(viewer));
+    if (!contentViewer.isAdmin) {
+      query = query.where(fileVisibilityPredicate(contentViewer));
     }
 
     query = query.limit(limit).offset(offset);
@@ -715,12 +759,12 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
           since,
         );
       }
-      if (gated) q = q.where(fileVisibilityPredicate(viewer));
+      if (gated) q = q.where(fileVisibilityPredicate(contentViewer));
       return q;
     };
 
-    const visibleCount = Number((await buildCountQuery(!viewer.isAdmin).executeTakeFirst())?.total ?? 0);
-    const hiddenCount = viewer.isAdmin
+    const visibleCount = Number((await buildCountQuery(!contentViewer.isAdmin).executeTakeFirst())?.total ?? 0);
+    const hiddenCount = contentViewer.isAdmin
       ? 0
       : Math.max(0, Number((await buildCountQuery(false).executeTakeFirst())?.total ?? 0) - visibleCount);
 
@@ -742,6 +786,151 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
       })),
       total: visibleCount,
       hiddenCount,
+    });
+  });
+
+  /**
+   * Manual entity share management.
+   *
+   * Authz: all routes are admin-only. Entities have no single owner (unlike
+   * connectors), so members cannot grant or revoke shares.
+   */
+  const shareEmailBodySchema = z.object({ email: z.string().email().toLowerCase() });
+  const shareEveryoneBodySchema = z.object({ enabled: z.boolean() });
+  const shareBatchBodySchema = z.object({
+    emails: z.array(z.string().email().toLowerCase()),
+    shareWithEveryone: z.boolean().optional(),
+  });
+
+  async function entityExists(entityId: string): Promise<boolean> {
+    const row = await db.selectFrom("entities").select("id").where("id", "=", entityId).executeTakeFirst();
+    return !!row;
+  }
+
+  routes.get("/:id/shares", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+    const entityId = c.req.param("id");
+    if (!(await entityExists(entityId))) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
+    }
+    const [shares, shareWithEveryone] = await Promise.all([
+      sharesRepo.listForEntity(entityId),
+      sharesRepo.getOrgWide(entityId),
+    ]);
+    return c.json({
+      shares: shares.map((s) => ({ email: s.email, grantedAt: s.granted_at })),
+      shareWithEveryone,
+    });
+  });
+
+  routes.post("/:id/shares", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+    const entityId = c.req.param("id");
+    if (!(await entityExists(entityId))) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
+    }
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = shareEmailBodySchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+    const grantedBy = c.get("sub") as string;
+    await sharesRepo.grantToEmail(entityId, parsed.data.email, grantedBy);
+    const shares = await sharesRepo.listForEntity(entityId);
+    return c.json({ shares: shares.map((s) => ({ email: s.email, grantedAt: s.granted_at })) });
+  });
+
+  routes.delete("/:id/shares/:email", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+    const entityId = c.req.param("id");
+    const email = decodeURIComponent(c.req.param("email"));
+    if (!(await entityExists(entityId))) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
+    }
+    await sharesRepo.revokeFromEmail(entityId, email);
+    return c.json({ success: true });
+  });
+
+  routes.put("/:id/share-everyone", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+    const entityId = c.req.param("id");
+    if (!(await entityExists(entityId))) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
+    }
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = shareEveryoneBodySchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+    await sharesRepo.setOrgWide(entityId, parsed.data.enabled);
+    return c.json({ shareWithEveryone: parsed.data.enabled });
+  });
+
+  routes.put("/:id/shares", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+    const entityId = c.req.param("id");
+    if (!(await entityExists(entityId))) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
+    }
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = shareBatchBodySchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid request";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+    const grantedBy = c.get("sub") as string;
+    const targetEmails = new Set(parsed.data.emails);
+    await db.transaction().execute(async (trx) => {
+      const existing = await trx
+        .selectFrom("entity_share_emails")
+        .select("email")
+        .where("entity_id", "=", entityId)
+        .execute();
+      const existingSet = new Set(existing.map((r) => r.email));
+      const toAdd = [...targetEmails].filter((e) => !existingSet.has(e));
+      const toRemove = [...existingSet].filter((e) => !targetEmails.has(e));
+      if (toAdd.length > 0) {
+        await trx
+          .insertInto("entity_share_emails")
+          .values(
+            toAdd.map((email) => ({
+              entity_id: entityId,
+              email,
+              granted_by_user_id: grantedBy,
+            })),
+          )
+          .onConflict((oc) => oc.columns(["entity_id", "email"]).doNothing())
+          .execute();
+      }
+      if (toRemove.length > 0) {
+        await trx
+          .deleteFrom("entity_share_emails")
+          .where("entity_id", "=", entityId)
+          .where("email", "in", toRemove)
+          .execute();
+      }
+      if (parsed.data.shareWithEveryone !== undefined) {
+        await trx
+          .updateTable("entities")
+          .set({ share_with_everyone: parsed.data.shareWithEveryone ? 1 : 0 })
+          .where("id", "=", entityId)
+          .execute();
+      }
+    });
+    const [shares, shareWithEveryone] = await Promise.all([
+      sharesRepo.listForEntity(entityId),
+      sharesRepo.getOrgWide(entityId),
+    ]);
+    return c.json({
+      shares: shares.map((s) => ({ email: s.email, grantedAt: s.granted_at })),
+      shareWithEveryone,
     });
   });
 

--- a/packages/server/src/api/entity-mentions-authz.test.ts
+++ b/packages/server/src/api/entity-mentions-authz.test.ts
@@ -1,11 +1,17 @@
 /**
  * RBAC tests for GET /api/entities/:id/mentions.
  *
- * Mirrors the file-visibility predicate model: admin sees all mentions; a member
- * sees only mentions that point to files they can access (unrestricted /
- * scope-member / per-file share). The hidden-count footer is computed as
- * unfiltered_total - filtered_total and exposed to the frontend so users see
- * "+N mentions in files you don't have access to".
+ * Mirrors the file-visibility predicate model: a member sees only mentions
+ * that point to files they can access (unrestricted / scope-member / per-file
+ * share). Admin sees all mentions only when the org-level setting
+ * `adminCanReadAllFiles` is enabled — the mentions endpoint returns
+ * context_snippet content, so it gates on `getContentViewer`, not the raw
+ * role check. This suite seeds the setting ON so admin tests exercise the
+ * full-visibility path.
+ *
+ * The hidden-count footer is computed as unfiltered_total - filtered_total
+ * and exposed to the frontend so users see "+N mentions in files you don't
+ * have access to".
  */
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -36,7 +42,7 @@ async function seedUsers(db: Kysely<DB>) {
   ] as const) {
     await users.create({ name, email, emailVerified: true, passwordHash: hash, authRole: role });
   }
-  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString(), adminCanReadAllFiles: true });
 }
 
 async function login(app: ReturnType<typeof createApp>, email: string): Promise<string> {

--- a/packages/server/src/api/settings.test.ts
+++ b/packages/server/src/api/settings.test.ts
@@ -112,6 +112,58 @@ describe("Settings API — security", () => {
     });
   });
 
+  describe("/api/settings/access", () => {
+    it("round-trips adminCanReadAllFiles for admins", async () => {
+      const app = createApp(db, config, { logger });
+      const adminCookie = await loginAdmin(app);
+
+      const initialRes = await app.request("/api/settings/access", { headers: { Cookie: adminCookie } });
+      expect(initialRes.status).toBe(200);
+      await expect(initialRes.json()).resolves.toEqual({ adminCanReadAllFiles: false });
+
+      const updateRes = await app.request("/api/settings/access", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Cookie: adminCookie },
+        body: JSON.stringify({ adminCanReadAllFiles: true }),
+      });
+      expect(updateRes.status).toBe(200);
+      await expect(updateRes.json()).resolves.toEqual({ adminCanReadAllFiles: true });
+
+      const afterRes = await app.request("/api/settings/access", { headers: { Cookie: adminCookie } });
+      expect(afterRes.status).toBe(200);
+      await expect(afterRes.json()).resolves.toEqual({ adminCanReadAllFiles: true });
+    });
+
+    it("requires admin access", async () => {
+      const app = createApp(db, config, { logger });
+      const memberCookie = await loginMember(app, db);
+
+      const getRes = await app.request("/api/settings/access", { headers: { Cookie: memberCookie } });
+      expect(getRes.status).toBe(403);
+
+      const putRes = await app.request("/api/settings/access", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Cookie: memberCookie },
+        body: JSON.stringify({ adminCanReadAllFiles: true }),
+      });
+      expect(putRes.status).toBe(403);
+    });
+
+    it("validates the update payload", async () => {
+      const app = createApp(db, config, { logger });
+      const adminCookie = await loginAdmin(app);
+
+      const res = await app.request("/api/settings/access", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Cookie: adminCookie },
+        body: JSON.stringify({ adminCanReadAllFiles: "yes" }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
   describe("/api/settings/api-key", () => {
     it("generates, returns, and revokes the Sketch API key", async () => {
       const app = createApp(db, config, { logger });

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -168,7 +168,7 @@ export function settingsRoutes(settings: SettingsRepo, db?: Kysely<DB>, logger?:
       return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
     }
 
-    await settings.update({ adminCanReadAllFiles: parsed.data.adminCanReadAllFiles ? 1 : 0 });
+    await settings.update({ adminCanReadAllFiles: parsed.data.adminCanReadAllFiles });
     return c.json({ adminCanReadAllFiles: parsed.data.adminCanReadAllFiles });
   });
 

--- a/packages/server/src/connectors/entity-linking.ts
+++ b/packages/server/src/connectors/entity-linking.ts
@@ -5,7 +5,7 @@
  * - Person resolution: matches LLM-discovered people to existing entities
  * - Fuzzy matching via Talisman Jaro-Winkler
  */
-import type { Kysely } from "kysely";
+import type { Kysely, Selectable } from "kysely";
 // @ts-expect-error talisman has no type declarations
 import jaroWinklerModule from "talisman/metrics/jaro-winkler";
 import { createEntityRepository } from "../db/repositories/entities";
@@ -19,7 +19,7 @@ const jaroWinkler: (a: string, b: string) => number =
 
 const JARO_WINKLER_THRESHOLD = 0.85;
 
-type Entity = EntitiesTable;
+type Entity = Selectable<EntitiesTable>;
 
 /**
  * Get entities relevant to a document's content for LLM prompt injection.

--- a/packages/server/src/connectors/search.test.ts
+++ b/packages/server/src/connectors/search.test.ts
@@ -181,6 +181,10 @@ describe("searchFiles — FTS5 query sanitization", () => {
     expect(results[0].fileName).toBe("planning.txt");
   });
 
+  it("returns no results when userEmails is []", async () => {
+    await expect(searchFiles(db, "planning", { userEmails: [] })).resolves.toEqual([]);
+  });
+
   it("search results include providerFileId (needed for integration handoff)", async () => {
     const results = await searchFiles(db, "planning");
     expect(results.length).toBeGreaterThan(0);
@@ -445,6 +449,32 @@ describe("search — recency browse applies RBAC before limit", () => {
     });
 
     expect(results.map((r) => r.id).sort()).toEqual(["manual-shared", "org-shared"]);
+  });
+
+  it("returns no recency results when userEmails is []", async () => {
+    await insertMeeting("accessible", "2026-04-30T07:00:00.000Z");
+
+    const results = await search(db, "", {
+      kindRules: KIND_TO_RULES.meeting,
+      sortBy: "recency",
+      limit: 1,
+      userEmails: [],
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it("returns no hybrid results when userEmails is []", async () => {
+    await insertMeeting("planning-meeting", "2026-04-30T07:00:00.000Z");
+    await db
+      .updateTable("indexed_files")
+      .set({ content: "quarterly planning details" })
+      .where("id", "=", "planning-meeting")
+      .execute();
+
+    const results = await search(db, "planning", { userEmails: [] });
+
+    expect(results).toEqual([]);
   });
 });
 

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -92,6 +92,7 @@ function fileAccessFilterSql(emailList: string[]) {
  */
 export async function searchFiles(db: Kysely<DB>, query: string, opts?: SearchOptions): Promise<SearchResult[]> {
   const limit = opts?.limit ?? 10;
+  if (opts?.userEmails !== undefined && opts.userEmails.length === 0) return [];
 
   const emailList = opts?.userEmails ?? [];
   const userFilter = emailList.length > 0 ? sql`AND ${fileAccessFilterSql(emailList)}` : sql``;
@@ -256,6 +257,28 @@ export async function getFileContent(
           if (shareMatch.length > 0) allowed = true;
         }
 
+        // Tier 5: entity-share propagation — a shared entity mentioned in
+        // this file grants read access to the file (read-time, no file_access
+        // rows written).
+        if (!allowed) {
+          const entityMatch = await db
+            .selectFrom("entity_mentions")
+            .innerJoin("entities", "entities.id", "entity_mentions.entity_id")
+            .leftJoin("entity_share_emails", (join) =>
+              join
+                .onRef("entity_share_emails.entity_id", "=", "entities.id")
+                .on("entity_share_emails.email", "in", userEmails),
+            )
+            .select("entities.id")
+            .where("entity_mentions.indexed_file_id", "=", fileId)
+            .where((eb) =>
+              eb.or([eb("entities.share_with_everyone", "=", 1), eb("entity_share_emails.email", "is not", null)]),
+            )
+            .limit(1)
+            .execute();
+          if (entityMatch.length > 0) allowed = true;
+        }
+
         if (!allowed) return null;
       }
     }
@@ -300,7 +323,7 @@ export async function filterAccessibleFileIds(
     .where("id", "in", fileIds)
     .execute();
 
-  const [fileAccessRows, scopeMemberRows, shareRows] = await Promise.all([
+  const [fileAccessRows, scopeMemberRows, shareRows, entityPropRows] = await Promise.all([
     db.selectFrom("file_access").select(["indexed_file_id", "email"]).where("indexed_file_id", "in", fileIds).execute(),
     (async () => {
       const scopeIds = files.map((f) => f.access_scope_id).filter((s): s is string => !!s);
@@ -317,6 +340,22 @@ export async function filterAccessibleFileIds(
       .select(["indexed_file_id", "email"])
       .where("indexed_file_id", "in", fileIds)
       .where("email", "in", userEmails)
+      .execute(),
+    // Entity-share propagation: a file is accessible if it mentions any entity
+    // that is shared with the viewer (or share_with_everyone). Read-time only.
+    db
+      .selectFrom("entity_mentions")
+      .innerJoin("entities", "entities.id", "entity_mentions.entity_id")
+      .leftJoin("entity_share_emails", (join) =>
+        join
+          .onRef("entity_share_emails.entity_id", "=", "entities.id")
+          .on("entity_share_emails.email", "in", userEmails),
+      )
+      .select(["entity_mentions.indexed_file_id"])
+      .where("entity_mentions.indexed_file_id", "in", fileIds)
+      .where((eb) =>
+        eb.or([eb("entities.share_with_everyone", "=", 1), eb("entity_share_emails.email", "is not", null)]),
+      )
       .execute(),
   ]);
 
@@ -335,6 +374,10 @@ export async function filterAccessibleFileIds(
   const manualSharesByFile = new Set<string>();
   for (const row of shareRows) {
     manualSharesByFile.add(row.indexed_file_id);
+  }
+  const entityPropByFile = new Set<string>();
+  for (const row of entityPropRows) {
+    entityPropByFile.add(row.indexed_file_id);
   }
 
   const emailSet = new Set(userEmails);
@@ -375,6 +418,11 @@ export async function filterAccessibleFileIds(
     }
 
     if (manualSharesByFile.has(file.id)) {
+      allowed.add(file.id);
+      continue;
+    }
+
+    if (entityPropByFile.has(file.id)) {
       allowed.add(file.id);
     }
   }
@@ -605,6 +653,7 @@ export async function hybridSearch(
   opts?: HybridSearchOptions,
 ): Promise<HybridSearchResult[]> {
   const limit = opts?.limit ?? 10;
+  if (opts?.userEmails !== undefined && opts.userEmails.length === 0) return [];
   const ftsResults = new Map<string, { rank: number; snippet: string | null }>();
   const vecResults = new Map<string, { rank: number; similarity: number; snippet: string | null }>();
 
@@ -1101,6 +1150,7 @@ async function browseLatest(
 ): Promise<HybridSearchResult[]> {
   // Caller is responsible for the empty-fileIds short-circuit; selectFrom().where("id", "in", [])
   // emits invalid `IN ()` SQL on SQLite.
+  if (opts.userEmails !== undefined && opts.userEmails.length === 0) return [];
   let q = db
     .selectFrom("indexed_files")
     .select([

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -70,6 +70,7 @@ import * as m067 from "./migrations/067-relation-evidence-fact-link";
 import * as m068 from "./migrations/068-entities-ai-brief";
 import * as m069 from "./migrations/069-admin-can-read-all-files";
 import * as m070 from "./migrations/070-file-shares";
+import * as m071 from "./migrations/071-entity-shares";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>): Promise<void> {
@@ -144,6 +145,7 @@ export async function runMigrations(db: Kysely<DB>): Promise<void> {
           "068-entities-ai-brief": m068,
           "069-admin-can-read-all-files": m069,
           "070-file-shares": m070,
+          "071-entity-shares": m071,
         };
       },
     },

--- a/packages/server/src/db/migrations/071-entity-shares.ts
+++ b/packages/server/src/db/migrations/071-entity-shares.ts
@@ -3,14 +3,11 @@
  *
  * - entity_share_emails: per-(entity, email) grants. Mirrors file_share_emails.
  * - entities.share_with_everyone: org-wide flag (admin-only toggle).
- * - Backfill: org-curated system entities (clickup_workspace, clickup_space) are
- *   set share_with_everyone = 1 so they remain visible to members after the
- *   default-deny RBAC change. Mirrors the SYSTEM_SOURCE_TYPES set in
- *   packages/server/src/entities/profile-facts.ts.
+ * System entities stay org-visible through entityVisibilityPredicate rather
+ * than this share flag, because share_with_everyone also grants every file
+ * mentioning the entity.
  */
 import { type Kysely, sql } from "kysely";
-
-const SYSTEM_SOURCE_TYPES = ["clickup_workspace", "clickup_space"];
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -30,11 +27,6 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .execute();
 
   await sql`CREATE INDEX idx_entities_share_with_everyone ON entities(share_with_everyone)`.execute(db);
-
-  // Backfill: keep system-typed entities org-visible after the RBAC change.
-  await sql`UPDATE entities SET share_with_everyone = 1 WHERE source_type IN (${sql.join(
-    SYSTEM_SOURCE_TYPES.map((t) => sql`${t}`),
-  )})`.execute(db);
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/packages/server/src/db/migrations/071-entity-shares.ts
+++ b/packages/server/src/db/migrations/071-entity-shares.ts
@@ -1,0 +1,45 @@
+/**
+ * Manual entity sharing + entity RBAC v1.
+ *
+ * - entity_share_emails: per-(entity, email) grants. Mirrors file_share_emails.
+ * - entities.share_with_everyone: org-wide flag (admin-only toggle).
+ * - Backfill: org-curated system entities (clickup_workspace, clickup_space) are
+ *   set share_with_everyone = 1 so they remain visible to members after the
+ *   default-deny RBAC change. Mirrors the SYSTEM_SOURCE_TYPES set in
+ *   packages/server/src/entities/profile-facts.ts.
+ */
+import { type Kysely, sql } from "kysely";
+
+const SYSTEM_SOURCE_TYPES = ["clickup_workspace", "clickup_space"];
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("entity_share_emails")
+    .addColumn("entity_id", "text", (col) => col.notNull().references("entities.id").onDelete("cascade"))
+    .addColumn("email", "text", (col) => col.notNull())
+    .addColumn("granted_by_user_id", "text", (col) => col.notNull().references("users.id"))
+    .addColumn("granted_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addPrimaryKeyConstraint("entity_share_emails_pk", ["entity_id", "email"])
+    .execute();
+
+  await sql`CREATE INDEX idx_entity_share_emails_email ON entity_share_emails(email)`.execute(db);
+
+  await db.schema
+    .alterTable("entities")
+    .addColumn("share_with_everyone", "integer", (col) => col.notNull().defaultTo(0))
+    .execute();
+
+  await sql`CREATE INDEX idx_entities_share_with_everyone ON entities(share_with_everyone)`.execute(db);
+
+  // Backfill: keep system-typed entities org-visible after the RBAC change.
+  await sql`UPDATE entities SET share_with_everyone = 1 WHERE source_type IN (${sql.join(
+    SYSTEM_SOURCE_TYPES.map((t) => sql`${t}`),
+  )})`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_entities_share_with_everyone`.execute(db);
+  await db.schema.alterTable("entities").dropColumn("share_with_everyone").execute();
+  await sql`DROP INDEX IF EXISTS idx_entity_share_emails_email`.execute(db);
+  await db.schema.dropTable("entity_share_emails").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(66);
+    expect(rows.rows).toHaveLength(67);
   });
 
   it("records migrations with correct names in order", async () => {
@@ -100,6 +100,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[63]).toBe("068-entities-ai-brief");
     expect(names[64]).toBe("069-admin-can-read-all-files");
     expect(names[65]).toBe("070-file-shares");
+    expect(names[66]).toBe("071-entity-shares");
   });
 
   it("running migrations twice is idempotent", async () => {
@@ -108,7 +109,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(66);
+    expect(rows.rows).toHaveLength(67);
   });
 
   it("creates the users table", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(66);
+    expect(rows.rows).toHaveLength(67);
   });
 
   it("records migrations with the correct names in order", async () => {
@@ -103,6 +103,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[63]).toBe("068-entities-ai-brief");
     expect(names[64]).toBe("069-admin-can-read-all-files");
     expect(names[65]).toBe("070-file-shares");
+    expect(names[66]).toBe("071-entity-shares");
   });
 
   it("creates the users table", async () => {
@@ -224,7 +225,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(66);
+    expect(rows.rows).toHaveLength(67);
   });
 });
 
@@ -256,6 +257,6 @@ describe("runMigrations — incremental upgrade", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(66);
+    expect(rows.rows).toHaveLength(67);
   });
 });

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -27,34 +27,54 @@ export interface FileViewer {
 /**
  * Predicate matching files visible to `viewer`. Composed into queries via `.where(...)`.
  *
- *   unrestricted    = no scope AND no per-file shares
- *   scoped          = caller is in access_scope_members for the file's scope
- *   per-file        = caller has a row in file_access for the file
- *   manual share    = caller's email is in file_share_emails for the file
- *   org-wide        = indexed_files.share_with_everyone = 1
+ *   unrestricted      = no scope AND no per-file shares
+ *   scoped            = caller is in access_scope_members for the file's scope
+ *   per-file          = caller has a row in file_access for the file
+ *   manual share      = caller's email is in file_share_emails for the file
+ *   org-wide          = indexed_files.share_with_everyone = 1
+ *   entity-share prop = caller has access to an entity mentioned in the file
+ *                       (via entity_share_emails OR entities.share_with_everyone).
+ *                       Read-time only — no rows are written to file_access.
  *
  * v1 matches the caller's primary email only; multi-email users (Slack login email
  * differs from connector-side email) under-see — the safe failure direction. v2 will
  * swap `= :email` for `IN (:emails[])` once we wire `getAllEmailsForUser` through.
  *
- * Callers must qualify the file table as `indexed_files` (or alias to it) — the
- * predicate references columns by that name.
+ * `alias` is the SQL identifier for `indexed_files` at the call site; pass a
+ * different name when the file table is aliased (entity visibility predicate
+ * inlines this with the alias of the outer query's join).
+ *
+ * Acyclic: this references the entity-share tables directly. It MUST NOT call
+ * entityVisibilityPredicate, which depends on file visibility — otherwise the
+ * planner sees mutually-recursive EXISTS chains.
  */
-export function fileVisibilityPredicate(viewer: FileViewer) {
+export function fileVisibilityPredicate(viewer: FileViewer, alias = "indexed_files") {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(alias)) {
+    throw new Error(`fileVisibilityPredicate: invalid table alias "${alias}"`);
+  }
+  const t = sql.raw(alias);
   const email = viewer.email ?? "";
   return sql<boolean>`(
-    (indexed_files.access_scope_id IS NULL
-      AND NOT EXISTS (SELECT 1 FROM file_access fa WHERE fa.indexed_file_id = indexed_files.id))
+    (${t}.access_scope_id IS NULL
+      AND NOT EXISTS (SELECT 1 FROM file_access fa WHERE fa.indexed_file_id = ${t}.id))
     OR EXISTS (SELECT 1 FROM access_scope_members asm
-               WHERE asm.access_scope_id = indexed_files.access_scope_id
+               WHERE asm.access_scope_id = ${t}.access_scope_id
                  AND asm.email = ${email})
     OR EXISTS (SELECT 1 FROM file_access fa
-               WHERE fa.indexed_file_id = indexed_files.id
+               WHERE fa.indexed_file_id = ${t}.id
                  AND fa.email = ${email})
     OR EXISTS (SELECT 1 FROM file_share_emails fse
-               WHERE fse.indexed_file_id = indexed_files.id
+               WHERE fse.indexed_file_id = ${t}.id
                  AND fse.email = ${email})
-    OR indexed_files.share_with_everyone = 1
+    OR ${t}.share_with_everyone = 1
+    OR EXISTS (
+      SELECT 1 FROM entity_mentions em_shared
+      INNER JOIN entities ent_shared ON ent_shared.id = em_shared.entity_id
+      LEFT JOIN entity_share_emails ese
+        ON ese.entity_id = ent_shared.id AND ese.email = ${email}
+      WHERE em_shared.indexed_file_id = ${t}.id
+        AND (ent_shared.share_with_everyone = 1 OR ese.email IS NOT NULL)
+    )
   )`;
 }
 

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -6,10 +6,13 @@ import { isPg } from "../dialect";
 import type { DB, EntitiesTable } from "../schema";
 import { type FileViewer, fileVisibilityPredicate } from "./connectors";
 
+const SYSTEM_ENTITY_SOURCE_TYPES = ["clickup_workspace", "clickup_space"];
+
 /**
  * Predicate matching entities visible to `viewer`. Composed into queries via `.where(...)`.
  *
  *   admin              = bypasses RBAC (single OR branch resolves to true)
+ *   system entity      = org-curated entities visible to all members
  *   org-wide           = entities.share_with_everyone = 1
  *   manual share       = caller's email is in entity_share_emails for the entity
  *   file co-mention    = caller can see at least one file mentioning the entity
@@ -33,7 +36,11 @@ export function entityVisibilityPredicate(viewer: FileViewer, alias = "entities"
   const email = viewer.email ?? "";
   const fileVis = fileVisibilityPredicate(viewer, "ifs_inner");
   return sql<boolean>`(
-    ${t}.share_with_everyone = 1
+    ${t}.source_type IN (${sql.join(
+      SYSTEM_ENTITY_SOURCE_TYPES.map((sourceType) => sql`${sourceType}`),
+      sql`,`,
+    )})
+    OR ${t}.share_with_everyone = 1
     OR EXISTS (SELECT 1 FROM entity_share_emails ese
                WHERE ese.entity_id = ${t}.id
                  AND ese.email = ${email})

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -4,6 +4,48 @@ import { sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
 import { isPg } from "../dialect";
 import type { DB, EntitiesTable } from "../schema";
+import { type FileViewer, fileVisibilityPredicate } from "./connectors";
+
+/**
+ * Predicate matching entities visible to `viewer`. Composed into queries via `.where(...)`.
+ *
+ *   admin              = bypasses RBAC (single OR branch resolves to true)
+ *   org-wide           = entities.share_with_everyone = 1
+ *   manual share       = caller's email is in entity_share_emails for the entity
+ *   file co-mention    = caller can see at least one file mentioning the entity
+ *                        (delegates to fileVisibilityPredicate via EXISTS)
+ *
+ * Acyclic: this calls fileVisibilityPredicate. fileVisibilityPredicate must
+ * never call back into entityVisibilityPredicate — entity-share propagation
+ * to files is expressed directly there against entity_share_emails / entities.
+ *
+ * `alias` is the SQL identifier for `entities` at the call site (default
+ * "entities"). Pass a different name when the entity table is aliased.
+ */
+export function entityVisibilityPredicate(viewer: FileViewer, alias = "entities") {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(alias)) {
+    throw new Error(`entityVisibilityPredicate: invalid table alias "${alias}"`);
+  }
+  if (viewer.isAdmin) {
+    return sql<boolean>`(1 = 1)`;
+  }
+  const t = sql.raw(alias);
+  const email = viewer.email ?? "";
+  const fileVis = fileVisibilityPredicate(viewer, "ifs_inner");
+  return sql<boolean>`(
+    ${t}.share_with_everyone = 1
+    OR EXISTS (SELECT 1 FROM entity_share_emails ese
+               WHERE ese.entity_id = ${t}.id
+                 AND ese.email = ${email})
+    OR EXISTS (
+      SELECT 1 FROM entity_mentions em_vis
+      INNER JOIN indexed_files AS ifs_inner ON ifs_inner.id = em_vis.indexed_file_id
+      WHERE em_vis.entity_id = ${t}.id
+        AND ifs_inner.is_archived = 0
+        AND ${fileVis}
+    )
+  )`;
+}
 
 export interface UpsertEntityData {
   name: string;
@@ -96,8 +138,18 @@ export function createEntityRepository(db: Kysely<DB>) {
       return await db.selectFrom("entities").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
     },
 
-    async getEntity(id: string) {
-      return db.selectFrom("entities").selectAll().where("id", "=", id).executeTakeFirst();
+    /**
+     * Fetch an entity. When `viewer` is omitted the entity is returned without
+     * RBAC — internal/server callers use this to operate on entities directly
+     * (e.g. enrichment, materialization). API handlers must pass a viewer so
+     * callers without access get null (which maps to 404).
+     */
+    async getEntity(id: string, viewer?: FileViewer) {
+      let query = db.selectFrom("entities").selectAll().where("id", "=", id);
+      if (viewer) {
+        query = query.where(entityVisibilityPredicate(viewer));
+      }
+      return query.executeTakeFirst();
     },
 
     async getEntities(ids: string[]) {
@@ -413,38 +465,52 @@ export function createEntityRepository(db: Kysely<DB>) {
 
     /**
      * One-shot aggregates for the drawer's profile section. Returns mention
-     * count + source breakdown (org aggregate, ignoring per-file RBAC since the
-     * entity itself is already org-visible), first/last-seen timestamps, and
-     * company domains. Does not parse the entity row itself — caller composes
-     * the response from `getEntity` + this.
+     * count + source breakdown, first/last-seen timestamps, and company
+     * domains. Mention-derived aggregates are filtered to files visible to
+     * `viewer` when provided and non-admin — otherwise the entity row itself
+     * can be visible (via manual share / share_with_everyone) while leaking
+     * activity from files the viewer cannot see. Server-internal callers may
+     * omit `viewer` for unfiltered aggregates.
      */
-    async getEntityProfileAggregates(entityId: string): Promise<{
+    async getEntityProfileAggregates(
+      entityId: string,
+      viewer?: FileViewer,
+    ): Promise<{
       mentionCount: number;
       sourceCounts: Record<string, number>;
       firstSeenAt: string | null;
       lastSeenAt: string | null;
       domainsForCompany: Array<{ domain: string; confidence: number; isPrimary: boolean }>;
     }> {
-      const mentionRow = await db
+      const filterByVisibility = viewer !== undefined && !viewer.isAdmin;
+
+      let mentionQuery = db
         .selectFrom("entity_mentions")
+        .innerJoin("indexed_files", "indexed_files.id", "entity_mentions.indexed_file_id")
         .select(sql<number>`count(*)`.as("c"))
-        .where("entity_id", "=", entityId)
-        .executeTakeFirst();
+        .where("entity_mentions.entity_id", "=", entityId);
+      if (filterByVisibility) {
+        mentionQuery = mentionQuery.where(fileVisibilityPredicate(viewer));
+      }
+      const mentionRow = await mentionQuery.executeTakeFirst();
       const mentionCount = Number(mentionRow?.c ?? 0);
 
-      const bySource = await db
+      let bySourceQuery = db
         .selectFrom("entity_mentions")
         .innerJoin("indexed_files", "indexed_files.id", "entity_mentions.indexed_file_id")
         .select(["indexed_files.source", sql<number>`count(*)`.as("c")])
         .where("entity_mentions.entity_id", "=", entityId)
-        .groupBy("indexed_files.source")
-        .execute();
+        .groupBy("indexed_files.source");
+      if (filterByVisibility) {
+        bySourceQuery = bySourceQuery.where(fileVisibilityPredicate(viewer));
+      }
+      const bySource = await bySourceQuery.execute();
       const sourceCounts: Record<string, number> = {};
       for (const row of bySource) {
         sourceCounts[row.source] = Number(row.c ?? 0);
       }
 
-      const range = await db
+      let rangeQuery = db
         .selectFrom("entity_mentions")
         .innerJoin("indexed_files", "indexed_files.id", "entity_mentions.indexed_file_id")
         .select([
@@ -459,8 +525,11 @@ export function createEntityRepository(db: Kysely<DB>) {
             "last_seen",
           ),
         ])
-        .where("entity_mentions.entity_id", "=", entityId)
-        .executeTakeFirst();
+        .where("entity_mentions.entity_id", "=", entityId);
+      if (filterByVisibility) {
+        rangeQuery = rangeQuery.where(fileVisibilityPredicate(viewer));
+      }
+      const range = await rangeQuery.executeTakeFirst();
 
       const domainRows = await db
         .selectFrom("entity_domains")

--- a/packages/server/src/db/repositories/entity-shares.ts
+++ b/packages/server/src/db/repositories/entity-shares.ts
@@ -1,0 +1,75 @@
+/**
+ * Repository for manual entity shares — `entity_share_emails` rows and the
+ * `entities.share_with_everyone` flag.
+ *
+ * Read-time propagation only: granting a share grants visibility into the
+ * entity AND into every file that mentions it, without writing any rows to
+ * `file_access` / `access_scope_members`. Un-sharing is instantaneous because
+ * there's no derived state to invalidate.
+ */
+import type { Kysely } from "kysely";
+import type { DB } from "../schema";
+
+export interface EntityShareRow {
+  email: string;
+  granted_by_user_id: string;
+  granted_at: string;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function createEntitySharesRepository(db: Kysely<DB>) {
+  return {
+    /** List manual grants for an entity, newest first. */
+    async listForEntity(entityId: string): Promise<EntityShareRow[]> {
+      return db
+        .selectFrom("entity_share_emails")
+        .select(["email", "granted_by_user_id", "granted_at"])
+        .where("entity_id", "=", entityId)
+        .orderBy("granted_at", "desc")
+        .execute();
+    },
+
+    /** Idempotent grant. */
+    async grantToEmail(entityId: string, email: string, grantedByUserId: string): Promise<void> {
+      await db
+        .insertInto("entity_share_emails")
+        .values({
+          entity_id: entityId,
+          email: normalizeEmail(email),
+          granted_by_user_id: grantedByUserId,
+        })
+        .onConflict((oc) => oc.columns(["entity_id", "email"]).doNothing())
+        .execute();
+    },
+
+    async revokeFromEmail(entityId: string, email: string): Promise<void> {
+      await db
+        .deleteFrom("entity_share_emails")
+        .where("entity_id", "=", entityId)
+        .where("email", "=", normalizeEmail(email))
+        .execute();
+    },
+
+    async setOrgWide(entityId: string, value: boolean): Promise<void> {
+      await db
+        .updateTable("entities")
+        .set({ share_with_everyone: value ? 1 : 0 })
+        .where("id", "=", entityId)
+        .execute();
+    },
+
+    async getOrgWide(entityId: string): Promise<boolean> {
+      const row = await db
+        .selectFrom("entities")
+        .select(["share_with_everyone"])
+        .where("id", "=", entityId)
+        .executeTakeFirst();
+      return row?.share_with_everyone === 1;
+    },
+  };
+}
+
+export type EntitySharesRepository = ReturnType<typeof createEntitySharesRepository>;

--- a/packages/server/src/db/repositories/file-visibility.test.ts
+++ b/packages/server/src/db/repositories/file-visibility.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestDb } from "../../test-utils";
 import type { DB } from "../schema";
 import { type FileViewer, createConnectorRepository } from "./connectors";
+import { createEntityRepository } from "./entities";
 
 describe("file-visibility predicate (RBAC for file list/count)", () => {
   let db: Kysely<DB>;
@@ -251,6 +252,52 @@ describe("file-visibility predicate (RBAC for file list/count)", () => {
 
       const eveFiles = await repo.listAllFiles({ limit: 50, offset: 0, viewer: member("eve@example.com") });
       expect(eveFiles.map((f) => f.id).sort()).toEqual(["f-scope-b", "f-unrestricted"]);
+    });
+  });
+
+  describe("system entity visibility", () => {
+    it("keeps system entities visible without granting files that mention them", async () => {
+      const now = new Date().toISOString();
+      await db
+        .insertInto("entities")
+        .values({
+          id: "ent-clickup-space",
+          name: "Engineering Space",
+          source_type: "clickup_space",
+          subtype: null,
+          aliases: null,
+          metadata: null,
+          source_ref_id: null,
+          status: "confirmed",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+      await db
+        .insertInto("entity_mentions")
+        .values({
+          id: "mention-clickup-space",
+          entity_id: "ent-clickup-space",
+          indexed_file_id: "f-scope-a",
+          chunk_index: null,
+          context_snippet: null,
+          confidence: "EXTRACTED",
+          source: "test",
+          relation: "mentioned",
+          mentioned_at: now,
+        })
+        .execute();
+
+      const viewer = member("stranger@example.com");
+      const fileRepo = createConnectorRepository(db);
+      const entityRepo = createEntityRepository(db);
+
+      const entity = await entityRepo.getEntity("ent-clickup-space", viewer);
+      const files = await fileRepo.listAllFiles({ limit: 50, offset: 0, viewer });
+
+      expect(entity?.id).toBe("ent-clickup-space");
+      expect(files.map((f) => f.id)).toEqual(["f-unrestricted"]);
     });
   });
 });

--- a/packages/server/src/db/repositories/settings.test.ts
+++ b/packages/server/src/db/repositories/settings.test.ts
@@ -87,10 +87,10 @@ describe("Settings repository", () => {
     const initial = await settings.get();
     expect(initial?.admin_can_read_all_files).toBe(0);
 
-    await settings.update({ adminCanReadAllFiles: 1 });
+    await settings.update({ adminCanReadAllFiles: true });
     expect((await settings.get())?.admin_can_read_all_files).toBe(1);
 
-    await settings.update({ adminCanReadAllFiles: 0 });
+    await settings.update({ adminCanReadAllFiles: false });
     expect((await settings.get())?.admin_can_read_all_files).toBe(0);
   });
 

--- a/packages/server/src/db/repositories/settings.ts
+++ b/packages/server/src/db/repositories/settings.ts
@@ -140,7 +140,7 @@ export function createSettingsRepository(db: Kysely<DB>, encryptionKey?: string)
         googleOauthClientSecret: string | null;
         geminiApiKey: string | null;
         enrichmentEnabled: number | null;
-        adminCanReadAllFiles: number;
+        adminCanReadAllFiles: boolean;
         syncIntervalMinutes: number | null;
         orgContext: string | null;
         sketchApiKey: string | null;
@@ -173,7 +173,7 @@ export function createSettingsRepository(db: Kysely<DB>, encryptionKey?: string)
       if (data.googleOauthClientSecret !== undefined) updates.google_oauth_client_secret = data.googleOauthClientSecret;
       if (data.geminiApiKey !== undefined) updates.gemini_api_key = data.geminiApiKey;
       if (data.enrichmentEnabled !== undefined) updates.enrichment_enabled = data.enrichmentEnabled;
-      if (data.adminCanReadAllFiles !== undefined) updates.admin_can_read_all_files = data.adminCanReadAllFiles;
+      if (data.adminCanReadAllFiles !== undefined) updates.admin_can_read_all_files = data.adminCanReadAllFiles ? 1 : 0;
       if (data.syncIntervalMinutes !== undefined) updates.sync_interval_minutes = data.syncIntervalMinutes;
       if (data.sketchApiKey !== undefined) updates.sketch_api_key = data.sketchApiKey;
       if (data.whatsappFallbackAgentId !== undefined) updates.whatsapp_fallback_agent_id = data.whatsappFallbackAgentId;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -333,6 +333,14 @@ export interface EntitiesTable {
   created_at: string;
   updated_at: string;
   ai_brief: string | null;
+  share_with_everyone: Generated<number>;
+}
+
+export interface EntityShareEmailsTable {
+  entity_id: string;
+  email: string;
+  granted_by_user_id: string;
+  granted_at: Generated<string>;
 }
 
 export interface EntitySourceRefsTable {
@@ -541,6 +549,7 @@ export interface DB {
   automation_step_content: AutomationStepContentTable;
   inbox_messages: InboxMessagesTable;
   entities: EntitiesTable;
+  entity_share_emails: EntityShareEmailsTable;
   entity_source_refs: EntitySourceRefsTable;
   entity_mentions: EntityMentionsTable;
   agent_runs: AgentRunsTable;

--- a/packages/server/src/entities/rank.test.ts
+++ b/packages/server/src/entities/rank.test.ts
@@ -16,6 +16,7 @@ function person(id: string, name: string): Entity {
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
     ai_brief: null,
+    share_with_everyone: 0,
   };
 }
 

--- a/packages/web/src/components/entity-drawer/entity-drawer.tsx
+++ b/packages/web/src/components/entity-drawer/entity-drawer.tsx
@@ -12,11 +12,20 @@
  * Driven by EntityUiProvider's stack. Each level renders independently —
  * pushing a related entity pushes a new id onto the stack; Back chip pops.
  */
+import { EntityShareDialog } from "@/components/entity-share-dialog";
 import type { EntityDetail, EntityRelationEvidenceRow, EntityRelationView, EntityRelationsResponse } from "@/lib/api";
 import { api } from "@/lib/api";
 import { EntityAvatar, EntityChip, entityAccent, useEntityUi } from "@/lib/entity-ui";
-import { ArrowLeftIcon, CaretDownIcon, CaretRightIcon, WarningIcon } from "@phosphor-icons/react";
+import {
+  ArrowLeftIcon,
+  CaretDownIcon,
+  CaretRightIcon,
+  GlobeIcon,
+  ShareNetworkIcon,
+  WarningIcon,
+} from "@phosphor-icons/react";
 import { Badge } from "@sketch/ui/components/badge";
+import { Button } from "@sketch/ui/components/button";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@sketch/ui/components/sheet";
 import { Skeleton } from "@sketch/ui/components/skeleton";
 import { cn } from "@sketch/ui/lib/utils";
@@ -150,6 +159,16 @@ interface DrawerHeaderProps {
 
 function DrawerHeader({ entity, stackDepth, previousName, onBack, accent }: DrawerHeaderProps) {
   const lastSeen = entity.profile.lastSeenAt;
+  // EntityDrawer mounts at root (outside the dashboard route context), so the
+  // route-context auth hook is not available here — query the session directly.
+  const sessionQuery = useQuery({
+    queryKey: ["auth-session"],
+    queryFn: () => api.auth.session(),
+    staleTime: 60_000,
+  });
+  const isAdmin = sessionQuery.data?.role === "admin";
+  const [shareOpen, setShareOpen] = useState(false);
+
   return (
     <div
       className="sticky top-0 z-10 border-b bg-background px-6 pb-4 pt-5"
@@ -170,11 +189,30 @@ function DrawerHeader({ entity, stackDepth, previousName, onBack, accent }: Draw
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-3">
             <h2 className="min-w-0 flex-1 truncate font-serif text-[20px] leading-tight">{entity.name}</h2>
-            {lastSeen ? (
-              <span className="shrink-0 whitespace-nowrap font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                Last seen {formatRelative(lastSeen)}
-              </span>
-            ) : null}
+            <div className="flex shrink-0 items-center gap-2">
+              {entity.shareWithEveryone ? (
+                <Badge variant="outline" className="gap-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  <GlobeIcon size={10} />
+                  Anyone in org
+                </Badge>
+              ) : null}
+              {lastSeen ? (
+                <span className="whitespace-nowrap font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                  Last seen {formatRelative(lastSeen)}
+                </span>
+              ) : null}
+              {isAdmin ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1 text-[11px]"
+                  onClick={() => setShareOpen(true)}
+                >
+                  <ShareNetworkIcon size={12} />
+                  Share
+                </Button>
+              ) : null}
+            </div>
           </div>
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
@@ -186,9 +224,17 @@ function DrawerHeader({ entity, stackDepth, previousName, onBack, accent }: Draw
                 {entity.status}
               </Badge>
             ) : null}
+            {(entity.manualShares?.length ?? 0) > 0 ? (
+              <Badge variant="secondary" className="text-[10px]">
+                Shared with {entity.manualShares?.length ?? 0}
+              </Badge>
+            ) : null}
           </div>
         </div>
       </div>
+      {isAdmin ? (
+        <EntityShareDialog entityId={entity.id} entityName={entity.name} open={shareOpen} onOpenChange={setShareOpen} />
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/components/entity-share-dialog.tsx
+++ b/packages/web/src/components/entity-share-dialog.tsx
@@ -1,0 +1,302 @@
+/**
+ * EntityShareDialog — manual sharing for an entity.
+ *
+ * Read-time propagation: granting a share gives the recipient read access to
+ * the entity AND to every file that mentions it. No `file_access` rows are
+ * written — visibility is recomputed at query time, so un-sharing is instant.
+ *
+ * Admin-only (entities have no single owner like connectors do). The drawer
+ * gates the trigger button on `auth.role === "admin"`.
+ */
+import { api } from "@/lib/api";
+import type { EntityManualShare, User } from "@/lib/api";
+import { GlobeIcon, LockSimpleIcon, SpinnerGapIcon, XIcon } from "@phosphor-icons/react";
+import { Button } from "@sketch/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@sketch/ui/components/dialog";
+import { Input } from "@sketch/ui/components/input";
+import { Switch } from "@sketch/ui/components/switch";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+interface EntityShareDialogProps {
+  entityId: string;
+  entityName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isEmail(value: string) {
+  return EMAIL_PATTERN.test(value.trim());
+}
+
+export function EntityShareDialog({ entityId, entityName, open, onOpenChange }: EntityShareDialogProps) {
+  const queryClient = useQueryClient();
+
+  const sharesQuery = useQuery({
+    queryKey: ["entity-shares", entityId],
+    queryFn: () => api.entities.listShares(entityId),
+    enabled: open,
+  });
+
+  const usersQuery = useQuery({
+    queryKey: ["users-for-share"],
+    queryFn: () => api.users.list(),
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const [pendingEmails, setPendingEmails] = useState<string[]>([]);
+  const [draft, setDraft] = useState("");
+  const [orgWideDraft, setOrgWideDraft] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setPendingEmails([]);
+      setDraft("");
+      setOrgWideDraft(null);
+    }
+  }, [open]);
+
+  const currentEmails = useMemo(() => sharesQuery.data?.shares.map((s) => s.email) ?? [], [sharesQuery.data]);
+  const finalEmails = useMemo(() => {
+    const combined = new Set([...currentEmails, ...pendingEmails]);
+    return [...combined];
+  }, [currentEmails, pendingEmails]);
+  const currentOrgWide = sharesQuery.data?.shareWithEveryone ?? false;
+  const effectiveOrgWide = orgWideDraft ?? currentOrgWide;
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      api.entities.updateShares(entityId, {
+        emails: finalEmails.map((e) => e.toLowerCase()),
+        shareWithEveryone: orgWideDraft ?? undefined,
+      }),
+    onSuccess: () => {
+      toast.success("Sharing updated");
+      queryClient.invalidateQueries({ queryKey: ["entity-shares", entityId] });
+      queryClient.invalidateQueries({ queryKey: ["entity-drawer", "profile", entityId] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (email: string) => api.entities.revokeShare(entityId, email),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["entity-shares", entityId] });
+      queryClient.invalidateQueries({ queryKey: ["entity-drawer", "profile", entityId] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  function tryAddEmail() {
+    const value = draft.trim().toLowerCase();
+    if (!value) return;
+    if (!isEmail(value)) {
+      toast.error("Enter a valid email");
+      return;
+    }
+    if (finalEmails.includes(value)) {
+      setDraft("");
+      return;
+    }
+    setPendingEmails((prev) => [...prev, value]);
+    setDraft("");
+  }
+
+  function removePending(email: string) {
+    setPendingEmails((prev) => prev.filter((e) => e !== email));
+  }
+
+  const hasOrgWideChange = orgWideDraft !== null && orgWideDraft !== currentOrgWide;
+  const hasPendingEmails = pendingEmails.length > 0;
+  const canSave = hasPendingEmails || hasOrgWideChange;
+
+  const suggestions = useMemo(() => {
+    const draftLower = draft.trim().toLowerCase();
+    if (!draftLower) return [];
+    const used = new Set(finalEmails);
+    return (usersQuery.data?.users ?? [])
+      .map((u) => u.email)
+      .filter((email): email is string => !!email)
+      .map((email) => email.toLowerCase())
+      .filter((email) => email.includes(draftLower) && !used.has(email))
+      .slice(0, 5);
+  }, [draft, finalEmails, usersQuery.data]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-base">Share "{entityName}"</DialogTitle>
+          <DialogDescription className="text-xs">
+            People you add can see this entity and every file that mentions it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-2">Add people</p>
+            <div className="flex gap-2">
+              <Input
+                placeholder="name@example.com"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === ",") {
+                    e.preventDefault();
+                    tryAddEmail();
+                  }
+                }}
+                className="text-sm"
+              />
+              <Button size="sm" variant="outline" onClick={tryAddEmail} disabled={!draft.trim()}>
+                Add
+              </Button>
+            </div>
+            {suggestions.length > 0 && (
+              <div className="mt-1 space-y-0.5">
+                {suggestions.map((email) => (
+                  <button
+                    type="button"
+                    key={email}
+                    className="block w-full rounded px-2 py-1 text-left text-xs hover:bg-muted"
+                    onClick={() => {
+                      setPendingEmails((prev) => (prev.includes(email) ? prev : [...prev, email]));
+                      setDraft("");
+                    }}
+                  >
+                    {email}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {sharesQuery.data?.shares.length || pendingEmails.length ? (
+            <div>
+              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-2">
+                People with access
+              </p>
+              <div className="space-y-1.5">
+                {sharesQuery.data?.shares.map((share) => (
+                  <ShareRow
+                    key={share.email}
+                    share={share}
+                    user={usersQuery.data?.users.find((u) => u.email?.toLowerCase() === share.email)}
+                    onRevoke={() => revokeMutation.mutate(share.email)}
+                    isRevoking={revokeMutation.isPending && revokeMutation.variables === share.email}
+                  />
+                ))}
+                {pendingEmails.map((email) => (
+                  <div
+                    key={email}
+                    className="flex items-center justify-between rounded-md border border-dashed border-border bg-muted/20 px-2.5 py-1.5 text-xs"
+                  >
+                    <span className="truncate">{email}</span>
+                    <span className="flex items-center gap-2">
+                      <span className="text-[10px] text-muted-foreground">Pending</span>
+                      <button
+                        type="button"
+                        onClick={() => removePending(email)}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label={`Remove ${email}`}
+                      >
+                        <XIcon size={12} />
+                      </button>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="rounded-lg border border-border px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                {effectiveOrgWide ? (
+                  <GlobeIcon size={14} className="text-muted-foreground" />
+                ) : (
+                  <LockSimpleIcon size={14} className="text-muted-foreground" />
+                )}
+                <div>
+                  <p className="text-xs font-medium">{effectiveOrgWide ? "Anyone in the org" : "Restricted"}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {effectiveOrgWide
+                      ? "Every authenticated user in the org can see this entity and its files."
+                      : "Only the people listed above and file co-mention propagation apply."}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                checked={effectiveOrgWide}
+                onCheckedChange={(value) => setOrgWideDraft(value)}
+                aria-label="Share with everyone in the org"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button size="sm" onClick={() => updateMutation.mutate()} disabled={!canSave || updateMutation.isPending}>
+            {updateMutation.isPending ? (
+              <>
+                <SpinnerGapIcon size={12} className="animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ShareRow({
+  share,
+  user,
+  onRevoke,
+  isRevoking,
+}: {
+  share: EntityManualShare;
+  user?: User;
+  onRevoke: () => void;
+  isRevoking: boolean;
+}) {
+  const displayName = user?.name ?? share.email;
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border px-2.5 py-1.5 text-xs">
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium">{displayName}</p>
+        {user?.name && <p className="truncate text-[11px] text-muted-foreground">{share.email}</p>}
+      </div>
+      <button
+        type="button"
+        onClick={onRevoke}
+        disabled={isRevoking}
+        className="ml-2 text-muted-foreground hover:text-destructive disabled:opacity-50"
+        aria-label={`Revoke ${share.email}`}
+      >
+        {isRevoking ? <SpinnerGapIcon size={12} className="animate-spin" /> : <XIcon size={12} />}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -335,8 +335,20 @@ export interface EntityProfile {
   summary: EntityProfileSummary;
 }
 
+export interface EntityManualShare {
+  email: string;
+  grantedAt: string;
+}
+
 export interface EntityDetail extends EntityListItem {
   profile: EntityProfile;
+  shareWithEveryone: boolean;
+  manualShares: EntityManualShare[];
+}
+
+export interface EntitySharesResponse {
+  shares: EntityManualShare[];
+  shareWithEveryone: boolean;
 }
 
 export interface EntitySourceRef {
@@ -1377,6 +1389,20 @@ export const api = {
     },
     timeline(id: string) {
       return request<EntityTimelineResponse>(`/api/entities/${id}/timeline`);
+    },
+    listShares(id: string) {
+      return request<EntitySharesResponse>(`/api/entities/${id}/shares`);
+    },
+    updateShares(id: string, data: { emails: string[]; shareWithEveryone?: boolean }) {
+      return request<EntitySharesResponse>(`/api/entities/${id}/shares`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      });
+    },
+    revokeShare(id: string, email: string) {
+      return request<{ success: boolean }>(`/api/entities/${id}/shares/${encodeURIComponent(email)}`, {
+        method: "DELETE",
+      });
     },
     mentions(id: string, opts?: { source?: string; since?: string; limit?: number; offset?: number }) {
       const params = new URLSearchParams();

--- a/packages/web/src/routes/files/file-detail-sheet.tsx
+++ b/packages/web/src/routes/files/file-detail-sheet.tsx
@@ -134,7 +134,7 @@ function FileDetailContent({
             ) : access.scope === "restricted" ? (
               <>
                 <LockSimpleIcon size={10} weight="fill" />
-                {access.members.length + access.manualShares.length} users
+                {(access.members?.length ?? 0) + (access.manualShares?.length ?? 0)} users
               </>
             ) : (
               <>
@@ -218,7 +218,9 @@ function FileDetailContent({
         </div>
       )}
 
-      {access && (access.members.length > 0 || access.manualShares.length > 0) && <AccessSection access={access} />}
+      {access && ((access.members?.length ?? 0) > 0 || (access.manualShares?.length ?? 0) > 0) && (
+        <AccessSection access={access} />
+      )}
 
       {file.content && <ContentPreview content={file.content} />}
     </div>
@@ -383,7 +385,8 @@ function memberInitial(member: { userName: string | null; email: string }) {
 
 function AccessSection({ access }: { access: FileAccess }) {
   const [expanded, setExpanded] = useState(false);
-  const members = access.members;
+  const members = access.members ?? [];
+  const manualShares = access.manualShares ?? [];
   const mappedCount = members.filter((m) => m.mapped).length;
   const showExpand = members.length > COLLAPSED_MEMBER_LIMIT;
   const visibleMembers = expanded ? members : members.slice(0, COLLAPSED_MEMBER_LIMIT);
@@ -468,13 +471,13 @@ function AccessSection({ access }: { access: FileAccess }) {
         </div>
       )}
 
-      {access.manualShares.length > 0 && (
+      {manualShares.length > 0 && (
         <div className="mt-2">
           <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
-            Manually shared ({access.manualShares.length})
+            Manually shared ({manualShares.length})
           </p>
           <div className="mt-1 flex flex-wrap gap-1">
-            {access.manualShares.map((share) => (
+            {manualShares.map((share) => (
               <Badge key={share.email} variant="outline" className="text-[10px]">
                 {share.email}
               </Badge>


### PR DESCRIPTION
Stacked on **#181** (file sharing) → **#180** (admin file bypass). Review last, after those land.

## Summary

- Adds manual entity sharing: per-email `entity_share_emails` rows + an `entities.share_with_everyone` org-wide flag, set from a Share dialog in the entity drawer (admin-only).
- Establishes entity-level RBAC for the first time. Default rule: a user can see an entity if any file mentioning it is visible to them (via the existing file-visibility predicate).
- Read-time propagation only — no writes to `file_access`. Sharing entity E with X also gives X read access to every file mentioning E (and transitively to entities mentioned in those files via file visibility). Un-sharing is instantaneous.
- Backfill marks `clickup_workspace` / `clickup_space` entities org-visible so the default-deny doesn't hide system-typed entities on rollout.

## Hardening rolled in (Codex review)

- `searchFiles` / `hybridSearch` / `browseLatest` / `GetEntityContext` short-circuit to `[]` when `userEmails` is empty (was a fail-open).
- `GET /api/entities/:id/mentions` switches from raw `viewer` to `contentViewer` so admin bypass for snippet content respects the `adminCanReadAllFiles` setting (matches `/files/:id/content`).
- `adminCanReadAllFiles` settings API takes `boolean` (was `0|1`); repository converts at the SQL edge.
- Defensive `?? []` / `?? 0` guards in `file-detail-sheet` and `entity-drawer` against undefined arrays from stale TanStack Query caches.
- EntityDrawer reads auth via `useQuery(api.auth.session)` instead of `useDashboardAuth()` so it works when mounted at root (above the dashboard route context).

## Behavior change to call out

The `/api/entities/:id/mentions` route now gates context_snippet content on `adminCanReadAllFiles` (same model as `/files/:id/content`). Admins without the setting see only mentions on files they have email access to, plus a `hiddenCount` for the rest. This matches the design contract for content visibility, but it's a behavior change from "admin always sees every mention."

## Test plan

- [x] `pnpm biome check`
- [x] `pnpm typecheck` (server + web)
- [x] `pnpm --filter @sketch/server test` — 2074/2074
- [x] `pnpm --filter @sketch/web test` — 154/154
- [x] `pnpm build` (server + web)
- [ ] Smoke: open entity drawer as admin → Share → add email → save → verify drawer for that user shows the entity + mentioned files
- [ ] Smoke: org-wide toggle persists across drawer reopen
- [ ] Smoke: revoke share — entity disappears for the revoked member immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)