### PR TITLE
fix: derive OAuth redirect origin from request for multi-tenant hosts

### DIFF
--- a/packages/server/src/api/oauth.test.ts
+++ b/packages/server/src/api/oauth.test.ts
@@ -1,0 +1,35 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { resolveOrigin } from "./oauth";
+
+/**
+ * Exercises the origin used to build OAuth redirect URIs. The production bug:
+ * behind a TLS-terminating proxy the request reaches Node as plain HTTP, so the
+ * redirect URI was built with `http://`, failing the provider's exact-match
+ * check (AADSTS50011). Multi-tenant hosts rule out a single configured BASE_URL,
+ * so the scheme must come from `X-Forwarded-Proto`.
+ */
+async function originFor(headers: Record<string, string>, baseUrl?: string): Promise<string> {
+  const app = new Hono();
+  app.get("/probe", (c) => c.text(resolveOrigin(c, baseUrl)));
+  const res = await app.request("http://capmobfinance.getsketch.ai/probe", { headers });
+  return res.text();
+}
+
+describe("resolveOrigin", () => {
+  it("upgrades to https from X-Forwarded-Proto behind a TLS-terminating proxy", async () => {
+    expect(await originFor({ "x-forwarded-proto": "https", host: "capmobfinance.getsketch.ai" })).toBe(
+      "https://capmobfinance.getsketch.ai",
+    );
+  });
+
+  it("prefers an explicit BASE_URL override over the request and forwarded headers", async () => {
+    expect(await originFor({ "x-forwarded-proto": "http", host: "evil.example" }, "https://override.example")).toBe(
+      "https://override.example",
+    );
+  });
+
+  it("falls back to the request origin when no forwarded headers are present", async () => {
+    expect(await originFor({ host: "capmobfinance.getsketch.ai" })).toBe("http://capmobfinance.getsketch.ai");
+  });
+});

--- a/packages/server/src/api/oauth.ts
+++ b/packages/server/src/api/oauth.ts
@@ -9,7 +9,7 @@
  * creates a connector_config, and redirects to a frontend success page.
  */
 import { randomBytes } from "node:crypto";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { getCookie } from "hono/cookie";
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
@@ -74,6 +74,27 @@ const pendingStates = new Map<
   string,
   { userId: string; expiresAt: number; connectorType?: ConnectorType; region?: (typeof ZOHO_REGIONS)[number] }
 >();
+
+/**
+ * Resolves the public origin (`scheme://host`) used to build OAuth redirect URIs.
+ *
+ * Multi-tenant deployments serve each tenant on its own host (e.g.
+ * `capmobfinance.getsketch.ai`), so a single configured origin cannot be used.
+ * We derive it from the request instead. Behind a TLS-terminating proxy the
+ * internal hop to Node is plain HTTP, so `c.req.url` reports `http://`; the
+ * proxy's `X-Forwarded-Proto`/`X-Forwarded-Host` headers carry the real public
+ * scheme and host and take precedence. An explicit `baseUrl` override (BASE_URL)
+ * wins when set, which is handy for local development.
+ */
+export function resolveOrigin(c: Context, baseUrl: string | undefined): string {
+  if (baseUrl) return baseUrl;
+  const requestUrl = new URL(c.req.url);
+  const forwardedProto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim();
+  const forwardedHost = c.req.header("x-forwarded-host")?.split(",")[0]?.trim();
+  const proto = forwardedProto || requestUrl.protocol.replace(/:$/, "");
+  const host = forwardedHost || requestUrl.host;
+  return `${proto}://${host}`;
+}
 
 function cleanupExpiredStates() {
   const now = Date.now();
@@ -226,7 +247,7 @@ export function oauthRoutes(
     pendingStates.set(nonce, { userId, connectorType, expiresAt: Date.now() + 10 * 60 * 1000 });
 
     // Build the callback URL from BASE_URL or the request's origin
-    const origin = baseUrl ?? new URL(c.req.url).origin;
+    const origin = resolveOrigin(c, baseUrl);
     const redirectUri = `${origin}/api/oauth/google/callback`;
 
     const params = new URLSearchParams({
@@ -289,7 +310,7 @@ export function oauthRoutes(
     }
 
     // Build redirect URI from BASE_URL or request origin (must match authorize step)
-    const origin = baseUrl ?? new URL(c.req.url).origin;
+    const origin = resolveOrigin(c, baseUrl);
     const redirectUri = `${origin}/api/oauth/google/callback`;
 
     try {
@@ -447,7 +468,7 @@ export function oauthRoutes(
     const state = `${userId}:${connectorType}:${nonce}`;
     pendingStates.set(nonce, { userId, connectorType, expiresAt: Date.now() + 10 * 60 * 1000 });
 
-    const origin = baseUrl ?? new URL(c.req.url).origin;
+    const origin = resolveOrigin(c, baseUrl);
     const redirectUri = `${origin}/api/oauth/microsoft/callback`;
     const params = new URLSearchParams({
       client_id: clientId,
@@ -501,7 +522,7 @@ export function oauthRoutes(
       return c.redirect(`/files?oauth=error&connector=${connectorType}&reason=not_configured`);
     }
 
-    const origin = baseUrl ?? new URL(c.req.url).origin;
+    const origin = resolveOrigin(c, baseUrl);
     const redirectUri = `${origin}/api/oauth/microsoft/callback`;
     const scope = microsoftScopesFor(connectorType);
 
@@ -671,7 +692,7 @@ export function oauthRoutes(
       const state = `${userId}:${nonce}`;
       pendingStates.set(nonce, { userId, region: parsedRegion.data, expiresAt: Date.now() + 10 * 60 * 1000 });
 
-      const origin = baseUrl ?? new URL(c.req.url).origin;
+      const origin = resolveOrigin(c, baseUrl);
       const redirectUri = `${origin}/api/oauth/zoho/callback`;
 
       const params = new URLSearchParams({
@@ -722,7 +743,7 @@ export function oauthRoutes(
 
       const accountsServer =
         c.req.query("accounts-server") ?? c.req.query("accounts_server") ?? zohoAccountsServer(pending.region);
-      const origin = baseUrl ?? new URL(c.req.url).origin;
+      const origin = resolveOrigin(c, baseUrl);
       const redirectUri = `${origin}/api/oauth/zoho/callback`;
 
       try {


### PR DESCRIPTION
## What & Why

The Outlook (Microsoft) connector fails on production with `AADSTS50011: The redirect URI 'http://capmobfinance.getsketch.ai/api/oauth/microsoft/callback' ... does not match the redirect URIs configured`. Works locally.

Root cause: OAuth redirect URIs are built from `BASE_URL` or, when unset, the raw request origin (`new URL(c.req.url).origin`). In our **multi-tenant** setup each tenant is served on its own host, so a single `BASE_URL` can't be used — it must stay unset. The request then reaches Node behind a TLS-terminating proxy as plain HTTP, so `c.req.url` reports `http://`. The redirect URI is built with `http://`, which fails the provider's exact-match check.

The host is already correct in every request; only the scheme was wrong.

## How

Add `resolveOrigin()` which resolves the public origin in priority order:
1. Explicit `BASE_URL` override (kept for local dev).
2. `X-Forwarded-Proto` / `X-Forwarded-Host` from the proxy — the real public scheme + per-tenant host.
3. Fallback to the raw request origin when no forwarded headers exist.

Applied to all 5 redirect-URI builders (Google, Microsoft, Zoho — authorize + callback). With `BASE_URL` unset in prod, each tenant subdomain now self-resolves to `https://<tenant>/api/oauth/.../callback`.

## Acceptance

- [x] `resolveOrigin` upgrades `http`→`https` from `X-Forwarded-Proto` behind a proxy
- [x] `BASE_URL` override still wins when set
- [x] Falls back to request origin when no forwarded headers
- [x] `pnpm typecheck` + biome clean; 3 new unit tests pass

## Out of scope / follow-ups

- Each tenant host must still be registered in the provider's redirect-URI allowlist (Azure/Google) — code change alone doesn't add them.
- Relies on the proxy/LB setting `X-Forwarded-Proto` (default on ALB/CloudFront/nginx).
- The nonce store (`pendingStates`) is in-memory; horizontal scaling across instances would need a shared store. Pre-existing, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)