### PR TITLE
fix: block image reads for visual analysis runs

### DIFF
--- a/packages/server/src/agent/permissions.test.ts
+++ b/packages/server/src/agent/permissions.test.ts
@@ -126,6 +126,53 @@ describe("createCanUseTool", () => {
       expect(result.message).toContain(blockedPath);
     });
 
+    it.each(["jpg", "jpeg", "png", "gif", "webp"])(
+      "denies Read for image extension .%s when image reads are disabled",
+      async (extension) => {
+        const logger = createTestLogger();
+        const imagePath = `${WORKSPACE}/attachments/photo.${extension}`;
+        const agentTool = createCanUseTool(WORKSPACE, logger, CLAUDE_DIR, { blockImageReads: true });
+
+        const result = await agentTool("Read", { file_path: imagePath });
+
+        expectDeny(result);
+        expect(result.message).toContain("Direct image reads are not supported for this model");
+        expect(result.message).toContain("Use mcp__sketch__VisualAnalysis");
+        expect(result.message).toContain("Do not use Read, Bash, cat, base64, or conversion workarounds");
+        expect(result.message).toContain(imagePath);
+      },
+    );
+
+    it("allows Read for image extensions when image reads are enabled", async () => {
+      const logger = createTestLogger();
+      const imagePath = `${WORKSPACE}/attachments/photo.png`;
+      const agentTool = createCanUseTool(WORKSPACE, logger, CLAUDE_DIR, { blockImageReads: false });
+
+      const result = await agentTool("Read", { file_path: imagePath });
+
+      expect(result.behavior).toBe("allow");
+    });
+
+    it("allows Read for non-image extensions when image reads are disabled", async () => {
+      const logger = createTestLogger();
+      const textPath = `${WORKSPACE}/attachments/notes.txt`;
+      const agentTool = createCanUseTool(WORKSPACE, logger, CLAUDE_DIR, { blockImageReads: true });
+
+      const result = await agentTool("Read", { file_path: textPath });
+
+      expect(result.behavior).toBe("allow");
+    });
+
+    it("allows non-Read file tools for image extensions when image reads are disabled", async () => {
+      const logger = createTestLogger();
+      const imagePath = `${WORKSPACE}/attachments/photo.png`;
+      const agentTool = createCanUseTool(WORKSPACE, logger, CLAUDE_DIR, { blockImageReads: true });
+
+      const result = await agentTool("Grep", { path: imagePath });
+
+      expect(result.behavior).toBe("allow");
+    });
+
     it("resolves blocked attachment paths before comparing", async () => {
       const logger = createTestLogger();
       const blockedPath = `${WORKSPACE}/attachments/image.png`;

--- a/packages/server/src/agent/permissions.ts
+++ b/packages/server/src/agent/permissions.ts
@@ -8,7 +8,7 @@
  * 3. Bash path validation — commands blocked if they reference absolute paths outside
  *    workspace/~/.claude.
  */
-import { isAbsolute, matchesGlob, relative, resolve } from "node:path";
+import { extname, isAbsolute, matchesGlob, relative, resolve } from "node:path";
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
 import { VISUAL_ANALYSIS_AGENT_TOOL_NAME } from "@sketch/shared";
 import type { Logger } from "../logger";
@@ -22,7 +22,10 @@ export const READ_ONLY_FILE_TOOLS = ["Read", "Glob", "Grep"];
 export interface CanUseToolOptions {
   agentAllowedTools?: string[] | null;
   blockedReadPaths?: Iterable<string> | null;
+  blockImageReads?: boolean;
 }
+
+const IMAGE_FILE_EXTENSIONS = new Set([".gif", ".jpeg", ".jpg", ".png", ".webp"]);
 
 /**
  * Returns true when filePath is exactly dir or a child of dir.
@@ -46,6 +49,10 @@ function commandWords(command: string): string[] {
 
 function hasGlobSyntax(value: string): boolean {
   return /[*?[\]{}]/.test(value);
+}
+
+function isImageFilePath(filePath: string): boolean {
+  return IMAGE_FILE_EXTENSIONS.has(extname(filePath).toLowerCase());
 }
 
 function matchesBlockedPathPattern(pattern: string, blockedPath: string, relativeBlockedPath: string): boolean {
@@ -116,11 +123,14 @@ export function createCanUseTool(
         };
       }
 
-      if (toolName === "Read" && blockedReadPaths.has(filePath)) {
+      if (
+        toolName === "Read" &&
+        (blockedReadPaths.has(filePath) || (options.blockImageReads && isImageFilePath(filePath)))
+      ) {
         logger.warn({ toolName, filePath }, "Blocked Read on attachment that requires VisualAnalysis");
         return {
           behavior: "deny",
-          message: `Use ${VISUAL_ANALYSIS_AGENT_TOOL_NAME} with this path instead of Read: ${filePath}`,
+          message: `Direct image reads are not supported for this model. Use ${VISUAL_ANALYSIS_AGENT_TOOL_NAME} with this exact path instead: ${filePath}. Do not use Read, Bash, cat, base64, or conversion workarounds for this image.`,
         };
       }
     }

--- a/packages/server/src/agent/runner.isolated.test.ts
+++ b/packages/server/src/agent/runner.isolated.test.ts
@@ -390,6 +390,7 @@ describe("runAgent", () => {
       );
       expect(vi.mocked(createCanUseTool).mock.calls.at(-1)?.[3]).toMatchObject({
         blockedReadPaths: [imagePath, backlogImagePath],
+        blockImageReads: true,
       });
       expect(result.rawUsage.promptMode).toBe("text");
       expect(result.rawUsage.imageCount).toBe(1);
@@ -451,6 +452,7 @@ describe("runAgent", () => {
       });
       expect(vi.mocked(createCanUseTool).mock.calls.at(-1)?.[3]).toMatchObject({
         agentAllowedTools: ["Read"],
+        blockImageReads: false,
       });
       expect(vi.mocked(createCanUseTool).mock.calls.at(-1)?.[3]?.blockedReadPaths).toBeUndefined();
       expect(result.rawUsage.promptMode).toBe("text");

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -406,6 +406,7 @@ export async function runAgent(params: RunAgentParams): Promise<RunAgentResult> 
   const baseCanUseTool = createCanUseTool(absWorkspace, logger, params.claudeConfigDir, {
     agentAllowedTools: params.agentAllowedTools,
     blockedReadPaths: blockedReadPaths.size > 0 ? Array.from(blockedReadPaths) : undefined,
+    blockImageReads: visualAnalysisAllowed,
   });
   const canUseToolTimings: CanUseToolTiming[] = [];
   const timedCanUseTool = async (toolName: string, input: Record<string, unknown>) => {


### PR DESCRIPTION
## Summary
- Deny `Read` on common image extensions when `VisualAnalysis` is available for the agent run.
- Keep non-image file reads and non-Read file tools unchanged.
- Strengthen the denial message so the agent uses `mcp__sketch__VisualAnalysis` with the exact file path instead of Read/Bash/cat/base64/conversion workarounds.

## Root Cause
For non-image models, an image file could still be read through `Read` after the visual-analysis path failed or was bypassed. That let image content enter the agent transcript directly, which can break models that do not support image blocks.

## Validation
- `pnpm biome check packages/server/src/agent/permissions.ts packages/server/src/agent/permissions.test.ts packages/server/src/agent/runner.ts packages/server/src/agent/runner.isolated.test.ts`
- `pnpm --filter @sketch/server exec vitest run --project unit --project unit-isolated src/agent/permissions.test.ts src/agent/runner.isolated.test.ts`
- `pnpm biome check .`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- pre-push hook: lint, typecheck, test, build
