### PR TITLE
SKE-144: Remove member from team is not working

### DIFF
--- a/packages/server/src/db/repositories/users.ts
+++ b/packages/server/src/db/repositories/users.ts
@@ -281,6 +281,27 @@ export function createUserRepository(db: UserDb): UserRepository {
     },
 
     async remove(id: string) {
+      await db
+        .deleteFrom("agent_environment_variable_shares")
+        .where("variable_id", "in", db.selectFrom("agent_environment_variables").select("id").where("user_id", "=", id))
+        .execute();
+      await db.deleteFrom("agent_environment_variable_shares").where("created_by", "=", id).execute();
+      await db.deleteFrom("agent_environment_variables").where("user_id", "=", id).execute();
+      await db.deleteFrom("user_provider_identities").where("user_id", "=", id).execute();
+      await db.deleteFrom("email_verification_tokens").where("user_id", "=", id).execute();
+      await db.deleteFrom("magic_link_tokens").where("user_id", "=", id).execute();
+      await db
+        .deleteFrom("inbox_messages")
+        .where((eb) => eb.or([eb("sender_user_id", "=", id), eb("recipient_user_id", "=", id)]))
+        .execute();
+      await db.updateTable("users").set({ reports_to: null }).where("reports_to", "=", id).execute();
+      await db.updateTable("channels").set({ agent_user_id: null }).where("agent_user_id", "=", id).execute();
+      await db.updateTable("whatsapp_groups").set({ agent_user_id: null }).where("agent_user_id", "=", id).execute();
+      await db
+        .updateTable("settings")
+        .set({ whatsapp_fallback_agent_id: null })
+        .where("whatsapp_fallback_agent_id", "=", id)
+        .execute();
       return db.deleteFrom("users").where("id", "=", id).execute();
     },
 

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1,5 +1,5 @@
 import { SignJWT } from "jose";
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { signJwt } from "./auth/jwt";
 import { hashPassword } from "./auth/password";
@@ -1996,6 +1996,57 @@ describe("Users API", () => {
       const getBody = await getRes.json();
       expect(getBody.users).toHaveLength(1);
       expect(getBody.users[0].email).toBe("admin@test.com");
+    });
+
+    it("removes user with dependent rows", async () => {
+      await sql`PRAGMA foreign_keys = ON`.execute(db);
+      const app = createApp(db, config);
+      const cookie = await setupAdmin(app);
+      const users = createUserRepository(db);
+      const admin = await users.findByEmail("admin@test.com");
+      if (!admin) throw new Error("Admin user missing");
+      const manager = await users.create({ name: "Manager", email: "manager@test.com" });
+      const report = await users.create({ name: "Report", email: "report@test.com", reportsTo: manager.id });
+
+      await db
+        .insertInto("user_provider_identities")
+        .values({
+          id: "identity-manager",
+          user_id: manager.id,
+          provider: "google_drive",
+          provider_user_id: "provider-manager",
+          provider_email: "manager@test.com",
+        })
+        .execute();
+      await db
+        .insertInto("inbox_messages")
+        .values({
+          id: "inbox-manager",
+          sender_user_id: admin.id,
+          recipient_user_id: manager.id,
+          message: "Please review this",
+          platform: "slack",
+        })
+        .execute();
+
+      const res = await app.request(`/api/users/${manager.id}`, {
+        method: "DELETE",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+
+      await expect(users.findById(manager.id)).resolves.toBeUndefined();
+      await expect(users.findById(report.id)).resolves.toMatchObject({ reports_to: null });
+      await expect(
+        db.selectFrom("user_provider_identities").select("id").where("user_id", "=", manager.id).execute(),
+      ).resolves.toEqual([]);
+      await expect(
+        db
+          .selectFrom("inbox_messages")
+          .select("id")
+          .where((eb) => eb.or([eb("sender_user_id", "=", manager.id), eb("recipient_user_id", "=", manager.id)]))
+          .execute(),
+      ).resolves.toEqual([]);
     });
 
     it("returns 404 for unknown id", async () => {


### PR DESCRIPTION
## Summary
- Fixes SKE-144, where removing a team member could fail with `FOREIGN KEY constraint failed` instead of deleting the member.
- Moves cleanup into `createUserRepository().remove()` so every caller of user removal gets the same dependency handling.
- Adds regression coverage for deleting a member that has provider identities, inbox messages, and org-chart reports.

## Linear Scope
- Linear issue: `SKE-144`
- Title: `Remove member from team is not working`
- Team: Sketch
- Project: Sketch OSS
- Label: Bug

## Root Cause
- The Team UI already called `DELETE /api/users/:id` correctly.
- The API route archived owned connectors, then called `users.remove(id)`.
- `users.remove(id)` previously only deleted the row from `users`.
- Several tables can reference `users.id`, including `user_provider_identities`, `inbox_messages`, agent environment variables/shares, verification tokens, magic-link tokens, org-chart `reports_to`, channel/group agent bindings, and the WhatsApp fallback agent setting.
- With SQLite foreign keys enabled, deleting a member with dependent rows fails and leaves the member in place. The same issue is relevant for Postgres because the schema contains non-cascading user references.

## Implementation Details
- Before deleting the user row, `createUserRepository().remove()` now:
  - Deletes agent environment variable shares owned by variables for the user.
  - Deletes agent environment variable shares created by the user.
  - Deletes agent environment variables owned by the user.
  - Deletes provider identity rows for the user.
  - Deletes email verification and magic-link tokens for the user.
  - Deletes inbox messages where the user is sender or recipient.
  - Nulls `users.reports_to` for direct reports of the deleted user.
  - Nulls Slack channel and WhatsApp group agent bindings for deleted agent users.
  - Nulls `settings.whatsapp_fallback_agent_id` when it points at the deleted user.
- The connector archival behavior in the API route remains unchanged: owned connector credentials are scrubbed before the user row is removed.
- No API shape, frontend behavior, migrations, or config changes are required.

## Regression Test
- Added an HTTP test for `DELETE /api/users/:id` with `PRAGMA foreign_keys = ON`.
- The test seeds:
  - Admin user
  - Removable team member
  - Direct report pointing at the removable member
  - `user_provider_identities` row for the removable member
  - `inbox_messages` row addressed to the removable member
- The test verifies:
  - The delete endpoint returns `200`
  - The removed user no longer exists
  - The direct report's `reports_to` is set to `null`
  - Provider identity rows are removed
  - Inbox message rows involving the user are removed

## Branch Behavior Comparison
- On `origin/main`, the same seeded scenario returns `500 Internal Server Error` and logs `SQLITE_CONSTRAINT_FOREIGNKEY`; the user, provider identity, inbox message, and `reports_to` reference remain.
- On `fix/ske-144-remove-member`, the same seeded scenario returns `200 {"success":true}`; the user is deleted, dependent rows are cleaned, and `reports_to` is nulled.

## Verification
- `pnpm --filter @sketch/server exec vitest run src/http.test.ts --testNamePattern "DELETE /api/users/:id"` - passed
- `pnpm --filter @sketch/server exec vitest run src/db/repositories/users.test.ts` - passed
- `pnpm biome check` - passed
- `pnpm typecheck` - passed
- `pnpm test` - passed
- `pnpm build` - passed
- Manual branch comparison harness on `origin/main` vs `fix/ske-144-remove-member` - confirmed failing-before and passing-after behavior

## Risk / Rollout
- This changes hard-delete cleanup semantics for team members. Historical connector data remains preserved because the existing connector archival path still runs before user deletion.
- Inbox messages involving removed users are deleted rather than retained, matching the need to satisfy user foreign-key references during account removal.
- No migration is needed because this is runtime cleanup of existing schema relationships.
