### PR TITLE
feat: entity dedup name matching

### DIFF
--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -14,6 +14,7 @@ import {
   buildCandidatePool,
   findFuzzyMatches,
   findStrictMatches,
+  findTokenSetMatches,
   removeFromCandidatePool,
 } from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
@@ -210,19 +211,25 @@ export async function buildMaterializeDeps(
       const entitiesById = new Map((index.entitiesByType.get(entityType) ?? []).map((entity) => [entity.id, entity]));
       const strict = findStrictMatches(name, pool);
       const strictEntityIds = new Set(strict.map((match) => match.entityId));
+      const tokenSet = findTokenSetMatches(name, pool);
+      const tokenSetEntityIds = new Set(tokenSet.map((match) => match.entityId));
       const fuzzy = findFuzzyMatches(name, pool);
       const byEntity = new Map<
         string,
         {
           entity: EntityRow;
           score: number;
-          reason: "strict-normalized" | "minhash";
+          reason: "strict-normalized" | "token-set" | "minhash";
         }
       >();
-      for (const match of [...strict, ...fuzzy]) {
+      for (const match of [...strict, ...tokenSet, ...fuzzy]) {
         const entity = entitiesById.get(match.entityId);
         if (!entity) continue;
-        const reason = strictEntityIds.has(match.entityId) ? "strict-normalized" : "minhash";
+        const reason = strictEntityIds.has(match.entityId)
+          ? "strict-normalized"
+          : tokenSetEntityIds.has(match.entityId)
+            ? "token-set"
+            : "minhash";
         const existing = byEntity.get(match.entityId);
         if (!existing || match.score > existing.score)
           byEntity.set(match.entityId, { entity, score: match.score, reason });

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -8,6 +8,14 @@ import { createEntitySuppressionRepository } from "../db/repositories/entity-sup
 import type { DB } from "../db/schema";
 import { parseAliasesString, readPersonEmailFromMetadata } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, LookupIndex, MaterializeDeps } from "./materialize-types";
+import {
+  type CandidatePoolEntry,
+  addToCandidatePool,
+  buildCandidatePool,
+  findFuzzyMatches,
+  findStrictMatches,
+  removeFromCandidatePool,
+} from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
 
 const DEFAULT_LLM_PROMOTION_THRESHOLD = 2;
@@ -47,9 +55,12 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
   for (const t of supportedTypes) entitiesByType.set(t, []);
   const byNormalizedName = new Map<string, EntityRow[]>();
   const byNormalizedAlias = new Map<string, EntityRow[]>();
+  const dedupEntriesByType = new Map<ProposeEntityType, CandidatePoolEntry[]>();
+  for (const t of supportedTypes) dedupEntriesByType.set(t, []);
   for (const e of entities) {
     const entityType = e.source_type as ProposeEntityType;
     entitiesByType.get(entityType)?.push(e);
+    dedupEntriesByType.get(entityType)?.push({ entityId: e.id, valueKind: "name", value: e.name });
     const nameKey = normalizeEntityMatchName(entityType, e.name);
     if (nameKey) {
       const bucket = byNormalizedName.get(nameKey);
@@ -57,6 +68,7 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
       else byNormalizedName.set(nameKey, [e]);
     }
     for (const alias of parseAliasesString(e.aliases)) {
+      dedupEntriesByType.get(entityType)?.push({ entityId: e.id, valueKind: "alias", value: alias });
       const aliasKey = normalizeEntityMatchName(entityType, alias);
       if (!aliasKey) continue;
       const bucket = byNormalizedAlias.get(aliasKey);
@@ -90,7 +102,9 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
     if (bucket) bucket.push(row.entity_id);
     else companyIdsByDomain.set(domain, [row.entity_id]);
   }
-  return { entitiesByType, byNormalizedName, byNormalizedAlias, bySourceRef, companyIdsByDomain };
+  const dedupPoolsByType = new Map<ProposeEntityType, ReturnType<typeof buildCandidatePool>>();
+  for (const t of supportedTypes) dedupPoolsByType.set(t, buildCandidatePool(dedupEntriesByType.get(t) ?? []));
+  return { entitiesByType, byNormalizedName, byNormalizedAlias, dedupPoolsByType, bySourceRef, companyIdsByDomain };
 }
 
 export function registerEntity(index: LookupIndex, entity: EntityRow): void {
@@ -117,6 +131,17 @@ export function registerEntity(index: LookupIndex, entity: EntityRow): void {
       index.byNormalizedAlias.set(aliasKey, [entity]);
     }
   }
+  const pool = index.dedupPoolsByType.get(entityType);
+  if (pool) {
+    addToCandidatePool(pool, [
+      { entityId: entity.id, valueKind: "name", value: entity.name },
+      ...parseAliasesString(entity.aliases).map((value) => ({
+        entityId: entity.id,
+        valueKind: "alias" as const,
+        value,
+      })),
+    ]);
+  }
 }
 
 function removeEntityFromMapBuckets<T extends EntityRow>(map: Map<string, T[]>, entityId: string): void {
@@ -134,6 +159,9 @@ function unregisterEntity(index: LookupIndex, entityId: string): void {
   }
   removeEntityFromMapBuckets(index.byNormalizedName, entityId);
   removeEntityFromMapBuckets(index.byNormalizedAlias, entityId);
+  for (const pool of index.dedupPoolsByType.values()) {
+    removeFromCandidatePool(pool, entityId);
+  }
 }
 
 export async function refreshResolvedEntityIndex(db: Kysely<DB>, index: LookupIndex, entity: Entity): Promise<void> {
@@ -176,6 +204,31 @@ export async function buildMaterializeDeps(
     getByNormalizedName: (n) => index.byNormalizedName.get(n) ?? [],
     getByAlias: (n) => index.byNormalizedAlias.get(n) ?? [],
     listByType: (t: ProposeEntityType) => index.entitiesByType.get(t) ?? [],
+    findNameDedupCandidates: (entityType, name) => {
+      const pool = index.dedupPoolsByType.get(entityType);
+      if (!pool) return [];
+      const entitiesById = new Map((index.entitiesByType.get(entityType) ?? []).map((entity) => [entity.id, entity]));
+      const strict = findStrictMatches(name, pool);
+      const strictEntityIds = new Set(strict.map((match) => match.entityId));
+      const fuzzy = findFuzzyMatches(name, pool);
+      const byEntity = new Map<
+        string,
+        {
+          entity: EntityRow;
+          score: number;
+          reason: "strict-normalized" | "minhash";
+        }
+      >();
+      for (const match of [...strict, ...fuzzy]) {
+        const entity = entitiesById.get(match.entityId);
+        if (!entity) continue;
+        const reason = strictEntityIds.has(match.entityId) ? "strict-normalized" : "minhash";
+        const existing = byEntity.get(match.entityId);
+        if (!existing || match.score > existing.score)
+          byEntity.set(match.entityId, { entity, score: match.score, reason });
+      }
+      return [...byEntity.values()].sort((a, b) => b.score - a.score || a.entity.id.localeCompare(b.entity.id));
+    },
     getCompanyIdsByDomain: (domain) => index.companyIdsByDomain.get(domain.toLowerCase()) ?? [],
   };
 

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -6,6 +6,7 @@ import type { createEntityReviewRepo } from "../db/repositories/entity-review";
 import type { EntitySuppressionRepository } from "../db/repositories/entity-suppressions";
 import type { IndexedFileFactType } from "../db/repositories/indexed-file-facts";
 import type { DB, EntitiesTable, IndexedFileFactsTable } from "../db/schema";
+import type { CandidatePool } from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
 
 export interface ReplayFactsSummary {
@@ -31,6 +32,7 @@ export interface LookupIndex {
   entitiesByType: Map<ProposeEntityType, EntityRow[]>;
   byNormalizedName: Map<string, EntityRow[]>;
   byNormalizedAlias: Map<string, EntityRow[]>;
+  dedupPoolsByType: Map<ProposeEntityType, CandidatePool>;
   bySourceRef: Map<string, EntityRow>;
   companyIdsByDomain: Map<string, string[]>;
 }

--- a/packages/server/src/entities/name-dedup.test.ts
+++ b/packages/server/src/entities/name-dedup.test.ts
@@ -3,9 +3,13 @@ import {
   buildCandidatePool,
   findDedupCandidates,
   findFuzzyMatch,
+  findStrictMatches,
+  findTokenSetMatches,
   jaccard,
   lshBands,
   minhashSignature,
+  normalizeTokenSet,
+  removeFromCandidatePool,
   shingles,
 } from "./name-dedup";
 
@@ -44,5 +48,28 @@ describe("name-dedup", () => {
 
     expect(findFuzzyMatch("Sarah", sarahPool)).toBeNull();
     expect(findFuzzyMatch("KT", initialsPool)).toBeNull();
+  });
+
+  it("unifies a word-order permutation the strict key misses", () => {
+    const pool = buildCandidatePool([{ entityId: "ohoud", valueKind: "name", value: "Ohoud Zitan" }]);
+
+    expect(findStrictMatches("Zitan, Ohoud", pool)).toEqual([]);
+    expect(findTokenSetMatches("Zitan, Ohoud", pool)).toEqual([
+      { entityId: "ohoud", score: 1, valueKind: "name", value: "Ohoud Zitan" },
+    ]);
+  });
+
+  it("does not key bare single-token names", () => {
+    expect(normalizeTokenSet("Sanaa")).toBe("");
+    const pool = buildCandidatePool([{ entityId: "sanaa-a", valueKind: "name", value: "Sanaa" }]);
+    expect(findTokenSetMatches("Sanaa", pool)).toEqual([]);
+  });
+
+  it("prunes token-set buckets when an entity is removed", () => {
+    const pool = buildCandidatePool([{ entityId: "ohoud", valueKind: "name", value: "Ohoud Zitan" }]);
+    removeFromCandidatePool(pool, "ohoud");
+
+    expect(findTokenSetMatches("Zitan, Ohoud", pool)).toEqual([]);
+    expect(pool.byTokenSetKey.size).toBe(0);
   });
 });

--- a/packages/server/src/entities/name-dedup.test.ts
+++ b/packages/server/src/entities/name-dedup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCandidatePool,
+  findDedupCandidates,
+  findFuzzyMatch,
+  jaccard,
+  lshBands,
+  minhashSignature,
+  shingles,
+} from "./name-dedup";
+
+describe("name-dedup", () => {
+  it("strict-normalizes whitespace, casing, and punctuation", () => {
+    const pool = buildCandidatePool([{ entityId: "redseer", valueKind: "name", value: "Redseer Consulting" }]);
+
+    expect(findFuzzyMatch("RedseerConsulting", pool)).toMatchObject({ entityId: "redseer", score: 1 });
+    expect(findFuzzyMatch("REDSEER consulting", pool)).toMatchObject({ entityId: "redseer", score: 1 });
+    expect(findFuzzyMatch("Redseer  Consulting", pool)).toMatchObject({ entityId: "redseer", score: 1 });
+  });
+
+  it("uses spaces-in, no-padding 3-grams for the typo acceptance case", () => {
+    const existing = shingles("Apperture Technologies");
+    const proposed = shingles("Aperture Technologies");
+    const score = jaccard(existing, proposed);
+
+    expect(score).toBeCloseTo(18 / 21, 6);
+
+    const existingBands = new Set(lshBands(minhashSignature(existing)));
+    const proposedBands = lshBands(minhashSignature(proposed));
+    expect(proposedBands.some((band) => existingBands.has(band))).toBe(true);
+    const pinnedSharedBand = "2:012805ecd75c9f08:05afe1752c9b0fe1:1709b7f28c96be6d:117d40be1d2ccf14";
+    expect(existingBands.has(pinnedSharedBand)).toBe(true);
+    expect(proposedBands).toContain(pinnedSharedBand);
+
+    const pool = buildCandidatePool([{ entityId: "apperture", valueKind: "name", value: "Apperture Technologies" }]);
+    expect(findDedupCandidates("Aperture Technologies", pool, { threshold: 0.85 })).toEqual([
+      { entityId: "apperture", score, valueKind: "name", value: "Apperture Technologies" },
+    ]);
+  });
+
+  it("does not collide short or low-entropy names", () => {
+    const sarahPool = buildCandidatePool([{ entityId: "saran", valueKind: "name", value: "Saran" }]);
+    const initialsPool = buildCandidatePool([{ entityId: "kp", valueKind: "name", value: "KP" }]);
+
+    expect(findFuzzyMatch("Sarah", sarahPool)).toBeNull();
+    expect(findFuzzyMatch("KT", initialsPool)).toBeNull();
+  });
+});

--- a/packages/server/src/entities/name-dedup.ts
+++ b/packages/server/src/entities/name-dedup.ts
@@ -14,6 +14,7 @@ interface IndexedCandidatePoolEntry extends CandidatePoolEntry {
 
 export interface CandidatePool {
   byStrictKey: Map<string, CandidatePoolEntry[]>;
+  byTokenSetKey: Map<string, CandidatePoolEntry[]>;
   shinglesByEntryKey: Map<string, Set<string>>;
   entriesByKey: Map<string, CandidatePoolEntry>;
   lshBucketsByBand: Map<string, string[]>;
@@ -38,6 +39,27 @@ export function normalizeStrict(name: string): string {
   return stripDomainSuffix(name)
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Order-insensitive key: lowercase, strip non-alphanumerics to spaces, then
+ * sort the tokens. `Ohoud Zitan` and `Zitan, Ohoud` both collapse to
+ * `ohoud zitan`, catching the "Last, First" vs "First Last" permutation class
+ * that {@link normalizeStrict} (order-preserving) misses.
+ *
+ * Returns `""` for fewer than two tokens. A single-token bag carries no
+ * reordering signal, so keying it would over-collapse bare first names
+ * (`Sanaa` vs an unrelated `Sanaa`). The caller treats `""` as "no key".
+ */
+export function normalizeTokenSet(name: string): string {
+  const tokens = stripDomainSuffix(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+  if (tokens.length < 2) return "";
+  return tokens.sort().join(" ");
 }
 
 export function normalizeFuzzy(name: string): string {
@@ -112,6 +134,7 @@ export function lshBands(signature: BigUint64Array, bandSize = BAND_SIZE): strin
 export function buildCandidatePool(entries: CandidatePoolEntry[]): CandidatePool {
   const pool: CandidatePool = {
     byStrictKey: new Map(),
+    byTokenSetKey: new Map(),
     shinglesByEntryKey: new Map(),
     entriesByKey: new Map(),
     lshBucketsByBand: new Map(),
@@ -128,6 +151,13 @@ export function addToCandidatePool(pool: CandidatePool, entries: CandidatePoolEn
       const bucket = pool.byStrictKey.get(strictKey);
       if (bucket) bucket.push(indexed);
       else pool.byStrictKey.set(strictKey, [indexed]);
+    }
+
+    const tokenSetKey = normalizeTokenSet(indexed.value);
+    if (tokenSetKey) {
+      const bucket = pool.byTokenSetKey.get(tokenSetKey);
+      if (bucket) bucket.push(indexed);
+      else pool.byTokenSetKey.set(tokenSetKey, [indexed]);
     }
 
     const entryShingles = shingles(indexed.value);
@@ -151,6 +181,12 @@ export function removeFromCandidatePool(pool: CandidatePool, entityId: string): 
     else if (filtered.length !== bucket.length) pool.byStrictKey.set(key, filtered);
   }
 
+  for (const [key, bucket] of pool.byTokenSetKey) {
+    const filtered = bucket.filter((entry) => entry.entityId !== entityId);
+    if (filtered.length === 0) pool.byTokenSetKey.delete(key);
+    else if (filtered.length !== bucket.length) pool.byTokenSetKey.set(key, filtered);
+  }
+
   const removedKeys = new Set<string>();
   for (const [entryKey, entry] of pool.entriesByKey) {
     if (entry.entityId === entityId) {
@@ -170,6 +206,20 @@ export function removeFromCandidatePool(pool: CandidatePool, entityId: string): 
 
 export function findStrictMatches(name: string, pool: CandidatePool): DedupHit[] {
   const matches = pool.byStrictKey.get(normalizeStrict(name)) ?? [];
+  return dedupeEntityMatches(matches.map((entry) => ({ ...entry, score: 1 })));
+}
+
+/**
+ * Order-insensitive matches: entities whose name/alias is a token-permutation
+ * of `name` (e.g. `Zitan, Ohoud` against an existing `Ohoud Zitan`). Score 1 —
+ * the token bag is identical — but unlike a strict match this is genuinely
+ * ambiguous (a reorder vs two namesakes like `Li Wang` / `Wang Li`), so callers
+ * must treat it as a recall candidate to adjudicate, not an auto-link.
+ */
+export function findTokenSetMatches(name: string, pool: CandidatePool): DedupHit[] {
+  const key = normalizeTokenSet(name);
+  if (!key) return [];
+  const matches = pool.byTokenSetKey.get(key) ?? [];
   return dedupeEntityMatches(matches.map((entry) => ({ ...entry, score: 1 })));
 }
 
@@ -199,7 +249,11 @@ export function findFuzzyMatches(name: string, pool: CandidatePool, opts: { thre
 
 export function findDedupCandidates(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit[] {
   const byEntity = new Map<string, DedupHit>();
-  for (const match of [...findStrictMatches(name, pool), ...findFuzzyMatches(name, pool, opts)]) {
+  for (const match of [
+    ...findStrictMatches(name, pool),
+    ...findTokenSetMatches(name, pool),
+    ...findFuzzyMatches(name, pool, opts),
+  ]) {
     const existing = byEntity.get(match.entityId);
     if (!existing || match.score > existing.score) byEntity.set(match.entityId, match);
   }

--- a/packages/server/src/entities/name-dedup.ts
+++ b/packages/server/src/entities/name-dedup.ts
@@ -1,0 +1,263 @@
+import { createHash } from "node:crypto";
+
+export type CandidateValueKind = "name" | "alias";
+
+export interface CandidatePoolEntry {
+  entityId: string;
+  valueKind: CandidateValueKind;
+  value: string;
+}
+
+interface IndexedCandidatePoolEntry extends CandidatePoolEntry {
+  entryKey: string;
+}
+
+export interface CandidatePool {
+  byStrictKey: Map<string, CandidatePoolEntry[]>;
+  shinglesByEntryKey: Map<string, Set<string>>;
+  entriesByKey: Map<string, CandidatePoolEntry>;
+  lshBucketsByBand: Map<string, string[]>;
+  nextEntryId: number;
+}
+
+export interface DedupHit {
+  entityId: string;
+  score: number;
+  valueKind: CandidateValueKind;
+  value: string;
+}
+
+const DEFAULT_THRESHOLD = 0.85;
+const SHINGLE_SIZE = 3;
+const SIGNATURE_SIZE = 32;
+const BAND_SIZE = 4;
+const MAX_UINT64 = 0xffffffffffffffffn;
+const BLAKE2B64_OUTPUT_LENGTH_SUPPORTED = canCreateBlake2b64();
+
+export function normalizeStrict(name: string): string {
+  return stripDomainSuffix(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+export function normalizeFuzzy(name: string): string {
+  return stripDomainSuffix(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9'\s]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function shingles(name: string, n = SHINGLE_SIZE): Set<string> {
+  const normalized = normalizeFuzzy(name);
+  const out = new Set<string>();
+  if (!normalized) return out;
+  if (normalized.length < n) {
+    out.add(normalized);
+    return out;
+  }
+  for (let i = 0; i <= normalized.length - n; i += 1) {
+    out.add(normalized.slice(i, i + n));
+  }
+  return out;
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const value of a) {
+    if (b.has(value)) intersection += 1;
+  }
+  return intersection / (a.size + b.size - intersection);
+}
+
+export function hasHighEntropy(normalized: string): boolean {
+  const compact = normalized.replace(/\s+/g, "");
+  if (!compact) return false;
+  const counts = new Map<string, number>();
+  for (const ch of compact) counts.set(ch, (counts.get(ch) ?? 0) + 1);
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const p = count / compact.length;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy >= 1.5;
+}
+
+export function minhashSignature(values: Set<string>): BigUint64Array {
+  const signature = new BigUint64Array(SIGNATURE_SIZE);
+  signature.fill(MAX_UINT64);
+  for (const value of values) {
+    for (let seed = 0; seed < SIGNATURE_SIZE; seed += 1) {
+      const hash = blake2b64(`${seed}:${value}`);
+      if (hash < signature[seed]) signature[seed] = hash;
+    }
+  }
+  return signature;
+}
+
+export function lshBands(signature: BigUint64Array, bandSize = BAND_SIZE): string[] {
+  const bands: string[] = [];
+  for (let start = 0; start < signature.length; start += bandSize) {
+    const bandIndex = start / bandSize;
+    const values = Array.from(signature.slice(start, start + bandSize), (value) =>
+      value.toString(16).padStart(16, "0"),
+    ).join(":");
+    bands.push(`${bandIndex}:${values}`);
+  }
+  return bands;
+}
+
+export function buildCandidatePool(entries: CandidatePoolEntry[]): CandidatePool {
+  const pool: CandidatePool = {
+    byStrictKey: new Map(),
+    shinglesByEntryKey: new Map(),
+    entriesByKey: new Map(),
+    lshBucketsByBand: new Map(),
+    nextEntryId: 0,
+  };
+  addToCandidatePool(pool, entries);
+  return pool;
+}
+
+export function addToCandidatePool(pool: CandidatePool, entries: CandidatePoolEntry[]): void {
+  for (const indexed of indexEntries(entries, pool)) {
+    const strictKey = normalizeStrict(indexed.value);
+    if (strictKey) {
+      const bucket = pool.byStrictKey.get(strictKey);
+      if (bucket) bucket.push(indexed);
+      else pool.byStrictKey.set(strictKey, [indexed]);
+    }
+
+    const entryShingles = shingles(indexed.value);
+    pool.entriesByKey.set(indexed.entryKey, indexed);
+    pool.shinglesByEntryKey.set(indexed.entryKey, entryShingles);
+    if (!shouldUseMinhash(indexed.value, entryShingles)) continue;
+
+    const signature = minhashSignature(entryShingles);
+    for (const band of lshBands(signature)) {
+      const bucket = pool.lshBucketsByBand.get(band);
+      if (bucket) bucket.push(indexed.entryKey);
+      else pool.lshBucketsByBand.set(band, [indexed.entryKey]);
+    }
+  }
+}
+
+export function removeFromCandidatePool(pool: CandidatePool, entityId: string): void {
+  for (const [key, bucket] of pool.byStrictKey) {
+    const filtered = bucket.filter((entry) => entry.entityId !== entityId);
+    if (filtered.length === 0) pool.byStrictKey.delete(key);
+    else if (filtered.length !== bucket.length) pool.byStrictKey.set(key, filtered);
+  }
+
+  const removedKeys = new Set<string>();
+  for (const [entryKey, entry] of pool.entriesByKey) {
+    if (entry.entityId === entityId) {
+      removedKeys.add(entryKey);
+      pool.entriesByKey.delete(entryKey);
+      pool.shinglesByEntryKey.delete(entryKey);
+    }
+  }
+
+  if (removedKeys.size === 0) return;
+  for (const [band, bucket] of pool.lshBucketsByBand) {
+    const filtered = bucket.filter((entryKey) => !removedKeys.has(entryKey));
+    if (filtered.length === 0) pool.lshBucketsByBand.delete(band);
+    else if (filtered.length !== bucket.length) pool.lshBucketsByBand.set(band, filtered);
+  }
+}
+
+export function findStrictMatches(name: string, pool: CandidatePool): DedupHit[] {
+  const matches = pool.byStrictKey.get(normalizeStrict(name)) ?? [];
+  return dedupeEntityMatches(matches.map((entry) => ({ ...entry, score: 1 })));
+}
+
+export function findFuzzyMatches(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit[] {
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+  const queryShingles = shingles(name);
+  if (!shouldUseMinhash(name, queryShingles)) return [];
+
+  const signature = minhashSignature(queryShingles);
+  const candidateKeys = new Set<string>();
+  for (const band of lshBands(signature)) {
+    for (const entryKey of pool.lshBucketsByBand.get(band) ?? []) {
+      candidateKeys.add(entryKey);
+    }
+  }
+
+  const matches: DedupHit[] = [];
+  for (const entryKey of candidateKeys) {
+    const candidateShingles = pool.shinglesByEntryKey.get(entryKey);
+    const candidate = pool.entriesByKey.get(entryKey);
+    if (!candidateShingles || !candidate) continue;
+    const score = jaccard(queryShingles, candidateShingles);
+    if (score >= threshold) matches.push({ ...candidate, score });
+  }
+  return dedupeEntityMatches(matches).sort((a, b) => b.score - a.score || a.entityId.localeCompare(b.entityId));
+}
+
+export function findDedupCandidates(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit[] {
+  const byEntity = new Map<string, DedupHit>();
+  for (const match of [...findStrictMatches(name, pool), ...findFuzzyMatches(name, pool, opts)]) {
+    const existing = byEntity.get(match.entityId);
+    if (!existing || match.score > existing.score) byEntity.set(match.entityId, match);
+  }
+  return [...byEntity.values()].sort((a, b) => b.score - a.score || a.entityId.localeCompare(b.entityId));
+}
+
+export function findFuzzyMatch(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit | null {
+  return findDedupCandidates(name, pool, opts)[0] ?? null;
+}
+
+function shouldUseMinhash(value: string, valueShingles: Set<string>): boolean {
+  const normalized = normalizeFuzzy(value);
+  if (valueShingles.size === 0) return false;
+  if (normalized.length < 6 && normalized.split(" ").filter(Boolean).length < 2) return false;
+  if (!hasHighEntropy(normalized)) return false;
+  return true;
+}
+
+function indexEntries(entries: CandidatePoolEntry[], pool: CandidatePool): IndexedCandidatePoolEntry[] {
+  return entries.map((entry) => ({
+    ...entry,
+    entryKey: `${entry.entityId}:${entry.valueKind}:${pool.nextEntryId++}`,
+  }));
+}
+
+function dedupeEntityMatches(matches: DedupHit[]): DedupHit[] {
+  const byEntity = new Map<string, DedupHit>();
+  for (const match of matches) {
+    const clean = {
+      entityId: match.entityId,
+      score: match.score,
+      valueKind: match.valueKind,
+      value: match.value,
+    };
+    const existing = byEntity.get(match.entityId);
+    if (!existing || match.score > existing.score) byEntity.set(match.entityId, clean);
+  }
+  return [...byEntity.values()];
+}
+
+function blake2b64(value: string): bigint {
+  const digest = createBlake2b64().update(value).digest();
+  return digest.readBigUInt64BE(0);
+}
+
+function createBlake2b64() {
+  return BLAKE2B64_OUTPUT_LENGTH_SUPPORTED ? createHash("blake2b512", { outputLength: 8 }) : createHash("blake2b512");
+}
+
+function canCreateBlake2b64(): boolean {
+  try {
+    createHash("blake2b512", { outputLength: 8 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stripDomainSuffix(value: string): string {
+  return value.trim().replace(/\.(com|org|net|io|ai|co|in|dev|app)\b\.?$/i, "");
+}

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1390,4 +1390,42 @@ describe("proposeEntity", () => {
     expect(second.kind).toBe("linked");
     expect(projects).toHaveLength(1);
   });
+
+  it("27. strict name dedup links and appends the incoming spelling as an alias", async () => {
+    const entityRepo = createEntityRepository(db);
+    const redseer = await entityRepo.upsertEntity({
+      name: "Redseer Consulting",
+      sourceType: "company",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const materializeDeps = await buildMaterializeDeps(db);
+
+    const result = await proposeEntity(
+      {
+        entityRepo: materializeDeps.entityRepo,
+        reviewRepo: materializeDeps.reviewRepo,
+        lookup: materializeDeps.lookup,
+        readEmail: materializeDeps.readEmail,
+        onEntityResolved: materializeDeps.onEntityResolved,
+      },
+      {
+        name: "RedseerConsulting",
+        entityType: "company",
+        subtype: "external",
+        source: "llm",
+        sourceId: "mention-redseer",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("linked");
+    if (result.kind !== "linked") throw new Error("unreachable");
+    expect(result.entity.id).toBe(redseer.id);
+    expect(JSON.parse(result.entity.aliases ?? "[]")).toContain("RedseerConsulting");
+    expect(materializeDeps.index.byNormalizedAlias.get(normalizeName("RedseerConsulting"))?.map((e) => e.id)).toContain(
+      redseer.id,
+    );
+  });
 });

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1459,6 +1459,7 @@ describe("proposeEntity", () => {
     );
 
     expect(result.kind).toBe("queued");
+    if (result.kind !== "queued") throw new Error("unreachable");
     expect(result.candidateEntityId).toBe(ann.id);
     const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
     expect(queue.candidate_entity_id).toBe(ann.id);
@@ -1495,6 +1496,7 @@ describe("proposeEntity", () => {
     );
 
     expect(result.kind).toBe("queued");
+    if (result.kind !== "queued") throw new Error("unreachable");
     expect(result.candidateEntityId).toBe(ohoud.id);
     const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
     expect(queue.candidate_entity_id).toBe(ohoud.id);

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1428,4 +1428,76 @@ describe("proposeEntity", () => {
       redseer.id,
     );
   });
+
+  it("28. compact person strict-name collisions queue instead of auto-linking", async () => {
+    const entityRepo = createEntityRepository(db);
+    const ann = await entityRepo.upsertEntity({
+      name: "Ann A",
+      sourceType: "person",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const materializeDeps = await buildMaterializeDeps(db);
+
+    const result = await proposeEntity(
+      {
+        entityRepo: materializeDeps.entityRepo,
+        reviewRepo: materializeDeps.reviewRepo,
+        lookup: materializeDeps.lookup,
+        readEmail: materializeDeps.readEmail,
+        onEntityResolved: materializeDeps.onEntityResolved,
+      },
+      {
+        name: "Anna",
+        entityType: "person",
+        subtype: "external",
+        source: "llm",
+        sourceId: "mention-anna",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("queued");
+    expect(result.candidateEntityId).toBe(ann.id);
+    const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(queue.candidate_entity_id).toBe(ann.id);
+    expect(queue.candidate_reason).toBe("strict-normalized");
+  });
+
+  it("29. materialized lookup queues token-set reorder matches", async () => {
+    const entityRepo = createEntityRepository(db);
+    const ohoud = await entityRepo.upsertEntity({
+      name: "Ohoud Zitan",
+      sourceType: "person",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const materializeDeps = await buildMaterializeDeps(db);
+
+    const result = await proposeEntity(
+      {
+        entityRepo: materializeDeps.entityRepo,
+        reviewRepo: materializeDeps.reviewRepo,
+        lookup: materializeDeps.lookup,
+        readEmail: materializeDeps.readEmail,
+        onEntityResolved: materializeDeps.onEntityResolved,
+      },
+      {
+        name: "Zitan, Ohoud",
+        entityType: "person",
+        subtype: "external",
+        source: "llm",
+        sourceId: "mention-zitan-ohoud",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("queued");
+    expect(result.candidateEntityId).toBe(ohoud.id);
+    const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(queue.candidate_entity_id).toBe(ohoud.id);
+    expect(queue.candidate_reason).toBe("token-set");
+  });
 });

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -27,7 +27,14 @@ import type { EntitiesTable } from "../db/schema";
 export type Entity = Selectable<EntitiesTable>;
 
 export type ProposeEntityType = "person" | "company" | "product" | "project" | "team" | "deal";
-export type CandidateReason = "token-superset" | "prefix" | "exact-ambiguous" | "llm-ambiguous" | "birth-gated";
+export type CandidateReason =
+  | "token-superset"
+  | "prefix"
+  | "exact-ambiguous"
+  | "llm-ambiguous"
+  | "birth-gated"
+  | "strict-normalized"
+  | "minhash";
 
 export interface ProposeInput {
   name: string;
@@ -89,6 +96,11 @@ export type EntityLookup = {
   getByAlias?(normalized: string): Entity[];
   /** All entities of the given type (used for prefix/token-superset scan). */
   listByType(entityType: ProposeEntityType): Entity[];
+  /** Same-type normalized-strict or MinHash candidates over names and aliases. */
+  findNameDedupCandidates?(
+    entityType: ProposeEntityType,
+    name: string,
+  ): Array<{ entity: Entity; score: number; reason: Extract<CandidateReason, "strict-normalized" | "minhash"> }>;
   /** Company ids associated with a normalized corporate domain. */
   getCompanyIdsByDomain?(domain: string): string[];
 };
@@ -251,6 +263,19 @@ async function persistEntity(
     sourceId: input.sourceId,
   });
   return { entity, created: true };
+}
+
+async function linkNameDedupCandidate(deps: ProposeDeps, input: ProposeInput, matched: Entity): Promise<ProposeResult> {
+  const { entity } = await persistEntity(deps, input, matched);
+  const aliasesToAppend = [input.name, ...(input.aliases ?? [])].filter(
+    (alias) => alias.trim() && alias.trim().toLowerCase() !== matched.name.trim().toLowerCase(),
+  );
+  for (const alias of aliasesToAppend) {
+    await deps.entityRepo.appendAlias(entity.id, alias);
+  }
+  const refreshed = (await deps.entityRepo.getEntity(entity.id)) ?? entity;
+  await deps.onEntityResolved?.(refreshed);
+  return { kind: "linked", entity: refreshed };
 }
 
 /**
@@ -460,6 +485,23 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
         );
       }
     }
+  }
+
+  const dedupCandidates = deps.lookup.findNameDedupCandidates?.(input.entityType, input.name) ?? [];
+  if (dedupCandidates.length > 0) {
+    let ranked: RankedCandidate[] = dedupCandidates.map((candidate) => ({
+      entity: candidate.entity,
+      score: candidate.score,
+      reason: candidate.reason,
+    }));
+    const filtered: RankedCandidate[] = [];
+    for (const r of ranked) {
+      const rejected = await deps.reviewRepo.isRejected(r.entity.id, normalized);
+      if (!rejected) filtered.push(r);
+    }
+    ranked = filtered;
+    if (ranked.length === 1) return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    if (ranked.length > 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
   }
 
   if (input.precomputedCandidates && input.precomputedCandidates.length > 0) {

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -34,6 +34,7 @@ export type CandidateReason =
   | "llm-ambiguous"
   | "birth-gated"
   | "strict-normalized"
+  | "token-set"
   | "minhash";
 
 export interface ProposeInput {
@@ -96,11 +97,15 @@ export type EntityLookup = {
   getByAlias?(normalized: string): Entity[];
   /** All entities of the given type (used for prefix/token-superset scan). */
   listByType(entityType: ProposeEntityType): Entity[];
-  /** Same-type normalized-strict or MinHash candidates over names and aliases. */
+  /** Same-type normalized-strict, token-set, or MinHash candidates over names and aliases. */
   findNameDedupCandidates?(
     entityType: ProposeEntityType,
     name: string,
-  ): Array<{ entity: Entity; score: number; reason: Extract<CandidateReason, "strict-normalized" | "minhash"> }>;
+  ): Array<{
+    entity: Entity;
+    score: number;
+    reason: Extract<CandidateReason, "strict-normalized" | "token-set" | "minhash">;
+  }>;
   /** Company ids associated with a normalized corporate domain. */
   getCompanyIdsByDomain?(domain: string): string[];
 };
@@ -164,6 +169,12 @@ function hasTokenOverlap(a: string[], b: string[]): boolean {
   if (a.length === 0 || b.length === 0) return false;
   const bSet = new Set(b);
   return a.some((token) => bSet.has(token));
+}
+
+function canAutoLinkNameDedupCandidate(input: ProposeInput, candidate: RankedCandidate): boolean {
+  if (candidate.reason === "token-set") return false;
+  if (input.entityType === "person" && candidate.reason === "strict-normalized" && !input.email) return false;
+  return true;
 }
 
 /**
@@ -500,7 +511,10 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
       if (!rejected) filtered.push(r);
     }
     ranked = filtered;
-    if (ranked.length === 1) return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    if (ranked.length === 1 && canAutoLinkNameDedupCandidate(input, ranked[0])) {
+      return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    }
+    if (ranked.length === 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
     if (ranked.length > 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
   }
 


### PR DESCRIPTION
Stack position: 1/12
Base: main
Head: feat/entity-dedup-name
Migrations introduced: none

Name dedup: MinHash/LSH prevention, token-set recall, and queued ambiguous candidate fixes.

Split from superseded entity-spine stack (#260/#261/#262). Verified locally with pnpm typecheck and pnpm build at this branch tip.