### PR TITLE
feat: add Gemini enrichment rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,8 @@ LOG_LEVEL=info          # debug | info | warn | error
 # FEATURE_ARCHIVE_MIN_MENTIONS=2
 # FEATURE_ARCHIVE_AGE_DAYS=30
 # FEATURE_ARCHIVE_MAX_PER_RUN=1000
+# GEMINI_MAX_RPM=60
+# GEMINI_MAX_RETRIES=4
 
 # Sync stale-fact reconciliation guard
 # SYNC_MAX_RECONCILE_RATIO=0.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ New features that aren't ready for general availability are gated behind `config
 
 The flag flows: `config` → `bootstrap.ts` (injected in `trackedRunAgent`) → `RunAgentParams` → both `SketchMcpDeps` (tools) and `buildSystemContext` (prompt).
 
-Currently gated: Files UI, Connections UI, entity/connector/identity/OAuth APIs, agent search tools (Search, SearchEntities, GetEntityContext), and Information Discovery system prompt section.
+Currently gated: nothing. The Files/knowledge feature (connectors, entity explorer, entity drawer Timeline/Relationships, entity-review) is GA and no longer gated. The `EXPERIMENTAL_FLAG` mechanism remains available for future features — config flag, the `experimentalFlag` field on `/api/setup/status`, and the `experimentalOnly` nav-item field in `app-sidebar.tsx`.
 
 ## Related Repos
 

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -139,6 +139,7 @@ export interface RunAgentParams {
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };
   activeQueueKey?: string;
   toolConfig?: { BASE_URL?: string; PORT: number };
+  geminiConfig?: { maxRpm?: number; maxRetries?: number };
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   userRepo?: {
     list: () => Promise<Selectable<UsersTable>[]>;
@@ -310,6 +311,7 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResult> {
     queueManager: params.queueManager,
     activeQueueKey: params.activeQueueKey,
     toolConfig: params.toolConfig,
+    geminiConfig: params.geminiConfig,
     inboxMessagesRepo: params.inboxMessagesRepo,
     userRepo: params.userRepo,
     currentUserId: params.currentUserId ?? undefined,

--- a/packages/server/src/agent/tools/search.ts
+++ b/packages/server/src/agent/tools/search.ts
@@ -148,6 +148,8 @@ Use this to find information before asking others. Examples:
           sortBy,
           userEmails,
           skipAutoEntityBoost,
+          geminiMaxRpm: deps.geminiConfig?.maxRpm,
+          geminiMaxRetries: deps.geminiConfig?.maxRetries,
         });
 
         const effectiveSortBy = sortBy ?? "relevance";

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -48,6 +48,7 @@ export interface SketchMcpDeps {
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };
   toolConfig?: { BASE_URL?: string; PORT: number };
+  geminiConfig?: { maxRpm?: number; maxRetries?: number };
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   userRepo?: SearchableUserRepo;
   currentUserId?: string;

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -48,7 +48,14 @@ function syncInBackground(
   connectorId: string,
   logger: Logger,
   config?: Partial<
-    Pick<Config, "SYNC_ALLOW_LARGE_RECONCILE" | "SYNC_MAX_RECONCILE_RATIO" | "CO_MENTION_CONTRIBUTES_TO_THRESHOLD">
+    Pick<
+      Config,
+      | "SYNC_ALLOW_LARGE_RECONCILE"
+      | "SYNC_MAX_RECONCILE_RATIO"
+      | "CO_MENTION_CONTRIBUTES_TO_THRESHOLD"
+      | "GEMINI_MAX_RPM"
+      | "GEMINI_MAX_RETRIES"
+    >
   >,
 ) {
   runConnectorSync(db, connectorId, logger, config).catch((err) => {
@@ -107,7 +114,14 @@ export function connectorRoutes(
   logger: Logger,
   userRepo?: UserRepo,
   appConfig?: Partial<
-    Pick<Config, "SYNC_ALLOW_LARGE_RECONCILE" | "SYNC_MAX_RECONCILE_RATIO" | "CO_MENTION_CONTRIBUTES_TO_THRESHOLD">
+    Pick<
+      Config,
+      | "SYNC_ALLOW_LARGE_RECONCILE"
+      | "SYNC_MAX_RECONCILE_RATIO"
+      | "CO_MENTION_CONTRIBUTES_TO_THRESHOLD"
+      | "GEMINI_MAX_RPM"
+      | "GEMINI_MAX_RETRIES"
+    >
   >,
 ) {
   const routes = new Hono();
@@ -348,6 +362,8 @@ export function connectorRoutes(
       after: after ?? undefined,
       before: before ?? undefined,
       userEmails,
+      geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
+      geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
     });
     return c.json({ results });
   });
@@ -1326,7 +1342,12 @@ export function connectorRoutes(
       .where("id", "=", "default")
       .executeTakeFirst();
     const embeddingProvider = settings?.gemini_api_key
-      ? createEmbeddingProvider({ provider: "gemini", apiKey: settings.gemini_api_key })
+      ? createEmbeddingProvider({
+          provider: "gemini",
+          apiKey: settings.gemini_api_key,
+          maxRpm: appConfig?.GEMINI_MAX_RPM,
+          maxRetries: appConfig?.GEMINI_MAX_RETRIES,
+        })
       : null;
 
     // Enrich only this specific file.
@@ -1340,6 +1361,8 @@ export function connectorRoutes(
       logger: logger.child({ component: "enrichment", fileId }),
       embeddingProvider,
       geminiApiKey: settings?.gemini_api_key,
+      geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
+      geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
       fileIds: [fileId],
       debugDumpDir,
     }).catch((err) => {

--- a/packages/server/src/api/entities.test.ts
+++ b/packages/server/src/api/entities.test.ts
@@ -1573,13 +1573,13 @@ describe("Entity drawer routes", () => {
     expect(body.totalCount).toBe(2);
   });
 
-  it("GET /api/entities/:id/relations is gated by EXPERIMENTAL_FLAG", async () => {
+  it("GET /api/entities/:id/relations works without EXPERIMENTAL_FLAG (Files is GA)", async () => {
     const offConfig = createTestConfig({ EXPERIMENTAL_FLAG: false });
     const offApp = createApp(db, offConfig, { logger });
     await seedEntity("e1", "Sarah", "person");
     const offCookie = await login(offApp);
     const res = await offApp.request("/api/entities/e1/relations", { headers: { Cookie: offCookie } });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
   });
 
   it("GET /api/entities/:id/relations/:rid/evidence applies file RBAC (visibleCount < totalCount)", async () => {

--- a/packages/server/src/api/entities/maintenance-routes.ts
+++ b/packages/server/src/api/entities/maintenance-routes.ts
@@ -374,6 +374,8 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
           lockAlreadyHeld,
           llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
           coMentionContributesToThreshold: config.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
+          geminiMaxRpm: config.GEMINI_MAX_RPM,
+          geminiMaxRetries: config.GEMINI_MAX_RETRIES,
           onPhase: (phase) => {
             job.phase = phase;
           },

--- a/packages/server/src/api/entities/profile-routes.ts
+++ b/packages/server/src/api/entities/profile-routes.ts
@@ -236,13 +236,12 @@ function relationCompare(a: RelationListEntry, b: RelationListEntry): number {
   return a.id.localeCompare(b.id);
 }
 
-export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps) {
+export function createEntityProfileRoutes(db: Kysely<DB>, _deps: EntityRoutesDeps) {
   const routes = new Hono();
   const repo = createEntityRepository(db);
   const relRepo = createEntityRelationshipsRepository(db);
   const timelineRepo = createEntityTimelineRepository(db);
   const sharesRepo = createEntitySharesRepository(db);
-  const { config } = deps;
 
   const RELATIONS_LIMIT = 200;
   const EVIDENCE_LIMIT = 100;
@@ -560,12 +559,9 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
   /**
    * GET /api/entities/:id/relations
    * Drawer Relationships section. Caps each side at 200; sets `truncated`
-   * when more rows exist. Gated by EXPERIMENTAL_FLAG (drawer UI is flagged).
+   * when more rows exist.
    */
   routes.get("/:id/relations", async (c) => {
-    if (!config.EXPERIMENTAL_FLAG) {
-      return c.json({ error: { code: "NOT_FOUND", message: "Not found" } }, 404);
-    }
     const viewer = getFileViewer(c);
     const entity = await repo.getEntity(c.req.param("id"), viewer);
     if (!entity) {
@@ -588,9 +584,6 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
    * snippets are filtered out for hidden rows).
    */
   routes.get("/:id/relations/:rid/evidence", async (c) => {
-    if (!config.EXPERIMENTAL_FLAG) {
-      return c.json({ error: { code: "NOT_FOUND", message: "Not found" } }, 404);
-    }
     const entityId = c.req.param("id");
     const relationshipId = c.req.param("rid");
     const viewer = getFileViewer(c);
@@ -612,9 +605,6 @@ export function createEntityProfileRoutes(db: Kysely<DB>, deps: EntityRoutesDeps
    * applied; capped at 100 visible rows.
    */
   routes.get("/:id/timeline", async (c) => {
-    if (!config.EXPERIMENTAL_FLAG) {
-      return c.json({ error: { code: "NOT_FOUND", message: "Not found" } }, 404);
-    }
     const viewer = getFileViewer(c);
     const entity = await repo.getEntity(c.req.param("id"), viewer);
     if (!entity) {

--- a/packages/server/src/api/settings.test.ts
+++ b/packages/server/src/api/settings.test.ts
@@ -112,6 +112,23 @@ describe("Settings API — security", () => {
     });
   });
 
+  describe("PUT /api/settings/search — input normalization", () => {
+    it("trims surrounding whitespace from a pasted gemini_api_key before storing", async () => {
+      const app = createApp(db, config, { logger });
+      const adminCookie = await loginAdmin(app);
+
+      const res = await app.request("/api/settings/search", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Cookie: adminCookie },
+        body: JSON.stringify({ geminiApiKey: "  AIza-super-secret-key-12345\n" }),
+      });
+      expect(res.status).toBe(200);
+
+      const stored = await createSettingsRepository(db).get();
+      expect(stored?.gemini_api_key).toBe("AIza-super-secret-key-12345");
+    });
+  });
+
   describe("/api/settings/access", () => {
     it("round-trips adminCanReadAllFiles for admins", async () => {
       const app = createApp(db, config, { logger });

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -9,7 +9,7 @@ import { type createSettingsRepository, parseOrgContext } from "../db/repositori
 import type { DB } from "../db/schema";
 
 const searchConfigSchema = z.object({
-  geminiApiKey: z.string().nullable().optional(),
+  geminiApiKey: z.string().trim().nullable().optional(),
   enrichmentEnabled: z.boolean().optional(),
   syncIntervalMinutes: z.number().int().min(5).max(1440).optional(),
 });

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -3,6 +3,7 @@ import { type Context, Hono } from "hono";
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
 import { z } from "zod";
+import type { Config } from "../config";
 import { createEmbeddingProvider } from "../connectors/embeddings";
 import { runEnrichment } from "../connectors/enrichment";
 import { type createSettingsRepository, parseOrgContext } from "../db/repositories/settings";
@@ -41,7 +42,12 @@ function requireAdmin(c: Context) {
   return null;
 }
 
-export function settingsRoutes(settings: SettingsRepo, db?: Kysely<DB>, logger?: Logger) {
+export function settingsRoutes(
+  settings: SettingsRepo,
+  db?: Kysely<DB>,
+  logger?: Logger,
+  config?: Pick<Config, "GEMINI_MAX_RPM" | "GEMINI_MAX_RETRIES">,
+) {
   const routes = new Hono();
 
   routes.get("/identity", async (c) => {
@@ -131,7 +137,12 @@ export function settingsRoutes(settings: SettingsRepo, db?: Kysely<DB>, logger?:
     }
 
     const embeddingProvider = row?.gemini_api_key
-      ? createEmbeddingProvider({ provider: "gemini", apiKey: row.gemini_api_key })
+      ? createEmbeddingProvider({
+          provider: "gemini",
+          apiKey: row.gemini_api_key,
+          maxRpm: config?.GEMINI_MAX_RPM,
+          maxRetries: config?.GEMINI_MAX_RETRIES,
+        })
       : null;
 
     // Run in background
@@ -140,6 +151,8 @@ export function settingsRoutes(settings: SettingsRepo, db?: Kysely<DB>, logger?:
       logger: logger.child({ component: "enrichment" }),
       embeddingProvider,
       geminiApiKey: row?.gemini_api_key,
+      geminiMaxRpm: config?.GEMINI_MAX_RPM,
+      geminiMaxRetries: config?.GEMINI_MAX_RETRIES,
     }).catch((err) => {
       logger.error({ err }, "Manual enrichment run failed");
     });

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -127,6 +127,10 @@ export async function createServer(config: Config, options?: CreateServerOptions
     const enrichedParams = {
       ...params,
       loadTranscriptionSettings: params.loadTranscriptionSettings ?? (() => settingsRepo.get()),
+      geminiConfig: params.geminiConfig ?? {
+        maxRpm: config.GEMINI_MAX_RPM,
+        maxRetries: config.GEMINI_MAX_RETRIES,
+      },
       ...(Object.keys(resolvedAgentEnv).length > 0
         ? {
             agentEnv: resolvedAgentEnv,

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -35,6 +35,8 @@ export const configSchema = z.object({
   FEATURE_ARCHIVE_MIN_MENTIONS: z.coerce.number().int().min(1).default(2),
   FEATURE_ARCHIVE_AGE_DAYS: z.coerce.number().int().min(1).default(30),
   FEATURE_ARCHIVE_MAX_PER_RUN: z.coerce.number().int().min(1).default(1000),
+  GEMINI_MAX_RPM: z.coerce.number().int().min(1).default(60),
+  GEMINI_MAX_RETRIES: z.coerce.number().int().min(0).default(4),
 
   // Sync reconciliation
   SYNC_ALLOW_LARGE_RECONCILE: z

--- a/packages/server/src/connectors/embeddings/gemini.ts
+++ b/packages/server/src/connectors/embeddings/gemini.ts
@@ -6,6 +6,7 @@
  *
  * API reference: https://ai.google.dev/gemini-api/docs/embeddings
  */
+import { type GeminiClientOptions, GeminiHttpError, runGeminiRequest } from "../gemini-control";
 import type { EmbeddingProvider } from "./types";
 
 const GEMINI_EMBED_URL =
@@ -19,27 +20,24 @@ const DIMENSIONS = 3072;
 /** Max texts per batch request. */
 const BATCH_SIZE = 100;
 
-export function createGeminiEmbeddingProvider(apiKey: string): EmbeddingProvider {
-  async function request(url: string, body: unknown, retries = 5): Promise<unknown> {
-    for (let attempt = 0; attempt <= retries; attempt++) {
-      const res = await fetch(`${url}?key=${apiKey}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
+export function createGeminiEmbeddingProvider(apiKey: string, options?: GeminiClientOptions): EmbeddingProvider {
+  async function request(url: string, body: unknown): Promise<unknown> {
+    return runGeminiRequest(
+      apiKey,
+      async () => {
+        const res = await fetch(`${url}?key=${apiKey}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
 
-      if (res.ok) return res.json();
+        if (res.ok) return res.json();
 
-      if (res.status === 429 && attempt < retries) {
-        const delay = Math.min(1000 * 2 ** attempt, 30000);
-        await new Promise((r) => setTimeout(r, delay));
-        continue;
-      }
-
-      const text = await res.text();
-      throw new Error(`Gemini Embedding API error (${res.status}): ${text}`);
-    }
-    throw new Error("Gemini: retries exhausted");
+        const text = await res.text();
+        throw new GeminiHttpError(res.status, text);
+      },
+      options,
+    );
   }
 
   return {
@@ -102,23 +100,31 @@ export function createGeminiEmbeddingProvider(apiKey: string): EmbeddingProvider
  * Embed a search query (vs document embedding above which uses RETRIEVAL_DOCUMENT).
  * Separate function because task type differs for queries vs documents.
  */
-export function createGeminiQueryEmbedder(apiKey: string) {
+export function createGeminiQueryEmbedder(apiKey: string, options?: GeminiClientOptions) {
   return async function embedQuery(query: string): Promise<number[]> {
-    const res = await fetch(`${GEMINI_EMBED_URL}?key=${apiKey}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        content: { parts: [{ text: query }] },
-        taskType: "RETRIEVAL_QUERY",
-      }),
-    });
-
-    if (!res.ok) {
-      const text = await res.text();
-      throw new Error(`Gemini Embedding API error (${res.status}): ${text}`);
-    }
-
-    const result = (await res.json()) as { embedding: { values: number[] } };
+    const result = (await requestQueryEmbedding(apiKey, query, options)) as { embedding: { values: number[] } };
     return result.embedding.values;
   };
+}
+
+async function requestQueryEmbedding(apiKey: string, query: string, options?: GeminiClientOptions): Promise<unknown> {
+  return runGeminiRequest(
+    apiKey,
+    async () => {
+      const res = await fetch(`${GEMINI_EMBED_URL}?key=${apiKey}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: { parts: [{ text: query }] },
+          taskType: "RETRIEVAL_QUERY",
+        }),
+      });
+
+      if (res.ok) return res.json();
+
+      const text = await res.text();
+      throw new GeminiHttpError(res.status, text);
+    },
+    options,
+  );
 }

--- a/packages/server/src/connectors/embeddings/index.ts
+++ b/packages/server/src/connectors/embeddings/index.ts
@@ -12,7 +12,10 @@ export type { EmbeddingProvider, EmbeddingProviderConfig };
 export function createEmbeddingProvider(config: EmbeddingProviderConfig): EmbeddingProvider {
   switch (config.provider) {
     case "gemini":
-      return createGeminiEmbeddingProvider(config.apiKey);
+      return createGeminiEmbeddingProvider(config.apiKey, {
+        maxRpm: config.maxRpm,
+        maxRetries: config.maxRetries,
+      });
     default:
       throw new Error(`Unknown embedding provider: ${config.provider}`);
   }
@@ -21,7 +24,10 @@ export function createEmbeddingProvider(config: EmbeddingProviderConfig): Embedd
 export function createQueryEmbedder(config: EmbeddingProviderConfig): (query: string) => Promise<number[]> {
   switch (config.provider) {
     case "gemini":
-      return createGeminiQueryEmbedder(config.apiKey);
+      return createGeminiQueryEmbedder(config.apiKey, {
+        maxRpm: config.maxRpm,
+        maxRetries: config.maxRetries,
+      });
     default:
       throw new Error(`Unknown embedding provider: ${config.provider}`);
   }

--- a/packages/server/src/connectors/embeddings/types.ts
+++ b/packages/server/src/connectors/embeddings/types.ts
@@ -20,4 +20,6 @@ export interface EmbeddingProvider {
 export interface EmbeddingProviderConfig {
   provider: "gemini";
   apiKey: string;
+  maxRpm?: number;
+  maxRetries?: number;
 }

--- a/packages/server/src/connectors/enrichment.test.ts
+++ b/packages/server/src/connectors/enrichment.test.ts
@@ -548,4 +548,46 @@ describe("runEnrichment — chronological pending-files order", () => {
     expect(explicitEmbedding.filesProcessed).toBe(1);
     expect(explicitSummary.filesProcessed).toBe(1);
   });
+
+  it("embedding retries preserve completed summary state", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, "retry body ".repeat(120));
+    await db
+      .updateTable("indexed_files")
+      .set({
+        embedding_status: "failed",
+        embedding_attempts: 1,
+        embedding_next_retry_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        summary_status: "done",
+        summary_attempts: 0,
+        summary_next_retry_at: null,
+      })
+      .where("id", "=", fileId)
+      .execute();
+
+    const result = await runEnrichment({
+      db,
+      logger: createTestLogger(),
+      embeddingProvider: {
+        name: "stub",
+        dimensions: 8,
+        supportsImages: false,
+        async embedTexts(texts: string[]) {
+          return texts.map(() => new Array(8).fill(0));
+        },
+      },
+    });
+
+    const row = await db
+      .selectFrom("indexed_files")
+      .select(["embedding_status", "summary_status", "summary_attempts", "summary_next_retry_at"])
+      .where("id", "=", fileId)
+      .executeTakeFirstOrThrow();
+
+    expect(result.filesProcessed).toBe(1);
+    expect(row.embedding_status).toBe("done");
+    expect(row.summary_status).toBe("done");
+    expect(row.summary_attempts).toBe(0);
+    expect(row.summary_next_retry_at).toBeNull();
+  });
 });

--- a/packages/server/src/connectors/enrichment.test.ts
+++ b/packages/server/src/connectors/enrichment.test.ts
@@ -504,4 +504,48 @@ describe("runEnrichment — chronological pending-files order", () => {
     expect(result.filesProcessed).toBe(4);
     expect(order).toEqual([oldest, middleEarlier, middleLater, newest]);
   });
+
+  it("honors scheduled retry backoff but lets explicit reruns bypass it", async () => {
+    const embeddingFileId = randomUUID();
+    const summaryFileId = randomUUID();
+    await seedFile(db, embeddingFileId, "embedding retry body");
+    await seedFile(db, summaryFileId, "summary retry body");
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    await db
+      .updateTable("indexed_files")
+      .set({ embedding_status: "failed", embedding_attempts: 1, embedding_next_retry_at: future })
+      .where("id", "=", embeddingFileId)
+      .execute();
+    await db
+      .updateTable("indexed_files")
+      .set({
+        embedding_status: "done",
+        summary_status: "failed",
+        summary_attempts: 1,
+        summary_next_retry_at: future,
+      })
+      .where("id", "=", summaryFileId)
+      .execute();
+
+    const scheduled = await runEnrichment({ db, logger: createTestLogger(), embeddingProvider: null });
+    expect(scheduled.filesProcessed).toBe(0);
+    expect(scheduled.filesFailed).toBe(0);
+
+    const explicitEmbedding = await runEnrichment({
+      db,
+      logger: createTestLogger(),
+      embeddingProvider: null,
+      fileIds: [embeddingFileId],
+    });
+    const explicitSummary = await runEnrichment({
+      db,
+      logger: createTestLogger(),
+      embeddingProvider: null,
+      fileIds: [summaryFileId],
+    });
+
+    expect(explicitEmbedding.filesProcessed).toBe(1);
+    expect(explicitSummary.filesProcessed).toBe(1);
+  });
 });

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -470,6 +470,7 @@ async function enrichTextDocument(
     source_path: string | null;
     source_created_at: string | null;
     source_updated_at: string | null;
+    summary_status: string;
     summary_attempts: number;
   },
   isStructured: boolean,
@@ -520,7 +521,8 @@ async function enrichTextDocument(
   const wordCount = file.content.split(/\s+/).length;
   let usedSmartEnrichment = false;
   let smartEnrichmentFailed = false;
-  if (deps.geminiApiKey && wordCount >= 100) {
+  const summaryAlreadyResolved = file.summary_status === "done" || file.summary_status === "skipped";
+  if (!summaryAlreadyResolved && deps.geminiApiKey && wordCount >= 100) {
     try {
       const generator = createGeminiGenerator(deps.geminiApiKey, {
         maxRpm: deps.geminiMaxRpm,
@@ -577,7 +579,7 @@ async function enrichTextDocument(
     }
   }
 
-  if (!usedSmartEnrichment) {
+  if (!summaryAlreadyResolved && !usedSmartEnrichment) {
     await linkEntitiesDeterministic(db, file.id, file.content, chunks);
     // 'failed' = retryable (Gemini error), 'skipped' = intentional (no key or content too short)
     await db

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -38,6 +38,14 @@ export const MAX_FILES_PER_RUN = 5000;
 const MIN_ENTITY_NAME_LENGTH = 3;
 
 const DETERMINISTIC_LINK_BATCH_SIZE = 500;
+const ENRICHMENT_BACKOFF_MS = [
+  30 * 60 * 1000,
+  60 * 60 * 1000,
+  2 * 60 * 60 * 1000,
+  4 * 60 * 60 * 1000,
+  8 * 60 * 60 * 1000,
+  24 * 60 * 60 * 1000,
+] as const;
 
 let enrichmentActive = false;
 export function isEnrichmentActive(): boolean {
@@ -70,6 +78,37 @@ function parseDescription(raw: string | null): string | undefined {
   }
 }
 
+function nextRetryAt(attempts: number): string {
+  const index = Math.min(Math.max(attempts, 1) - 1, ENRICHMENT_BACKOFF_MS.length - 1);
+  return new Date(Date.now() + ENRICHMENT_BACKOFF_MS[index]).toISOString();
+}
+
+async function markSummaryFailure(db: Kysely<DB>, fileId: string, currentAttempts: number): Promise<void> {
+  const attempts = currentAttempts + 1;
+  await db
+    .updateTable("indexed_files")
+    .set({ summary_status: "failed", summary_attempts: attempts, summary_next_retry_at: nextRetryAt(attempts) })
+    .where("id", "=", fileId)
+    .execute();
+}
+
+async function resetSummaryRetry(db: Kysely<DB>, fileId: string): Promise<void> {
+  await db
+    .updateTable("indexed_files")
+    .set({ summary_attempts: 0, summary_next_retry_at: null })
+    .where("id", "=", fileId)
+    .execute();
+}
+
+async function markEmbeddingFailure(db: Kysely<DB>, fileId: string, currentAttempts: number): Promise<void> {
+  const attempts = currentAttempts + 1;
+  await db
+    .updateTable("indexed_files")
+    .set({ embedding_status: "failed", embedding_attempts: attempts, embedding_next_retry_at: nextRetryAt(attempts) })
+    .where("id", "=", fileId)
+    .execute();
+}
+
 export async function loadBaselineKnownEntities(db: Kysely<DB>): Promise<KnownEntityForPrompt[]> {
   const entities = await db
     .selectFrom("entities")
@@ -93,6 +132,8 @@ export interface EnrichmentDeps {
   embeddingProvider: EmbeddingProvider | null;
   /** Gemini API key for AI-powered enrichment (summaries, entity extraction). */
   geminiApiKey?: string | null;
+  geminiMaxRpm?: number;
+  geminiMaxRetries?: number;
   /** Download image from Google Drive by provider file ID. Returns buffer + mime type. */
   downloadImage?: (providerFileId: string, connectorConfigId: string) => Promise<{ buffer: Buffer; mimeType: string }>;
   /** If set, only enrich these specific file IDs (ignoring pending status). */
@@ -192,16 +233,30 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
       "source_updated_at",
       "embedding_status",
       "summary_status",
+      "embedding_attempts",
+      "embedding_next_retry_at",
+      "summary_attempts",
+      "summary_next_retry_at",
     ])
     .where("is_archived", "=", 0);
 
   if (deps.fileIds && deps.fileIds.length > 0) {
     query = query.where("id", "in", deps.fileIds);
   } else {
+    const now = new Date().toISOString();
     query = query.where((eb) =>
       eb.or([
-        eb("embedding_status", "in", ["pending", "failed"]),
-        eb.and([eb("embedding_status", "=", "done"), eb("summary_status", "in", ["pending", "failed"])]),
+        eb("embedding_status", "=", "pending"),
+        eb.and([
+          eb("embedding_status", "=", "failed"),
+          eb.or([eb("embedding_next_retry_at", "is", null), eb("embedding_next_retry_at", "<=", now)]),
+        ]),
+        eb.and([eb("embedding_status", "=", "done"), eb("summary_status", "=", "pending")]),
+        eb.and([
+          eb("embedding_status", "=", "done"),
+          eb("summary_status", "=", "failed"),
+          eb.or([eb("summary_next_retry_at", "is", null), eb("summary_next_retry_at", "<=", now)]),
+        ]),
       ]),
     );
   }
@@ -237,7 +292,10 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
           const wordCount = file.content.split(/\s+/).length;
           if (wordCount >= 100) {
             try {
-              const generator = createGeminiGenerator(deps.geminiApiKey);
+              const generator = createGeminiGenerator(deps.geminiApiKey, {
+                maxRpm: deps.geminiMaxRpm,
+                maxRetries: deps.geminiMaxRetries,
+              });
               const knownEntities = await buildFileScopedKnownEntities(
                 { db, logger },
                 file.id,
@@ -284,6 +342,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
               if (floor.emitted > 0) {
                 await materializeUnmaterializedFacts(db, logger);
               }
+              await resetSummaryRetry(db, file.id);
             } catch (err) {
               logger.warn(
                 {
@@ -298,23 +357,23 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
                 },
                 "Summary-only enrichment failed",
               );
-              await db
-                .updateTable("indexed_files")
-                .set({ summary_status: "failed" })
-                .where("id", "=", file.id)
-                .execute();
+              await markSummaryFailure(db, file.id, Number(file.summary_attempts ?? 0));
               result.filesFailed++;
               continue;
             }
           } else {
             await db
               .updateTable("indexed_files")
-              .set({ summary_status: "skipped" })
+              .set({ summary_status: "skipped", summary_attempts: 0, summary_next_retry_at: null })
               .where("id", "=", file.id)
               .execute();
           }
         } else {
-          await db.updateTable("indexed_files").set({ summary_status: "skipped" }).where("id", "=", file.id).execute();
+          await db
+            .updateTable("indexed_files")
+            .set({ summary_status: "skipped", summary_attempts: 0, summary_next_retry_at: null })
+            .where("id", "=", file.id)
+            .execute();
         }
         result.filesProcessed++;
         const elapsed = ((Date.now() - fileStart) / 1000).toFixed(1);
@@ -355,7 +414,11 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
       }
 
       // Mark as done
-      await db.updateTable("indexed_files").set({ embedding_status: "done" }).where("id", "=", file.id).execute();
+      await db
+        .updateTable("indexed_files")
+        .set({ embedding_status: "done", embedding_attempts: 0, embedding_next_retry_at: null })
+        .where("id", "=", file.id)
+        .execute();
 
       result.filesProcessed++;
 
@@ -374,7 +437,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
       result.errors.push({ fileId: file.id, error: message });
       result.filesFailed++;
 
-      await db.updateTable("indexed_files").set({ embedding_status: "failed" }).where("id", "=", file.id).execute();
+      await markEmbeddingFailure(db, file.id, Number(file.embedding_attempts ?? 0));
     } finally {
       deps.onProgress?.({ phase: "enrich", completed: idx + 1, total: pendingFiles.length });
       await yieldToEventLoop();
@@ -407,6 +470,7 @@ async function enrichTextDocument(
     source_path: string | null;
     source_created_at: string | null;
     source_updated_at: string | null;
+    summary_attempts: number;
   },
   isStructured: boolean,
   deps: EnrichmentDeps,
@@ -458,7 +522,10 @@ async function enrichTextDocument(
   let smartEnrichmentFailed = false;
   if (deps.geminiApiKey && wordCount >= 100) {
     try {
-      const generator = createGeminiGenerator(deps.geminiApiKey);
+      const generator = createGeminiGenerator(deps.geminiApiKey, {
+        maxRpm: deps.geminiMaxRpm,
+        maxRetries: deps.geminiMaxRetries,
+      });
       const knownEntities = await buildFileScopedKnownEntities(
         { db, logger },
         file.id,
@@ -502,6 +569,7 @@ async function enrichTextDocument(
       if (floor.emitted > 0) {
         await materializeUnmaterializedFacts(db, logger);
       }
+      await resetSummaryRetry(db, file.id);
       usedSmartEnrichment = true;
     } catch (err) {
       smartEnrichmentFailed = true;
@@ -514,17 +582,31 @@ async function enrichTextDocument(
     // 'failed' = retryable (Gemini error), 'skipped' = intentional (no key or content too short)
     await db
       .updateTable("indexed_files")
-      .set({ summary_status: smartEnrichmentFailed ? "failed" : "skipped" })
+      .set(
+        smartEnrichmentFailed
+          ? {
+              summary_status: "failed",
+              summary_attempts: Number(file.summary_attempts ?? 0) + 1,
+              summary_next_retry_at: nextRetryAt(Number(file.summary_attempts ?? 0) + 1),
+            }
+          : { summary_status: "skipped", summary_attempts: 0, summary_next_retry_at: null },
+      )
       .where("id", "=", file.id)
       .execute();
   }
 
   // 5. Embed chunks (best-effort — entity linking still succeeds if embedding fails)
   if (embeddingProvider && chunks.length > 0) {
+    const texts = chunks.map((c) => c.content);
+    let embeddings: number[][];
     try {
-      const texts = chunks.map((c) => c.content);
-      const embeddings = await embeddingProvider.embedTexts(texts);
+      embeddings = await embeddingProvider.embedTexts(texts);
+    } catch (err) {
+      logger.warn({ err, fileId: file.id }, "Embedding provider failed");
+      throw err;
+    }
 
+    try {
       const storedChunks = await db
         .selectFrom("document_chunks")
         .select(["id", "chunk_index"])
@@ -550,7 +632,7 @@ async function enrichTextDocument(
       );
       logger.info({ fileId: file.id, chunks: pairs.length }, "Embeddings created");
     } catch (err) {
-      logger.warn({ err, fileId: file.id }, "Embedding failed, entity linking still saved");
+      logger.warn({ err, fileId: file.id }, "Embedding storage failed, entity linking still saved");
     }
   }
 }

--- a/packages/server/src/connectors/gemini-control.test.ts
+++ b/packages/server/src/connectors/gemini-control.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { GeminiHttpError, resetGeminiControlsForTests, runGeminiRequest } from "./gemini-control";
+
+describe("Gemini request controls", () => {
+  it("paces requests sharing the same quota identity", async () => {
+    resetGeminiControlsForTests();
+    let now = 0;
+    const sleeps: number[] = [];
+    const options = {
+      maxRpm: 60,
+      maxRetries: 0,
+      quotaIdentity: "project-1",
+      now: () => now,
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+        now += ms;
+      },
+    };
+
+    await runGeminiRequest("key-a", async () => "generation", options);
+    await runGeminiRequest("key-a", async () => "embedding", options);
+    await runGeminiRequest("key-a", async () => "query", options);
+
+    expect(sleeps).toEqual([1000, 1000]);
+  });
+
+  it("retries transient failures with bounded backoff", async () => {
+    resetGeminiControlsForTests();
+    let calls = 0;
+    let retries = 0;
+
+    const result = await runGeminiRequest(
+      "key-a",
+      async () => {
+        calls++;
+        if (calls === 1) throw new GeminiHttpError(429, "quota exceeded");
+        return "ok";
+      },
+      {
+        maxRpm: 1000,
+        maxRetries: 2,
+        sleep: async () => {},
+        onRetry: () => {
+          retries++;
+        },
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+    expect(retries).toBe(1);
+  });
+
+  it("only retries API_KEY_INVALID when the key recently validated", async () => {
+    resetGeminiControlsForTests();
+    let validCalls = 0;
+    const validResult = await runGeminiRequest(
+      "valid-key",
+      async () => {
+        validCalls++;
+        if (validCalls === 1) throw new GeminiHttpError(400, "API_KEY_INVALID");
+        return "ok";
+      },
+      {
+        maxRpm: 1000,
+        maxRetries: 1,
+        sleep: async () => {},
+        validateKey: async () => "valid",
+      },
+    );
+
+    resetGeminiControlsForTests();
+    let invalidCalls = 0;
+    await expect(
+      runGeminiRequest(
+        "invalid-key",
+        async () => {
+          invalidCalls++;
+          throw new GeminiHttpError(400, "API_KEY_INVALID");
+        },
+        {
+          maxRpm: 1000,
+          maxRetries: 1,
+          sleep: async () => {},
+          validateKey: async () => "invalid",
+        },
+      ),
+    ).rejects.toThrow("Gemini API error (400)");
+
+    expect(validResult).toBe("ok");
+    expect(validCalls).toBe(2);
+    expect(invalidCalls).toBe(1);
+  });
+});

--- a/packages/server/src/connectors/gemini-control.ts
+++ b/packages/server/src/connectors/gemini-control.ts
@@ -1,0 +1,173 @@
+export type GeminiSleep = (ms: number) => Promise<void>;
+export type GeminiNow = () => number;
+
+export interface GeminiClientOptions {
+  maxRpm?: number;
+  maxRetries?: number;
+  quotaIdentity?: string;
+  sleep?: GeminiSleep;
+  now?: GeminiNow;
+  validateKey?: (apiKey: string) => Promise<"valid" | "invalid" | "unknown">;
+  onRetry?: (event: { attempt: number; maxRetries: number; delayMs: number; reason: string }) => void;
+}
+
+export class GeminiHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`Gemini API error (${status}): ${body}`);
+    this.name = "GeminiHttpError";
+  }
+}
+
+type Limiter = {
+  nextAt: number;
+  tail: Promise<void>;
+};
+
+type ValidationCacheEntry = {
+  apiKey: string;
+  status: "valid" | "invalid" | "unknown";
+  expiresAt: number;
+};
+
+const DEFAULT_MAX_RPM = 60;
+const DEFAULT_MAX_RETRIES = 4;
+const VALIDATION_TTL_MS = 10 * 60 * 1000;
+const limiterByQuotaIdentity = new Map<string, Limiter>();
+const validationByQuotaIdentity = new Map<string, ValidationCacheEntry>();
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeOptions(apiKey: string, options?: GeminiClientOptions) {
+  const maxRpm = Math.max(1, Math.floor(options?.maxRpm ?? DEFAULT_MAX_RPM));
+  const maxRetries = Math.max(0, Math.floor(options?.maxRetries ?? DEFAULT_MAX_RETRIES));
+  const quotaIdentity = options?.quotaIdentity ?? apiKey;
+  return {
+    maxRpm,
+    maxRetries,
+    quotaIdentity,
+    sleep: options?.sleep ?? defaultSleep,
+    now: options?.now ?? Date.now,
+    validateKey: options?.validateKey ?? validateGeminiKey,
+    onRetry: options?.onRetry,
+  };
+}
+
+async function acquireGeminiSlot(apiKey: string, options?: GeminiClientOptions): Promise<void> {
+  const opts = normalizeOptions(apiKey, options);
+  const intervalMs = Math.ceil(60000 / opts.maxRpm);
+  let limiter = limiterByQuotaIdentity.get(opts.quotaIdentity);
+  if (!limiter) {
+    limiter = { nextAt: 0, tail: Promise.resolve() };
+    limiterByQuotaIdentity.set(opts.quotaIdentity, limiter);
+  }
+
+  const run = limiter.tail.then(async () => {
+    const waitMs = Math.max(0, limiter.nextAt - opts.now());
+    if (waitMs > 0) await opts.sleep(waitMs);
+    limiter.nextAt = opts.now() + intervalMs;
+  });
+  limiter.tail = run.catch(() => {});
+  await run;
+}
+
+function retryDelayMs(attempt: number): number {
+  const base = Math.min(500 * 2 ** attempt, 4000);
+  const jitter = Math.floor(Math.random() * Math.min(250, base / 2));
+  return base + jitter;
+}
+
+function errorText(err: unknown): string {
+  if (err instanceof GeminiHttpError) return err.body;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function errorStatus(err: unknown): number | undefined {
+  if (err instanceof GeminiHttpError) return err.status;
+  if (err && typeof err === "object") {
+    const raw = err as Record<string, unknown>;
+    const status = raw.status ?? raw.statusCode ?? raw.code;
+    if (typeof status === "number") return status;
+    if (typeof status === "string" && /^\d+$/.test(status)) return Number(status);
+  }
+  return undefined;
+}
+
+function isApiKeyInvalid(err: unknown): boolean {
+  return errorText(err).includes("API_KEY_INVALID");
+}
+
+async function validateGeminiKey(apiKey: string): Promise<"valid" | "invalid" | "unknown"> {
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}`,
+    );
+    if (res.ok) return "valid";
+    if (res.status === 400 || res.status === 403) {
+      const body = await res.text();
+      if (body.includes("API_KEY_INVALID")) return "invalid";
+    }
+    if (res.status === 429 || res.status >= 500) return "unknown";
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+async function validationStatus(
+  apiKey: string,
+  options?: GeminiClientOptions,
+): Promise<"valid" | "invalid" | "unknown"> {
+  const opts = normalizeOptions(apiKey, options);
+  const cached = validationByQuotaIdentity.get(opts.quotaIdentity);
+  if (cached && cached.apiKey === apiKey && cached.expiresAt > opts.now()) return cached.status;
+
+  const status = await opts.validateKey(apiKey);
+  validationByQuotaIdentity.set(opts.quotaIdentity, {
+    apiKey,
+    status,
+    expiresAt: opts.now() + VALIDATION_TTL_MS,
+  });
+  return status;
+}
+
+async function retryReason(err: unknown, apiKey: string, options?: GeminiClientOptions): Promise<string | null> {
+  const status = errorStatus(err);
+  if (status === 429) return "rate_limit";
+  if (status !== undefined && status >= 500) return "server_error";
+  if (isApiKeyInvalid(err)) {
+    return (await validationStatus(apiKey, options)) === "valid" ? "api_key_invalid_throttle" : null;
+  }
+  return null;
+}
+
+export async function runGeminiRequest<T>(
+  apiKey: string,
+  operation: () => Promise<T>,
+  options?: GeminiClientOptions,
+): Promise<T> {
+  const opts = normalizeOptions(apiKey, options);
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    await acquireGeminiSlot(apiKey, options);
+    try {
+      return await operation();
+    } catch (err) {
+      const reason = await retryReason(err, apiKey, options);
+      if (!reason || attempt >= opts.maxRetries) throw err;
+      const delayMs = retryDelayMs(attempt);
+      opts.onRetry?.({ attempt: attempt + 1, maxRetries: opts.maxRetries, delayMs, reason });
+      await opts.sleep(delayMs);
+    }
+  }
+  throw new Error("Gemini: retries exhausted");
+}
+
+export function resetGeminiControlsForTests(): void {
+  limiterByQuotaIdentity.clear();
+  validationByQuotaIdentity.clear();
+}

--- a/packages/server/src/connectors/gemini-generate.ts
+++ b/packages/server/src/connectors/gemini-generate.ts
@@ -10,6 +10,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { type GenerateContentResponse, GoogleGenAI } from "@google/genai";
+import { type GeminiClientOptions, runGeminiRequest } from "./gemini-control";
 
 const MODEL = "gemini-2.5-flash";
 
@@ -55,7 +56,7 @@ export interface GenerateOptions {
   dumpDir?: string;
 }
 
-export function createGeminiGenerator(apiKey: string) {
+export function createGeminiGenerator(apiKey: string, options?: GeminiClientOptions) {
   const ai = new GoogleGenAI({ apiKey });
 
   /**
@@ -74,14 +75,19 @@ export function createGeminiGenerator(apiKey: string) {
 
     const labelPrefix = opts?.label ? `[${opts.label}] ` : "";
 
-    const response: GenerateContentResponse = await ai.models.generateContent({
-      model: MODEL,
-      contents: prompt,
-      config: {
-        ...config,
-        systemInstruction: opts?.systemPrompt,
-      },
-    });
+    const response: GenerateContentResponse = await runGeminiRequest(
+      apiKey,
+      () =>
+        ai.models.generateContent({
+          model: MODEL,
+          contents: prompt,
+          config: {
+            ...config,
+            systemInstruction: opts?.systemPrompt,
+          },
+        }),
+      options,
+    );
 
     const candidate = response.candidates?.[0];
     const finishReason = candidate?.finishReason;

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -1265,6 +1265,8 @@ export async function search(
     sortBy?: "relevance" | "recency";
     /** Suppress search()'s own auto-entity-boost (caller will manage entityFileIds itself). */
     skipAutoEntityBoost?: boolean;
+    geminiMaxRpm?: number;
+    geminiMaxRetries?: number;
   },
 ): Promise<HybridSearchResult[]> {
   const limit = opts?.limit ?? 10;
@@ -1311,7 +1313,12 @@ export async function search(
       .where("id", "=", "default")
       .executeTakeFirst();
     if (settings?.gemini_api_key && settings.enrichment_enabled !== 0) {
-      const embedQuery = createQueryEmbedder({ provider: "gemini", apiKey: settings.gemini_api_key });
+      const embedQuery = createQueryEmbedder({
+        provider: "gemini",
+        apiKey: settings.gemini_api_key,
+        maxRpm: opts?.geminiMaxRpm,
+        maxRetries: opts?.geminiMaxRetries,
+      });
       queryEmbedding = await embedQuery(trimmedQuery);
     }
   } catch {

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -106,6 +106,8 @@ export async function runConnectorSync(
       | "FEATURE_ARCHIVE_MIN_MENTIONS"
       | "FEATURE_ARCHIVE_AGE_DAYS"
       | "FEATURE_ARCHIVE_MAX_PER_RUN"
+      | "GEMINI_MAX_RPM"
+      | "GEMINI_MAX_RETRIES"
     >
   >,
 ): Promise<SyncResult> {
@@ -357,6 +359,8 @@ export interface SyncSchedulerDeps {
       | "FEATURE_ARCHIVE_MIN_MENTIONS"
       | "FEATURE_ARCHIVE_AGE_DAYS"
       | "FEATURE_ARCHIVE_MAX_PER_RUN"
+      | "GEMINI_MAX_RPM"
+      | "GEMINI_MAX_RETRIES"
     >
   >;
 }
@@ -433,7 +437,12 @@ export async function runAllSyncs(db: Kysely<DB>, logger: Logger, deps?: SyncSch
     }
 
     const embeddingProvider = settings?.gemini_api_key
-      ? createEmbeddingProvider({ provider: "gemini", apiKey: settings.gemini_api_key })
+      ? createEmbeddingProvider({
+          provider: "gemini",
+          apiKey: settings.gemini_api_key,
+          maxRpm: deps?.appConfig?.GEMINI_MAX_RPM,
+          maxRetries: deps?.appConfig?.GEMINI_MAX_RETRIES,
+        })
       : null;
 
     const enrichResult = await runEnrichment({
@@ -441,6 +450,8 @@ export async function runAllSyncs(db: Kysely<DB>, logger: Logger, deps?: SyncSch
       logger: logger.child({ component: "enrichment" }),
       embeddingProvider,
       geminiApiKey: settings?.gemini_api_key,
+      geminiMaxRpm: deps?.appConfig?.GEMINI_MAX_RPM,
+      geminiMaxRetries: deps?.appConfig?.GEMINI_MAX_RETRIES,
       downloadImage: deps?.downloadImage,
     });
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -71,6 +71,7 @@ import * as m068 from "./migrations/068-entities-ai-brief";
 import * as m069 from "./migrations/069-admin-can-read-all-files";
 import * as m070 from "./migrations/070-file-shares";
 import * as m071 from "./migrations/071-entity-shares";
+import * as m072 from "./migrations/072-enrichment-retry-backoff";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>): Promise<void> {
@@ -146,6 +147,7 @@ export async function runMigrations(db: Kysely<DB>): Promise<void> {
           "069-admin-can-read-all-files": m069,
           "070-file-shares": m070,
           "071-entity-shares": m071,
+          "072-enrichment-retry-backoff": m072,
         };
       },
     },

--- a/packages/server/src/db/migrations/072-enrichment-retry-backoff.ts
+++ b/packages/server/src/db/migrations/072-enrichment-retry-backoff.ts
@@ -1,0 +1,30 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("indexed_files")
+    .addColumn("embedding_attempts", "integer", (col) => col.notNull().defaultTo(0))
+    .execute();
+  await db.schema.alterTable("indexed_files").addColumn("embedding_next_retry_at", "text").execute();
+  await db.schema
+    .alterTable("indexed_files")
+    .addColumn("summary_attempts", "integer", (col) => col.notNull().defaultTo(0))
+    .execute();
+  await db.schema.alterTable("indexed_files").addColumn("summary_next_retry_at", "text").execute();
+
+  await sql`CREATE INDEX idx_indexed_files_embedding_retry ON indexed_files(embedding_status, embedding_next_retry_at)`.execute(
+    db,
+  );
+  await sql`CREATE INDEX idx_indexed_files_summary_retry ON indexed_files(summary_status, summary_next_retry_at)`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_indexed_files_summary_retry`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_indexed_files_embedding_retry`.execute(db);
+  await db.schema.alterTable("indexed_files").dropColumn("summary_next_retry_at").execute();
+  await db.schema.alterTable("indexed_files").dropColumn("summary_attempts").execute();
+  await db.schema.alterTable("indexed_files").dropColumn("embedding_next_retry_at").execute();
+  await db.schema.alterTable("indexed_files").dropColumn("embedding_attempts").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(67);
+    expect(rows.rows).toHaveLength(68);
   });
 
   it("records migrations with correct names in order", async () => {
@@ -101,6 +101,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[64]).toBe("069-admin-can-read-all-files");
     expect(names[65]).toBe("070-file-shares");
     expect(names[66]).toBe("071-entity-shares");
+    expect(names[67]).toBe("072-enrichment-retry-backoff");
   });
 
   it("running migrations twice is idempotent", async () => {
@@ -109,7 +110,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(67);
+    expect(rows.rows).toHaveLength(68);
   });
 
   it("creates the users table", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -40,7 +40,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(67);
+    expect(rows.rows).toHaveLength(68);
   });
 
   it("records migrations with the correct names in order", async () => {
@@ -104,6 +104,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[64]).toBe("069-admin-can-read-all-files");
     expect(names[65]).toBe("070-file-shares");
     expect(names[66]).toBe("071-entity-shares");
+    expect(names[67]).toBe("072-enrichment-retry-backoff");
   });
 
   it("creates the users table", async () => {
@@ -225,7 +226,7 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
 
-    expect(rows.rows).toHaveLength(67);
+    expect(rows.rows).toHaveLength(68);
   });
 });
 
@@ -257,6 +258,6 @@ describe("runMigrations — incremental upgrade", () => {
     const rows = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name ASC
     `.execute(db);
-    expect(rows.rows).toHaveLength(67);
+    expect(rows.rows).toHaveLength(68);
   });
 });

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -347,7 +347,14 @@ export function createConnectorRepository(db: Kysely<DB>) {
           synced_at: now,
         };
         if (data.mimeType !== undefined) updates.mime_type = data.mimeType;
-        if (contentChanged) updates.embedding_status = "pending";
+        if (contentChanged) {
+          updates.embedding_status = "pending";
+          updates.summary_status = "pending";
+          updates.embedding_attempts = 0;
+          updates.embedding_next_retry_at = null;
+          updates.summary_attempts = 0;
+          updates.summary_next_retry_at = null;
+        }
 
         await db.updateTable("indexed_files").set(updates).where("id", "=", existing.id).execute();
 
@@ -374,6 +381,7 @@ export function createConnectorRepository(db: Kysely<DB>) {
           synced_at: now,
           mime_type: data.mimeType ?? null,
           embedding_status: "pending",
+          summary_status: "pending",
         })
         .execute();
 

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -130,6 +130,10 @@ export interface IndexedFilesTable {
   mime_type: string | null;
   embedding_status: Generated<string>;
   summary_status: Generated<string>;
+  embedding_attempts: Generated<number>;
+  embedding_next_retry_at: string | null;
+  summary_attempts: Generated<number>;
+  summary_next_retry_at: string | null;
   share_with_everyone: Generated<number>;
 }
 

--- a/packages/server/src/entities/reenrich.ts
+++ b/packages/server/src/entities/reenrich.ts
@@ -67,6 +67,8 @@ export interface ReenrichDeps {
   missingFileIds?: string[];
   llmPromotionThreshold?: number;
   coMentionContributesToThreshold?: number;
+  geminiMaxRpm?: number;
+  geminiMaxRetries?: number;
   /**
    * Set when the caller already promoted a pending recreate lock (two-step
    * rebuild flow). Skips the internal beginRecreateLock/endRecreateLock so
@@ -488,7 +490,12 @@ export async function runReenrichJob(deps: ReenrichDeps): Promise<ReenrichSummar
       .where("id", "=", "default")
       .executeTakeFirst();
     const embeddingProvider = settings?.gemini_api_key
-      ? createEmbeddingProvider({ provider: "gemini", apiKey: settings.gemini_api_key })
+      ? createEmbeddingProvider({
+          provider: "gemini",
+          apiKey: settings.gemini_api_key,
+          maxRpm: deps.geminiMaxRpm,
+          maxRetries: deps.geminiMaxRetries,
+        })
       : null;
     if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
     const wipe = await wipeLlmEnrichmentForFiles(
@@ -507,6 +514,8 @@ export async function runReenrichJob(deps: ReenrichDeps): Promise<ReenrichSummar
         logger: deps.logger.child({ phase: "enrichment" }),
         embeddingProvider,
         geminiApiKey: settings?.gemini_api_key,
+        geminiMaxRpm: deps.geminiMaxRpm,
+        geminiMaxRetries: deps.geminiMaxRetries,
         runEnrichmentImpl: deps.runEnrichmentImpl,
         onProgress: deps.onProgress,
         shouldCancel: deps.shouldCancel,

--- a/packages/server/src/entities/review.test.ts
+++ b/packages/server/src/entities/review.test.ts
@@ -145,8 +145,8 @@ async function seedPendingRow(
   return id;
 }
 
-describe("entity-review routes — EXPERIMENTAL_FLAG", () => {
-  it("returns 404 when flag is off (route not mounted)", async () => {
+describe("entity-review routes — mounting", () => {
+  it("returns 200 without EXPERIMENTAL_FLAG (Files is GA, route always mounted)", async () => {
     const db = await createTestDb();
     try {
       await seedUsers(db);
@@ -155,7 +155,7 @@ describe("entity-review routes — EXPERIMENTAL_FLAG", () => {
       });
       const cookie = await login(app, OWNER_EMAIL);
       const res = await app.request("/api/entity-review", { headers: { Cookie: cookie } });
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(200);
     } finally {
       await db.destroy();
     }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -205,7 +205,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       userRepo: users,
     }),
   );
-  app.route("/api/settings", settingsRoutes(settings, db, deps?.logger));
+  app.route("/api/settings", settingsRoutes(settings, db, deps?.logger, config));
   app.route("/api/skills", skillsRoutes(config));
   app.route(
     "/api/users",

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -282,9 +282,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
 
   app.route("/api/usage", usageRoutes(db));
   app.route("/api/entities", entityRoutes(db, { logger, config }));
-  if (config.EXPERIMENTAL_FLAG) {
-    app.route("/api/entity-review", entityReviewRoutes(db));
-  }
+  app.route("/api/entity-review", entityReviewRoutes(db));
 
   if (deps?.logger) {
     app.route("/api/connectors", connectorRoutes(connectors, db, deps.logger, users, config));

--- a/packages/server/src/test-utils.ts
+++ b/packages/server/src/test-utils.ts
@@ -87,6 +87,8 @@ export function createTestConfig(overrides: Partial<Config> = {}): Config {
     FEATURE_ARCHIVE_MIN_MENTIONS: 2,
     FEATURE_ARCHIVE_AGE_DAYS: 30,
     FEATURE_ARCHIVE_MAX_PER_RUN: 1000,
+    GEMINI_MAX_RPM: 60,
+    GEMINI_MAX_RETRIES: 4,
     SYNC_ALLOW_LARGE_RECONCILE: false,
     SYNC_MAX_RECONCILE_RATIO: 0.5,
     DATA_DIR: "./data",

--- a/packages/web/src/routes/files/connector-picker.tsx
+++ b/packages/web/src/routes/files/connector-picker.tsx
@@ -427,7 +427,7 @@ function ConnectorSettings() {
     const updates: { syncIntervalMinutes?: number; enrichmentEnabled?: boolean; geminiApiKey?: string | null } = {};
     if (syncInterval !== data?.syncIntervalMinutes) updates.syncIntervalMinutes = syncInterval;
     if (enrichmentEnabled !== (data?.enrichmentEnabled === 1)) updates.enrichmentEnabled = enrichmentEnabled;
-    if (geminiKey.trim()) updates.geminiApiKey = geminiKey;
+    if (geminiKey.trim()) updates.geminiApiKey = geminiKey.trim();
     mutation.mutate(updates);
   }
 

--- a/packages/web/src/routes/files/entity-explorer.test.tsx
+++ b/packages/web/src/routes/files/entity-explorer.test.tsx
@@ -5,7 +5,7 @@
  * - count-probe short-circuits when no pending rows exist (no list query)
  * - pending review rows render as "ghost rows" at the top of the entities
  *   table; a divider separates them from confirmed entities
- * - EXPERIMENTAL_FLAG=false hides everything (no probe issued, no ghost rows)
+ * - Files is GA: the count probe fires regardless of EXPERIMENTAL_FLAG
  * - clicking a ghost row opens the drawer in review mode (two-column
  *   reconcile view with the proposed entity + ReviewActions)
  * - "Confirm" inside the drawer resolves the row and shrinks the ghost set
@@ -100,7 +100,7 @@ function rowFactory(over: Partial<Record<string, unknown>> = {}) {
 }
 
 describe("EntityExplorer ECR-03B inline review", () => {
-  it("EXPERIMENTAL_FLAG=false: no ghost rows, no count probe issued", async () => {
+  it("Files GA: count probe fires regardless of EXPERIMENTAL_FLAG (no ghost rows when empty)", async () => {
     let probeCalls = 0;
     server.use(
       http.get("/api/setup/status", () => statusResponse(false)),
@@ -113,8 +113,7 @@ describe("EntityExplorer ECR-03B inline review", () => {
 
     renderWithProviders(<EntityExplorer />);
     await waitFor(() => expect(screen.getByText("Simran S")).toBeInTheDocument());
-    await new Promise((r) => setTimeout(r, 50));
-    expect(probeCalls).toBe(0);
+    await waitFor(() => expect(probeCalls).toBeGreaterThan(0));
     expect(screen.queryByTestId("pending-reviews-badge")).not.toBeInTheDocument();
     expect(screen.queryByTestId(/^review-row-/)).not.toBeInTheDocument();
   });

--- a/packages/web/src/routes/files/entity-explorer.tsx
+++ b/packages/web/src/routes/files/entity-explorer.tsx
@@ -191,22 +191,15 @@ export function EntityExplorer() {
   const total = data?.total ?? 0;
   const tentativeCount = entities.filter((e) => e.status === "tentative").length;
 
-  // ECR-03B inline review surface — gated, two-stage fetch:
+  // ECR-03B inline review surface — two-stage fetch:
   // the cheap count probe gates the (heavier) list query.
-  const { data: setupStatus } = useQuery({
-    queryKey: ["setup", "status"],
-    queryFn: () => api.setup.status(),
-  });
-  const experimentalEnabled = setupStatus?.experimentalFlag === true;
-
   const { data: reviewCount } = useQuery({
     queryKey: countKey(debouncedSearch),
     queryFn: () => api.entityReview.list({ limit: 0, search: debouncedSearch || undefined }),
-    enabled: experimentalEnabled,
-    refetchInterval: experimentalEnabled ? 30000 : false,
+    refetchInterval: 30000,
   });
   const reviewTotal = reviewCount?.total ?? 0;
-  const hasPendingReviews = experimentalEnabled && reviewTotal > 0;
+  const hasPendingReviews = reviewTotal > 0;
 
   const { data: reviewList } = useQuery({
     queryKey: listKey(debouncedSearch),


### PR DESCRIPTION
## Summary
- add shared Gemini pacing/retry control for generation, embeddings, search, sync, manual enrichment, and re-enrichment
- add configurable `GEMINI_MAX_RPM` / `GEMINI_MAX_RETRIES` knobs and document them in `.env.example`
- add enrichment retry backoff columns, migration coverage, and scheduled retry filtering while preserving explicit reruns
- reset enrichment retry state when connector file content changes

## Testing
- `pnpm biome check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Notes
- Updated existing PR #189 on `fix/gemini-key-trim`; this branch also contains its earlier Gemini key trim / Files GA commits.
- The `.planning` submodule is still dirty locally and was not included in this main-repo commit.