### PR TITLE
feat: entity dedup person scope

### DIFF
--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -517,6 +517,7 @@ export async function handleCandidates(
           {
             entityRepo: materializeDeps.entityRepo,
             reviewRepo: materializeDeps.reviewRepo,
+            domainsRepo: materializeDeps.domainsRepo,
             lookup: materializeDeps.lookup,
             readEmail: materializeDeps.readEmail,
           },

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -1307,6 +1307,49 @@ export function createEntityRepository(db: Kysely<DB>) {
         .executeTakeFirstOrThrow();
     },
 
+    async createPersonEntity(data: UpsertPersonEntityData) {
+      const id = randomUUID();
+      const now = new Date().toISOString();
+      const metadata = data.email ? { email: data.email } : {};
+      const initialAliases = data.email ? JSON.stringify([data.email]) : null;
+
+      await db
+        .insertInto("entities")
+        .values({
+          id,
+          name: data.name,
+          source_type: "person",
+          subtype: data.subtype,
+          aliases: initialAliases,
+          metadata: JSON.stringify(metadata),
+          source_ref_id: null,
+          status: "confirmed",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+
+      await db
+        .insertInto("entity_source_refs")
+        .values({
+          id: randomUUID(),
+          entity_id: id,
+          source: data.source,
+          source_id: data.sourceId,
+          source_url: null,
+          last_seen_at: now,
+        })
+        .execute();
+
+      return await db
+        .selectFrom("entities")
+        .selectAll()
+        .where("id", "=", id)
+        .where(whereLiveEntity())
+        .executeTakeFirstOrThrow();
+    },
+
     // ── Archive / Cleanup ──
 
     async archiveEntitiesForArchivedFiles() {

--- a/packages/server/src/db/repositories/entity-domains.ts
+++ b/packages/server/src/db/repositories/entity-domains.ts
@@ -200,6 +200,19 @@ export function createEntityDomainsRepository(db: Kysely<DB>) {
       return (row ?? null) as EntitiesTable | null;
     },
 
+    async getCompanyIdsByDomain(domain: string): Promise<string[]> {
+      const rows = await db
+        .selectFrom("entity_domains")
+        .innerJoin("entities", "entities.id", "entity_domains.entity_id")
+        .select("entity_domains.entity_id")
+        .where("entity_domains.domain", "=", domain.toLowerCase())
+        .where("entity_domains.kind", "=", "corporate")
+        .where("entity_domains.entity_id", "is not", null)
+        .where(whereLiveEntity())
+        .execute();
+      return rows.flatMap((row) => (row.entity_id ? [row.entity_id] : []));
+    },
+
     async upsertDomain(input: UpsertDomainInput): Promise<void> {
       const existing = await db
         .selectFrom("entity_domains")

--- a/packages/server/src/entities/affiliations.test.ts
+++ b/packages/server/src/entities/affiliations.test.ts
@@ -400,11 +400,12 @@ describe("ELP-02: affiliation inference", () => {
     // test 18 — recreate must reproduce the same graph shape (one promoted
     // company, one corporate domain row, five works_at edges) as live sync
     // crossing the threshold organically.
-    for (let i = 0; i < 5; i++) {
+    const names = ["Charlie Adams", "Priya Rao", "Mateo Silva", "Noor Khan", "Elena Ivers"];
+    for (let i = 0; i < names.length; i++) {
       const fileId = await seedFile(db, `charlie-file-${i}`);
       await seedPersonSeedFact(db, {
         fileId,
-        name: `Charlie Person ${i}`,
+        name: names[i],
         email: `person${i}@charlie.com`,
         sourceId: `charlie-${i}`,
       });
@@ -479,11 +480,12 @@ describe("ELP-02: affiliation inference", () => {
       })
       .execute();
 
-    for (let i = 0; i < 5; i++) {
+    const names = ["Manual Charlie", "Iris Quinn", "Omar Reed", "Lina Soto", "Victor Tan"];
+    for (let i = 0; i < names.length; i++) {
       const fileId = await seedFile(db, `manual-charlie-file-${i}`);
       await seedPersonSeedFact(db, {
         fileId,
-        name: `Manual Charlie Person ${i}`,
+        name: names[i],
         email: `manual${i}@charlie.com`,
         sourceId: `manual-charlie-${i}`,
       });

--- a/packages/server/src/entities/affiliations.ts
+++ b/packages/server/src/entities/affiliations.ts
@@ -21,6 +21,28 @@ export interface InferAffiliationInput {
   firstObservedByUserId?: string | null;
 }
 
+export type PersonScopeKey = { kind: "company"; value: string } | { kind: "domain"; value: string };
+
+export function personScopeKeyId(scope: PersonScopeKey): string {
+  return `${scope.kind}:${scope.value}`;
+}
+
+export function isTrustedPersonScopeKey(scopeKey: string): boolean {
+  return scopeKey.startsWith("company:");
+}
+
+export async function personScopeKey(
+  email: string | null | undefined,
+  domainsRepo: EntityDomainsRepository,
+): Promise<PersonScopeKey | null> {
+  const domain = domainsRepo.normalizeEmailDomain(email);
+  if (!domain) return null;
+  if (await domainsRepo.isPersonalOrShared(domain)) return null;
+  const companyIds = await domainsRepo.getCompanyIdsByDomain(domain);
+  if (companyIds.length > 0) return { kind: "company", value: [...companyIds].sort()[0] };
+  return { kind: "domain", value: domain };
+}
+
 /**
  * Role-account local-parts: shared mailboxes, not real people. A single
  * `hello@stripe.com` notification email should NOT promote Stripe as a

--- a/packages/server/src/entities/domain-promotion.ts
+++ b/packages/server/src/entities/domain-promotion.ts
@@ -216,6 +216,7 @@ export async function sweepDomainPromotions(db: Kysely<DB>, logger: Logger): Pro
       {
         entityRepo,
         reviewRepo: createEntityReviewRepo(db),
+        domainsRepo,
         lookup,
         readEmail,
       },

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -6,6 +6,7 @@ import { createEntityDomainsRepository } from "../db/repositories/entity-domains
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
 import { createEntitySuppressionRepository } from "../db/repositories/entity-suppressions";
 import type { DB } from "../db/schema";
+import { personScopeKey, personScopeKeyId } from "./affiliations";
 import { parseAliasesString, readPersonEmailFromMetadata } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, LookupIndex, MaterializeDeps } from "./materialize-types";
 import {
@@ -105,10 +106,51 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
   }
   const dedupPoolsByType = new Map<ProposeEntityType, ReturnType<typeof buildCandidatePool>>();
   for (const t of supportedTypes) dedupPoolsByType.set(t, buildCandidatePool(dedupEntriesByType.get(t) ?? []));
-  return { entitiesByType, byNormalizedName, byNormalizedAlias, dedupPoolsByType, bySourceRef, companyIdsByDomain };
+  const personScopeKeysByEntityId = await buildPersonScopeKeys(
+    db,
+    entities.filter((entity) => entity.source_type === "person"),
+  );
+  return {
+    entitiesByType,
+    byNormalizedName,
+    byNormalizedAlias,
+    dedupPoolsByType,
+    bySourceRef,
+    companyIdsByDomain,
+    personScopeKeysByEntityId,
+  };
+}
+
+async function buildPersonScopeKeys(db: Kysely<DB>, persons: EntityRow[]): Promise<Map<string, string[]>> {
+  const scopeKeys = new Map<string, Set<string>>();
+  for (const person of persons) scopeKeys.set(person.id, new Set());
+  const domainsRepo = createEntityDomainsRepository(db);
+  for (const person of persons) {
+    const email = readPersonEmailFromMetadata(person.metadata);
+    const scope = await personScopeKey(email, domainsRepo);
+    if (scope) scopeKeys.get(person.id)?.add(personScopeKeyId(scope));
+  }
+
+  const personIds = persons.map((person) => person.id);
+  const worksAtRows =
+    personIds.length > 0
+      ? await db
+          .selectFrom("entity_relationships")
+          .select(["source_entity_id", "target_entity_id"])
+          .where("relationship_type", "=", "works_at")
+          .where("source_entity_id", "in", personIds)
+          .where("valid_to", "is", null)
+          .execute()
+      : [];
+  for (const row of worksAtRows) {
+    scopeKeys.get(row.source_entity_id)?.add(personScopeKeyId({ kind: "company", value: row.target_entity_id }));
+  }
+
+  return new Map([...scopeKeys].map(([entityId, keys]) => [entityId, [...keys]]));
 }
 
 export function registerEntity(index: LookupIndex, entity: EntityRow): void {
+  const existingPersonScopeKeys = index.personScopeKeysByEntityId.get(entity.id);
   unregisterEntity(index, entity.id);
   const entityType = entity.source_type as ProposeEntityType;
   const typeBucket = index.entitiesByType.get(entityType);
@@ -143,6 +185,9 @@ export function registerEntity(index: LookupIndex, entity: EntityRow): void {
       })),
     ]);
   }
+  if (entityType === "person" && existingPersonScopeKeys) {
+    index.personScopeKeysByEntityId.set(entity.id, existingPersonScopeKeys);
+  }
 }
 
 function removeEntityFromMapBuckets<T extends EntityRow>(map: Map<string, T[]>, entityId: string): void {
@@ -163,6 +208,7 @@ function unregisterEntity(index: LookupIndex, entityId: string): void {
   for (const pool of index.dedupPoolsByType.values()) {
     removeFromCandidatePool(pool, entityId);
   }
+  index.personScopeKeysByEntityId.delete(entityId);
 }
 
 export async function refreshResolvedEntityIndex(db: Kysely<DB>, index: LookupIndex, entity: Entity): Promise<void> {
@@ -177,6 +223,9 @@ export async function refreshResolvedEntityIndex(db: Kysely<DB>, index: LookupIn
     if (indexedEntity.id === entity.id) index.bySourceRef.delete(key);
   }
   registerEntity(index, row);
+  const scopeKeys = await buildPersonScopeKeys(db, row.source_type === "person" ? [row] : []);
+  const personScopeKeys = scopeKeys.get(row.id);
+  if (personScopeKeys) index.personScopeKeysByEntityId.set(row.id, personScopeKeys);
   for (const ref of sourceRefs) {
     index.bySourceRef.set(`${ref.source}:${ref.source_id}`, row);
   }
@@ -237,6 +286,7 @@ export async function buildMaterializeDeps(
       return [...byEntity.values()].sort((a, b) => b.score - a.score || a.entity.id.localeCompare(b.entity.id));
     },
     getCompanyIdsByDomain: (domain) => index.companyIdsByDomain.get(domain.toLowerCase()) ?? [],
+    getPersonScopeKeys: (entityId) => index.personScopeKeysByEntityId.get(entityId) ?? [],
   };
 
   const fileToConnector = new Map<string, string>();

--- a/packages/server/src/entities/materialize-llm-mentions.ts
+++ b/packages/server/src/entities/materialize-llm-mentions.ts
@@ -79,6 +79,7 @@ export async function materializeNonPersonLlmEntity(
     {
       entityRepo: deps.entityRepo,
       reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-person-scope.test.ts
+++ b/packages/server/src/entities/materialize-person-scope.test.ts
@@ -144,6 +144,31 @@ describe("materializePersonSeed company-scoped dedup", () => {
     expect(await people(db)).toHaveLength(2);
   });
 
+  it("preserves the matching company-scoped person when linking a new source ref", async () => {
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+    await createCompanyWithDomain(db, "company-globex", "Globex", "globex.com");
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@globex.com", sourceId: "person-2" });
+
+    await materializeUnmaterializedFacts(db, createTestLogger());
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish.alt@globex.com", sourceId: "person-3" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    const rows = await people(db);
+    expect(rows).toHaveLength(2);
+    const globexPerson = rows.find((row) => JSON.parse(row.metadata ?? "{}").email === "ashish@globex.com");
+    const sourceRef = await db
+      .selectFrom("entity_source_refs")
+      .selectAll()
+      .where("source", "=", "connector")
+      .where("source_id", "=", "person-3")
+      .executeTakeFirstOrThrow();
+    expect(sourceRef.entity_id).toBe(globexPerson?.id);
+    expect(JSON.parse(globexPerson?.aliases ?? "[]")).toContain("ashish.alt@globex.com");
+  });
+
   it("queues personal, candidate-unscoped, and name-only same-name seeds", async () => {
     const domainsRepo = createEntityDomainsRepository(db);
     await domainsRepo.upsertDomain({ entityId: null, domain: "gmail.com", kind: "personal", source: "test" });

--- a/packages/server/src/entities/materialize-person-scope.test.ts
+++ b/packages/server/src/entities/materialize-person-scope.test.ts
@@ -1,0 +1,188 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import type { DB } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { materializeUnmaterializedFacts } from "./materialize-replay";
+
+const ADMIN_ID = "admin-1";
+const CONNECTOR_ID = "cfg-person-scope";
+
+async function seedFile(db: Kysely<DB>): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: ADMIN_ID,
+      name: "Admin",
+      email: "admin@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "google_drive",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: ADMIN_ID,
+    })
+    .execute();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: "file-1",
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: "file-1",
+      file_name: "file-1",
+      file_type: "doc",
+      content_category: "document",
+      source: "google_drive",
+      content_hash: "hash-1",
+      is_archived: 0,
+      synced_at: now,
+    })
+    .execute();
+}
+
+async function upsertPersonSeed(
+  db: Kysely<DB>,
+  input: { name: string; email?: string | null; sourceId: string },
+): Promise<void> {
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: "file-1",
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: ADMIN_ID,
+    contentHash: "hash-1",
+    source: "connector",
+    factType: "person_seed",
+    relation: "seeded",
+    subjectName: input.name,
+    subjectEmail: input.email ?? null,
+    subjectSource: "connector",
+    subjectSourceId: input.sourceId,
+    raw: { subtype: "external" },
+  });
+}
+
+async function createCompanyWithDomain(db: Kysely<DB>, id: string, name: string, domain: string): Promise<void> {
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: "company",
+      subtype: "external",
+      aliases: null,
+      metadata: "{}",
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .execute();
+  await createEntityDomainsRepository(db).upsertDomain({
+    entityId: id,
+    domain,
+    kind: "corporate",
+    source: "test",
+  });
+}
+
+async function people(db: Kysely<DB>) {
+  return db.selectFrom("entities").selectAll().where("source_type", "=", "person").orderBy("name").execute();
+}
+
+describe("materializePersonSeed company-scoped dedup", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedFile(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("links same-name seeds at the same mapped company even when the incoming email is new", async () => {
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "ASHISH BANKA", email: "ashish.alt@acme.com", sourceId: "person-2" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    expect(await people(db)).toHaveLength(1);
+  });
+
+  it("links same-name seeds at the same unmapped corporate domain using the weak bare-domain scope", async () => {
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "ASHISH BANKA", email: "ashish.alt@acme.com", sourceId: "person-2" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    expect(await people(db)).toHaveLength(1);
+  });
+
+  it("creates a second same-name person when mapped corporate domains point to different companies", async () => {
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+    await createCompanyWithDomain(db, "company-globex", "Globex", "globex.com");
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@globex.com", sourceId: "person-2" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    expect(await people(db)).toHaveLength(2);
+  });
+
+  it("queues personal, candidate-unscoped, and name-only same-name seeds", async () => {
+    const domainsRepo = createEntityDomainsRepository(db);
+    await domainsRepo.upsertDomain({ entityId: null, domain: "gmail.com", kind: "personal", source: "test" });
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+
+    const entityRepo = createEntityRepository(db);
+    await entityRepo.createPersonEntity({
+      name: "Gmail Ashish",
+      email: "ashish@acme.com",
+      subtype: "external",
+      source: "existing",
+      sourceId: "gmail-existing",
+    });
+    await upsertPersonSeed(db, { name: "Gmail Ashish", email: "ashish@gmail.com", sourceId: "gmail-incoming" });
+
+    await entityRepo.createPersonEntity({
+      name: "Unscoped Ashish",
+      subtype: "external",
+      source: "existing",
+      sourceId: "unscoped-existing",
+    });
+    await upsertPersonSeed(db, {
+      name: "Unscoped Ashish",
+      email: "unscoped@acme.com",
+      sourceId: "unscoped-incoming",
+    });
+
+    await entityRepo.createPersonEntity({
+      name: "Name Only Ashish",
+      email: "nameonly@acme.com",
+      subtype: "external",
+      source: "existing",
+      sourceId: "name-only-existing",
+    });
+    await upsertPersonSeed(db, { name: "Name Only Ashish", sourceId: "name-only-incoming" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(3);
+    expect(await db.selectFrom("entity_review_queue").selectAll().execute()).toHaveLength(3);
+  });
+});

--- a/packages/server/src/entities/materialize-person.ts
+++ b/packages/server/src/entities/materialize-person.ts
@@ -22,15 +22,33 @@ export async function materializePersonSeed(
   if (!fact.subject_name || !fact.subject_source || !fact.subject_source_id) {
     return { kind: "skipped", reason: "missing_person_seed_subject" };
   }
+  const triggeredByUserId = deps.resolveOwner(fact);
+  if (!triggeredByUserId) return { kind: "skipped_missing_owner", reason: "missing_fact_owner" };
   const raw = readJsonObject(fact.raw);
   const subtype = raw.subtype === "internal" ? "internal" : "external";
-  const entity = (await deps.entityRepo.upsertPersonEntity({
-    name: fact.subject_name,
-    email: fact.subject_email ?? undefined,
-    subtype,
-    source: fact.subject_source,
-    sourceId: fact.subject_source_id,
-  })) as unknown as EntityRow;
+  const result = await proposeEntity(
+    {
+      entityRepo: deps.entityRepo,
+      reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
+      lookup: deps.lookup,
+      readEmail: deps.readEmail,
+      onEntityResolved: deps.onEntityResolved,
+    },
+    {
+      name: fact.subject_name,
+      email: fact.subject_email ?? null,
+      entityType: "person",
+      subtype,
+      source: fact.subject_source,
+      sourceId: fact.subject_source_id,
+      evidence: fact.indexed_file_id ? [{ indexedFileId: fact.indexed_file_id }] : [],
+      triggeredByUserId,
+      strictPersonScopeGate: true,
+    },
+  );
+  if (result.kind === "queued") return { kind: "queued", reviewId: result.reviewId };
+  const entity = result.entity as unknown as EntityRow;
   deps.index.bySourceRef.set(`${fact.subject_source}:${fact.subject_source_id}`, entity);
   registerEntity(deps.index, entity);
   await inferAffiliationFromEmail(
@@ -39,9 +57,10 @@ export async function materializePersonSeed(
       personEntityId: entity.id,
       email: fact.subject_email,
       evidenceFileId: fact.indexed_file_id,
-      firstObservedByUserId: fact.created_by_user_id,
+      firstObservedByUserId: triggeredByUserId,
     },
   );
+  await deps.onEntityResolved(entity);
   return { kind: "structural", entity };
 }
 
@@ -92,7 +111,10 @@ async function buildPersonRankerContext(
   };
 }
 
-async function loadWorksAtCompanies(deps: MaterializeDeps, personEntityIds: string[]): Promise<Map<string, string>> {
+async function loadWorksAtCompanies(
+  deps: MaterializeDeps,
+  personEntityIds: string[],
+): Promise<Map<string, Set<string>>> {
   if (personEntityIds.length === 0) return new Map();
   const rows = await deps.db
     .selectFrom("entity_relationships")
@@ -101,7 +123,13 @@ async function loadWorksAtCompanies(deps: MaterializeDeps, personEntityIds: stri
     .where("source_entity_id", "in", personEntityIds)
     .where("valid_to", "is", null)
     .execute();
-  return new Map(rows.map((row) => [row.source_entity_id, row.target_entity_id]));
+  const out = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const bucket = out.get(row.source_entity_id);
+    if (bucket) bucket.add(row.target_entity_id);
+    else out.set(row.source_entity_id, new Set([row.target_entity_id]));
+  }
+  return out;
 }
 
 export async function materializePersonFact(
@@ -152,7 +180,7 @@ export async function materializePersonFact(
         { name: fact.subject_name, aliases: variations, entityType: "person" },
         candidates,
         context,
-        (entityId) => worksAtByPerson.get(entityId) ?? null,
+        (entityId) => [...(worksAtByPerson.get(entityId) ?? [])],
       );
       if (decision.kind === "confident_match") {
         entity = decision.entity as unknown as EntityRow;
@@ -171,6 +199,7 @@ export async function materializePersonFact(
         {
           entityRepo: deps.entityRepo,
           reviewRepo: deps.reviewRepo,
+          domainsRepo: deps.domainsRepo,
           lookup: deps.lookup,
           readEmail: deps.readEmail,
           onEntityResolved: deps.onEntityResolved,
@@ -214,6 +243,7 @@ export async function materializePersonFact(
         firstObservedByUserId: fact.created_by_user_id,
       },
     );
+    await deps.onEntityResolved(entity);
   }
 
   if (!entity || !fact.indexed_file_id) return { kind: resultKind, entity, mentionWritten: false };

--- a/packages/server/src/entities/materialize-project.ts
+++ b/packages/server/src/entities/materialize-project.ts
@@ -21,6 +21,7 @@ export async function materializeProjectSeed(
     {
       entityRepo: deps.entityRepo,
       reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-relations.ts
+++ b/packages/server/src/entities/materialize-relations.ts
@@ -226,6 +226,7 @@ async function materializeRelationEndpoint(
     {
       entityRepo: deps.entityRepo,
       reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -35,6 +35,7 @@ export interface LookupIndex {
   dedupPoolsByType: Map<ProposeEntityType, CandidatePool>;
   bySourceRef: Map<string, EntityRow>;
   companyIdsByDomain: Map<string, string[]>;
+  personScopeKeysByEntityId: Map<string, string[]>;
 }
 
 export interface MaterializeDeps {

--- a/packages/server/src/entities/materialize.test.ts
+++ b/packages/server/src/entities/materialize.test.ts
@@ -849,6 +849,11 @@ describe("materializeFromFact — llm_relation typed edges", () => {
       confidenceScore: 0.9,
       source: "email_domain",
     });
+    await entityRepo.upsertSourceRef({
+      entityId: person.id,
+      source: "llm_relation",
+      sourceId: "file-1:hash-file-1:source:Sarah Chen",
+    });
     await domainsRepo.addEvidence({
       relationshipId,
       indexedFileId: "file-1",
@@ -896,7 +901,24 @@ describe("materializeFromFact — llm_relation typed edges", () => {
 
   it("removes relationships that lose their last source-fact evidence row", async () => {
     await seedFiles(db, 2);
-    await createEntityRepository(db).upsertEntityFromTool({
+    const entityRepo = createEntityRepository(db);
+    const person = await entityRepo.upsertPersonEntity({
+      name: "Sarah Chen",
+      subtype: "external",
+      source: "google_drive",
+      sourceId: "person:sarah",
+    });
+    await entityRepo.upsertSourceRef({
+      entityId: person.id,
+      source: "llm_relation",
+      sourceId: "file-1:hash-file-1:source:Sarah Chen",
+    });
+    await entityRepo.upsertSourceRef({
+      entityId: person.id,
+      source: "llm_relation",
+      sourceId: "file-2:hash-file-2:source:Sarah Chen",
+    });
+    await entityRepo.upsertEntityFromTool({
       name: "Project Atlas",
       sourceType: "project",
       source: "google_drive",

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1287,7 +1287,7 @@ describe("proposeEntity", () => {
     expect(refreshed.aliases ? JSON.parse(refreshed.aliases) : []).toContain("Project Atlas");
   });
 
-  it("25. person source-ref is skipped so email identity semantics still win", async () => {
+  it("25. person source-ref links before email identity", async () => {
     const entityRepo = createEntityRepository(db);
     const bob = await entityRepo.upsertPersonEntity({
       name: "Bob Chen",
@@ -1326,8 +1326,8 @@ describe("proposeEntity", () => {
 
     expect(result.kind).toBe("linked");
     if (result.kind !== "linked") throw new Error("unreachable");
-    expect(result.entity.id).toBe(alice.id);
-    expect(result.entity.id).not.toBe(bob.id);
+    expect(result.entity.id).toBe(bob.id);
+    expect(result.entity.id).not.toBe(alice.id);
   });
 
   it("26. same-batch source-ref link refreshes materialization index and avoids double-create", async () => {

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -21,8 +21,10 @@
 import type { Selectable } from "kysely";
 import { normalizeName } from "../connectors/name-normalize";
 import type { UpsertPersonEntityData, createEntityRepository } from "../db/repositories/entities";
+import type { EntityDomainsRepository } from "../db/repositories/entity-domains";
 import type { EntityReviewRepository } from "../db/repositories/entity-review";
 import type { EntitiesTable } from "../db/schema";
+import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "./affiliations";
 
 export type Entity = Selectable<EntitiesTable>;
 
@@ -67,6 +69,11 @@ export interface ProposeInput {
    * entity and queuing an ambiguous match are unaffected.
    */
   queueInsteadOfCreate?: boolean;
+  /**
+   * Applies the person seed creation gate for name-only proposals. When true,
+   * an unscoped incoming person proposal queues instead of linking by name.
+   */
+  strictPersonScopeGate?: boolean;
 }
 
 export type ProposeResult =
@@ -108,11 +115,13 @@ export type EntityLookup = {
   }>;
   /** Company ids associated with a normalized corporate domain. */
   getCompanyIdsByDomain?(domain: string): string[];
+  getPersonScopeKeys?(entityId: string): string[];
 };
 
 export interface ProposeDeps {
   entityRepo: ReturnType<typeof createEntityRepository>;
   reviewRepo: EntityReviewRepository;
+  domainsRepo?: EntityDomainsRepository;
   lookup: EntityLookup;
   /** Read an entity's email from its metadata JSON. */
   readEmail: (entity: Entity) => string | null;
@@ -240,15 +249,28 @@ async function persistEntity(
   matched?: Entity,
 ): Promise<{ entity: Entity; created: boolean }> {
   if (input.entityType === "person") {
+    if (matched) {
+      await deps.entityRepo.upsertSourceRef({
+        entityId: matched.id,
+        source: input.source,
+        sourceId: input.sourceId,
+      });
+      if (input.email) {
+        await deps.entityRepo.attachEmailIfAbsent(matched.id, input.email);
+        await deps.entityRepo.appendAlias(matched.id, input.email);
+      }
+      const entity = (await deps.entityRepo.getEntity(matched.id)) ?? matched;
+      return { entity, created: false };
+    }
     const personData: UpsertPersonEntityData = {
-      name: matched?.name ?? input.name,
+      name: input.name,
       email: input.email ?? undefined,
       subtype: input.subtype,
       source: input.source,
       sourceId: input.sourceId,
     };
-    const entity = await deps.entityRepo.upsertPersonEntity(personData);
-    return { entity, created: !matched };
+    const entity = await deps.entityRepo.createPersonEntity(personData);
+    return { entity, created: true };
   }
 
   if (matched) {
@@ -335,6 +357,15 @@ function pickConfirmedCanonical(candidates: Entity[], input: ProposeInput, looku
   return sorted[0];
 }
 
+function isSingleStrictPersonReference(ranked: RankedCandidate[]): boolean {
+  return (
+    ranked.length === 1 &&
+    (ranked[0].reason === "exact-ambiguous" ||
+      ranked[0].reason === "strict-normalized" ||
+      ranked[0].reason === "minhash")
+  );
+}
+
 async function queueProposal(
   deps: ProposeDeps,
   input: ProposeInput,
@@ -377,8 +408,95 @@ async function queueProposal(
   };
 }
 
+async function decideScopedPersonCandidates(
+  deps: ProposeDeps,
+  input: ProposeInput,
+  normalized: string,
+  ranked: RankedCandidate[],
+): Promise<ProposeResult> {
+  if (!deps.domainsRepo) {
+    if (input.email) {
+      const { entity } = await persistEntity(deps, input);
+      return { kind: "created", entity };
+    }
+    if (ranked.length === 1 && isSingleStrictPersonReference(ranked) && canAutoLinkNameDedupCandidate(input, ranked[0])) {
+      return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    }
+    return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+  }
+  const incomingScope = deps.domainsRepo ? await personScopeKey(input.email ?? null, deps.domainsRepo) : null;
+  if (!incomingScope) {
+    if (
+      !input.strictPersonScopeGate &&
+      isSingleStrictPersonReference(ranked) &&
+      canAutoLinkNameDedupCandidate(input, ranked[0])
+    ) {
+      return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    }
+    return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+  }
+  const incomingScopeId = personScopeKeyId(incomingScope);
+  const candidatesWithScopes = ranked.map((candidate) => {
+    const scopeKeys = new Set(deps.lookup.getPersonScopeKeys?.(candidate.entity.id) ?? []);
+    return { candidate, scopeKeys };
+  });
+  const matching = candidatesWithScopes.filter(({ scopeKeys }) => scopeKeys.has(incomingScopeId));
+  if (matching.length === 1) return linkNameDedupCandidate(deps, input, matching[0].candidate.entity);
+  if (matching.length >= 2) {
+    return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+  }
+  const allCandidatesTrusted = candidatesWithScopes.every(
+    ({ scopeKeys }) => scopeKeys.size > 0 && [...scopeKeys].some(isTrustedPersonScopeKey),
+  );
+  if (allCandidatesTrusted) {
+    if (input.queueInsteadOfCreate) {
+      return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+    }
+    const { entity } = await persistEntity(deps, input);
+    return { kind: "created", entity };
+  }
+  return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+}
+
+async function decideNameCandidates(
+  deps: ProposeDeps,
+  input: ProposeInput,
+  normalized: string,
+  ranked: RankedCandidate[],
+): Promise<ProposeResult> {
+  if (input.entityType === "person") return decideScopedPersonCandidates(deps, input, normalized, ranked);
+  if (ranked.length === 1) return linkNameDedupCandidate(deps, input, ranked[0].entity);
+  const winner = pickConfirmedCanonical(
+    ranked.map((candidate) => candidate.entity),
+    input,
+    deps.lookup,
+  );
+  if (winner) {
+    const { entity } = await persistEntity(deps, input, winner);
+    return { kind: "linked", entity };
+  }
+  return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+}
+
 export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Promise<ProposeResult> {
   const normalized = normalizeMatchName(input.entityType, input.name);
+
+  if (input.source && input.sourceId) {
+    const found = await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId);
+    if (found && found.source_type === input.entityType) {
+      await deps.entityRepo.upsertSourceRef({
+        entityId: found.id,
+        source: input.source,
+        sourceId: input.sourceId,
+      });
+      if (found.name.trim().toLowerCase() !== input.name.trim().toLowerCase()) {
+        await deps.entityRepo.appendAlias(found.id, input.name);
+      }
+      const entity = (await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId)) ?? found;
+      await deps.onEntityResolved?.(entity);
+      return { kind: "linked", entity };
+    }
+  }
 
   // 1) Email fast-path — exact match against existing entity's stored email.
   if (input.entityType === "person" && input.email) {
@@ -398,29 +516,6 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
         await deps.onEntityResolved?.(entity);
         return { kind: "linked", entity };
       }
-    }
-
-    // 2) Email present but no entity matched it. An email is identity-grade;
-    //    a name collision against a different email is a different person.
-    //    Auto-create instead of queuing.
-    const { entity } = await persistEntity(deps, input);
-    return { kind: "created", entity };
-  }
-
-  if (input.entityType !== "person" && input.source && input.sourceId) {
-    const found = await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId);
-    if (found && found.source_type === input.entityType) {
-      await deps.entityRepo.upsertSourceRef({
-        entityId: found.id,
-        source: input.source,
-        sourceId: input.sourceId,
-      });
-      if (found.name.trim().toLowerCase() !== input.name.trim().toLowerCase()) {
-        await deps.entityRepo.appendAlias(found.id, input.name);
-      }
-      const entity = (await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId)) ?? found;
-      await deps.onEntityResolved?.(entity);
-      return { kind: "linked", entity };
     }
   }
 
@@ -449,21 +544,14 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
   }
   if (exactById.size === 1) {
     const matched = exactById.values().next().value as Entity;
-    const { entity } = await persistEntity(deps, input, matched);
-    return { kind: "linked", entity };
+    return decideNameCandidates(deps, input, normalized, [{ entity: matched, score: 1, reason: "exact-ambiguous" }]);
   }
   if (exactById.size > 1) {
-    const winner = pickConfirmedCanonical([...exactById.values()], input, deps.lookup);
-    if (winner) {
-      const { entity } = await persistEntity(deps, input, winner);
-      return { kind: "linked", entity };
-    }
-    return queueProposal(
+    return decideNameCandidates(
       deps,
       input,
       normalized,
       [...exactById.values()].map((entity) => ({ entity, score: 1, reason: "exact-ambiguous" })),
-      "exact-ambiguous",
     );
   }
 
@@ -511,11 +599,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
       if (!rejected) filtered.push(r);
     }
     ranked = filtered;
-    if (ranked.length === 1 && canAutoLinkNameDedupCandidate(input, ranked[0])) {
-      return linkNameDedupCandidate(deps, input, ranked[0].entity);
-    }
-    if (ranked.length === 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
-    if (ranked.length > 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
+    if (ranked.length > 0) return decideNameCandidates(deps, input, normalized, ranked);
   }
 
   if (input.precomputedCandidates && input.precomputedCandidates.length > 0) {
@@ -561,5 +645,6 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
     const { entity } = await persistEntity(deps, input);
     return { kind: "created", entity };
   }
+  if (input.entityType === "person") return decideScopedPersonCandidates(deps, input, normalized, ranked);
   return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
 }

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -419,7 +419,11 @@ async function decideScopedPersonCandidates(
       const { entity } = await persistEntity(deps, input);
       return { kind: "created", entity };
     }
-    if (ranked.length === 1 && isSingleStrictPersonReference(ranked) && canAutoLinkNameDedupCandidate(input, ranked[0])) {
+    if (
+      ranked.length === 1 &&
+      isSingleStrictPersonReference(ranked) &&
+      canAutoLinkNameDedupCandidate(input, ranked[0])
+    ) {
       return linkNameDedupCandidate(deps, input, ranked[0].entity);
     }
     return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");

--- a/packages/server/src/entities/rank.test.ts
+++ b/packages/server/src/entities/rank.test.ts
@@ -35,7 +35,7 @@ describe("rankPersonLlmMention", () => {
         extractedCompanies: [],
         contextCompanies: [],
       },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("confident_match");
@@ -54,7 +54,7 @@ describe("rankPersonLlmMention", () => {
         extractedCompanies: [{ entityId: "company-1" }],
         contextCompanies: [],
       },
-      (entityId) => (entityId === "b" ? "company-1" : null),
+      (entityId) => (entityId === "b" ? ["company-1"] : []),
     );
 
     expect(decision.kind).toBe("confident_match");
@@ -66,7 +66,7 @@ describe("rankPersonLlmMention", () => {
       { name: "Sam", entityType: "person" },
       [person("a", "Sam Patel"), person("b", "Sam Prakash")],
       { fileId: "file-1", extractedPersons: [], extractedCompanies: [], contextCompanies: [] },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("ambiguous_existing");
@@ -77,7 +77,7 @@ describe("rankPersonLlmMention", () => {
       { name: "Sarah Cheng", entityType: "person" },
       [person("a", "Sarah C")],
       { fileId: "file-1", extractedPersons: [], extractedCompanies: [], contextCompanies: [] },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("ambiguous_new_entity");
@@ -88,7 +88,7 @@ describe("rankPersonLlmMention", () => {
       { name: "Priya Shah", entityType: "person" },
       [person("a", "Sarah Chen")],
       { fileId: "file-1", extractedPersons: [], extractedCompanies: [], contextCompanies: [] },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("confident_no_match");

--- a/packages/server/src/entities/rank.ts
+++ b/packages/server/src/entities/rank.ts
@@ -50,7 +50,7 @@ function scoreCandidate(
   mentionTokens: string[],
   entity: Entity,
   ctx: RankerContext,
-  worksAtLookup: (entityId: string) => string | null,
+  worksAtLookup: (entityId: string) => readonly string[],
 ): number | null {
   const entityTokens = tokens(entity.name);
   if (!hasTokenOverlap(mentionTokens, entityTokens)) return null;
@@ -58,8 +58,8 @@ function scoreCandidate(
   let score = 0;
   if (ctx.extractedPersons.some((p) => p.entityId === entity.id)) score += 10;
 
-  const companyId = worksAtLookup(entity.id);
-  if (companyId) {
+  const companyIds = worksAtLookup(entity.id);
+  for (const companyId of companyIds) {
     if (ctx.extractedCompanies.some((c) => c.entityId === companyId)) score += 5;
     else if (ctx.contextCompanies.some((c) => c.entityId === companyId)) score += 2;
   }
@@ -72,7 +72,7 @@ export function rankPersonLlmMention(
   mention: ExtractedMention,
   candidates: Entity[],
   ctx: RankerContext,
-  worksAtLookup: (entityId: string) => string | null,
+  worksAtLookup: (entityId: string) => readonly string[],
 ): LlmMentionDecision {
   const mentionTokens = tokens(mention.name);
   const ranked = candidates

--- a/packages/server/src/entities/replay.test.ts
+++ b/packages/server/src/entities/replay.test.ts
@@ -125,6 +125,7 @@ async function seedRawCorpus(db: Kysely<DB>) {
 
   // Person seed (file-less, e.g. ClickUp directory).
   await factRepo.upsertFact({
+    createdByUserId: TEST_USER_ID,
     source: "clickup",
     factType: "person_seed",
     relation: "seeded",
@@ -437,6 +438,7 @@ describe("replaySourceFacts", () => {
      */
     for (let i = 0; i < 25; i++) {
       await repo.upsertFact({
+        createdByUserId: TEST_USER_ID,
         source: "manual",
         factType: "person_seed",
         relation: "seeded",
@@ -452,6 +454,7 @@ describe("replaySourceFacts", () => {
     await first;
 
     await repo.upsertFact({
+      createdByUserId: TEST_USER_ID,
       source: "manual",
       factType: "person_seed",
       relation: "seeded",


### PR DESCRIPTION
Stack position: 2/12
Base: feat/entity-dedup-name
Head: feat/entity-dedup-person
Migrations introduced: none

Person dedup: connector/seed person dedup with company-scope gate and scoped match preservation.

Split from superseded entity-spine stack (#260/#261/#262). Verified locally with pnpm typecheck and pnpm build at this branch tip.