### PR TITLE
feat: encrypt connector + provider-identity credentials at rest

### DIFF
--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -55,6 +55,7 @@ function syncInBackground(
       | "CO_MENTION_CONTRIBUTES_TO_THRESHOLD"
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
+      | "ENCRYPTION_KEY"
     >
   >,
 ) {

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -659,7 +659,7 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     // other attendees still see previously-synced meetings via file_access.
     // Fail-noisy: if archival throws we let the 500 surface so the admin retries
     // rather than silently leaving credentials in DB after the user row is gone.
-    const result = await createConnectorRepository(deps.db).archiveConnectorsForOwner(id);
+    const result = await createConnectorRepository(deps.db, deps.config.ENCRYPTION_KEY).archiveConnectorsForOwner(id);
     if (result.archived > 0) {
       deps.logger.info({ userId: id, count: result.archived }, "Archived connectors after user removal");
     }

--- a/packages/server/src/auth/secret-fields.ts
+++ b/packages/server/src/auth/secret-fields.ts
@@ -1,0 +1,13 @@
+import { decrypt, encrypt } from "./encryption";
+
+export function encodeSecretField(value: string, encryptionKey?: string): string {
+  return encryptionKey ? encrypt(value, encryptionKey) : value;
+}
+
+export function decodeSecretField(value: string, encryptionKey: string | undefined, fieldName: string): string {
+  if (!value.startsWith("enc:")) return value;
+  if (!encryptionKey) {
+    throw new Error(`Encrypted value found for ${fieldName} but ENCRYPTION_KEY is not set`);
+  }
+  return decrypt(value, encryptionKey);
+}

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -13,6 +13,7 @@ import { type AgentResult, runAgent } from "./agent/runner";
 import type { McpServerConfig, RunAgentParams } from "./agent/runner";
 import type { Config } from "./config";
 import { startSyncScheduler } from "./connectors/sync";
+import { backfillFilesConnectorCredentialEncryption } from "./db/credential-encryption-backfill";
 import { createDatabase } from "./db/index";
 import { runMigrations } from "./db/migrate";
 import { createAgentEnvironmentVariableRepository } from "./db/repositories/agent-environment-variables";
@@ -101,6 +102,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const channels = createChannelRepository(db);
   const settingsRepo = createSettingsRepository(db, config.ENCRYPTION_KEY);
   const agentEnvironmentVariables = createAgentEnvironmentVariableRepository(db, config.ENCRYPTION_KEY);
+  await backfillFilesConnectorCredentialEncryption(db, config.ENCRYPTION_KEY, logger);
   await runManagedSeed(config, settingsRepo, users);
   const mcpServersRepo = createMcpServerRepository(db);
   const whatsappGroupsRepo = createWhatsAppGroupRepository(db);

--- a/packages/server/src/connectors/sync-item.ts
+++ b/packages/server/src/connectors/sync-item.ts
@@ -21,6 +21,7 @@ export interface ProcessSyncedItemParams {
   connectorType: ConnectorType;
   item: SyncedItem;
   existingHashes: ExistingContentHashMap;
+  encryptionKey?: string;
 }
 
 export async function loadExistingContentHashes(
@@ -53,6 +54,7 @@ export async function processSyncedItem({
   connectorType,
   item,
   existingHashes,
+  encryptionKey,
 }: ProcessSyncedItemParams): Promise<ProcessSyncedItemResult> {
   if (!item.fileName && !item.content) {
     return { kind: "skipped_empty" };
@@ -82,7 +84,7 @@ export async function processSyncedItem({
   }
 
   const itemResult = await db.transaction().execute(async (trx) => {
-    const txRepo = createConnectorRepository(trx);
+    const txRepo = createConnectorRepository(trx, encryptionKey);
     const upsertResult = await txRepo.upsertFile({
       connectorConfigId,
       source: connectorType,

--- a/packages/server/src/connectors/sync-reconcile.ts
+++ b/packages/server/src/connectors/sync-reconcile.ts
@@ -18,6 +18,7 @@ export interface ReconcileConnectorSyncParams {
   seenProviderFileIds: Set<string>;
   allowLargeReconcile?: boolean;
   maxReconcileRatio?: number;
+  encryptionKey?: string;
   logger: Logger;
 }
 
@@ -36,9 +37,10 @@ export async function reconcileConnectorSync({
   seenProviderFileIds,
   allowLargeReconcile,
   maxReconcileRatio,
+  encryptionKey,
   logger,
 }: ReconcileConnectorSyncParams): Promise<{ itemsArchived: number; affectedIndexedFileIds: string[] }> {
-  const repo = createConnectorRepository(db);
+  const repo = createConnectorRepository(db, encryptionKey);
   const entityRepo = createEntityRepository(db);
   const reconcileResult = await factRepo.reconcileStaleFacts(
     { kind: "connector", connectorConfigId, syncRunId },

--- a/packages/server/src/connectors/sync-utils.ts
+++ b/packages/server/src/connectors/sync-utils.ts
@@ -26,8 +26,8 @@ export function truncateErrorMessage(message: string): string {
   return collapsed.length > MAX_ERROR_MESSAGE_LENGTH ? `${collapsed.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…` : collapsed;
 }
 
-export function parseCredentials(encrypted: string): ConnectorCredentials {
-  return JSON.parse(encrypted) as ConnectorCredentials;
+export function parseCredentials(raw: string): ConnectorCredentials {
+  return JSON.parse(raw) as ConnectorCredentials;
 }
 
 export function serializeCredentials(credentials: ConnectorCredentials): string {

--- a/packages/server/src/connectors/sync.isolated.test.ts
+++ b/packages/server/src/connectors/sync.isolated.test.ts
@@ -11,6 +11,7 @@
  */
 import type { Kysely } from "kysely";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { encrypt } from "../auth/encryption";
 import { createConnectorRepository } from "../db/repositories/connectors";
 import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
@@ -19,6 +20,8 @@ import { createTestDb, createTestLogger } from "../test-utils";
 import { clearEnrichmentData } from "./enrichment";
 import { recoverStaleEnrichments, runAllSyncs, runConnectorSync, startSyncScheduler } from "./sync";
 import type { NameResolver, SyncedItem } from "./types";
+
+const TEST_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 // Stub the heavy enrichment/sync work to keep tests fast
 vi.mock("./enrichment", () => ({
@@ -468,6 +471,34 @@ describe("runAllSyncs (Fix A + Fix C)", () => {
       .selectFrom("connector_configs")
       .select(["sync_status", "error_message"])
       .where("id", "=", "stuck")
+      .executeTakeFirstOrThrow();
+    expect(row.sync_status).toBe("error");
+    expect(row.error_message).toMatch(/auto-recovered/);
+  });
+
+  it("recovers stale-syncing rows with encrypted credentials", async () => {
+    db = await createTestDb();
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "encrypted-stuck",
+        connector_type: "fireflies",
+        auth_type: "api_key",
+        credentials: encrypt(JSON.stringify({ type: "api_key", api_key: "secret" }), TEST_KEY),
+        created_by: "user-encrypted-stuck",
+        sync_status: "syncing",
+        updated_at: twoHoursAgo,
+        last_synced_at: new Date().toISOString(),
+      })
+      .execute();
+
+    await expect(runAllSyncs(db, logger, { appConfig: { ENCRYPTION_KEY: TEST_KEY } })).resolves.toBeUndefined();
+
+    const row = await db
+      .selectFrom("connector_configs")
+      .select(["sync_status", "error_message"])
+      .where("id", "=", "encrypted-stuck")
       .executeTakeFirstOrThrow();
     expect(row.sync_status).toBe("error");
     expect(row.error_message).toMatch(/auto-recovered/);

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -108,6 +108,7 @@ export async function runConnectorSync(
       | "FEATURE_ARCHIVE_MAX_PER_RUN"
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
+      | "ENCRYPTION_KEY"
     >
   >,
 ): Promise<SyncResult> {
@@ -123,7 +124,7 @@ export async function runConnectorSync(
     };
   }
 
-  const repo = createConnectorRepository(db);
+  const repo = createConnectorRepository(db, appConfig?.ENCRYPTION_KEY);
   const entityRepo = createEntityRepository(db);
   const factRepo = createIndexedFileFactRepository(db);
   const userRepo = createUserRepository(db);
@@ -232,6 +233,7 @@ export async function runConnectorSync(
           connectorType,
           item,
           existingHashes,
+          encryptionKey: appConfig?.ENCRYPTION_KEY,
         });
 
         if (itemResult.kind === "skipped_empty") {
@@ -290,6 +292,7 @@ export async function runConnectorSync(
         seenProviderFileIds,
         allowLargeReconcile: appConfig?.SYNC_ALLOW_LARGE_RECONCILE,
         maxReconcileRatio: appConfig?.SYNC_MAX_RECONCILE_RATIO,
+        encryptionKey: appConfig?.ENCRYPTION_KEY,
         logger: syncLogger,
       });
       result.itemsArchived = reconcileResult.itemsArchived;
@@ -361,6 +364,7 @@ export interface SyncSchedulerDeps {
       | "FEATURE_ARCHIVE_MAX_PER_RUN"
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
+      | "ENCRYPTION_KEY"
     >
   >;
 }
@@ -395,12 +399,12 @@ export async function runAllSyncs(db: Kysely<DB>, logger: Logger, deps?: SyncSch
     return;
   }
 
-  const repo = createConnectorRepository(db);
+  const repo = createConnectorRepository(db, deps?.appConfig?.ENCRYPTION_KEY);
 
   // Auto-recover any connector stuck in `syncing` past the staleness threshold —
   // a row stuck mid-process is otherwise excluded from `findSyncableConfigs` and
   // would never retry until the server restarts.
-  await recoverStaleSyncs(db, logger, STALE_SYNCING_THRESHOLD_MS);
+  await recoverStaleSyncs(db, logger, STALE_SYNCING_THRESHOLD_MS, deps?.appConfig?.ENCRYPTION_KEY);
 
   // Same idea for enrichment: scheduled runs only claim `pending`/`failed` (so
   // an in-flight run can't be re-claimed mid-flight and race on chunk inserts),
@@ -502,8 +506,13 @@ export async function runAllSyncs(db: Kysely<DB>, logger: Logger, deps?: SyncSch
  * process. Recovered rows are flipped to "error" so `findSyncableConfigs` re-includes
  * them on the next eligibility pass.
  */
-async function recoverStaleSyncs(db: Kysely<DB>, logger: Logger, staleThresholdMs = 0): Promise<void> {
-  const repo = createConnectorRepository(db);
+async function recoverStaleSyncs(
+  db: Kysely<DB>,
+  logger: Logger,
+  staleThresholdMs = 0,
+  encryptionKey?: string,
+): Promise<void> {
+  const repo = createConnectorRepository(db, encryptionKey);
   const stale = await repo.findStaleSyncingConfigs(staleThresholdMs);
 
   if (stale.length === 0) return;
@@ -563,7 +572,7 @@ export function startSyncScheduler(
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   // Recover any connectors stuck in "syncing" from a previous crash
-  recoverStaleSyncs(db, logger).catch((err) => {
+  recoverStaleSyncs(db, logger, 0, deps?.appConfig?.ENCRYPTION_KEY).catch((err) => {
     logger.error({ err }, "Failed to recover stale syncs on startup");
   });
 

--- a/packages/server/src/db/credential-encryption-backfill.ts
+++ b/packages/server/src/db/credential-encryption-backfill.ts
@@ -1,0 +1,55 @@
+import type { Kysely } from "kysely";
+import type { Logger } from "pino";
+import { encrypt } from "../auth/encryption";
+import type { DB } from "./schema";
+
+export async function backfillFilesConnectorCredentialEncryption(
+  db: Kysely<DB>,
+  encryptionKey: string | undefined,
+  logger?: Pick<Logger, "info">,
+): Promise<{ connectorCredentials: number; providerIdentityTokenFields: number }> {
+  if (!encryptionKey) {
+    return { connectorCredentials: 0, providerIdentityTokenFields: 0 };
+  }
+
+  let connectorCredentials = 0;
+  const connectorRows = await db.selectFrom("connector_configs").select(["id", "credentials"]).execute();
+  for (const row of connectorRows) {
+    if (row.credentials.startsWith("enc:")) continue;
+    await db
+      .updateTable("connector_configs")
+      .set({ credentials: encrypt(row.credentials, encryptionKey) })
+      .where("id", "=", row.id)
+      .execute();
+    connectorCredentials++;
+  }
+
+  let providerIdentityTokenFields = 0;
+  const identityRows = await db
+    .selectFrom("user_provider_identities")
+    .select(["id", "access_token", "refresh_token"])
+    .execute();
+  for (const row of identityRows) {
+    const updates: { access_token?: string; refresh_token?: string } = {};
+    if (row.access_token && !row.access_token.startsWith("enc:")) {
+      updates.access_token = encrypt(row.access_token, encryptionKey);
+      providerIdentityTokenFields++;
+    }
+    if (row.refresh_token && !row.refresh_token.startsWith("enc:")) {
+      updates.refresh_token = encrypt(row.refresh_token, encryptionKey);
+      providerIdentityTokenFields++;
+    }
+    if (Object.keys(updates).length > 0) {
+      await db.updateTable("user_provider_identities").set(updates).where("id", "=", row.id).execute();
+    }
+  }
+
+  if (connectorCredentials > 0) {
+    logger?.info({ count: connectorCredentials }, "Encrypted legacy connector credential rows");
+  }
+  if (providerIdentityTokenFields > 0) {
+    logger?.info({ count: providerIdentityTokenFields }, "Encrypted legacy provider identity token fields");
+  }
+
+  return { connectorCredentials, providerIdentityTokenFields };
+}

--- a/packages/server/src/db/repositories/connector-credential-encryption.test.ts
+++ b/packages/server/src/db/repositories/connector-credential-encryption.test.ts
@@ -1,0 +1,196 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { encrypt } from "../../auth/encryption";
+import { parseCredentials } from "../../connectors/sync-utils";
+import { createTestDb, createTestLogger } from "../../test-utils";
+import { backfillFilesConnectorCredentialEncryption } from "../credential-encryption-backfill";
+import type { DB } from "../schema";
+import { createConnectorRepository } from "./connectors";
+import { createProviderIdentityRepository } from "./provider-identities";
+
+const TEST_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+async function rawConnectorCredentials(db: Kysely<DB>, id: string): Promise<string> {
+  const row = await db
+    .selectFrom("connector_configs")
+    .select("credentials")
+    .where("id", "=", id)
+    .executeTakeFirstOrThrow();
+  return row.credentials;
+}
+
+async function seedUser(db: Kysely<DB>) {
+  await db.insertInto("users").values({ id: "user-1", name: "Test User", email: "user@example.com" }).execute();
+}
+
+describe("Files connector credential encryption", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("stores connector credentials encrypted and returns decrypted credentials", async () => {
+    const repo = createConnectorRepository(db, TEST_KEY);
+    const credentials = {
+      type: "oauth",
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      client_secret: "client-secret",
+    };
+
+    const created = await repo.createConfig({
+      connectorType: "google_drive",
+      authType: "oauth",
+      credentials: JSON.stringify(credentials),
+      createdBy: "user-1",
+    });
+
+    const raw = await rawConnectorCredentials(db, created.id);
+    expect(raw.startsWith("enc:")).toBe(true);
+    expect(raw).not.toContain("refresh-token");
+    expect(raw).not.toContain("client-secret");
+    expect(parseCredentials(created.credentials)).toMatchObject(credentials);
+
+    const fetched = await repo.findConfigById(created.id);
+    expect(parseCredentials(fetched?.credentials ?? "{}")).toMatchObject(credentials);
+  });
+
+  it("reads legacy plaintext connector credentials and heals them on write", async () => {
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "legacy-connector",
+        connector_type: "google_drive",
+        auth_type: "oauth",
+        credentials: JSON.stringify({ type: "oauth", refresh_token: "legacy-refresh" }),
+        created_by: "user-1",
+      })
+      .execute();
+
+    const repo = createConnectorRepository(db, TEST_KEY);
+    const legacy = await repo.findConfigById("legacy-connector");
+    expect(legacy?.credentials).toContain("legacy-refresh");
+
+    await repo.updateConfig("legacy-connector", {
+      credentials: JSON.stringify({ type: "oauth", refresh_token: "rotated-refresh" }),
+    });
+
+    const raw = await rawConnectorCredentials(db, "legacy-connector");
+    expect(raw.startsWith("enc:")).toBe(true);
+    expect(raw).not.toContain("rotated-refresh");
+  });
+
+  it("preserves plaintext connector behavior when no key is configured", async () => {
+    const repo = createConnectorRepository(db);
+    const created = await repo.createConfig({
+      connectorType: "fireflies",
+      authType: "api_key",
+      credentials: JSON.stringify({ type: "api_key", api_key: "plain-api-key" }),
+      createdBy: "user-1",
+    });
+
+    const raw = await rawConnectorCredentials(db, created.id);
+    expect(raw).toContain("plain-api-key");
+
+    const fetched = await repo.findConfigById(created.id);
+    expect(fetched?.credentials).toContain("plain-api-key");
+  });
+
+  it("throws clearly when connector credentials are encrypted but no key is configured", async () => {
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "encrypted-connector",
+        connector_type: "google_drive",
+        auth_type: "oauth",
+        credentials: encrypt(JSON.stringify({ type: "oauth", refresh_token: "secret" }), TEST_KEY),
+        created_by: "user-1",
+      })
+      .execute();
+
+    const repo = createConnectorRepository(db);
+    await expect(repo.findConfigById("encrypted-connector")).rejects.toThrow("ENCRYPTION_KEY");
+  });
+
+  it("stores provider identity tokens encrypted and returns decrypted tokens", async () => {
+    await seedUser(db);
+    const repo = createProviderIdentityRepository(db, TEST_KEY);
+
+    const identity = await repo.upsert({
+      userId: "user-1",
+      provider: "google_drive",
+      providerUserId: "provider-user",
+      providerEmail: "user@example.com",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      tokenExpiresAt: "2026-06-02T00:00:00.000Z",
+    });
+
+    const raw = await db
+      .selectFrom("user_provider_identities")
+      .select(["access_token", "refresh_token"])
+      .where("id", "=", identity.id)
+      .executeTakeFirstOrThrow();
+
+    expect(raw.access_token?.startsWith("enc:")).toBe(true);
+    expect(raw.refresh_token?.startsWith("enc:")).toBe(true);
+    expect(raw.access_token).not.toContain("access-token");
+    expect(raw.refresh_token).not.toContain("refresh-token");
+    expect(identity.access_token).toBe("access-token");
+    expect(identity.refresh_token).toBe("refresh-token");
+
+    const fetched = await repo.findByUserAndProvider("user-1", "google_drive");
+    expect(fetched?.access_token).toBe("access-token");
+    expect(fetched?.refresh_token).toBe("refresh-token");
+  });
+
+  it("backfills legacy plaintext connector and provider identity secrets", async () => {
+    await seedUser(db);
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "legacy-connector",
+        connector_type: "google_drive",
+        auth_type: "oauth",
+        credentials: JSON.stringify({ type: "oauth", refresh_token: "legacy-refresh" }),
+        created_by: "user-1",
+      })
+      .execute();
+    await db
+      .insertInto("user_provider_identities")
+      .values({
+        id: "legacy-identity",
+        user_id: "user-1",
+        provider: "google_drive",
+        provider_user_id: "provider-user",
+        provider_email: "user@example.com",
+        access_token: "legacy-access",
+        refresh_token: "legacy-refresh",
+      })
+      .execute();
+
+    const result = await backfillFilesConnectorCredentialEncryption(db, TEST_KEY, createTestLogger());
+    expect(result).toEqual({ connectorCredentials: 1, providerIdentityTokenFields: 2 });
+
+    const rawConnector = await rawConnectorCredentials(db, "legacy-connector");
+    const rawIdentity = await db
+      .selectFrom("user_provider_identities")
+      .select(["access_token", "refresh_token"])
+      .where("id", "=", "legacy-identity")
+      .executeTakeFirstOrThrow();
+
+    expect(rawConnector.startsWith("enc:")).toBe(true);
+    expect(rawIdentity.access_token?.startsWith("enc:")).toBe(true);
+    expect(rawIdentity.refresh_token?.startsWith("enc:")).toBe(true);
+
+    const connectorRepo = createConnectorRepository(db, TEST_KEY);
+    const identityRepo = createProviderIdentityRepository(db, TEST_KEY);
+    expect((await connectorRepo.findConfigById("legacy-connector"))?.credentials).toContain("legacy-refresh");
+    expect((await identityRepo.findByUserAndProvider("user-1", "google_drive"))?.refresh_token).toBe("legacy-refresh");
+  });
+});

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
+import { decodeSecretField, encodeSecretField } from "../../auth/secret-fields";
 import type { ConnectorType, ContentCategory, SyncStatus } from "../../connectors/types";
 import type { DB } from "../schema";
 
@@ -78,21 +79,35 @@ export function fileVisibilityPredicate(viewer: FileViewer, alias = "indexed_fil
   )`;
 }
 
-export function createConnectorRepository(db: Kysely<DB>) {
+function decodeConnectorConfigRow<T extends { credentials: string }>(row: T, encryptionKey?: string): T {
+  return {
+    ...row,
+    credentials: decodeSecretField(row.credentials, encryptionKey, "connector_configs.credentials"),
+  };
+}
+
+export function createConnectorRepository(db: Kysely<DB>, encryptionKey?: string) {
   return {
     /** List all connector configs. */
     async listConfigs() {
-      return db.selectFrom("connector_configs").selectAll().orderBy("created_at", "desc").execute();
+      const rows = await db.selectFrom("connector_configs").selectAll().orderBy("created_at", "desc").execute();
+      return rows.map((row) => decodeConnectorConfigRow(row, encryptionKey));
     },
 
     /** Find a connector config by ID. */
     async findConfigById(id: string) {
-      return db.selectFrom("connector_configs").selectAll().where("id", "=", id).executeTakeFirst();
+      const row = await db.selectFrom("connector_configs").selectAll().where("id", "=", id).executeTakeFirst();
+      return row ? decodeConnectorConfigRow(row, encryptionKey) : undefined;
     },
 
     /** Find connector configs by type. */
     async findConfigsByType(connectorType: ConnectorType) {
-      return db.selectFrom("connector_configs").selectAll().where("connector_type", "=", connectorType).execute();
+      const rows = await db
+        .selectFrom("connector_configs")
+        .selectAll()
+        .where("connector_type", "=", connectorType)
+        .execute();
+      return rows.map((row) => decodeConnectorConfigRow(row, encryptionKey));
     },
 
     /**
@@ -103,12 +118,13 @@ export function createConnectorRepository(db: Kysely<DB>) {
     async findSyncableConfigs(opts?: { staleAfterMs?: number }) {
       const staleAfterMs = opts?.staleAfterMs ?? 15 * 60 * 1000;
       const cutoff = new Date(Date.now() - staleAfterMs).toISOString();
-      return db
+      const rows = await db
         .selectFrom("connector_configs")
         .selectAll()
         .where("sync_status", "in", ["active", "pending", "error"])
         .where((eb) => eb.or([eb("last_synced_at", "is", null), eb("last_synced_at", "<", cutoff)]))
         .execute();
+      return rows.map((row) => decodeConnectorConfigRow(row, encryptionKey));
     },
 
     /** Find connector configs stuck in `syncing` state past the staleness threshold. */
@@ -124,12 +140,13 @@ export function createConnectorRepository(db: Kysely<DB>) {
 
     /** All connector configs owned by a user. */
     async listByOwner(createdBy: string) {
-      return db
+      const rows = await db
         .selectFrom("connector_configs")
         .selectAll()
         .where("created_by", "=", createdBy)
         .orderBy("created_at", "desc")
         .execute();
+      return rows.map((row) => decodeConnectorConfigRow(row, encryptionKey));
     },
 
     /**
@@ -145,7 +162,7 @@ export function createConnectorRepository(db: Kysely<DB>) {
           .updateTable("connector_configs")
           .set({
             sync_status: "disabled",
-            credentials: scrubbed,
+            credentials: encodeSecretField(scrubbed, encryptionKey),
             credential_hint: null,
             error_message: "Owner removed from workspace",
             updated_at: new Date().toISOString(),
@@ -158,12 +175,13 @@ export function createConnectorRepository(db: Kysely<DB>) {
 
     /** Find a connector config of a given type owned by the given user (used for per-user uniqueness). */
     async findByTypeAndOwner(connectorType: ConnectorType, createdBy: string) {
-      return db
+      const row = await db
         .selectFrom("connector_configs")
         .selectAll()
         .where("connector_type", "=", connectorType)
         .where("created_by", "=", createdBy)
         .executeTakeFirst();
+      return row ? decodeConnectorConfigRow(row, encryptionKey) : undefined;
     },
 
     /** Look up the connector config that owns a given indexed file (for file-scoped authz). */
@@ -192,14 +210,15 @@ export function createConnectorRepository(db: Kysely<DB>) {
           id,
           connector_type: data.connectorType,
           auth_type: data.authType,
-          credentials: data.credentials,
+          credentials: encodeSecretField(data.credentials, encryptionKey),
           scope_config: data.scopeConfig ?? "{}",
           created_by: data.createdBy,
           credential_hint: data.credentialHint ?? null,
         })
         .execute();
 
-      return db.selectFrom("connector_configs").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
+      const row = await db.selectFrom("connector_configs").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
+      return decodeConnectorConfigRow(row, encryptionKey);
     },
 
     /** Update connector config fields. */
@@ -217,7 +236,7 @@ export function createConnectorRepository(db: Kysely<DB>) {
       }>,
     ) {
       const values: Record<string, unknown> = {};
-      if (data.credentials !== undefined) values.credentials = data.credentials;
+      if (data.credentials !== undefined) values.credentials = encodeSecretField(data.credentials, encryptionKey);
       if (data.scopeConfig !== undefined) values.scope_config = data.scopeConfig;
       if (data.syncStatus !== undefined) values.sync_status = data.syncStatus;
       if (data.syncCursor !== undefined) values.sync_cursor = data.syncCursor;
@@ -231,7 +250,8 @@ export function createConnectorRepository(db: Kysely<DB>) {
         await db.updateTable("connector_configs").set(values).where("id", "=", id).execute();
       }
 
-      return db.selectFrom("connector_configs").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
+      const row = await db.selectFrom("connector_configs").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
+      return decodeConnectorConfigRow(row, encryptionKey);
     },
 
     /** Get all file IDs linked to a connector. */
@@ -680,12 +700,13 @@ export function createConnectorRepository(db: Kysely<DB>) {
     /** List connector configs accessible by a set of connector IDs. */
     async listConfigsByIds(ids: string[]) {
       if (ids.length === 0) return [];
-      return db
+      const rows = await db
         .selectFrom("connector_configs")
         .selectAll()
         .where("id", "in", ids)
         .orderBy("created_at", "desc")
         .execute();
+      return rows.map((row) => decodeConnectorConfigRow(row, encryptionKey));
     },
 
     /**

--- a/packages/server/src/db/repositories/provider-identities.ts
+++ b/packages/server/src/db/repositories/provider-identities.ts
@@ -6,29 +6,49 @@
  */
 import { randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";
+import { decodeSecretField, encodeSecretField } from "../../auth/secret-fields";
 import type { ConnectorType } from "../../connectors/types";
 import type { DB } from "../schema";
 
-export function createProviderIdentityRepository(db: Kysely<DB>) {
+function decodeProviderIdentityRow<T extends { access_token: string | null; refresh_token: string | null }>(
+  row: T,
+  encryptionKey?: string,
+): T {
+  return {
+    ...row,
+    access_token:
+      row.access_token === null
+        ? null
+        : decodeSecretField(row.access_token, encryptionKey, "user_provider_identities.access_token"),
+    refresh_token:
+      row.refresh_token === null
+        ? null
+        : decodeSecretField(row.refresh_token, encryptionKey, "user_provider_identities.refresh_token"),
+  };
+}
+
+export function createProviderIdentityRepository(db: Kysely<DB>, encryptionKey?: string) {
   return {
     /** Find a user's identity for a specific provider. */
     async findByUserAndProvider(userId: string, provider: ConnectorType) {
-      return db
+      const row = await db
         .selectFrom("user_provider_identities")
         .selectAll()
         .where("user_id", "=", userId)
         .where("provider", "=", provider)
         .executeTakeFirst();
+      return row ? decodeProviderIdentityRow(row, encryptionKey) : undefined;
     },
 
     /** Get all provider identities for a user. */
     async findByUser(userId: string) {
-      return db
+      const rows = await db
         .selectFrom("user_provider_identities")
         .selectAll()
         .where("user_id", "=", userId)
         .orderBy("connected_at", "desc")
         .execute();
+      return rows.map((row) => decodeProviderIdentityRow(row, encryptionKey));
     },
 
     /** Get all connected provider user IDs for a user (across all providers). */
@@ -59,17 +79,23 @@ export function createProviderIdentityRepository(db: Kysely<DB>) {
           provider_user_id: data.providerUserId,
         };
         if (data.providerEmail !== undefined) values.provider_email = data.providerEmail;
-        if (data.accessToken !== undefined) values.access_token = data.accessToken;
-        if (data.refreshToken !== undefined) values.refresh_token = data.refreshToken;
+        if (data.accessToken !== undefined) {
+          values.access_token = data.accessToken === null ? null : encodeSecretField(data.accessToken, encryptionKey);
+        }
+        if (data.refreshToken !== undefined) {
+          values.refresh_token =
+            data.refreshToken === null ? null : encodeSecretField(data.refreshToken, encryptionKey);
+        }
         if (data.tokenExpiresAt !== undefined) values.token_expires_at = data.tokenExpiresAt;
 
         await db.updateTable("user_provider_identities").set(values).where("id", "=", existing.id).execute();
 
-        return db
+        const row = await db
           .selectFrom("user_provider_identities")
           .selectAll()
           .where("id", "=", existing.id)
           .executeTakeFirstOrThrow();
+        return decodeProviderIdentityRow(row, encryptionKey);
       }
 
       const id = randomUUID();
@@ -81,13 +107,24 @@ export function createProviderIdentityRepository(db: Kysely<DB>) {
           provider: data.provider,
           provider_user_id: data.providerUserId,
           provider_email: data.providerEmail ?? null,
-          access_token: data.accessToken ?? null,
-          refresh_token: data.refreshToken ?? null,
+          access_token:
+            data.accessToken === undefined || data.accessToken === null
+              ? null
+              : encodeSecretField(data.accessToken, encryptionKey),
+          refresh_token:
+            data.refreshToken === undefined || data.refreshToken === null
+              ? null
+              : encodeSecretField(data.refreshToken, encryptionKey),
           token_expires_at: data.tokenExpiresAt ?? null,
         })
         .execute();
 
-      return db.selectFrom("user_provider_identities").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
+      const row = await db
+        .selectFrom("user_provider_identities")
+        .selectAll()
+        .where("id", "=", id)
+        .executeTakeFirstOrThrow();
+      return decodeProviderIdentityRow(row, encryptionKey);
     },
 
     /** Remove a provider identity (disconnect). */
@@ -101,7 +138,12 @@ export function createProviderIdentityRepository(db: Kysely<DB>) {
 
     /** List all identities for a provider (admin view). */
     async findByProvider(provider: ConnectorType) {
-      return db.selectFrom("user_provider_identities").selectAll().where("provider", "=", provider).execute();
+      const rows = await db
+        .selectFrom("user_provider_identities")
+        .selectAll()
+        .where("provider", "=", provider)
+        .execute();
+      return rows.map((row) => decodeProviderIdentityRow(row, encryptionKey));
     },
   };
 }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -94,7 +94,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   const channels = createChannelRepository(db);
   const whatsappGroups = createWhatsAppGroupRepository(db);
   const inboxMessages = createInboxMessagesRepository(db);
-  const connectors = createConnectorRepository(db);
+  const connectors = createConnectorRepository(db, config.ENCRYPTION_KEY);
   const agentEnvVars = createAgentEnvironmentVariableRepository(db, config.ENCRYPTION_KEY);
   const mcpServers = createMcpServerRepository(db);
   const logger = deps?.logger ?? (console as unknown as Logger);
@@ -324,7 +324,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     app.route("/api/connectors", connectorRoutes(connectors, db, deps.logger, users, config));
   }
 
-  const identities = createProviderIdentityRepository(db);
+  const identities = createProviderIdentityRepository(db, config.ENCRYPTION_KEY);
   app.route("/api/identities", providerIdentityRoutes(identities, users));
 
   if (deps?.logger) {


### PR DESCRIPTION
## What & why

Encrypts `connector_configs.credentials` and `user_provider_identities` access/refresh tokens **at rest**, closing the gap where OAuth refresh tokens and API keys were stored in plaintext. This is a prerequisite for the per-user Gmail/email connectors (which persist real OAuth refresh tokens) — split out as its own PR so the security change lands and reviews independently.

## How

- Encrypt/decrypt at the **repository layer** using the existing AES-256-GCM helper, with an `enc:` prefix marker.
- **Backward-compatible passthrough** for legacy plaintext rows, plus a startup **backfill** (`credential-encryption-backfill.ts`) that migrates existing rows.
- Thread `ENCRYPTION_KEY` through all connector / provider-identity repository construction sites.
- New `secret-fields.ts` helper centralizes which fields are encrypted.

## Scope

- 14 files, +410/−36. No schema migration — encryption is transparent at the repo layer.
- Server-only; no API or UI surface change.

## Testing

- `connector-credential-encryption.test.ts` (6 tests): round-trip encrypt/decrypt, legacy-plaintext passthrough, backfill behavior.
- Full `pnpm test` + `pnpm build` pass via the pre-push gate.

## Notes for reviewers

This is **PR 1 of 2** in the comms-connectors stack. The Gmail/email connector work (shared email layer, adapter, thread-aware enrichment, UI) follows in a second PR once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)