### PR TITLE
feat: public MCP server over /mcp, PAT-authed (3/4)

### DIFF
--- a/packages/server/src/mcp/server/auth.ts
+++ b/packages/server/src/mcp/server/auth.ts
@@ -1,0 +1,65 @@
+import type { Context, Next } from "hono";
+import type { Logger } from "pino";
+import { hashApiToken, isSketchPat } from "../../auth/api-token";
+import type { createApiTokenRepository } from "../../db/repositories/api-tokens";
+import type { createUserRepository } from "../../db/repositories/users";
+import { createTokenBucketRateLimiter } from "./rate-limit";
+
+type ApiTokenRepo = ReturnType<typeof createApiTokenRepository>;
+type UserRepo = ReturnType<typeof createUserRepository>;
+
+export interface McpAuthContext {
+  tokenId: string;
+  userId: string;
+  userEmail: string | null;
+  tokenPrefix: string;
+}
+
+declare module "hono" {
+  interface ContextVariableMap {
+    mcpAuth: McpAuthContext;
+  }
+}
+
+const limiter = createTokenBucketRateLimiter({ capacity: 60, refillPerMinute: 60 });
+
+export function createMcpAuthMiddleware(params: { apiTokens: ApiTokenRepo; users: UserRepo; logger: Logger }) {
+  return async (c: Context, next: Next) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return c.json({ error: { code: "UNAUTHORIZED", message: "Bearer token required" } }, 401);
+    }
+
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (!isSketchPat(token)) {
+      return c.json({ error: { code: "UNAUTHORIZED", message: "Invalid token" } }, 401);
+    }
+
+    const row = await params.apiTokens.findByHash(hashApiToken(token));
+    if (!row) {
+      return c.json({ error: { code: "UNAUTHORIZED", message: "Invalid token" } }, 401);
+    }
+
+    const user = await params.users.findById(row.user_id);
+    if (!user) {
+      return c.json({ error: { code: "UNAUTHORIZED", message: "Invalid token" } }, 401);
+    }
+
+    if (!limiter.consume(row.id)) {
+      return c.json({ error: { code: "RATE_LIMITED", message: "Too many MCP requests" } }, 429);
+    }
+
+    c.set("mcpAuth", {
+      tokenId: row.id,
+      userId: row.user_id,
+      userEmail: user.email,
+      tokenPrefix: row.prefix,
+    });
+
+    void params.apiTokens.touchLastUsed(row.id).catch((err) => {
+      params.logger.warn({ err, tokenId: row.id }, "Failed to update API token last_used_at");
+    });
+
+    return next();
+  };
+}

--- a/packages/server/src/mcp/server/public-server.test.ts
+++ b/packages/server/src/mcp/server/public-server.test.ts
@@ -1,0 +1,103 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { generateApiToken, getApiTokenDisplayPrefix, hashApiToken } from "../../auth/api-token";
+import { createApiTokenRepository } from "../../db/repositories/api-tokens";
+import { createSettingsRepository } from "../../db/repositories/settings";
+import { createUserRepository } from "../../db/repositories/users";
+import type { DB } from "../../db/schema";
+import { createApp } from "../../http";
+import { createTestConfig, createTestDb, createTestLogger } from "../../test-utils";
+
+let db: Kysely<DB>;
+
+beforeEach(async () => {
+  db = await createTestDb();
+});
+
+afterEach(async () => {
+  await db.destroy();
+});
+
+async function createPat() {
+  const settings = createSettingsRepository(db);
+  await settings.create();
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+  const users = createUserRepository(db);
+  const user = await users.create({ name: "MCP User", email: "mcp@example.com", emailVerified: true });
+  const plaintext = generateApiToken();
+  await createApiTokenRepository(db).create({
+    userId: user.id,
+    name: "Claude Code",
+    tokenHash: hashApiToken(plaintext),
+    prefix: getApiTokenDisplayPrefix(plaintext),
+  });
+  return plaintext;
+}
+
+function mcpHeaders(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json, text/event-stream",
+    "Content-Type": "application/json",
+    "Mcp-Protocol-Version": "2025-03-26",
+  };
+}
+
+describe("public MCP server", () => {
+  it("is invisible when EXPERIMENTAL_FLAG is off", async () => {
+    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: false }), { logger: createTestLogger() });
+    const res = await app.request("/mcp", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects non-Sketch PAT bearer tokens", async () => {
+    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: mcpHeaders("sk_live_wrong"),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("lists the four public sketch tools for a valid PAT", async () => {
+    const token = await createPat();
+    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: mcpHeaders(token),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: { tools: Array<{ name: string }> } };
+    expect(body.result.tools.map((tool) => tool.name).sort()).toEqual([
+      "sketch_get_entity_context",
+      "sketch_get_file_content",
+      "sketch_search",
+      "sketch_search_entities",
+    ]);
+  });
+
+  it("rate limits by token even when the forwarded IP changes", async () => {
+    const token = await createPat();
+    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    const statuses: number[] = [];
+
+    for (let i = 0; i < 61; i += 1) {
+      const res = await app.request("/mcp", {
+        method: "POST",
+        headers: {
+          ...mcpHeaders(token),
+          "x-forwarded-for": `203.0.113.${i}`,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: i + 1, method: "tools/list" }),
+      });
+      statuses.push(res.status);
+    }
+
+    expect(statuses.filter((status) => status === 200)).toHaveLength(60);
+    expect(statuses.at(-1)).toBe(429);
+  });
+});

--- a/packages/server/src/mcp/server/public-server.ts
+++ b/packages/server/src/mcp/server/public-server.ts
@@ -1,0 +1,92 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type { Kysely } from "kysely";
+import {
+  getEntityContextToolDescription,
+  getEntityContextToolSchema,
+  getFileContentToolDescription,
+  getFileContentToolSchema,
+  handleGetEntityContext,
+  handleGetFileContent,
+  handleSearch,
+  handleSearchEntities,
+  searchEntitiesToolDescription,
+  searchEntitiesToolSchema,
+  searchToolDescription,
+  searchToolSchema,
+} from "../../agent/tools/search";
+import { type SketchMcpDeps, UploadCollector } from "../../agent/tools/types";
+import type { createExternalMcpToolCallRepository } from "../../db/repositories/external-mcp-tool-calls";
+import type { createUserRepository } from "../../db/repositories/users";
+import type { DB } from "../../db/schema";
+import { Semaphore } from "./rate-limit";
+
+type UserRepo = ReturnType<typeof createUserRepository>;
+type AuditRepo = ReturnType<typeof createExternalMcpToolCallRepository>;
+
+const MAX_FILE_CONTENT_CHARS = 50_000;
+const toolSemaphore = new Semaphore(4);
+
+export async function createPublicSketchMcpServer(params: {
+  db: Kysely<DB>;
+  userRepo: UserRepo;
+  userId: string;
+  tokenId: string;
+  workspaceDir: string;
+  auditRepo: AuditRepo;
+}): Promise<McpServer> {
+  const userEmails = await params.userRepo.getVerifiedEmailsForUser(params.userId);
+  const deps: SketchMcpDeps = {
+    uploadCollector: new UploadCollector(),
+    workspaceDir: params.workspaceDir,
+    db: params.db,
+    userRepo: params.userRepo,
+    currentUserId: params.userId,
+    publicMcp: {
+      userEmails,
+      filterEntityMetadata: true,
+      maxFileContentChars: MAX_FILE_CONTENT_CHARS,
+    },
+  };
+  const server = new McpServer({ name: "sketch", version: "1.0.0" });
+
+  function register<TArgs extends Record<string, unknown>>(
+    name: string,
+    description: string,
+    inputSchema: ZodRawShapeCompat,
+    handler: (args: TArgs, deps: SketchMcpDeps) => Promise<{ content: { type: "text"; text: string }[] }>,
+  ) {
+    server.registerTool(name, { description, inputSchema }, async (args) => {
+      const startedAt = Date.now();
+      let success = false;
+      try {
+        const result = await toolSemaphore.run(() => handler(args as TArgs, deps));
+        success = true;
+        return result;
+      } finally {
+        const durationMs = Date.now() - startedAt;
+        void params.auditRepo
+          .create({
+            tokenId: params.tokenId,
+            userId: params.userId,
+            toolName: name,
+            success,
+            durationMs,
+          })
+          .catch(() => undefined);
+      }
+    });
+  }
+
+  register("sketch_search", searchToolDescription, searchToolSchema, handleSearch);
+  register("sketch_search_entities", searchEntitiesToolDescription, searchEntitiesToolSchema, handleSearchEntities);
+  register(
+    "sketch_get_entity_context",
+    getEntityContextToolDescription,
+    getEntityContextToolSchema,
+    handleGetEntityContext,
+  );
+  register("sketch_get_file_content", getFileContentToolDescription, getFileContentToolSchema, handleGetFileContent);
+
+  return server;
+}

--- a/packages/server/src/mcp/server/rate-limit.test.ts
+++ b/packages/server/src/mcp/server/rate-limit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { Semaphore, createTokenBucketRateLimiter } from "./rate-limit";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("token bucket rate limiter", () => {
+  it("limits by the provided key", () => {
+    const limiter = createTokenBucketRateLimiter({ capacity: 2, refillPerMinute: 0 });
+
+    expect(limiter.consume("token-1")).toBe(true);
+    expect(limiter.consume("token-1")).toBe(true);
+    expect(limiter.consume("token-1")).toBe(false);
+    expect(limiter.consume("token-2")).toBe(true);
+  });
+});
+
+describe("Semaphore", () => {
+  it("never runs more than max tasks concurrently", async () => {
+    const semaphore = new Semaphore(2);
+    let active = 0;
+    let maxSeen = 0;
+    const releases = Array.from({ length: 8 }, () => deferred());
+
+    const tasks = releases.map((release) =>
+      semaphore.run(async () => {
+        active += 1;
+        maxSeen = Math.max(maxSeen, active);
+        await release.promise;
+        active -= 1;
+      }),
+    );
+
+    await Promise.resolve();
+    expect(maxSeen).toBe(2);
+
+    for (const release of releases) {
+      release.resolve();
+      await Promise.resolve();
+      expect(maxSeen).toBeLessThanOrEqual(2);
+    }
+
+    await Promise.all(tasks);
+    expect(active).toBe(0);
+  });
+});

--- a/packages/server/src/mcp/server/rate-limit.ts
+++ b/packages/server/src/mcp/server/rate-limit.ts
@@ -1,0 +1,63 @@
+interface Bucket {
+  tokens: number;
+  updatedAt: number;
+}
+
+export function createTokenBucketRateLimiter(options: { capacity: number; refillPerMinute: number }) {
+  const buckets = new Map<string, Bucket>();
+
+  return {
+    consume(key: string, now = Date.now()): boolean {
+      const refillPerMs = options.refillPerMinute / 60_000;
+      const bucket = buckets.get(key) ?? { tokens: options.capacity, updatedAt: now };
+      const elapsed = Math.max(0, now - bucket.updatedAt);
+      bucket.tokens = Math.min(options.capacity, bucket.tokens + elapsed * refillPerMs);
+      bucket.updatedAt = now;
+
+      if (bucket.tokens < 1) {
+        buckets.set(key, bucket);
+        return false;
+      }
+
+      bucket.tokens -= 1;
+      buckets.set(key, bucket);
+      return true;
+    },
+  };
+}
+
+export class Semaphore {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(private readonly max: number) {}
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+
+  private async acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active += 1;
+      return;
+    }
+
+    return new Promise<void>((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+      return;
+    }
+    this.active -= 1;
+  }
+}

--- a/packages/server/src/mcp/server/transport.ts
+++ b/packages/server/src/mcp/server/transport.ts
@@ -1,0 +1,49 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { Context, Hono } from "hono";
+import type { Kysely } from "kysely";
+import type { Logger } from "pino";
+import { createApiTokenRepository } from "../../db/repositories/api-tokens";
+import { createExternalMcpToolCallRepository } from "../../db/repositories/external-mcp-tool-calls";
+import type { createUserRepository } from "../../db/repositories/users";
+import type { DB } from "../../db/schema";
+import { createMcpAuthMiddleware } from "./auth";
+import { createPublicSketchMcpServer } from "./public-server";
+
+export function mountPublicMcpServer(params: {
+  app: Hono;
+  db: Kysely<DB>;
+  userRepo: ReturnType<typeof createUserRepository>;
+  workspaceDir: string;
+  logger: Logger;
+}) {
+  const apiTokens = createApiTokenRepository(params.db);
+  const auditRepo = createExternalMcpToolCallRepository(params.db);
+  const auth = createMcpAuthMiddleware({ apiTokens, users: params.userRepo, logger: params.logger });
+
+  params.app.use("/mcp", auth);
+  params.app.on(["GET", "DELETE"], "/mcp", (c) =>
+    c.json({ error: { code: "METHOD_NOT_ALLOWED", message: "Only POST is supported for stateless MCP v1" } }, 405),
+  );
+  params.app.post("/mcp", async (c: Context) => {
+    const authContext = c.get("mcpAuth");
+    const server = await createPublicSketchMcpServer({
+      db: params.db,
+      userRepo: params.userRepo,
+      userId: authContext.userId,
+      tokenId: authContext.tokenId,
+      workspaceDir: params.workspaceDir,
+      auditRepo,
+    });
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    await server.connect(transport);
+    try {
+      return await transport.handleRequest(c.req.raw);
+    } finally {
+      await server.close();
+    }
+  });
+}


### PR DESCRIPTION
**Stack 3 of 4 — external MCP server.** Based on #185. Review after 2/4.

The remote MCP server itself — stateless Streamable HTTP exposing the four `sketch_*` tools to external agents (Claude Code, Cursor, Inspector).

This slice (`packages/server/src/mcp/server/`):
- `WebStandardStreamableHTTPServerTransport`, stateless — fresh server + transport per POST, closed in `finally`; `GET`/`DELETE` → 405
- PAT bearer middleware: `skp_`-only (the shared `sk_live_` org key and session cookies are rejected on `/mcp`), 401 with no/invalid token
- per-token rate limiting + a global concurrency semaphore (external load can't starve the shared process)
- best-effort audit rows per tool call
- RBAC reused from 2/4: email-scoped only, **never** the admin content-read bypass; entity-metadata filtered; team-directory enumeration disabled on the external path

Mounted in `http.ts` behind `EXPERIMENTAL_FLAG` in the next slice.

Plan: `.planning/external-mcp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)