### PR TITLE
fix: add OpenRouter enrichment fallback

### DIFF
--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -177,6 +177,8 @@ export interface RunAgentParams {
   activeQueueKey?: string;
   toolConfig?: { BASE_URL?: string; PORT: number };
   geminiConfig?: { maxRpm?: number; maxRetries?: number };
+  openRouterApiKey?: string;
+  settingsEncryptionKey?: string;
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   userRepo?: {
     list: () => Promise<Selectable<UsersTable>[]>;
@@ -371,6 +373,8 @@ export async function runAgent(params: RunAgentParams): Promise<RunAgentResult> 
     activeQueueKey: params.activeQueueKey,
     toolConfig: params.toolConfig,
     geminiConfig: params.geminiConfig,
+    openRouterApiKey: params.openRouterApiKey,
+    settingsEncryptionKey: params.settingsEncryptionKey,
     inboxMessagesRepo: params.inboxMessagesRepo,
     userRepo: params.userRepo,
     currentUserId: params.currentUserId ?? undefined,

--- a/packages/server/src/agent/tools/search.ts
+++ b/packages/server/src/agent/tools/search.ts
@@ -234,6 +234,8 @@ export async function handleSearch(
     skipAutoEntityBoost,
     geminiMaxRpm: deps.geminiConfig?.maxRpm,
     geminiMaxRetries: deps.geminiConfig?.maxRetries,
+    openRouterApiKey: deps.openRouterApiKey,
+    settingsEncryptionKey: deps.settingsEncryptionKey,
   });
 
   const effectiveSortBy = sortBy ?? "relevance";

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -57,6 +57,8 @@ export interface SketchMcpDeps {
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };
   toolConfig?: { BASE_URL?: string; PORT: number };
   geminiConfig?: { maxRpm?: number; maxRetries?: number };
+  openRouterApiKey?: string;
+  settingsEncryptionKey?: string;
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   userRepo?: SearchableUserRepo;
   currentUserId?: string;

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -492,6 +492,8 @@ export function connectorRoutes(
       userEmails,
       geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
       geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
+      openRouterApiKey: appConfig?.OPENROUTER_API_KEY,
+      settingsEncryptionKey: appConfig?.ENCRYPTION_KEY,
     });
     return c.json({ results });
   });

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -18,8 +18,12 @@ import type { Config } from "../config";
 import { browseClickUpWorkspaces } from "../connectors/clickup";
 import { parseEmailAddrJson, parseEmailAddrListJson } from "../connectors/email/envelope-metadata";
 import type { EmailAddr } from "../connectors/email/normalized-email";
-import { createEmbeddingProvider } from "../connectors/embeddings";
 import { isEnrichmentActive, runEnrichment } from "../connectors/enrichment";
+import {
+  createEnrichmentEmbeddingProvider,
+  createEnrichmentGenerator,
+  resolveOpenRouterEnrichmentConfig,
+} from "../connectors/enrichment-providers";
 import { buildCredentialHint } from "../connectors/fireflies";
 import { ensureValidToken, listFolderContents, listMyDriveFolders, listSharedDrives } from "../connectors/google-drive";
 import { browseNotionRootPages, getBrowseStatus, startNotionBrowse } from "../connectors/notion";
@@ -37,6 +41,7 @@ import type { ApiKeyCredentials, ConnectorCredentials, ConnectorType, OAuthCrede
 import type { createConnectorRepository } from "../db/repositories/connectors";
 import { createEntityRepository } from "../db/repositories/entities";
 import { createFileSharesRepository } from "../db/repositories/file-shares";
+import { createSettingsRepository } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import {
@@ -193,6 +198,8 @@ export function connectorRoutes(
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
       | "EXPERIMENTAL_FLAG"
+      | "ENCRYPTION_KEY"
+      | "OPENROUTER_API_KEY"
     >
   >,
 ) {
@@ -1726,19 +1733,17 @@ export function connectorRoutes(
     const denied = denyIfCannotEdit(c, owningConfig);
     if (denied) return denied;
 
-    const settings = await db
-      .selectFrom("settings")
-      .select("gemini_api_key")
-      .where("id", "=", "default")
-      .executeTakeFirst();
-    const embeddingProvider = settings?.gemini_api_key
-      ? createEmbeddingProvider({
-          provider: "gemini",
-          apiKey: settings.gemini_api_key,
-          maxRpm: appConfig?.GEMINI_MAX_RPM,
-          maxRetries: appConfig?.GEMINI_MAX_RETRIES,
-        })
-      : null;
+    const settings = await createSettingsRepository(db, appConfig?.ENCRYPTION_KEY).get();
+    const openRouterConfig = resolveOpenRouterEnrichmentConfig(settings, appConfig?.OPENROUTER_API_KEY);
+    const providerConfig = {
+      geminiApiKey: settings?.gemini_api_key,
+      geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
+      geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
+      logger,
+      ...openRouterConfig,
+    };
+    const embeddingProvider = createEnrichmentEmbeddingProvider(providerConfig);
+    const generator = createEnrichmentGenerator(providerConfig);
 
     // Enrich only this specific file.
     // This endpoint is the per-file "Enrich File" debug surface — always dump
@@ -1750,6 +1755,7 @@ export function connectorRoutes(
       db,
       logger: logger.child({ component: "enrichment", fileId }),
       embeddingProvider,
+      generator,
       geminiApiKey: settings?.gemini_api_key,
       geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
       geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -4,8 +4,12 @@ import type { Kysely } from "kysely";
 import type { Logger } from "pino";
 import { z } from "zod";
 import type { Config } from "../config";
-import { createEmbeddingProvider } from "../connectors/embeddings";
 import { runEnrichment } from "../connectors/enrichment";
+import {
+  createEnrichmentEmbeddingProvider,
+  createEnrichmentGenerator,
+  resolveOpenRouterEnrichmentConfig,
+} from "../connectors/enrichment-providers";
 import { type createSettingsRepository, parseOrgContext } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 
@@ -46,7 +50,7 @@ export function settingsRoutes(
   settings: SettingsRepo,
   db?: Kysely<DB>,
   logger?: Logger,
-  config?: Pick<Config, "GEMINI_MAX_RPM" | "GEMINI_MAX_RETRIES">,
+  config?: Pick<Config, "GEMINI_MAX_RPM" | "GEMINI_MAX_RETRIES" | "OPENROUTER_API_KEY">,
 ) {
   const routes = new Hono();
 
@@ -136,20 +140,23 @@ export function settingsRoutes(
       return c.json({ error: { code: "DISABLED", message: "Enrichment is disabled" } }, 400);
     }
 
-    const embeddingProvider = row?.gemini_api_key
-      ? createEmbeddingProvider({
-          provider: "gemini",
-          apiKey: row.gemini_api_key,
-          maxRpm: config?.GEMINI_MAX_RPM,
-          maxRetries: config?.GEMINI_MAX_RETRIES,
-        })
-      : null;
+    const openRouterConfig = resolveOpenRouterEnrichmentConfig(row, config?.OPENROUTER_API_KEY);
+    const providerConfig = {
+      geminiApiKey: row?.gemini_api_key,
+      geminiMaxRpm: config?.GEMINI_MAX_RPM,
+      geminiMaxRetries: config?.GEMINI_MAX_RETRIES,
+      logger,
+      ...openRouterConfig,
+    };
+    const embeddingProvider = createEnrichmentEmbeddingProvider(providerConfig);
+    const generator = createEnrichmentGenerator(providerConfig);
 
     // Run in background
     runEnrichment({
       db,
       logger: logger.child({ component: "enrichment" }),
       embeddingProvider,
+      generator,
       geminiApiKey: row?.gemini_api_key,
       geminiMaxRpm: config?.GEMINI_MAX_RPM,
       geminiMaxRetries: config?.GEMINI_MAX_RETRIES,

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -169,6 +169,8 @@ export async function createServer(config: Config, options?: CreateServerOptions
         maxRpm: config.GEMINI_MAX_RPM,
         maxRetries: config.GEMINI_MAX_RETRIES,
       },
+      openRouterApiKey: params.openRouterApiKey ?? config.OPENROUTER_API_KEY,
+      settingsEncryptionKey: params.settingsEncryptionKey ?? config.ENCRYPTION_KEY,
       localDeviceInvoker: params.localDeviceInvoker ?? localDeviceGateway,
       localClaudeSessionService: params.localClaudeSessionService ?? localClaudeSessionService,
       ...(Object.keys(resolvedAgentEnv).length > 0

--- a/packages/server/src/connectors/embeddings/openrouter.ts
+++ b/packages/server/src/connectors/embeddings/openrouter.ts
@@ -1,0 +1,72 @@
+import type { EmbeddingProvider } from "./types";
+
+const OPENROUTER_EMBEDDINGS_URL = "https://openrouter.ai/api/v1/embeddings";
+const DEFAULT_MODEL = "google/gemini-embedding-2-preview";
+const DIMENSIONS = 3072;
+
+interface OpenRouterEmbeddingOptions {
+  model?: string;
+  dimensions?: number;
+  timeoutMs?: number;
+}
+
+interface OpenRouterEmbeddingResponse {
+  data?: Array<{ embedding?: unknown }>;
+  error?: {
+    message?: string;
+  };
+}
+
+export function createOpenRouterEmbeddingProvider(
+  apiKey: string,
+  options: OpenRouterEmbeddingOptions = {},
+): EmbeddingProvider {
+  const model = options.model ?? DEFAULT_MODEL;
+  const dimensions = options.dimensions ?? DIMENSIONS;
+
+  async function request(input: string | string[]): Promise<number[][]> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 60_000);
+
+    try {
+      const res = await fetch(OPENROUTER_EMBEDDINGS_URL, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ model, input, dimensions }),
+      });
+
+      const body = (await res.json().catch(() => ({}))) as OpenRouterEmbeddingResponse;
+      if (!res.ok) {
+        throw new Error(body.error?.message ?? `OpenRouter embedding failed with HTTP ${res.status}`);
+      }
+
+      const embeddings = body.data?.map((item) => item.embedding);
+      if (!embeddings || embeddings.length === 0) {
+        throw new Error("OpenRouter embedding response did not include embeddings");
+      }
+
+      return embeddings.map((embedding) => {
+        if (!Array.isArray(embedding) || embedding.some((value) => typeof value !== "number")) {
+          throw new Error("OpenRouter embedding response contained a non-numeric vector");
+        }
+        if (embedding.length !== dimensions) {
+          throw new Error(`OpenRouter embedding returned ${embedding.length} dimensions, expected ${dimensions}`);
+        }
+        return embedding;
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return {
+    name: "openrouter",
+    dimensions,
+    supportsImages: false,
+    embedTexts: request,
+  };
+}

--- a/packages/server/src/connectors/enrichment-providers.isolated.test.ts
+++ b/packages/server/src/connectors/enrichment-providers.isolated.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "../test-utils";
+import { createEnrichmentEmbeddingProvider, resolveOpenRouterEnrichmentConfig } from "./enrichment-providers";
+
+function vector(dimensions = 3072): number[] {
+  return Array.from({ length: dimensions }, (_, i) => i / dimensions);
+}
+
+describe("enrichment providers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses direct Gemini embeddings when the primary provider succeeds", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        embedding: { values: vector() },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = createEnrichmentEmbeddingProvider({
+      geminiApiKey: "gemini-key",
+      openRouterApiKey: "openrouter-key",
+      logger: createTestLogger(),
+    });
+
+    const embeddings = await provider?.embedTexts(["hello"]);
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+
+    expect(embeddings?.[0]).toHaveLength(3072);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(calls[0][0])).toContain("generativelanguage.googleapis.com");
+  });
+
+  it("falls back to OpenRouter embeddings when Gemini quota is exhausted", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ error: { code: 429, message: "RESOURCE_EXHAUSTED" } }, { status: 429 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          data: [{ embedding: vector() }],
+          model: "gemini-embedding-2-preview",
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = createEnrichmentEmbeddingProvider({
+      geminiApiKey: "gemini-key",
+      geminiMaxRetries: 0,
+      openRouterApiKey: "openrouter-key",
+      logger: createTestLogger(),
+    });
+
+    const embeddings = await provider?.embedTexts(["hello"]);
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const openRouterBody = JSON.parse(calls[1][1]?.body as string) as {
+      model: string;
+      dimensions: number;
+    };
+
+    expect(embeddings?.[0]).toHaveLength(3072);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(calls[1][0])).toBe("https://openrouter.ai/api/v1/embeddings");
+    expect(openRouterBody).toMatchObject({
+      model: "google/gemini-embedding-2-preview",
+      dimensions: 3072,
+    });
+  });
+
+  it("uses OpenRouter embeddings directly when Gemini is not configured", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        data: [{ embedding: vector() }],
+        model: "gemini-embedding-2-preview",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = createEnrichmentEmbeddingProvider({
+      geminiApiKey: null,
+      openRouterApiKey: "openrouter-key",
+      logger: createTestLogger(),
+    });
+
+    const embeddings = await provider?.embedTexts(["hello"]);
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+
+    expect(embeddings?.[0]).toHaveLength(3072);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(calls[0][0])).toBe("https://openrouter.ai/api/v1/embeddings");
+  });
+
+  it("resolves OpenRouter enrichment config from DB settings before env", () => {
+    expect(
+      resolveOpenRouterEnrichmentConfig(
+        { llm_provider: "openrouter", anthropic_api_key: " sk-db ", model_id: " model-db " },
+        "sk-env",
+      ),
+    ).toEqual({
+      openRouterApiKey: "sk-db",
+      openRouterModel: "model-db",
+    });
+  });
+
+  it("does not treat a non-OpenRouter DB LLM key as an OpenRouter key", () => {
+    expect(
+      resolveOpenRouterEnrichmentConfig(
+        { llm_provider: "anthropic", anthropic_api_key: " sk-ant ", model_id: "claude-sonnet" },
+        "sk-env",
+      ),
+    ).toEqual({
+      openRouterApiKey: "sk-env",
+      openRouterModel: null,
+    });
+  });
+});

--- a/packages/server/src/connectors/enrichment-providers.isolated.test.ts
+++ b/packages/server/src/connectors/enrichment-providers.isolated.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "../test-utils";
-import { createEnrichmentEmbeddingProvider, resolveOpenRouterEnrichmentConfig } from "./enrichment-providers";
+import {
+  createEnrichmentEmbeddingProvider,
+  createEnrichmentQueryEmbedder,
+  resolveOpenRouterEnrichmentConfig,
+} from "./enrichment-providers";
 
 function vector(dimensions = 3072): number[] {
   return Array.from({ length: dimensions }, (_, i) => i / dimensions);
@@ -90,6 +94,66 @@ describe("enrichment providers", () => {
     expect(embeddings?.[0]).toHaveLength(3072);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(calls[0][0])).toBe("https://openrouter.ai/api/v1/embeddings");
+  });
+
+  it("uses Gemini RETRIEVAL_QUERY for query embeddings when Gemini succeeds", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        embedding: { values: vector() },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const embedQuery = createEnrichmentQueryEmbedder({
+      geminiApiKey: "gemini-key",
+      openRouterApiKey: "openrouter-key",
+      logger: createTestLogger(),
+    });
+
+    const embedding = await embedQuery?.("hello");
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const geminiBody = JSON.parse(String(calls[0][1]?.body));
+
+    expect(embedding).toHaveLength(3072);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(calls[0][0])).toContain("generativelanguage.googleapis.com");
+    expect(geminiBody).toMatchObject({
+      content: { parts: [{ text: "hello" }] },
+      taskType: "RETRIEVAL_QUERY",
+    });
+  });
+
+  it("falls back to OpenRouter query embeddings when Gemini query embedding fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ error: { code: 429, message: "RESOURCE_EXHAUSTED" } }, { status: 429 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          data: [{ embedding: vector() }],
+          model: "gemini-embedding-2-preview",
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const embedQuery = createEnrichmentQueryEmbedder({
+      geminiApiKey: "gemini-key",
+      geminiMaxRetries: 0,
+      openRouterApiKey: "openrouter-key",
+      logger: createTestLogger(),
+    });
+
+    const embedding = await embedQuery?.("hello");
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const openRouterBody = JSON.parse(String(calls[1][1]?.body));
+
+    expect(embedding).toHaveLength(3072);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(calls[1][0])).toBe("https://openrouter.ai/api/v1/embeddings");
+    expect(openRouterBody).toMatchObject({
+      model: "google/gemini-embedding-2-preview",
+      input: ["hello"],
+      dimensions: 3072,
+    });
   });
 
   it("resolves OpenRouter enrichment config from DB settings before env", () => {

--- a/packages/server/src/connectors/enrichment-providers.ts
+++ b/packages/server/src/connectors/enrichment-providers.ts
@@ -1,0 +1,110 @@
+import type { Logger } from "pino";
+import { type EmbeddingProvider, createEmbeddingProvider } from "./embeddings";
+import { createOpenRouterEmbeddingProvider } from "./embeddings/openrouter";
+import { type GeminiGenerator, createGeminiGenerator } from "./gemini-generate";
+import { createOpenRouterGenerator } from "./openrouter-generate";
+import { isRetryableProviderError, withProviderFallback } from "./provider-fallback";
+
+export interface EnrichmentProviderConfig {
+  geminiApiKey?: string | null;
+  geminiMaxRpm?: number;
+  geminiMaxRetries?: number;
+  openRouterApiKey?: string | null;
+  openRouterModel?: string | null;
+  logger?: Logger;
+}
+
+export function hasOpenRouterSettings(settings: { llm_provider?: string | null; anthropic_api_key?: string | null }) {
+  return (
+    (settings.llm_provider === "openrouter" || settings.llm_provider === "openrouter_bedrock") &&
+    !!settings.anthropic_api_key?.trim()
+  );
+}
+
+export function resolveOpenRouterEnrichmentConfig(
+  settings: { llm_provider?: string | null; anthropic_api_key?: string | null; model_id?: string | null } | null,
+  envApiKey?: string | null,
+) {
+  const useDbSettings = settings ? hasOpenRouterSettings(settings) : false;
+  const dbKey = useDbSettings ? settings?.anthropic_api_key?.trim() : null;
+  return {
+    openRouterApiKey: dbKey || envApiKey?.trim() || null,
+    openRouterModel: useDbSettings ? settings?.model_id?.trim() || null : null,
+  };
+}
+
+export function createEnrichmentGenerator(config: EnrichmentProviderConfig): GeminiGenerator | null {
+  const primary = config.geminiApiKey
+    ? createGeminiGenerator(config.geminiApiKey, {
+        maxRpm: config.geminiMaxRpm,
+        maxRetries: config.geminiMaxRetries,
+      })
+    : null;
+  const fallback = config.openRouterApiKey
+    ? createOpenRouterGenerator(config.openRouterApiKey, { model: config.openRouterModel })
+    : null;
+
+  if (!primary) return fallback;
+  if (!fallback) return primary;
+
+  return {
+    generate(prompt, opts) {
+      return withProviderFallback({
+        operation: opts?.label ?? "generate",
+        primary: () => primary.generate(prompt, opts),
+        fallback: () => fallback.generate(prompt, opts),
+        logger: config.logger,
+      });
+    },
+    generateJSON(prompt, opts) {
+      return withProviderFallback({
+        operation: opts?.label ?? "generateJSON",
+        primary: () => primary.generateJSON(prompt, opts),
+        fallback: () => fallback.generateJSON(prompt, opts),
+        logger: config.logger,
+      });
+    },
+  };
+}
+
+export function createEnrichmentEmbeddingProvider(config: EnrichmentProviderConfig): EmbeddingProvider | null {
+  const primary = config.geminiApiKey
+    ? createEmbeddingProvider({
+        provider: "gemini",
+        apiKey: config.geminiApiKey,
+        maxRpm: config.geminiMaxRpm,
+        maxRetries: config.geminiMaxRetries,
+      })
+    : null;
+  const fallback = config.openRouterApiKey ? createOpenRouterEmbeddingProvider(config.openRouterApiKey) : null;
+
+  if (!primary) return fallback;
+  if (!fallback) return primary;
+
+  const primaryEmbedImage = primary.embedImage;
+  const fallbackEmbedImage = fallback.supportsImages ? fallback.embedImage : undefined;
+
+  return {
+    name: `${primary.name}+openrouter-fallback`,
+    dimensions: primary.dimensions,
+    supportsImages: primary.supportsImages,
+    embedTexts(texts) {
+      return withProviderFallback({
+        operation: "embedTexts",
+        primary: () => primary.embedTexts(texts),
+        fallback: () => fallback.embedTexts(texts),
+        logger: config.logger,
+      });
+    },
+    embedImage: primaryEmbedImage
+      ? (imageBuffer, mimeType) =>
+          withProviderFallback({
+            operation: "embedImage",
+            primary: () => primaryEmbedImage(imageBuffer, mimeType),
+            fallback: fallbackEmbedImage ? () => fallbackEmbedImage(imageBuffer, mimeType) : null,
+            shouldFallback: (err) => fallback.supportsImages && isRetryableProviderError(err),
+            logger: config.logger,
+          })
+      : undefined,
+  };
+}

--- a/packages/server/src/connectors/enrichment-providers.ts
+++ b/packages/server/src/connectors/enrichment-providers.ts
@@ -108,3 +108,15 @@ export function createEnrichmentEmbeddingProvider(config: EnrichmentProviderConf
       : undefined,
   };
 }
+
+export function createEnrichmentQueryEmbedder(
+  config: EnrichmentProviderConfig,
+): ((query: string) => Promise<number[]>) | null {
+  const provider = createEnrichmentEmbeddingProvider(config);
+  if (!provider) return null;
+  return async (query) => {
+    const [embedding] = await provider.embedTexts([query]);
+    if (!embedding) throw new Error("Embedding provider did not return a query embedding");
+    return embedding;
+  };
+}

--- a/packages/server/src/connectors/enrichment-providers.ts
+++ b/packages/server/src/connectors/enrichment-providers.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "pino";
 import { type EmbeddingProvider, createEmbeddingProvider } from "./embeddings";
+import { createGeminiQueryEmbedder } from "./embeddings/gemini";
 import { createOpenRouterEmbeddingProvider } from "./embeddings/openrouter";
 import { type GeminiGenerator, createGeminiGenerator } from "./gemini-generate";
 import { createOpenRouterGenerator } from "./openrouter-generate";
@@ -112,11 +113,30 @@ export function createEnrichmentEmbeddingProvider(config: EnrichmentProviderConf
 export function createEnrichmentQueryEmbedder(
   config: EnrichmentProviderConfig,
 ): ((query: string) => Promise<number[]>) | null {
-  const provider = createEnrichmentEmbeddingProvider(config);
-  if (!provider) return null;
-  return async (query) => {
-    const [embedding] = await provider.embedTexts([query]);
-    if (!embedding) throw new Error("Embedding provider did not return a query embedding");
-    return embedding;
+  const primary = config.geminiApiKey
+    ? createGeminiQueryEmbedder(config.geminiApiKey, {
+        maxRpm: config.geminiMaxRpm,
+        maxRetries: config.geminiMaxRetries,
+      })
+    : null;
+  const fallbackProvider = config.openRouterApiKey ? createOpenRouterEmbeddingProvider(config.openRouterApiKey) : null;
+  const fallback = fallbackProvider
+    ? async (query: string) => {
+        const [embedding] = await fallbackProvider.embedTexts([query]);
+        if (!embedding) throw new Error("OpenRouter did not return a query embedding");
+        return embedding;
+      }
+    : null;
+
+  if (!primary) return fallback;
+  if (!fallback) return primary;
+
+  return (query) => {
+    return withProviderFallback({
+      operation: "embedQuery",
+      primary: () => primary(query),
+      fallback: () => fallback(query),
+      logger: config.logger,
+    });
   };
 }

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -26,8 +26,7 @@ import { ensureEmailThreadSummary, rebuildEmailThreadSummary } from "./email/thr
 import type { EmbeddingProvider } from "./embeddings/types";
 import { applyEngagementFloor } from "./engagement-floor";
 import { type KnownEntityForPrompt, buildFileScopedKnownEntities } from "./file-scope-context";
-import { createGeminiGenerator } from "./gemini-generate";
-import type { GeminiGenerator } from "./gemini-generate";
+import { type GeminiGenerator, createGeminiGenerator } from "./gemini-generate";
 import { buildParticipantBlock } from "./participant-block";
 import { smartEnrichFile } from "./smart-enrichment";
 import { extractDatesFromText } from "./tagging";
@@ -131,7 +130,8 @@ export interface EnrichmentDeps {
   db: Kysely<DB>;
   logger: Logger;
   embeddingProvider: EmbeddingProvider | null;
-  /** Gemini API key for AI-powered enrichment (summaries, entity extraction). */
+  generator?: GeminiGenerator | null;
+  /** Gemini API key for AI-powered enrichment when a generator is not supplied. */
   geminiApiKey?: string | null;
   geminiMaxRpm?: number;
   geminiMaxRetries?: number;
@@ -215,8 +215,9 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
     // entities table may not exist yet — ignore
   }
 
-  let generatorForRun: GeminiGenerator | null = null;
+  let generatorForRun: GeminiGenerator | null = deps.generator ?? null;
   const getGenerator = () => {
+    if (generatorForRun) return generatorForRun;
     if (!deps.geminiApiKey) return null;
     generatorForRun ??= createGeminiGenerator(deps.geminiApiKey, {
       maxRpm: deps.geminiMaxRpm,
@@ -224,6 +225,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
     });
     return generatorForRun;
   };
+  const hasGenerator = () => !!deps.generator || !!deps.geminiApiKey;
   const touchedEmailThreads = new Map<string, { connectorConfigId: string; threadId: string }>();
 
   // Find files needing enrichment
@@ -311,13 +313,13 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
         file.embedding_status === "done" && file.summary_status !== "done" && file.summary_status !== "skipped";
 
       if (needsSummaryOnly) {
-        if (file.content && !isImage && !isStructured && deps.geminiApiKey) {
+        if (file.content && !isImage && !isStructured && hasGenerator()) {
           const wordCount = file.content.split(/\s+/).filter(Boolean).length;
           const minWordsForSummary = isEmailMessage ? (threadContext ? 1 : 10) : 100;
           if (wordCount >= minWordsForSummary) {
             try {
               const generator = getGenerator();
-              if (!generator) throw new Error("Gemini generator unavailable");
+              if (!generator) throw new Error("Enrichment generator unavailable");
               const knownEntities = await buildFileScopedKnownEntities(
                 { db, logger },
                 file.id,
@@ -575,12 +577,17 @@ async function enrichTextDocument(
   const summaryAlreadyResolved = file.summary_status === "done" || file.summary_status === "skipped";
   const isEmailMessage = file.file_type === "email_message";
   const minWordsForSummary = isEmailMessage ? (threadContext ? 1 : 10) : 100;
-  if (!summaryAlreadyResolved && deps.geminiApiKey && wordCount >= minWordsForSummary) {
+  const generator =
+    deps.generator ??
+    (deps.geminiApiKey
+      ? createGeminiGenerator(deps.geminiApiKey, {
+          maxRpm: deps.geminiMaxRpm,
+          maxRetries: deps.geminiMaxRetries,
+        })
+      : null);
+
+  if (!summaryAlreadyResolved && generator && wordCount >= minWordsForSummary) {
     try {
-      const generator = createGeminiGenerator(deps.geminiApiKey, {
-        maxRpm: deps.geminiMaxRpm,
-        maxRetries: deps.geminiMaxRetries,
-      });
       const knownEntities = await buildFileScopedKnownEntities(
         { db, logger },
         file.id,

--- a/packages/server/src/connectors/openrouter-generate.ts
+++ b/packages/server/src/connectors/openrouter-generate.ts
@@ -1,0 +1,144 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { GeminiGenerator, GenerateOptions } from "./gemini-generate";
+
+const OPENROUTER_CHAT_URL = "https://openrouter.ai/api/v1/chat/completions";
+const DEFAULT_MODEL = "google/gemini-2.5-flash";
+const DEFAULT_MAX_TOKENS = 8192;
+
+interface OpenRouterGeneratorOptions {
+  model?: string | null;
+  timeoutMs?: number;
+}
+
+interface OpenRouterChatResponse {
+  choices?: Array<{
+    finish_reason?: string;
+    message?: {
+      content?: unknown;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+  error?: {
+    message?: string;
+  };
+}
+
+function extractTextContent(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+
+  const parts: string[] = [];
+  for (const part of content) {
+    if (part && typeof part === "object" && "type" in part && part.type === "text" && typeof part.text === "string") {
+      parts.push(part.text);
+    }
+  }
+  const text = parts.join("\n").trim();
+  return text.length > 0 ? text : null;
+}
+
+function stripJsonFence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1].trim() : trimmed;
+}
+
+async function dumpCall(
+  dumpDir: string,
+  payload: {
+    label: string;
+    prompt: string;
+    systemPrompt?: string;
+    maxTokens: number;
+    text: string | undefined;
+    finishReason: string | undefined;
+    promptTokens: number | undefined;
+    completionTokens: number | undefined;
+  },
+): Promise<void> {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const safeLabel = payload.label.replace(/[^a-zA-Z0-9_-]/g, "_");
+  try {
+    await mkdir(dumpDir, { recursive: true });
+    await writeFile(join(dumpDir, `${ts}__openrouter_${safeLabel}.json`), JSON.stringify(payload, null, 2), "utf8");
+  } catch {}
+}
+
+export function createOpenRouterGenerator(apiKey: string, options: OpenRouterGeneratorOptions = {}): GeminiGenerator {
+  const model = options.model?.trim() || DEFAULT_MODEL;
+
+  async function generate(prompt: string, opts?: GenerateOptions): Promise<string> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 60_000);
+    const maxTokens = opts?.maxTokens ?? DEFAULT_MAX_TOKENS;
+
+    try {
+      const response = await fetch(OPENROUTER_CHAT_URL, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          usage: { include: true },
+          messages: [
+            ...(opts?.systemPrompt ? [{ role: "system", content: opts.systemPrompt }] : []),
+            { role: "user", content: prompt },
+          ],
+          max_tokens: maxTokens,
+          temperature: 0,
+        }),
+      });
+
+      const body = (await response.json().catch(() => ({}))) as OpenRouterChatResponse;
+      if (!response.ok) {
+        throw new Error(body.error?.message ?? `OpenRouter generation failed with HTTP ${response.status}`);
+      }
+
+      const choice = body.choices?.[0];
+      const text = extractTextContent(choice?.message?.content)?.trim();
+
+      if (opts?.dumpDir) {
+        await dumpCall(opts.dumpDir, {
+          label: opts?.label ?? "unlabeled",
+          prompt,
+          systemPrompt: opts?.systemPrompt,
+          maxTokens,
+          text,
+          finishReason: choice?.finish_reason,
+          promptTokens: body.usage?.prompt_tokens,
+          completionTokens: body.usage?.completion_tokens,
+        });
+      }
+
+      if (!text) throw new Error("OpenRouter generation response did not include text");
+      if (choice?.finish_reason === "length") {
+        throw new Error(`OpenRouter response truncated (length), got ${text.length} chars`);
+      }
+
+      return text;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async function generateJSON<T>(prompt: string, opts?: Omit<GenerateOptions, "responseMimeType">): Promise<T> {
+    const text = await generate(prompt, opts);
+    try {
+      return JSON.parse(stripJsonFence(text)) as T;
+    } catch (err) {
+      const labelPrefix = opts?.label ? `[${opts.label}] ` : "";
+      throw new Error(
+        `OpenRouter ${labelPrefix}failed to parse JSON response (${text.length} chars, starts: ${text.slice(0, 100)}): ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  return { generate, generateJSON };
+}

--- a/packages/server/src/connectors/provider-fallback.test.ts
+++ b/packages/server/src/connectors/provider-fallback.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { GeminiHttpError } from "./gemini-control";
+import { isRetryableProviderError, withProviderFallback } from "./provider-fallback";
+
+describe("provider fallback", () => {
+  it("falls back for Gemini quota failures", async () => {
+    const result = await withProviderFallback({
+      operation: "embedTexts",
+      primary: async () => {
+        throw new GeminiHttpError(429, "RESOURCE_EXHAUSTED");
+      },
+      fallback: async () => "ok",
+    });
+
+    expect(result).toBe("ok");
+  });
+
+  it("does not fall back for non-retryable failures", async () => {
+    await expect(
+      withProviderFallback({
+        operation: "generateJSON",
+        primary: async () => {
+          throw new Error("failed to parse JSON response");
+        },
+        fallback: async () => "ok",
+      }),
+    ).rejects.toThrow("failed to parse JSON response");
+  });
+
+  it("classifies timeout-like errors as retryable", () => {
+    expect(isRetryableProviderError(new Error("fetch failed"))).toBe(true);
+    expect(isRetryableProviderError(new Error("prepayment credits are depleted"))).toBe(true);
+    expect(isRetryableProviderError(new GeminiHttpError(500, "server error"))).toBe(true);
+    expect(isRetryableProviderError(new GeminiHttpError(400, "API_KEY_INVALID"))).toBe(true);
+    expect(isRetryableProviderError(new Error("invalid api key"))).toBe(true);
+  });
+});

--- a/packages/server/src/connectors/provider-fallback.ts
+++ b/packages/server/src/connectors/provider-fallback.ts
@@ -1,0 +1,45 @@
+import type { Logger } from "pino";
+import { GeminiHttpError } from "./gemini-control";
+
+export function isRetryableProviderError(err: unknown): boolean {
+  if (err instanceof GeminiHttpError) {
+    const text = err.body.toLowerCase();
+    if (text.includes("api_key_invalid") || text.includes("invalid api key")) return true;
+    return err.status === 429 || err.status >= 500;
+  }
+
+  if (err instanceof Error) {
+    const text = err.message.toLowerCase();
+    return (
+      err.name === "AbortError" ||
+      text.includes("resource_exhausted") ||
+      text.includes("prepayment credits") ||
+      text.includes("quota") ||
+      text.includes("rate limit") ||
+      text.includes("timeout") ||
+      text.includes("fetch failed") ||
+      text.includes("api_key_invalid") ||
+      text.includes("invalid api key")
+    );
+  }
+
+  return false;
+}
+
+export async function withProviderFallback<T>(params: {
+  operation: string;
+  primary: () => Promise<T>;
+  fallback: (() => Promise<T>) | null | undefined;
+  shouldFallback?: (err: unknown) => boolean;
+  logger?: Logger;
+}): Promise<T> {
+  try {
+    return await params.primary();
+  } catch (err) {
+    const shouldFallback = params.shouldFallback ?? isRetryableProviderError;
+    if (!params.fallback || !shouldFallback(err)) throw err;
+
+    params.logger?.warn({ err, operation: params.operation }, "Primary enrichment provider failed, using fallback");
+    return params.fallback();
+  }
+}

--- a/packages/server/src/connectors/search-providers.isolated.test.ts
+++ b/packages/server/src/connectors/search-providers.isolated.test.ts
@@ -1,0 +1,56 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSettingsRepository } from "../db/repositories/settings";
+import type { DB } from "../db/schema";
+import { createTestDb } from "../test-utils";
+import { search } from "./search";
+
+const TEST_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("search provider fallback", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await db.destroy();
+  });
+
+  it("uses the decrypted OpenRouter settings key for query embeddings when Gemini is not configured", async () => {
+    const settings = createSettingsRepository(db, TEST_KEY);
+    await settings.ensure();
+    await settings.update({
+      llmProvider: "openrouter",
+      anthropicApiKey: "sk-or-db",
+      modelId: "openrouter/chat-model",
+      geminiApiKey: null,
+      enrichmentEnabled: 1,
+    });
+
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Response.json({ error: { message: "stop after provider selection" } }, { status: 500 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await search(db, "habuild fireflies", {
+      openRouterApiKey: "sk-or-env",
+      settingsEncryptionKey: TEST_KEY,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://openrouter.ai/api/v1/embeddings");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer sk-or-db",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      model: "google/gemini-embedding-2-preview",
+      input: ["habuild fireflies"],
+      dimensions: 3072,
+    });
+  });
+});

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -20,10 +20,11 @@ import { sql } from "kysely";
 import { isPg } from "../db/dialect";
 import { EMBEDDING_DIMENSIONS } from "../db/index";
 import { createEntityRepository } from "../db/repositories/entities";
+import { createSettingsRepository } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 import { parseEmailAddrJson, parseEmailAddrListJson } from "./email/envelope-metadata";
 import type { EmailAddr } from "./email/normalized-email";
-import { createQueryEmbedder } from "./embeddings";
+import { createEnrichmentQueryEmbedder, resolveOpenRouterEnrichmentConfig } from "./enrichment-providers";
 
 export interface SearchResult {
   id: string;
@@ -1464,6 +1465,8 @@ export async function search(
     skipAutoEntityBoost?: boolean;
     geminiMaxRpm?: number;
     geminiMaxRetries?: number;
+    openRouterApiKey?: string;
+    settingsEncryptionKey?: string;
   },
 ): Promise<HybridSearchResult[]> {
   const limit = opts?.limit ?? 10;
@@ -1504,19 +1507,16 @@ export async function search(
 
   let queryEmbedding: number[] | undefined;
   try {
-    const settings = await db
-      .selectFrom("settings")
-      .select(["gemini_api_key", "enrichment_enabled"])
-      .where("id", "=", "default")
-      .executeTakeFirst();
-    if (settings?.gemini_api_key && settings.enrichment_enabled !== 0) {
-      const embedQuery = createQueryEmbedder({
-        provider: "gemini",
-        apiKey: settings.gemini_api_key,
-        maxRpm: opts?.geminiMaxRpm,
-        maxRetries: opts?.geminiMaxRetries,
+    const settings = await createSettingsRepository(db, opts?.settingsEncryptionKey).get();
+    if (settings?.enrichment_enabled !== 0) {
+      const openRouterConfig = resolveOpenRouterEnrichmentConfig(settings, opts?.openRouterApiKey);
+      const embedQuery = createEnrichmentQueryEmbedder({
+        geminiApiKey: settings?.gemini_api_key,
+        geminiMaxRpm: opts?.geminiMaxRpm,
+        geminiMaxRetries: opts?.geminiMaxRetries,
+        ...openRouterConfig,
       });
-      queryEmbedding = await embedQuery(trimmedQuery);
+      if (embedQuery) queryEmbedding = await embedQuery(trimmedQuery);
     }
   } catch {
     // Vector search is best-effort — fall back to FTS5 only

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -21,8 +21,12 @@ import { runFeatureArchiveSweep } from "../entities/feature-archive-sweep";
 import { isRecreateActive } from "../entities/recreate-state";
 import { reconcileDanglingCrmRollups, refreshCrmActivityRollups } from "./crm-rollup";
 import { isEmailSyncedItem, persistEnvelopeMetadata, recordSuppressedEmailRecord } from "./email";
-import { type EmbeddingProviderConfig, createEmbeddingProvider } from "./embeddings";
 import { runEnrichment } from "./enrichment";
+import {
+  createEnrichmentEmbeddingProvider,
+  createEnrichmentGenerator,
+  resolveOpenRouterEnrichmentConfig,
+} from "./enrichment-providers";
 import { createGeminiGenerator } from "./gemini-generate";
 import { runPostSyncGraphPipeline } from "./post-sync";
 import { getConnector } from "./registry";
@@ -442,6 +446,7 @@ export interface SyncSchedulerDeps {
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
       | "ENCRYPTION_KEY"
+      | "OPENROUTER_API_KEY"
     >
   >;
 }
@@ -506,30 +511,29 @@ export async function runAllSyncs(db: Kysely<DB>, logger: Logger, deps?: SyncSch
 
   // Run enrichment after all syncs complete
   try {
-    const settings = await db
-      .selectFrom("settings")
-      .select(["gemini_api_key", "enrichment_enabled"])
-      .where("id", "=", "default")
-      .executeTakeFirst();
+    const settings = await createSettingsRepository(db, deps?.appConfig?.ENCRYPTION_KEY).get();
 
     if (settings?.enrichment_enabled === 0) {
       logger.info("Enrichment disabled, skipping post-sync enrichment");
       return;
     }
 
-    const embeddingProvider = settings?.gemini_api_key
-      ? createEmbeddingProvider({
-          provider: "gemini",
-          apiKey: settings.gemini_api_key,
-          maxRpm: deps?.appConfig?.GEMINI_MAX_RPM,
-          maxRetries: deps?.appConfig?.GEMINI_MAX_RETRIES,
-        })
-      : null;
+    const openRouterConfig = resolveOpenRouterEnrichmentConfig(settings, deps?.appConfig?.OPENROUTER_API_KEY);
+    const providerConfig = {
+      geminiApiKey: settings?.gemini_api_key,
+      geminiMaxRpm: deps?.appConfig?.GEMINI_MAX_RPM,
+      geminiMaxRetries: deps?.appConfig?.GEMINI_MAX_RETRIES,
+      logger,
+      ...openRouterConfig,
+    };
+    const embeddingProvider = createEnrichmentEmbeddingProvider(providerConfig);
+    const generator = createEnrichmentGenerator(providerConfig);
 
     const enrichResult = await runEnrichment({
       db,
       logger: logger.child({ component: "enrichment" }),
       embeddingProvider,
+      generator,
       geminiApiKey: settings?.gemini_api_key,
       geminiMaxRpm: deps?.appConfig?.GEMINI_MAX_RPM,
       geminiMaxRetries: deps?.appConfig?.GEMINI_MAX_RETRIES,


### PR DESCRIPTION
## Summary

- Adds OpenRouter generation and embedding providers for connector enrichment.
- Keeps Gemini as the primary enrichment provider when configured, with OpenRouter fallback for quota/prepayment/rate-limit/server/timeout failures, invalid Gemini keys, and missing Gemini configuration.
- Wires the fallback through scheduled sync enrichment, manual global enrichment, and per-file debug enrichment.
- Uses `google/gemini-embedding-2-preview` via OpenRouter for text embeddings with 3072 dimensions.

## RCA Context

Habuild enrichment was blocked because Gemini enrichment calls returned quota/prepayment failures during the Fireflies recovery RCA. Operationally, Habuild can keep moving with OpenRouter credentials that are already configured and verified. This PR makes that path automatic instead of requiring manual intervention.

Related Linear: SKE-199. Follow-up from SKE-198.

## Validation

- `pnpm biome check .`
- `pnpm typecheck`
- `pnpm --filter @sketch/server exec vitest run --project unit --project unit-isolated src/connectors/provider-fallback.test.ts src/connectors/enrichment-providers.isolated.test.ts`
- `pnpm build`
- `pnpm test`
- pre-push hook passed on push