### PR TITLE
feat: add Outlook connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ LOG_LEVEL=info          # debug | info | warn | error
 # ZOHO_CLIENT_ID=
 # ZOHO_CLIENT_SECRET=
 
+# Microsoft OAuth (required for Outlook connector)
+# MICROSOFT_CLIENT_ID=
+# MICROSOFT_CLIENT_SECRET=
+
 # Visual analysis tool for text-only LLM deployments
 # VISION_ENABLED=false
 # VISION_MODEL=xiaomi/mimo-v2.5

--- a/packages/server/src/api/oauth.ts
+++ b/packages/server/src/api/oauth.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { verifyJwt } from "../auth/jwt";
 import type { Config } from "../config";
 import { ensureValidToken } from "../connectors/google-drive";
+import { validateOutlookCredentials } from "../connectors/outlook";
 import { runConnectorSync } from "../connectors/sync";
 import type { ConnectorType, OAuthCredentials } from "../connectors/types";
 import { validateZohoCrmCredentials } from "../connectors/zoho-crm";
@@ -44,6 +45,8 @@ const zohoRegionSchema = z.enum(ZOHO_REGIONS);
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const MICROSOFT_AUTH_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
+const MICROSOFT_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
 const DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.readonly";
 const GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
 const USERINFO_SCOPE = "https://www.googleapis.com/auth/userinfo.email";
@@ -102,6 +105,8 @@ export function oauthRoutes(
         experimentalFlag?: boolean;
         zohoClientId?: string;
         zohoClientSecret?: string;
+        microsoftClientId?: string;
+        microsoftClientSecret?: string;
       } = {},
 ) {
   const routes = new Hono();
@@ -110,6 +115,8 @@ export function oauthRoutes(
   const experimentalFlag = typeof opts === "string" ? false : (opts.experimentalFlag ?? false);
   const zohoClientId = typeof opts === "string" ? undefined : opts.zohoClientId;
   const zohoClientSecret = typeof opts === "string" ? undefined : opts.zohoClientSecret;
+  const microsoftClientId = typeof opts === "string" ? undefined : opts.microsoftClientId;
+  const microsoftClientSecret = typeof opts === "string" ? undefined : opts.microsoftClientSecret;
 
   /**
    * GET /google/authorize
@@ -322,6 +329,190 @@ export function oauthRoutes(
     return c.json({
       configured: !!(config?.google_oauth_client_id && config?.google_oauth_client_secret),
       clientId: config?.google_oauth_client_id ?? null,
+      baseUrl: baseUrl ?? null,
+    });
+  });
+
+  routes.get("/microsoft/authorize", async (c) => {
+    if (!microsoftClientId || !microsoftClientSecret) {
+      return c.json(
+        {
+          error: {
+            code: "OAUTH_CLIENT_NOT_CONFIGURED",
+            message: "Set MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET before connecting Outlook",
+            connector: "outlook",
+          },
+        },
+        412,
+      );
+    }
+
+    const userId = c.get("sub");
+    if (!userId || typeof userId !== "string") {
+      return c.json({ error: { code: "UNAUTHORIZED", message: "Authentication required" } }, 401);
+    }
+
+    const existingConnector = await connectors.findByTypeAndOwner("outlook", userId);
+    if (existingConnector) {
+      return c.json(
+        {
+          error: {
+            code: "ALREADY_CONNECTED",
+            message: "Outlook is already connected for this user.",
+            connector: "outlook",
+          },
+        },
+        409,
+      );
+    }
+
+    cleanupExpiredStates();
+
+    const nonce = randomBytes(16).toString("hex");
+    const state = `${userId}:${nonce}`;
+    pendingStates.set(nonce, { userId, connectorType: "outlook", expiresAt: Date.now() + 10 * 60 * 1000 });
+
+    const origin = baseUrl ?? new URL(c.req.url).origin;
+    const redirectUri = `${origin}/api/oauth/microsoft/callback`;
+    const params = new URLSearchParams({
+      client_id: microsoftClientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      response_mode: "query",
+      scope: "offline_access User.Read Mail.Read",
+      state,
+    });
+
+    return c.redirect(`${MICROSOFT_AUTH_URL}?${params.toString()}`);
+  });
+
+  routes.get("/microsoft/callback", async (c) => {
+    const code = c.req.query("code");
+    const state = c.req.query("state");
+    const error = c.req.query("error");
+
+    if (error) {
+      logger.warn({ error }, "Microsoft OAuth denied");
+      return c.redirect("/files?oauth=error&connector=outlook&reason=denied");
+    }
+
+    if (!code || !state) {
+      return c.redirect("/files?oauth=error&connector=outlook&reason=missing_params");
+    }
+
+    const colonIdx = state.indexOf(":");
+    if (colonIdx === -1) {
+      return c.redirect("/files?oauth=error&connector=outlook&reason=invalid_state");
+    }
+
+    const userId = state.substring(0, colonIdx);
+    const nonce = state.substring(colonIdx + 1);
+
+    cleanupExpiredStates();
+    const pending = pendingStates.get(nonce);
+    if (!pending || pending.userId !== userId || pending.connectorType !== "outlook") {
+      return c.redirect("/files?oauth=error&connector=outlook&reason=invalid_state");
+    }
+    pendingStates.delete(nonce);
+
+    if (!microsoftClientId || !microsoftClientSecret) {
+      return c.redirect("/files?oauth=error&connector=outlook&reason=not_configured");
+    }
+
+    const origin = baseUrl ?? new URL(c.req.url).origin;
+    const redirectUri = `${origin}/api/oauth/microsoft/callback`;
+
+    try {
+      const existingConnector = await connectors.findByTypeAndOwner("outlook", userId);
+      if (existingConnector) {
+        return c.redirect(
+          `/files?oauth=error&connector=outlook&reason=already_connected&connectorId=${existingConnector.id}`,
+        );
+      }
+
+      const tokenRes = await fetch(MICROSOFT_TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          code,
+          client_id: microsoftClientId,
+          client_secret: microsoftClientSecret,
+          redirect_uri: redirectUri,
+          grant_type: "authorization_code",
+          scope: "offline_access User.Read Mail.Read",
+        }),
+      });
+
+      if (!tokenRes.ok) {
+        const errBody = await tokenRes.text();
+        logger.error({ status: tokenRes.status, body: errBody }, "Microsoft token exchange failed");
+        return c.redirect("/files?oauth=error&connector=outlook&reason=token_exchange");
+      }
+
+      const tokenData = (await tokenRes.json()) as {
+        access_token: string;
+        refresh_token?: string;
+        expires_in: number;
+        token_type?: string;
+      };
+
+      if (!tokenData.refresh_token) {
+        logger.error("No Microsoft refresh_token in response");
+        return c.redirect("/files?oauth=error&connector=outlook&reason=no_refresh_token");
+      }
+
+      const expiresAt = new Date(Date.now() + tokenData.expires_in * 1000).toISOString();
+      const oauthCreds: OAuthCredentials = {
+        type: "oauth",
+        access_token: tokenData.access_token,
+        refresh_token: tokenData.refresh_token,
+        token_type: tokenData.token_type,
+        expires_at: expiresAt,
+        client_id: microsoftClientId,
+        client_secret: microsoftClientSecret,
+      };
+
+      await validateOutlookCredentials(oauthCreds);
+      const profile = await fetchMicrosoftCurrentUser(oauthCreds, logger);
+      const providerEmail = profile.mail ?? profile.userPrincipalName ?? null;
+      const providerUserId = profile.id ?? providerEmail ?? userId;
+
+      await identities.upsert({
+        userId,
+        provider: "outlook",
+        providerUserId,
+        providerEmail,
+        accessToken: tokenData.access_token,
+        refreshToken: tokenData.refresh_token,
+        tokenExpiresAt: expiresAt,
+      });
+
+      const connectorConfig = await connectors.createConfig({
+        connectorType: "outlook",
+        authType: "oauth",
+        credentials: JSON.stringify(oauthCreds),
+        scopeConfig: JSON.stringify({}),
+        createdBy: userId,
+        credentialHint: providerEmail,
+      });
+
+      logger.info({ userId, connectorId: connectorConfig.id, providerEmail }, "Microsoft OAuth tokens saved");
+
+      runConnectorSync(db, connectorConfig.id, logger, appConfig).catch((err) => {
+        logger.error({ err, connectorId: connectorConfig.id }, "Outlook first sync failed");
+      });
+
+      return c.redirect(`/files?oauth=success&connector=outlook&connectorId=${connectorConfig.id}`);
+    } catch (err) {
+      logger.error({ err, userId }, "Microsoft OAuth callback failed");
+      return c.redirect("/files?oauth=error&connector=outlook&reason=internal");
+    }
+  });
+
+  routes.get("/microsoft/status", (c) => {
+    return c.json({
+      configured: !!(microsoftClientId && microsoftClientSecret),
+      clientId: microsoftClientId ?? null,
       baseUrl: baseUrl ?? null,
     });
   });
@@ -570,5 +761,23 @@ async function fetchZohoCurrentUserHint(credentials: OAuthCredentials, logger: L
   } catch (err) {
     logger.warn({ err }, "Failed to fetch Zoho CRM current user hint");
     return null;
+  }
+}
+
+async function fetchMicrosoftCurrentUser(
+  credentials: OAuthCredentials,
+  logger: Logger,
+): Promise<{ id?: string; mail?: string | null; userPrincipalName?: string | null }> {
+  try {
+    const url = new URL("https://graph.microsoft.com/v1.0/me");
+    url.searchParams.set("$select", "id,mail,userPrincipalName");
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${credentials.access_token}` },
+    });
+    if (!res.ok) return {};
+    return (await res.json()) as { id?: string; mail?: string | null; userPrincipalName?: string | null };
+  } catch (err) {
+    logger.warn({ err }, "Failed to fetch Microsoft current user hint");
+    return {};
   }
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -72,6 +72,10 @@ export const configSchema = z.object({
   ZOHO_CLIENT_ID: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   ZOHO_CLIENT_SECRET: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
 
+  // Microsoft OAuth
+  MICROSOFT_CLIENT_ID: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
+  MICROSOFT_CLIENT_SECRET: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
+
   // PostHog (optional, enables LLM Analytics via OpenTelemetry)
   POSTHOG_API_KEY: z.string().optional(),
   POSTHOG_HOST: z.string().default("https://us.i.posthog.com"),

--- a/packages/server/src/connectors/outlook.test.ts
+++ b/packages/server/src/connectors/outlook.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "../test-utils";
+import type { EmailSyncedItem } from "./email";
+import { type OutlookMessage, createOutlookConnector, toNormalizedOutlookEmail } from "./outlook";
+import type { OAuthCredentials } from "./types";
+
+const logger = createTestLogger();
+
+function outlookMessage(
+  id: string,
+  overrides: {
+    internetMessageId?: string | null;
+    from?: { name?: string; address?: string };
+    to?: Array<{ name?: string; address?: string }>;
+    subject?: string;
+    body?: string;
+    headers?: Array<{ name: string; value: string }>;
+  } = {},
+): OutlookMessage {
+  return {
+    id,
+    internetMessageId: overrides.internetMessageId ?? `<${id}@example.com>`,
+    conversationId: "conversation-1",
+    subject: overrides.subject ?? "Pricing discussion",
+    sentDateTime: "2026-02-04T10:00:00Z",
+    receivedDateTime: "2026-02-04T10:00:02Z",
+    webLink: `https://outlook.office.com/mail/id/${id}`,
+    from: { emailAddress: overrides.from ?? { name: "Jane Doe", address: "jane@example.com" } },
+    toRecipients: (overrides.to ?? [{ name: "Owner", address: "owner@canvasx.ai" }]).map((emailAddress) => ({
+      emailAddress,
+    })),
+    ccRecipients: [],
+    bccRecipients: [],
+    body: { contentType: "text", content: overrides.body ?? "Can we discuss pricing?" },
+    bodyPreview: overrides.body ?? "Can we discuss pricing?",
+    internetMessageHeaders: overrides.headers ?? [{ name: "Message-ID", value: `<${id}@example.com>` }],
+  };
+}
+
+describe("Outlook connector", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes Microsoft Graph messages into the shared email envelope shape", () => {
+    const normalized = toNormalizedOutlookEmail(outlookMessage("outlook-1"), "owner@canvasx.ai");
+
+    expect(normalized).toMatchObject({
+      providerFileId: "outlook-1",
+      providerMessageId: "<outlook-1@example.com>",
+      threadId: "conversation-1",
+      folder: "inbox",
+      bodyText: "Can we discuss pricing?",
+    });
+    expect(normalized?.from).toEqual({ name: "Jane Doe", email: "jane@example.com" });
+  });
+
+  it("syncs retained reciprocal messages and records suppressed bulk messages", async () => {
+    const connector = createOutlookConnector();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+      const url = new URL(input.toString());
+
+      if (url.pathname === "/v1.0/me/messages") {
+        return jsonResponse({ value: [{ id: "retained" }, { id: "bulk" }] });
+      }
+
+      if (url.pathname === "/v1.0/me/mailFolders/sentitems/messages") {
+        return jsonResponse({ value: [{ id: "sent" }] });
+      }
+
+      if (url.pathname.endsWith("/messages/retained")) {
+        return jsonResponse(outlookMessage("retained"));
+      }
+
+      if (url.pathname.endsWith("/messages/bulk")) {
+        return jsonResponse(
+          outlookMessage("bulk", {
+            from: { name: "Newsletter", address: "news@example.com" },
+            subject: "Weekly update",
+            headers: [{ name: "List-Unsubscribe", value: "<mailto:unsubscribe@example.com>" }],
+          }),
+        );
+      }
+
+      if (url.pathname.endsWith("/messages/sent")) {
+        return jsonResponse(
+          outlookMessage("sent", {
+            from: { name: "Owner", address: "owner@canvasx.ai" },
+            to: [{ name: "Jane Doe", address: "jane@example.com" }],
+          }),
+        );
+      }
+
+      throw new Error(`unexpected fetch ${url.toString()}`);
+    });
+
+    const suppressed: Array<{ providerFileId: string; reason: string }> = [];
+    const items: EmailSyncedItem[] = [];
+    for await (const item of connector.sync({
+      connectorConfigId: "connector-outlook",
+      credentials: validCredentials(),
+      scopeConfig: { initialDays: 90, maxMessages: 10, maxReciprocitySent: 10 },
+      cursor: null,
+      logger,
+      ownerEmail: "owner@canvasx.ai",
+      onEmailSuppressed: async (record) => {
+        suppressed.push({ providerFileId: record.providerFileId, reason: record.reason });
+      },
+    })) {
+      items.push(item as EmailSyncedItem);
+    }
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      providerFileId: "retained",
+      providerMessageId: "<retained@example.com>",
+      fileType: "email_message",
+      accessEmails: ["jane@example.com", "owner@canvasx.ai"],
+      authorEmail: "jane@example.com",
+    });
+    expect(items[0].emailEnvelope.connectorConfigId).toBe("connector-outlook");
+    expect(suppressed).toEqual([{ providerFileId: "bulk", reason: "bulk" }]);
+  });
+});
+
+function validCredentials(): OAuthCredentials {
+  return {
+    type: "oauth",
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    client_id: "client",
+    client_secret: "secret",
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+}

--- a/packages/server/src/connectors/outlook.ts
+++ b/packages/server/src/connectors/outlook.ts
@@ -1,0 +1,451 @@
+import type { Logger } from "pino";
+import { emailToSyncedItem } from "./email";
+import {
+  type EmailAddr,
+  type NormalizedEmail,
+  normalizeEmailValue,
+  normalizeHeaderMap,
+  shouldSuppressEmail,
+  updateReciprocitySet,
+} from "./email";
+import { runWithConcurrency } from "./sync-utils";
+import type { Connector, ConnectorCredentials, OAuthCredentials, SuppressedEmailRecord } from "./types";
+
+const GRAPH_API = "https://graph.microsoft.com/v1.0";
+const TOKEN_ENDPOINT = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 1000;
+const DEFAULT_INITIAL_DAYS = 90;
+const DEFAULT_MAX_MESSAGES = 500;
+const DEFAULT_RECIPROCITY_DAYS = 365;
+const DEFAULT_MAX_RECIPROCITY_SENT = 250;
+const MESSAGE_FETCH_CONCURRENCY = 12;
+
+interface OutlookEmailAddress {
+  name?: string | null;
+  address?: string | null;
+}
+
+interface OutlookRecipient {
+  emailAddress?: OutlookEmailAddress | null;
+}
+
+interface OutlookHeader {
+  name?: string | null;
+  value?: string | null;
+}
+
+export interface OutlookMessage {
+  id: string;
+  internetMessageId?: string | null;
+  conversationId?: string | null;
+  subject?: string | null;
+  sentDateTime?: string | null;
+  receivedDateTime?: string | null;
+  webLink?: string | null;
+  from?: OutlookRecipient | null;
+  sender?: OutlookRecipient | null;
+  toRecipients?: OutlookRecipient[];
+  ccRecipients?: OutlookRecipient[];
+  bccRecipients?: OutlookRecipient[];
+  body?: { contentType?: string | null; content?: string | null } | null;
+  bodyPreview?: string | null;
+  internetMessageHeaders?: OutlookHeader[];
+}
+
+interface OutlookListResponse<T> {
+  value?: T[];
+  "@odata.nextLink"?: string;
+}
+
+type OutlookCursor = { mode: "time"; since: string; reciprocityEmails?: string[] };
+
+function assertOAuth(credentials: ConnectorCredentials): asserts credentials is OAuthCredentials {
+  if (credentials.type !== "oauth") {
+    throw new Error("Outlook connector requires OAuth credentials");
+  }
+}
+
+function parsePositiveInt(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(Math.floor(value), max));
+}
+
+function parseCursor(cursor: string | null): OutlookCursor | null {
+  if (!cursor) return null;
+  try {
+    const parsed = JSON.parse(cursor) as Partial<OutlookCursor>;
+    if (parsed.mode !== "time" || !parsed.since) return null;
+    return { mode: "time", since: parsed.since, reciprocityEmails: parsed.reciprocityEmails };
+  } catch {
+    return null;
+  }
+}
+
+function serializeCursor(cursor: OutlookCursor): string {
+  return JSON.stringify(cursor);
+}
+
+function cursorReciprocity(cursor: OutlookCursor | null): Set<string> {
+  return new Set(cursor?.reciprocityEmails ?? []);
+}
+
+function withReciprocity(cursor: Omit<OutlookCursor, "reciprocityEmails">, reciprocity: ReadonlySet<string>) {
+  return { ...cursor, reciprocityEmails: [...reciprocity].slice(0, 5000) };
+}
+
+function isTokenExpired(credentials: OAuthCredentials): boolean {
+  if (!credentials.expires_at) return true;
+  return new Date(credentials.expires_at).getTime() < Date.now() + 60_000;
+}
+
+async function refreshOAuthToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: credentials.refresh_token,
+      client_id: credentials.client_id,
+      client_secret: credentials.client_secret,
+      scope: "offline_access User.Read Mail.Read",
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Microsoft token refresh failed (${response.status}): ${body}`);
+  }
+
+  const data = (await response.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+    token_type?: string;
+  };
+
+  return {
+    ...credentials,
+    access_token: data.access_token,
+    refresh_token: data.refresh_token ?? credentials.refresh_token,
+    token_type: data.token_type ?? credentials.token_type,
+    expires_at: new Date(Date.now() + data.expires_in * 1000).toISOString(),
+  };
+}
+
+async function ensureValidMicrosoftToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+  return isTokenExpired(credentials) ? refreshOAuthToken(credentials) : credentials;
+}
+
+async function graphRequest(
+  pathOrUrl: string,
+  accessToken: string,
+  opts?: { params?: Record<string, string> },
+  attempt = 1,
+): Promise<unknown> {
+  const url = pathOrUrl.startsWith("http") ? new URL(pathOrUrl) : new URL(`${GRAPH_API}${pathOrUrl}`);
+  for (const [key, value] of Object.entries(opts?.params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (attempt < MAX_RETRIES) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_BASE_MS * 2 ** (attempt - 1)));
+      return graphRequest(pathOrUrl, accessToken, opts, attempt + 1);
+    }
+    throw err;
+  }
+
+  if (response.status === 429 || response.status >= 500) {
+    if (attempt < MAX_RETRIES) {
+      const retryAfter = response.headers.get("Retry-After");
+      const waitMs = retryAfter ? Number.parseInt(retryAfter, 10) * 1000 : RETRY_BASE_MS * 2 ** (attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+      return graphRequest(pathOrUrl, accessToken, opts, attempt + 1);
+    }
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Microsoft Graph ${url.pathname} failed (${response.status}): ${body}`);
+  }
+
+  return response.json();
+}
+
+function toEmailAddr(recipient: OutlookRecipient | null | undefined): EmailAddr | null {
+  const raw = recipient?.emailAddress;
+  const email = normalizeEmailValue(raw?.address);
+  if (!email) return null;
+  const name = raw?.name?.trim();
+  return name && name !== email ? { name, email } : { email };
+}
+
+function toEmailAddrs(recipients: OutlookRecipient[] | undefined): EmailAddr[] {
+  return (recipients ?? [])
+    .map((recipient) => toEmailAddr(recipient))
+    .filter((addr): addr is EmailAddr => Boolean(addr));
+}
+
+function normalizeDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function fallbackMessageId(message: OutlookMessage): string {
+  return `outlook:${message.id}`;
+}
+
+export function toNormalizedOutlookEmail(message: OutlookMessage, ownerEmail: string | null): NormalizedEmail | null {
+  if (!message.id) return null;
+  const from = toEmailAddr(message.from) ?? toEmailAddr(message.sender);
+  if (!from) return null;
+
+  const bodyType = message.body?.contentType?.toLowerCase();
+  const bodyContent = message.body?.content ?? null;
+  const headers = normalizeHeaderMap(
+    (message.internetMessageHeaders ?? []).map((header) => [header.name ?? "", header.value ?? ""]),
+  );
+  const owner = normalizeEmailValue(ownerEmail);
+  const fromOwner = Boolean(owner && normalizeEmailValue(from.email) === owner);
+
+  return {
+    providerMessageId: message.internetMessageId?.trim() || fallbackMessageId(message),
+    providerFileId: message.id,
+    threadId: message.conversationId ?? null,
+    subject: message.subject ?? null,
+    sentAt: normalizeDate(message.sentDateTime ?? message.receivedDateTime),
+    from,
+    to: toEmailAddrs(message.toRecipients),
+    cc: toEmailAddrs(message.ccRecipients),
+    bcc: toEmailAddrs(message.bccRecipients),
+    headers,
+    bodyHtml: bodyType === "html" ? bodyContent : null,
+    bodyText: bodyType !== "html" ? (bodyContent ?? message.bodyPreview ?? null) : (message.bodyPreview ?? null),
+    providerUrl: message.webLink ?? null,
+    ownerEmail: owner,
+    folder: fromOwner ? "sent" : "inbox",
+  };
+}
+
+async function listMessages(
+  accessToken: string,
+  path: string,
+  params: Record<string, string>,
+  maxMessages: number,
+): Promise<OutlookMessage[]> {
+  const messages: OutlookMessage[] = [];
+  let nextUrl: string | undefined;
+  do {
+    const result = (await graphRequest(
+      nextUrl ?? path,
+      accessToken,
+      nextUrl ? undefined : { params },
+    )) as OutlookListResponse<OutlookMessage>;
+    messages.push(...(result.value ?? []));
+    nextUrl = result["@odata.nextLink"];
+  } while (nextUrl && messages.length < maxMessages);
+  return messages.slice(0, maxMessages);
+}
+
+async function getMessage(accessToken: string, id: string): Promise<OutlookMessage> {
+  const select = [
+    "id",
+    "internetMessageId",
+    "conversationId",
+    "subject",
+    "sentDateTime",
+    "receivedDateTime",
+    "webLink",
+    "from",
+    "sender",
+    "toRecipients",
+    "ccRecipients",
+    "bccRecipients",
+    "body",
+    "bodyPreview",
+    "internetMessageHeaders",
+  ].join(",");
+  return (await graphRequest(`/me/messages/${encodeURIComponent(id)}`, accessToken, {
+    params: { $select: select },
+  })) as OutlookMessage;
+}
+
+async function getNormalizedMessages(
+  accessToken: string,
+  messages: OutlookMessage[],
+  ownerEmail: string | null,
+  logger: Logger,
+): Promise<NormalizedEmail[]> {
+  const normalized: Array<NormalizedEmail | null> = new Array(messages.length).fill(null);
+  await runWithConcurrency(
+    messages.map((message, index) => ({ message, index })),
+    MESSAGE_FETCH_CONCURRENCY,
+    async ({ message, index }) => {
+      try {
+        const full =
+          message.body && message.internetMessageHeaders ? message : await getMessage(accessToken, message.id);
+        normalized[index] = toNormalizedOutlookEmail(full, ownerEmail);
+      } catch (err) {
+        logger.warn({ err, messageId: message.id }, "Failed to fetch Outlook message");
+      }
+    },
+  );
+  return normalized.filter((message): message is NormalizedEmail => Boolean(message));
+}
+
+async function loadRecentSentMessages(
+  accessToken: string,
+  ownerEmail: string | null,
+  scopeConfig: Record<string, unknown>,
+  logger: Logger,
+): Promise<NormalizedEmail[]> {
+  const days = parsePositiveInt(scopeConfig.reciprocityDays, DEFAULT_RECIPROCITY_DAYS, 3650);
+  const maxMessages = parsePositiveInt(scopeConfig.maxReciprocitySent, DEFAULT_MAX_RECIPROCITY_SENT, 2000);
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  const messages = await listMessages(
+    accessToken,
+    "/me/mailFolders/sentitems/messages",
+    {
+      $top: String(Math.min(maxMessages, 100)),
+      $orderby: "sentDateTime desc",
+      $filter: `sentDateTime ge ${since}`,
+      $select: "id,internetMessageId,conversationId,subject,sentDateTime,webLink,from,toRecipients,ccRecipients",
+    },
+    maxMessages,
+  );
+  return getNormalizedMessages(accessToken, messages, ownerEmail, logger);
+}
+
+function mergeReciprocity(
+  base: ReadonlySet<string>,
+  emails: NormalizedEmail[],
+  recentSent: NormalizedEmail[] = [],
+): Set<string> {
+  const reciprocity = new Set(base);
+  const ownerEmail = emails[0]?.ownerEmail ?? recentSent[0]?.ownerEmail ?? null;
+  for (const email of updateReciprocitySet([...recentSent, ...emails], ownerEmail)) {
+    reciprocity.add(email);
+  }
+  return reciprocity;
+}
+
+async function* emitFilteredEmails(
+  connectorConfigId: string,
+  emails: NormalizedEmail[],
+  reciprocity: ReadonlySet<string>,
+  onEmailSuppressed: ((record: SuppressedEmailRecord) => Promise<void>) | undefined,
+): AsyncGenerator<ReturnType<typeof emailToSyncedItem>> {
+  for (const email of emails) {
+    const decision = shouldSuppressEmail(email, reciprocity);
+    if (decision.suppressed) {
+      await onEmailSuppressed?.({
+        providerFileId: email.providerFileId,
+        providerMessageId: email.providerMessageId,
+        threadId: email.threadId,
+        reason: decision.reason,
+      });
+      continue;
+    }
+    yield emailToSyncedItem(connectorConfigId, email, decision.gate);
+  }
+}
+
+async function getMe(
+  accessToken: string,
+): Promise<{ id?: string; mail?: string | null; userPrincipalName?: string | null }> {
+  return (await graphRequest("/me", accessToken, {
+    params: { $select: "id,mail,userPrincipalName" },
+  })) as { id?: string; mail?: string | null; userPrincipalName?: string | null };
+}
+
+export async function validateOutlookCredentials(credentials: ConnectorCredentials): Promise<void> {
+  assertOAuth(credentials);
+  const valid = await ensureValidMicrosoftToken(credentials);
+  await getMe(valid.access_token);
+}
+
+export function createOutlookConnector(): Connector {
+  let nextCursor: OutlookCursor | null = null;
+
+  return {
+    type: "outlook",
+    perUserAuth: true,
+    requiresOAuthClientSetup: false,
+    emitsCorrespondentFacts: true,
+
+    validateCredentials: validateOutlookCredentials,
+
+    async *sync({
+      connectorConfigId = "outlook",
+      credentials,
+      scopeConfig,
+      cursor,
+      logger,
+      ownerEmail,
+      onEmailSuppressed,
+    }) {
+      assertOAuth(credentials);
+      const valid = await ensureValidMicrosoftToken(credentials);
+      const parsedCursor = parseCursor(cursor);
+      const initialDays = parsePositiveInt(scopeConfig.initialDays, DEFAULT_INITIAL_DAYS, 3650);
+      const maxMessages = parsePositiveInt(scopeConfig.maxMessages, DEFAULT_MAX_MESSAGES, 5000);
+      const since = parsedCursor?.since ?? new Date(Date.now() - initialDays * 24 * 60 * 60 * 1000).toISOString();
+      const select = [
+        "id",
+        "internetMessageId",
+        "conversationId",
+        "subject",
+        "sentDateTime",
+        "receivedDateTime",
+        "webLink",
+        "from",
+        "sender",
+        "toRecipients",
+        "ccRecipients",
+        "bodyPreview",
+      ].join(",");
+      const messages = await listMessages(
+        valid.access_token,
+        "/me/messages",
+        {
+          $top: String(Math.min(maxMessages, 100)),
+          $orderby: "receivedDateTime desc",
+          $filter: `receivedDateTime ge ${since}`,
+          $select: select,
+        },
+        maxMessages,
+      );
+      const emails = await getNormalizedMessages(valid.access_token, messages, ownerEmail ?? null, logger);
+      const recentSent = parsedCursor
+        ? []
+        : await loadRecentSentMessages(valid.access_token, ownerEmail ?? null, scopeConfig, logger);
+      const reciprocity = mergeReciprocity(cursorReciprocity(parsedCursor), emails, recentSent);
+      const maxSeen = emails
+        .map((email) => email.sentAt)
+        .filter((value): value is string => Boolean(value))
+        .sort()
+        .at(-1);
+      nextCursor = withReciprocity({ mode: "time", since: maxSeen ?? new Date().toISOString() }, reciprocity);
+
+      yield* emitFilteredEmails(connectorConfigId, emails, reciprocity, onEmailSuppressed);
+    },
+
+    async getCursor() {
+      return nextCursor ? serializeCursor(nextCursor) : null;
+    },
+
+    async refreshTokens(credentials) {
+      return isTokenExpired(credentials) ? refreshOAuthToken(credentials) : null;
+    },
+  };
+}

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -18,11 +18,13 @@ import { createGmailConnector } from "./gmail";
 import { createGoogleDriveConnector } from "./google-drive";
 import { createLinearConnector } from "./linear";
 import { createNotionConnector } from "./notion";
+import { createOutlookConnector } from "./outlook";
 import { createZohoCrmConnector } from "./zoho-crm";
 
 export const connectorFactories: Record<ConnectorType, () => Connector> = {
   google_drive: createGoogleDriveConnector,
   gmail: createGmailConnector,
+  outlook: createOutlookConnector,
   clickup: createClickUpConnector,
   notion: createNotionConnector,
   linear: createLinearConnector,

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -8,7 +8,15 @@
  */
 import type { Logger } from "pino";
 
-export type ConnectorType = "google_drive" | "gmail" | "clickup" | "notion" | "linear" | "fireflies" | "zoho_crm";
+export type ConnectorType =
+  | "google_drive"
+  | "gmail"
+  | "outlook"
+  | "clickup"
+  | "notion"
+  | "linear"
+  | "fireflies"
+  | "zoho_crm";
 
 export type AuthType = "oauth" | "api_key" | "service_account";
 

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -360,6 +360,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
         experimentalFlag: config.EXPERIMENTAL_FLAG,
         zohoClientId: config.ZOHO_CLIENT_ID,
         zohoClientSecret: config.ZOHO_CLIENT_SECRET,
+        microsoftClientId: config.MICROSOFT_CLIENT_ID,
+        microsoftClientSecret: config.MICROSOFT_CLIENT_SECRET,
       }),
     );
   }

--- a/packages/web/src/components/connect-integration-dialog.tsx
+++ b/packages/web/src/components/connect-integration-dialog.tsx
@@ -103,6 +103,7 @@ export function ConnectIntegrationDialog({
 
   const isOAuthRedirect = integration?.oauthRedirect === true;
   const isZoho = integration?.type === "zoho_crm";
+  const isMicrosoft = integration?.type === "outlook";
 
   // Notion browse polling — updates root pages list in real-time as scan progresses
   useEffect(() => {
@@ -140,8 +141,9 @@ export function ConnectIntegrationDialog({
 
   // Check if the provider's OAuth is configured (for OAuth redirect integrations)
   const oauthStatus = useQuery({
-    queryKey: [isZoho ? "zoho-oauth-status" : "google-oauth-status"],
-    queryFn: () => (isZoho ? api.zohoOAuth.status() : api.googleOAuth.status()),
+    queryKey: [isZoho ? "zoho-oauth-status" : isMicrosoft ? "microsoft-oauth-status" : "google-oauth-status"],
+    queryFn: () =>
+      isZoho ? api.zohoOAuth.status() : isMicrosoft ? api.microsoftOAuth.status() : api.googleOAuth.status(),
     enabled: open && isOAuthRedirect,
   });
 
@@ -358,6 +360,10 @@ export function ConnectIntegrationDialog({
     window.open(url, "_self");
   };
 
+  const handleConnectWithMicrosoft = () => {
+    window.open(api.microsoftOAuth.authorizeUrl(), "_self");
+  };
+
   const allFieldsFilled = integration?.authFields.every((f) => (fieldValues[f.key] ?? "").trim().length > 0) ?? false;
   const toggleNotionPage = (pageId: string) => {
     setSelectedNotionPageIds((prev) => {
@@ -531,6 +537,36 @@ export function ConnectIntegrationDialog({
               <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
                 Zoho OAuth isn't configured on the server yet. Set <code>ZOHO_CLIENT_ID</code> and{" "}
                 <code>ZOHO_CLIENT_SECRET</code> in the environment, then reload.
+              </div>
+            )}
+          </>
+        ) : step === "credentials" && isOAuthRedirect && isMicrosoft ? (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2.5">
+                <IntegrationIcon color={integration.color} name={integration.name} type={integration.type} />
+                Connect {integration.name}
+              </DialogTitle>
+              <DialogDescription>
+                Sign in with your Microsoft account to authorize read-only access to your mailbox.
+              </DialogDescription>
+            </DialogHeader>
+
+            <ol className="list-inside list-decimal space-y-1.5 text-xs text-muted-foreground">
+              {integration.connectSteps.map((s) => (
+                <li key={s}>{s}</li>
+              ))}
+            </ol>
+
+            {isOAuthConfigured ? (
+              <Button size="lg" className="w-full gap-2" onClick={handleConnectWithMicrosoft}>
+                <ConnectorLogo type="outlook" size={16} className="text-white" />
+                Connect with Microsoft
+              </Button>
+            ) : (
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+                Microsoft OAuth isn't configured on the server yet. Set <code>MICROSOFT_CLIENT_ID</code> and{" "}
+                <code>MICROSOFT_CLIENT_SECRET</code> in the environment, then reload.
               </div>
             )}
           </>

--- a/packages/web/src/components/connector-logos.tsx
+++ b/packages/web/src/components/connector-logos.tsx
@@ -46,6 +46,22 @@ export function GmailLogo({ size = 16, className, style }: LogoProps) {
   );
 }
 
+export function OutlookLogo({ size = 16, className, style }: LogoProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      width={size}
+      height={size}
+      className={className}
+      style={style}
+      aria-hidden="true"
+    >
+      <path d="M3 4.5 13.5 2v20L3 19.5v-15Zm4.9 10.3c1.7 0 2.9-1.4 2.9-3.3s-1.2-3.3-2.9-3.3S5 9.6 5 11.5s1.2 3.3 2.9 3.3Zm0-1.4c-.8 0-1.3-.7-1.3-1.9s.5-1.9 1.3-1.9 1.3.7 1.3 1.9-.5 1.9-1.3 1.9ZM15 5h6v14h-6v-2h4v-6.1l-2.5 1.7L15 11.5V5Zm1.2 2v2.7l.3.2L19 8.2V7h-2.8Z" />
+    </svg>
+  );
+}
+
 export function ClickUpLogo({ size = 16, className, style }: LogoProps) {
   return (
     <svg
@@ -128,6 +144,8 @@ export function ConnectorLogo({
       return <GoogleDriveLogo {...props} />;
     case "gmail":
       return <GmailLogo {...props} />;
+    case "outlook":
+      return <OutlookLogo {...props} />;
     case "clickup":
       return <ClickUpLogo {...props} />;
     case "notion":

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1335,6 +1335,16 @@ export const api = {
       return `/api/oauth/zoho/authorize?region=${encodeURIComponent(region)}`;
     },
   },
+  microsoftOAuth: {
+    status() {
+      return request<{ configured: boolean; clientId: string | null; baseUrl: string | null }>(
+        "/api/oauth/microsoft/status",
+      );
+    },
+    authorizeUrl() {
+      return "/api/oauth/microsoft/authorize";
+    },
+  },
   identities: {
     listForUser(userId: string) {
       return request<{ identities: ProviderIdentity[] }>(`/api/identities/user/${userId}`);

--- a/packages/web/src/lib/integrations.ts
+++ b/packages/web/src/lib/integrations.ts
@@ -8,7 +8,15 @@
  * Today: 4 connectors. Tomorrow: 50+. This registry scales to both.
  */
 
-export type IntegrationType = "google_drive" | "gmail" | "clickup" | "notion" | "linear" | "fireflies" | "zoho_crm";
+export type IntegrationType =
+  | "google_drive"
+  | "gmail"
+  | "outlook"
+  | "clickup"
+  | "notion"
+  | "linear"
+  | "fireflies"
+  | "zoho_crm";
 
 export type AuthFieldType = "text" | "password" | "textarea" | "file";
 
@@ -177,6 +185,28 @@ export const INTEGRATIONS: IntegrationDefinition[] = [
     ],
     perUserAuth: true,
     requiresOAuthClientSetup: true,
+  },
+  {
+    type: "outlook",
+    name: "Outlook",
+    description: "Microsoft 365 email messages and threads",
+    category: "Communication",
+    color: "#0078D4",
+    authType: "oauth",
+    oauthRedirect: true,
+    authFields: [],
+    scopeLabel: "mailbox",
+    scopeType: "none",
+    itemNoun: "emails",
+    credentialUrl: "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
+    connectSteps: [
+      "Register an app in Microsoft Entra",
+      "Add the redirect URI shown by your deployment",
+      "Grant delegated Mail.Read, User.Read, and offline_access permissions",
+      "Set MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET on the server",
+    ],
+    perUserAuth: true,
+    requiresOAuthClientSetup: false,
   },
   {
     type: "clickup",


### PR DESCRIPTION
## Summary
- add Outlook connector backed by Microsoft Graph mail APIs
- add Microsoft OAuth authorize/callback/status routes and env config
- expose Outlook in the integrations UI with connector logo and connect flow
- add Outlook connector tests for normalization, suppression, and email pipeline integration

## Notes
- This PR is stacked on #214 because the Outlook branch was built on the locally resolved PR 214 merge. After #214 lands, this can be retargeted to main.
- First slice uses a time-based mailbox cursor; Graph delta sync and folder-aware deletion handling remain follow-ups.

## Tests
- pnpm biome check
- pnpm typecheck
- pnpm test
- pnpm build