### PR TITLE
fix: bound replay concurrent-callers test fixture to avoid 5s timeout

### DIFF
--- a/packages/server/src/entities/replay.test.ts
+++ b/packages/server/src/entities/replay.test.ts
@@ -388,7 +388,13 @@ describe("replaySourceFacts", () => {
   it("runs a follow-up materialization pass for concurrent callers", async () => {
     await db.deleteFrom("indexed_file_facts").execute();
     const repo = createIndexedFileFactRepository(db);
-    for (let i = 0; i < 1000; i++) {
+    /**
+     * The first pass only needs a non-empty batch to materialize; the assertion
+     * is that a late fact inserted afterward gets picked up by a follow-up pass.
+     * A small batch keeps this CPU-bound test well under the unit tier's default
+     * 5s timeout, which a 1000-fact batch tipped over under full-suite contention.
+     */
+    for (let i = 0; i < 25; i++) {
       await repo.upsertFact({
         source: "manual",
         factType: "person_seed",


### PR DESCRIPTION
## Summary

`replaySourceFacts > "runs a follow-up materialization pass for concurrent callers"` (in `entities/replay.test.ts`) materialized **1000 facts** through the full entity pipeline, which measures **~1.7s solo on an idle machine**. The `unit` Vitest tier sets no `testTimeout`, so it inherits the default **5000ms** (only `integration` overrides to 30s).

Under a full parallel pre-push run (the `unit` and `unit-isolated` projects share the worker pool, threads pool sized to cores-1) plus parallel-worktree contention, that single CPU-bound test slowed past 5s and timed out, flaking the pre-push hook. It passed CI for #191 only because the runner happened to stay under 5s; the slow test predates #191.

## Fix

Cap the first-pass batch at **25**. The test's surviving assertion only needs a non-empty first batch plus one late-inserted fact picked up by a follow-up pass, so the 1000 volume was unnecessary. The test now runs in **~13ms** (≈128x faster), with ample headroom under the 5s timeout.

## Test plan

- `replay.test.ts`: 15/15 pass; the heavy test 1668ms → 13ms.
- `biome check` clean, `pnpm typecheck` clean.
- Full pre-push gate (`pnpm test` + build) passed on push.

## Out of scope (noted, not changed)

- The `unit` tier has no explicit `testTimeout`; other heavy tests could hit the same 5s wall someday (a modest explicit bump would be defense-in-depth, but it masks slowness).
- The de-flake in #191 made this test strictly sequential despite its "concurrent callers" name, so it no longer exercises the queue-overlap path. Re-introducing a genuine concurrent assertion is a small follow-up if desired.

Follow-up to #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)