### PR TITLE
fix: use SDK visual analysis tool name

### DIFF
--- a/packages/server/src/agent/permissions.test.ts
+++ b/packages/server/src/agent/permissions.test.ts
@@ -122,7 +122,7 @@ describe("createCanUseTool", () => {
       const result = await agentTool("Read", { file_path: blockedPath });
 
       expectDeny(result);
-      expect(result.message).toContain("Use VisualAnalysis");
+      expect(result.message).toContain("Use mcp__sketch__VisualAnalysis");
       expect(result.message).toContain(blockedPath);
     });
 
@@ -134,7 +134,7 @@ describe("createCanUseTool", () => {
       const result = await agentTool("Read", { file_path: `${WORKSPACE}/attachments/../attachments/image.png` });
 
       expectDeny(result);
-      expect(result.message).toContain("Use VisualAnalysis");
+      expect(result.message).toContain("Use mcp__sketch__VisualAnalysis");
     });
 
     it("allows non-Read file tools for blocked attachment paths", async () => {
@@ -155,7 +155,7 @@ describe("createCanUseTool", () => {
       const result = await agentTool("Bash", { command: `base64 "${blockedPath}"` });
 
       expectDeny(result);
-      expect(result.message).toContain("Use VisualAnalysis");
+      expect(result.message).toContain("Use mcp__sketch__VisualAnalysis");
       expect(result.message).toContain(blockedPath);
     });
 
@@ -167,7 +167,7 @@ describe("createCanUseTool", () => {
       const result = await agentTool("Bash", { command: "cat ./attachments/image.png" });
 
       expectDeny(result);
-      expect(result.message).toContain("Use VisualAnalysis");
+      expect(result.message).toContain("Use mcp__sketch__VisualAnalysis");
     });
 
     it("denies Bash commands with relative globs that match blocked attachment paths", async () => {
@@ -178,7 +178,7 @@ describe("createCanUseTool", () => {
       const result = await agentTool("Bash", { command: "base64 attachments/*.png" });
 
       expectDeny(result);
-      expect(result.message).toContain("Use VisualAnalysis");
+      expect(result.message).toContain("Use mcp__sketch__VisualAnalysis");
     });
 
     it("denies Bash commands with absolute globs that match blocked attachment paths", async () => {
@@ -189,7 +189,7 @@ describe("createCanUseTool", () => {
       const result = await agentTool("Bash", { command: `cat ${WORKSPACE}/attachments/photo.*` });
 
       expectDeny(result);
-      expect(result.message).toContain("Use VisualAnalysis");
+      expect(result.message).toContain("Use mcp__sketch__VisualAnalysis");
     });
 
     it("allows Bash commands that do not reference blocked attachment paths", async () => {

--- a/packages/server/src/agent/permissions.ts
+++ b/packages/server/src/agent/permissions.ts
@@ -10,6 +10,7 @@
  */
 import { isAbsolute, matchesGlob, relative, resolve } from "node:path";
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
+import { VISUAL_ANALYSIS_AGENT_TOOL_NAME } from "@sketch/shared";
 import type { Logger } from "../logger";
 
 export const PERMITTED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch", "WebFetch", "Skill"];
@@ -119,7 +120,7 @@ export function createCanUseTool(
         logger.warn({ toolName, filePath }, "Blocked Read on attachment that requires VisualAnalysis");
         return {
           behavior: "deny",
-          message: `Use VisualAnalysis with this path instead of Read: ${filePath}`,
+          message: `Use ${VISUAL_ANALYSIS_AGENT_TOOL_NAME} with this path instead of Read: ${filePath}`,
         };
       }
     }
@@ -132,7 +133,7 @@ export function createCanUseTool(
           logger.warn({ toolName, blockedPath }, "Blocked Bash command on attachment that requires VisualAnalysis");
           return {
             behavior: "deny",
-            message: `Use VisualAnalysis with this path instead of Bash: ${blockedPath}`,
+            message: `Use ${VISUAL_ANALYSIS_AGENT_TOOL_NAME} with this path instead of Bash: ${blockedPath}`,
           };
         }
       }

--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -798,7 +798,7 @@ describe("buildSketchContext", () => {
 
       const result = buildSketchContext(sketchContext);
 
-      expect(result).toContain('hint="Use VisualAnalysis with this path to understand the image."');
+      expect(result).toContain('hint="Use mcp__sketch__VisualAnalysis with this path to understand the image."');
       expect(getImageAttachmentPathsFromSketchContext(sketchContext)).toEqual(["/ws/attachments/photo.jpg"]);
     });
 

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -1,3 +1,4 @@
+import { VISUAL_ANALYSIS_AGENT_TOOL_NAME } from "@sketch/shared";
 import type { Attachment, AttachmentPromptOptions } from "../files";
 import { formatAttachmentsForPrompt, isImageAttachment } from "../files";
 
@@ -353,7 +354,7 @@ export function buildSystemContext(params: {
     "## File Attachments",
     "",
     params.visionAnalysisEnabled
-      ? "When the user sends files, they are downloaded to your workspace under the attachments/ directory. Visual files may be referenced in <attachments> blocks by attachment path. When visual tasks like OCR, screenshot inspection, diagram interpretation, or animation review are relevant and you do not already have native vision, use the VisualAnalysis tool with the attachment path. Non-visual files are referenced in <attachments> blocks -- use the Read tool to view their contents. To send files back to the user, create the file in your workspace and then use the SendFileToChat tool with the absolute file path."
+      ? `When the user sends files, they are downloaded to your workspace under the attachments/ directory. Visual files may be referenced in <attachments> blocks by attachment path. When visual tasks like OCR, screenshot inspection, diagram interpretation, or animation review are relevant and you do not already have native vision, use the ${VISUAL_ANALYSIS_AGENT_TOOL_NAME} tool with the attachment path. Non-visual files are referenced in <attachments> blocks -- use the Read tool to view their contents. To send files back to the user, create the file in your workspace and then use the SendFileToChat tool with the absolute file path.`
       : "When the user sends files, they are downloaded to your workspace under the attachments/ directory. Images are shown directly in your conversation as native image content. Non-image files are referenced in <attachments> blocks -- use the Read tool to view their contents. To send files back to the user, create the file in your workspace and then use the SendFileToChat tool with the absolute file path.",
     "Audio files may be referenced as attachments. If a transcript is provided in the message context, treat it as the spoken content of that audio. If no transcript is provided and a TranscribeAudio tool is available, use it with the attachment path when the spoken content is relevant.",
   );

--- a/packages/server/src/agent/runner.isolated.test.ts
+++ b/packages/server/src/agent/runner.isolated.test.ts
@@ -385,7 +385,9 @@ describe("runAgent", () => {
       expect(typeof capturedPrompt).toBe("string");
       expect(capturedPrompt).toContain("<attachments>");
       expect(capturedPrompt).toContain(`path="${imagePath}"`);
-      expect(capturedPrompt).toContain('hint="Use VisualAnalysis with this path to understand the image."');
+      expect(capturedPrompt).toContain(
+        'hint="Use mcp__sketch__VisualAnalysis with this path to understand the image."',
+      );
       expect(vi.mocked(createCanUseTool).mock.calls.at(-1)?.[3]).toMatchObject({
         blockedReadPaths: [imagePath, backlogImagePath],
       });
@@ -443,7 +445,7 @@ describe("runAgent", () => {
 
       expect(typeof capturedPrompt).toBe("string");
       expect(capturedPrompt).toContain("<attachments>");
-      expect(capturedPrompt).not.toContain("Use VisualAnalysis");
+      expect(capturedPrompt).not.toContain("mcp__sketch__VisualAnalysis");
       expect(vi.mocked(createSketchMcpServer).mock.calls.at(-1)?.[0]).toMatchObject({
         visionAnalysisEnabled: false,
       });

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -9,7 +9,7 @@
  */
 import { resolve } from "node:path";
 import { type SDKUserMessage, query } from "@anthropic-ai/claude-agent-sdk";
-import { AGENT_BUILT_IN_TOOL_NAMES } from "@sketch/shared";
+import { AGENT_BUILT_IN_TOOL_NAMES, VISUAL_ANALYSIS_AGENT_TOOL_NAME } from "@sketch/shared";
 import type { Kysely, Selectable } from "kysely";
 import { listIndexedSourcesForPrompt } from "../connectors/search";
 import type { createAutomationRunsRepository } from "../db/repositories/automation-runs";
@@ -196,14 +196,13 @@ export interface RunAgentParams {
 }
 
 const DEFAULT_RUN_TOOLS: readonly string[] = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill"];
-const VISUAL_ANALYSIS_TOOL_NAME = "mcp__sketch__VisualAnalysis";
 
 export function canUseVisualAnalysisTool(
   visionConfig: VisionConfig | null,
   agentAllowedTools?: string[] | null,
 ): boolean {
   if (!visionConfig) return false;
-  return agentAllowedTools == null || agentAllowedTools.includes(VISUAL_ANALYSIS_TOOL_NAME);
+  return agentAllowedTools == null || agentAllowedTools.includes(VISUAL_ANALYSIS_AGENT_TOOL_NAME);
 }
 
 /**

--- a/packages/server/src/files.test.ts
+++ b/packages/server/src/files.test.ts
@@ -169,7 +169,7 @@ describe("formatAttachmentsForPrompt", () => {
     );
 
     expect(result).toContain(
-      '<file name="b.png" path="/w/b.png" mime="image/png" size="2048" hint="Use VisualAnalysis with this path to understand the image." />',
+      '<file name="b.png" path="/w/b.png" mime="image/png" size="2048" hint="Use mcp__sketch__VisualAnalysis with this path to understand the image." />',
     );
     expect(result).toContain('<file name="a.txt" path="/w/a.txt" mime="text/plain" size="10" />');
   });
@@ -180,7 +180,7 @@ describe("formatAttachmentsForPrompt", () => {
       { visionAnalysisEnabled: false },
     );
 
-    expect(result).not.toContain("VisualAnalysis");
+    expect(result).not.toContain("mcp__sketch__VisualAnalysis");
     expect(result).toContain('<file name="b.png" path="/w/b.png" mime="image/png" size="2048" />');
   });
 

--- a/packages/server/src/files.ts
+++ b/packages/server/src/files.ts
@@ -12,6 +12,7 @@
  */
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
+import { VISUAL_ANALYSIS_AGENT_TOOL_NAME } from "@sketch/shared";
 import type { WASocket, proto } from "@whiskeysockets/baileys";
 import type { Logger } from "./logger";
 import { shouldTreatAsAudioAttachment } from "./transcription/audio-types";
@@ -125,7 +126,7 @@ export function formatAttachmentsForPrompt(attachments: Attachment[], options: A
     .map((a) => {
       let visionHint = "";
       if (options.visionAnalysisEnabled && isImageAttachment(a)) {
-        visionHint = ' hint="Use VisualAnalysis with this path to understand the image."';
+        visionHint = ` hint="Use ${VISUAL_ANALYSIS_AGENT_TOOL_NAME} with this path to understand the image."`;
       }
       return `<file name="${a.originalName}" path="${a.localPath}" mime="${a.mimeType}" size="${a.sizeBytes}"${visionHint} />`;
     })

--- a/packages/shared/src/agent-tools.ts
+++ b/packages/shared/src/agent-tools.ts
@@ -18,6 +18,8 @@ export interface AgentToolCatalogEntry {
   category: AgentToolCategory;
 }
 
+export const VISUAL_ANALYSIS_AGENT_TOOL_NAME = "mcp__sketch__VisualAnalysis";
+
 export const AGENT_TOOL_CATALOG: AgentToolCatalogEntry[] = [
   {
     name: "Read",
@@ -92,7 +94,7 @@ export const AGENT_TOOL_CATALOG: AgentToolCatalogEntry[] = [
     category: "sketch",
   },
   {
-    name: "mcp__sketch__VisualAnalysis",
+    name: VISUAL_ANALYSIS_AGENT_TOOL_NAME,
     label: "Visual analysis",
     description:
       "Inspect visual attachments in the workspace for tasks such as OCR, screenshots, diagrams, or animations using the configured vision model.",


### PR DESCRIPTION
## Summary
- Use the SDK-exposed mcp__sketch__VisualAnalysis tool name in attachment hints and system prompt guidance.
- Return the same namespaced tool name when Read/Bash are blocked for visual attachments.
- Update regression tests for prompt, attachment, permission, and runner behavior.

## Verification
- pnpm biome check .
- pnpm typecheck
- pnpm test:unit
- pnpm build
- pre-push hook: pnpm lint, pnpm typecheck, pnpm test, pnpm build