### PR TITLE
feat: entity creation gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ LOG_LEVEL=info          # debug | info | warn | error
 
 # Feature flags
 # EXPERIMENTAL_FLAG=false       # Set to true to enable Files & Connections UI
+# BIRTH_GATE_DRY_RUN=true       # When EXPERIMENTAL_FLAG=true, log project/product/team birth gates without enforcing
 
 # Zoho CRM OAuth (required when Zoho CRM connector is enabled)
 # ZOHO_CLIENT_ID=

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -449,7 +449,8 @@ export function buildSystemContext(params: {
       "Tool chain:",
       "- **Search** — hybrid keyword + semantic search across all indexed sources. Supports filtering by source, content `kind` (meeting/doc/task/message), date range, and entity scope. Each result includes `sketchId` (for GetFileContent), `providerId` (the external ID integration tools expect), and `url` (when available).",
       "- **GetFileContent** — retrieve the full content of an indexed file by its `sketchId`. Use when you need the complete document, transcript, or task detail.",
-      "- **SearchEntities** — find projects, people, teams, and databases across connected sources. Pass multiple name variations to maximize matches. Returns entity IDs.",
+      "- **SearchEntities** — find projects, people, teams, companies, and products across connected sources. " +
+        "Pass multiple name variations to maximize matches. Returns entity IDs.",
       "- **GetEntityContext** — get a cross-source timeline of mentions for an entity (from SearchEntities).",
       "",
       'Recency questions ("latest", "most recent", "last X"):',

--- a/packages/server/src/agent/tools/search.ts
+++ b/packages/server/src/agent/tools/search.ts
@@ -51,7 +51,7 @@ export const searchToolSchema = {
   limit: z.number().optional().describe("Max results (default 10; default 3 when sortBy=recency)."),
 };
 
-export const searchEntitiesToolDescription = `Search for entities (projects, people, teams, databases) across all connected sources. Accepts multiple query variations to catch abbreviations and informal names. Returns matched entities with their type, status, and mention count.
+export const searchEntitiesToolDescription = `Search for entities (projects, people, teams, companies, products) across all connected sources. Accepts multiple query variations to catch abbreviations and informal names. Returns matched entities with their type, status, and mention count.
 
 Use this when the user asks about a project, person, or any named thing tracked across the org's tools. Pass multiple name variations (e.g. ["Beetu", "B2", "beetu app"]) to maximize matches.`;
 

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -200,6 +200,7 @@ export function connectorRoutes(
       | "CO_MENTION_CONTRIBUTES_TO_THRESHOLD"
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
+      | "EXPERIMENTAL_FLAG"
       | "ENCRYPTION_KEY"
       | "OPENROUTER_API_KEY"
     >
@@ -1821,6 +1822,7 @@ export function connectorRoutes(
       geminiApiKey: settings?.gemini_api_key,
       geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
       geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
+      experimentalFlag: appConfig?.EXPERIMENTAL_FLAG,
       fileIds: [fileId],
       debugDumpDir,
     }).catch((err) => {

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -46,6 +46,7 @@ import { createFileSharesRepository } from "../db/repositories/file-shares";
 import { createSettingsRepository } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
+import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 import {
   type ConnectorPermissions,
   connectorPermissions,
@@ -625,6 +626,7 @@ export function connectorRoutes(
         "entity_mentions.context_snippet",
       ])
       .where("entity_mentions.indexed_file_id", "=", fileId)
+      .where("entities.source_type", "not in", Array.from(HIDDEN_ENTITY_SOURCE_TYPES))
       .where(whereLiveEntity())
       .execute();
 

--- a/packages/server/src/api/entities/maintenance-routes.ts
+++ b/packages/server/src/api/entities/maintenance-routes.ts
@@ -54,7 +54,7 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
   const routes = new Hono();
   const { logger, config } = deps;
 
-  const ORG_SOURCE_TYPES = ["person", "company", "product", "team", "project"];
+  const ORG_SOURCE_TYPES = ["person", "company", "product", "team", "project", "tool"];
 
   /**
    * GET /api/entities/resets/jobs

--- a/packages/server/src/api/entities/maintenance-routes.ts
+++ b/packages/server/src/api/entities/maintenance-routes.ts
@@ -372,6 +372,7 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
           missingFileIds: resolved.missingFileIds,
           runAfter,
           lockAlreadyHeld,
+          experimentalFlag: config.EXPERIMENTAL_FLAG,
           llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
           coMentionContributesToThreshold: config.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
           geminiMaxRpm: config.GEMINI_MAX_RPM,

--- a/packages/server/src/api/entities/profile-routes.ts
+++ b/packages/server/src/api/entities/profile-routes.ts
@@ -13,7 +13,11 @@ import { createEntitySuppressionRepository } from "../../db/repositories/entity-
 import { createEntityTimelineRepository } from "../../db/repositories/entity-timeline";
 import type { DB } from "../../db/schema";
 import { normalizeEntityMatchName } from "../../entities/materialize-deps";
-import { type EntityProfileFacts, SYSTEM_SOURCE_TYPES, mapSourceTypeToEntityType } from "../../entities/profile-facts";
+import {
+  type EntityProfileFacts,
+  HIDDEN_ENTITY_SOURCE_TYPES,
+  mapSourceTypeToEntityType,
+} from "../../entities/profile-facts";
 import { denyIfNotAdmin, getContentViewer, getFileViewer } from "../auth-helpers";
 import type { EntityRoutesDeps } from "./types";
 
@@ -308,7 +312,7 @@ export function createEntityProfileRoutes(db: Kysely<DB>, _deps: EntityRoutesDep
     const offset = Number(c.req.query("offset")) || 0;
     const includeSystem = c.req.query("includeSystem") === "true";
     const includeArchived = c.req.query("includeArchived") === "true";
-    const systemTypes = [...SYSTEM_SOURCE_TYPES];
+    const systemTypes = [...HIDDEN_ENTITY_SOURCE_TYPES];
     const viewer = getFileViewer(c);
 
     // For non-admin viewers, the mention_count and last_mention_at subqueries
@@ -437,7 +441,7 @@ export function createEntityProfileRoutes(db: Kysely<DB>, _deps: EntityRoutesDep
   routes.get("/graph", async (c) => {
     const limit = Math.min(Number(c.req.query("limit")) || 500, 1000);
     const includeSystem = c.req.query("includeSystem") === "true";
-    const systemTypes = [...SYSTEM_SOURCE_TYPES];
+    const systemTypes = [...HIDDEN_ENTITY_SOURCE_TYPES];
     const viewer = getFileViewer(c);
 
     let nodeQuery = db

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -50,7 +50,7 @@ export function settingsRoutes(
   settings: SettingsRepo,
   db?: Kysely<DB>,
   logger?: Logger,
-  config?: Pick<Config, "GEMINI_MAX_RPM" | "GEMINI_MAX_RETRIES" | "OPENROUTER_API_KEY">,
+  config?: Pick<Config, "GEMINI_MAX_RPM" | "GEMINI_MAX_RETRIES" | "OPENROUTER_API_KEY" | "EXPERIMENTAL_FLAG">,
 ) {
   const routes = new Hono();
 
@@ -160,6 +160,7 @@ export function settingsRoutes(
       geminiApiKey: row?.gemini_api_key,
       geminiMaxRpm: config?.GEMINI_MAX_RPM,
       geminiMaxRetries: config?.GEMINI_MAX_RETRIES,
+      experimentalFlag: config?.EXPERIMENTAL_FLAG,
     }).catch((err) => {
       logger.error({ err }, "Manual enrichment run failed");
     });

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -91,6 +91,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
       ? new Set<ProposeEntityType>(["project", "product", "team"])
       : new Set<ProposeEntityType>(),
     birthGateDryRun: config.BIRTH_GATE_DRY_RUN,
+    experimentalFlag: config.EXPERIMENTAL_FLAG,
   });
 
   // Migration 039 backfills the legacy admin-owned Fireflies row to a real user id.

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -33,6 +33,7 @@ import { createUserRepository } from "./db/repositories/users";
 import { createWhatsAppGroupRepository } from "./db/repositories/whatsapp-groups";
 import type { DB } from "./db/schema";
 import { configureMaterializeDefaults } from "./entities/materialize";
+import type { ProposeEntityType } from "./entities/propose";
 import { createApp } from "./http";
 import { buildMcpConfig, createProvider } from "./integrations/factory";
 import type { IntegrationProvider, IntegrationStatus } from "./integrations/types";
@@ -84,7 +85,13 @@ export async function createServer(config: Config, options?: CreateServerOptions
   await runMigrations(db);
   logger.info("Database ready");
 
-  configureMaterializeDefaults({ llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD });
+  configureMaterializeDefaults({
+    llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
+    birthGateTypes: config.EXPERIMENTAL_FLAG
+      ? new Set<ProposeEntityType>(["project", "product", "team"])
+      : new Set<ProposeEntityType>(),
+    birthGateDryRun: config.BIRTH_GATE_DRY_RUN,
+  });
 
   // Migration 039 backfills the legacy admin-owned Fireflies row to a real user id.
   // If no users exist yet, the row stays owned by 'admin' and never becomes editable

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -27,6 +27,10 @@ export const configSchema = z.object({
     .enum(["true", "false", "1", "0"])
     .default("false")
     .transform((v) => v === "true" || v === "1"),
+  BIRTH_GATE_DRY_RUN: z
+    .enum(["true", "false", "1", "0"])
+    .default("true")
+    .transform((v) => v === "true" || v === "1"),
   VISION_ENABLED: z
     .enum(["true", "false", "1", "0"])
     .default("false")

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -19,6 +19,7 @@ import { isPg } from "../db/dialect";
 import { createEntityRepository, whereLiveEntity } from "../db/repositories/entities";
 import type { DB } from "../db/schema";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
+import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 import { yieldToEventLoop } from "../lib/event-loop";
 import type { Chunk } from "./chunking";
 import { chunkText } from "./chunking";
@@ -483,6 +484,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
                   orgContext: deps.orgContext,
                   knownEntities,
                   participantBlock,
+                  experimentalFlag: deps.experimentalFlag,
                   debugDumpDir: deps.debugDumpDir,
                   ensureFresh: () => ensureFileFresh(db, file.id, fileVersion),
                 },
@@ -512,7 +514,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
               );
               await ensureFileFresh(db, file.id, fileVersion);
               if (floor.emitted > 0) {
-                await materializeUnmaterializedFacts(db, logger);
+                await materializeUnmaterializedFacts(db, logger, { experimentalFlag: deps.experimentalFlag });
               }
               await resetSummaryRetry(db, file.id, fileVersion);
             } catch (err) {
@@ -802,7 +804,7 @@ async function enrichTextDocument(
       );
       await ensureFileFresh(db, file.id, fileVersion);
       if (floor.emitted > 0) {
-        await materializeUnmaterializedFacts(db, logger);
+        await materializeUnmaterializedFacts(db, logger, { experimentalFlag: deps.experimentalFlag });
       }
       await resetSummaryRetry(db, file.id, fileVersion);
       usedSmartEnrichment = true;
@@ -957,7 +959,9 @@ export function matchesAsWord(content: string, name: string): boolean {
 
 export async function linkEntitiesByDeterministicMatch(db: Kysely<DB>, logger: Logger): Promise<EnrichmentResult> {
   const result: EnrichmentResult = { filesProcessed: 0, filesSkipped: 0, filesFailed: 0, errors: [] };
-  const allEntities = await createEntityRepository(db).getEntitiesByStatus("confirmed");
+  const allEntities = await createEntityRepository(db).getEntitiesByStatus("confirmed", {
+    excludeSourceTypes: Array.from(HIDDEN_ENTITY_SOURCE_TYPES),
+  });
   let lastFileId: string | null = null;
 
   while (true) {
@@ -1030,7 +1034,11 @@ async function linkEntitiesDeterministic(
 
   await deleteStaleLegacyDeterministicMentions(db, fileId);
 
-  const entities = allEntities ?? (await entityRepo.getEntitiesByStatus("confirmed"));
+  const entities =
+    allEntities ??
+    (await entityRepo.getEntitiesByStatus("confirmed", {
+      excludeSourceTypes: Array.from(HIDDEN_ENTITY_SOURCE_TYPES),
+    }));
   const contentLower = content.toLowerCase();
 
   for (const entity of entities) {

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -41,6 +41,7 @@ export const SCHEDULED_ENRICHMENT_TIME_BUDGET_MS = 5 * 60 * 1000;
 const MIN_ENTITY_NAME_LENGTH = 3;
 
 const DETERMINISTIC_LINK_BATCH_SIZE = 500;
+const PROJECT_BASELINE_LIMIT = 200;
 const ENRICHMENT_BACKOFF_MS = [
   30 * 60 * 1000,
   60 * 60 * 1000,
@@ -226,14 +227,30 @@ async function markEmbeddingFailure(
   await query.execute();
 }
 
-export async function loadBaselineKnownEntities(db: Kysely<DB>): Promise<KnownEntityForPrompt[]> {
-  const entities = await db
+export async function loadBaselineKnownEntities(
+  db: Kysely<DB>,
+  opts: { experimentalFlag?: boolean } = {},
+): Promise<KnownEntityForPrompt[]> {
+  const baseEntities = await db
     .selectFrom("entities")
     .select(["id", "name", "source_type", "aliases", "metadata", "hotness"])
     .where("source_type", "in", ["product", "team"])
     .where("status", "=", "confirmed")
     .where(whereLiveEntity())
     .execute();
+  const projectEntities = opts.experimentalFlag
+    ? await db
+        .selectFrom("entities")
+        .select(["id", "name", "source_type", "aliases", "metadata", "hotness"])
+        .where("source_type", "=", "project")
+        .where("status", "=", "confirmed")
+        .where(whereLiveEntity())
+        .orderBy("hotness", "desc")
+        .orderBy("name", "asc")
+        .limit(PROJECT_BASELINE_LIMIT)
+        .execute()
+    : [];
+  const entities = [...baseEntities, ...projectEntities];
   return entities.map((entity) => ({
     id: entity.id,
     name: entity.name,
@@ -261,7 +278,7 @@ export interface EnrichmentDeps {
   /** Org context for enrichment prompts. Populated at start of enrichment run. */
   orgContext?: { orgName?: string; description?: string; industry?: string } | null;
   /**
-   * Org-wide baseline of confirmed entities (products + teams) used as a
+   * Org-wide baseline of confirmed entities used as a
    * fallback when a file has no resolvable anchors. The per-file scoped list
    * is built on top of this by `buildFileScopedKnownEntities`.
    */
@@ -337,7 +354,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
   }
 
   try {
-    deps.knownEntities = await loadBaselineKnownEntities(db);
+    deps.knownEntities = await loadBaselineKnownEntities(db, { experimentalFlag: deps.experimentalFlag });
   } catch {
     // entities table may not exist yet — ignore
   }
@@ -466,7 +483,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
               const generator = getGenerator();
               if (!generator) throw new Error("Enrichment generator unavailable");
               const knownEntities = await buildFileScopedKnownEntities(
-                { db, logger },
+                { db, logger, experimentalFlag: deps.experimentalFlag },
                 file.id,
                 deps.knownEntities ?? [],
                 file.content,
@@ -759,7 +776,7 @@ async function enrichTextDocument(
   if (!summaryAlreadyResolved && generator && wordCount >= minWordsForSummary) {
     try {
       const knownEntities = await buildFileScopedKnownEntities(
-        { db, logger },
+        { db, logger, experimentalFlag: deps.experimentalFlag },
         file.id,
         deps.knownEntities ?? [],
         file.content,

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -252,6 +252,7 @@ export interface EnrichmentDeps {
   geminiApiKey?: string | null;
   geminiMaxRpm?: number;
   geminiMaxRetries?: number;
+  experimentalFlag?: boolean;
   /** Download image from Google Drive by provider file ID. Returns buffer + mime type. */
   downloadImage?: (providerFileId: string, connectorConfigId: string) => Promise<{ buffer: Buffer; mimeType: string }>;
   /** If set, only enrich these specific file IDs (ignoring pending status). */
@@ -773,6 +774,7 @@ async function enrichTextDocument(
           participantBlock,
           debugDumpDir: deps.debugDumpDir,
           ensureFresh: () => ensureFileFresh(db, file.id, fileVersion),
+          experimentalFlag: deps.experimentalFlag,
         },
         {
           id: file.id,

--- a/packages/server/src/connectors/entity-linking.ts
+++ b/packages/server/src/connectors/entity-linking.ts
@@ -10,6 +10,7 @@ import type { Kysely, Selectable } from "kysely";
 import jaroWinklerModule from "talisman/metrics/jaro-winkler";
 import { createEntityRepository } from "../db/repositories/entities";
 import type { DB, EntitiesTable } from "../db/schema";
+import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 
 /** talisman is CJS — handle both default and named export shapes */
 const jaroWinkler: (a: string, b: string) => number =
@@ -28,7 +29,9 @@ type Entity = Selectable<EntitiesTable>;
  */
 export async function getHotEntitiesForPrompt(db: Kysely<DB>, content: string): Promise<Entity[]> {
   const entityRepo = createEntityRepository(db);
-  const allEntities = await entityRepo.getEntitiesByStatus("confirmed");
+  const allEntities = await entityRepo.getEntitiesByStatus("confirmed", {
+    excludeSourceTypes: Array.from(HIDDEN_ENTITY_SOURCE_TYPES),
+  });
   const contentLower = content.toLowerCase();
 
   const matched = allEntities.filter((e) => {

--- a/packages/server/src/connectors/file-scope-context.test.ts
+++ b/packages/server/src/connectors/file-scope-context.test.ts
@@ -12,13 +12,16 @@
  */
 import { randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
 import { createTestDb } from "../test-utils";
+import { loadBaselineKnownEntities } from "./enrichment";
 import {
+  BASELINE_ALWAYS_INCLUDE_CAP,
   BASELINE_RELEVANCE_CAP,
   HALF_LIFE_DAYS,
+  HUB_PERSON_DEGREE_CAP,
   MAX_ANCHORS_PER_SIDE,
   MIN_SCORE,
   PER_ANCHOR_INITIATIVE_CAP,
@@ -76,7 +79,7 @@ async function seedFile(db: Kysely<DB>, id: string, sourceUpdatedAt: string | nu
 
 async function seedEntity(
   db: Kysely<DB>,
-  args: { id: string; name: string; sourceType: string; hotness?: number },
+  args: { id: string; name: string; sourceType: string; hotness?: number; metadata?: Record<string, unknown> },
 ): Promise<void> {
   const now = new Date().toISOString();
   await db
@@ -87,13 +90,29 @@ async function seedEntity(
       source_type: args.sourceType,
       subtype: null,
       aliases: null,
-      metadata: null,
+      metadata: args.metadata ? JSON.stringify(args.metadata) : null,
       source_ref_id: null,
       status: "confirmed",
       hotness: args.hotness ?? 0,
       created_at: now,
       updated_at: now,
       ai_brief: null,
+    })
+    .execute();
+}
+
+async function seedContactPoint(db: Kysely<DB>, args: { entityId: string; email: string }): Promise<void> {
+  await db
+    .insertInto("entity_contact_points")
+    .values({
+      id: randomUUID(),
+      entity_id: args.entityId,
+      kind: "email",
+      value: args.email.toLowerCase(),
+      display_value: args.email,
+      label: null,
+      is_primary: 1,
+      source: "test",
     })
     .execute();
 }
@@ -404,5 +423,146 @@ describe("file-scope-context", () => {
       mentionCount: undefined,
       recentlyActive: undefined,
     });
+  });
+
+  it("uses person anchors when company anchoring fails and skips ambiguous participant emails", async () => {
+    const now = Date.UTC(2026, 4, 26);
+    const recentDate = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const promptFile = "file-person-anchor-prompt";
+    const aliceEvidenceFile = "file-person-anchor-alice-evidence";
+    const ambiguousEvidenceFile = "file-person-anchor-ambiguous-evidence";
+    await seedFile(db, promptFile, recentDate);
+    await seedFile(db, aliceEvidenceFile, recentDate);
+    await seedFile(db, ambiguousEvidenceFile, recentDate);
+
+    await seedEntity(db, { id: "person-alice", name: "Alice Internal", sourceType: "person", hotness: 5 });
+    await seedContactPoint(db, { entityId: "person-alice", email: "alice@internal.test" });
+    await seedEntity(db, { id: "project-alice", name: "Internal Atlas", sourceType: "project", hotness: 5 });
+    await seedEntity(db, { id: "person-ambiguous-a", name: "Ambiguous A", sourceType: "person", hotness: 10 });
+    await seedEntity(db, { id: "person-ambiguous-b", name: "Ambiguous B", sourceType: "person", hotness: 9 });
+    await seedContactPoint(db, { entityId: "person-ambiguous-a", email: "shared@internal.test" });
+    await seedContactPoint(db, { entityId: "person-ambiguous-b", email: "shared@internal.test" });
+    await seedEntity(db, { id: "project-ambiguous", name: "Ambiguous Project", sourceType: "project", hotness: 20 });
+
+    await seedAttendeeFact(db, { fileId: promptFile, name: "Alice", email: "alice@internal.test" });
+    await seedAttendeeFact(db, { fileId: promptFile, name: "Shared", email: "shared@internal.test" });
+    await seedMention(db, { entityId: "person-alice", fileId: aliceEvidenceFile });
+    await seedMention(db, { entityId: "project-alice", fileId: aliceEvidenceFile });
+    await seedMention(db, { entityId: "person-ambiguous-a", fileId: ambiguousEvidenceFile });
+    await seedMention(db, { entityId: "project-ambiguous", fileId: ambiguousEvidenceFile });
+
+    const companyOnly = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, [], "");
+    const personAnchored = await buildFileScopedKnownEntities(
+      { db, now: () => now, experimentalFlag: true },
+      promptFile,
+      [],
+      "",
+    );
+
+    expect(companyOnly).toEqual([]);
+    expect(personAnchored).toContainEqual({
+      name: "Internal Atlas",
+      type: "project",
+      mentionCount: 1,
+      recentlyActive: true,
+    });
+    expect(personAnchored.map((entry) => entry.name)).not.toContain("Alice Internal");
+    expect(personAnchored.map((entry) => entry.name)).not.toContain("Ambiguous Project");
+  });
+
+  it("skips hub person anchors before adjacency while retaining low-degree person adjacency", async () => {
+    const now = Date.UTC(2026, 4, 26);
+    const recentDate = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const promptFile = "file-hub-person-prompt";
+    const lowEvidenceFile = "file-low-person-evidence";
+    await seedFile(db, promptFile, recentDate);
+    await seedFile(db, lowEvidenceFile, recentDate);
+    await seedEntity(db, { id: "person-hub", name: "Hub Person", sourceType: "person", hotness: 100 });
+    await seedEntity(db, { id: "person-low", name: "Low Degree Person", sourceType: "person", hotness: 1 });
+    await seedContactPoint(db, { entityId: "person-hub", email: "hub@internal.test" });
+    await seedContactPoint(db, { entityId: "person-low", email: "low@internal.test" });
+    await seedEntity(db, { id: "project-low", name: "Low Degree Project", sourceType: "project", hotness: 5 });
+    await seedAttendeeFact(db, { fileId: promptFile, name: "Hub", email: "hub@internal.test" });
+    await seedAttendeeFact(db, { fileId: promptFile, name: "Low", email: "low@internal.test" });
+    await seedMention(db, { entityId: "person-low", fileId: lowEvidenceFile });
+    await seedMention(db, { entityId: "project-low", fileId: lowEvidenceFile });
+
+    for (let i = 0; i <= HUB_PERSON_DEGREE_CAP; i++) {
+      const fileId = `file-hub-evidence-${i}`;
+      const projectId = `project-hub-${i}`;
+      await seedFile(db, fileId, recentDate);
+      await seedEntity(db, { id: projectId, name: `Hub Project ${i}`, sourceType: "project", hotness: i });
+      await seedMention(db, { entityId: "person-hub", fileId });
+      await seedMention(db, { entityId: projectId, fileId });
+    }
+
+    const adjacencyCalls: string[] = [];
+    const loadAdjacencyForAnchor = vi.fn(async (deps, anchorId: string) => {
+      adjacencyCalls.push(anchorId);
+      return adjacencyForAnchor(deps, anchorId);
+    });
+    const known = await buildFileScopedKnownEntities(
+      { db, now: () => now, experimentalFlag: true, loadAdjacencyForAnchor },
+      promptFile,
+      [],
+      "",
+    );
+
+    expect(adjacencyCalls).not.toContain("person-hub");
+    expect(adjacencyCalls).toContain("person-low");
+    expect(known.map((entry) => entry.name)).toContain("Low Degree Project");
+    expect(known.map((entry) => entry.name).some((name) => name.startsWith("Hub Project"))).toBe(false);
+  });
+
+  it("keeps company-only ranking unchanged with flag off and bounds project baseline expansion with flag on", async () => {
+    const now = Date.UTC(2026, 4, 26);
+    const recentDate = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const promptFile = "file-flag-off-parity";
+    const coMentionFile = "file-flag-off-parity-evidence";
+    await seedFile(db, promptFile, recentDate);
+    await seedFile(db, coMentionFile, recentDate);
+    await seedEntity(db, { id: "ent-parity-company", name: "Parity Co", sourceType: "company", hotness: 10 });
+    await seedEntity(db, { id: "ent-parity-product", name: "Parity Product", sourceType: "product", hotness: 10 });
+    await seedDomain(db, { entityId: "ent-parity-company", domain: "parity.example", kind: "corporate" });
+    await seedAttendeeFact(db, { fileId: promptFile, name: "Parity Person", email: "person@parity.example" });
+    await seedMention(db, { entityId: "ent-parity-company", fileId: coMentionFile });
+    await seedMention(db, { entityId: "ent-parity-product", fileId: coMentionFile });
+
+    const baseline = [
+      { id: "baseline-cold", name: "Cold Product", type: "product", hotness: 1 },
+      { id: "ent-parity-product", name: "Parity Product", type: "product", hotness: 10 },
+    ];
+    const legacyFlagOmitted = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, baseline, "");
+    const explicitFlagOff = await buildFileScopedKnownEntities(
+      { db, now: () => now, experimentalFlag: false },
+      promptFile,
+      baseline,
+      "",
+    );
+    expect(explicitFlagOff).toEqual(legacyFlagOmitted);
+
+    for (let i = 0; i < 80; i++) {
+      await seedEntity(db, {
+        id: `baseline-project-${i}`,
+        name: `Bounded Project ${i}`,
+        sourceType: "project",
+        hotness: i,
+      });
+    }
+    const baselineFlagOff = await loadBaselineKnownEntities(db, { experimentalFlag: false });
+    const baselineFlagOn = await loadBaselineKnownEntities(db, { experimentalFlag: true });
+    expect(baselineFlagOff.map((entry) => entry.type)).not.toContain("project");
+    expect(baselineFlagOn.map((entry) => entry.name)).toContain("Bounded Project 79");
+
+    const content = Array.from({ length: 80 }, (_, i) => `Bounded Project ${i}`).join("\n");
+    const known = await buildFileScopedKnownEntities(
+      { db, now: () => now, experimentalFlag: true },
+      "file-baseline-bound",
+      baselineFlagOn,
+      content,
+    );
+    expect(known.filter((entry) => entry.type === "project").length).toBeLessThanOrEqual(
+      BASELINE_ALWAYS_INCLUDE_CAP + BASELINE_RELEVANCE_CAP,
+    );
   });
 });

--- a/packages/server/src/connectors/file-scope-context.ts
+++ b/packages/server/src/connectors/file-scope-context.ts
@@ -26,7 +26,7 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import type { Logger } from "pino";
-import { whereLiveEntity } from "../db/repositories/entities";
+import { createEntityRepository, whereLiveEntity } from "../db/repositories/entities";
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
 import { PERSON_PARTICIPANT_FACT_TYPES } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
@@ -42,12 +42,18 @@ export const RECENTLY_ACTIVE_WINDOW_DAYS = 14;
 export const BASELINE_RELEVANCE_CAP = 15;
 export const BASELINE_RECENCY_WINDOW_DAYS = 30;
 export const MIN_VERBATIM_NAME_LENGTH = 4;
+export const MAX_PERSON_ANCHORS = 5;
+export const HUB_PERSON_DEGREE_CAP = 30;
+export const BASELINE_ALWAYS_INCLUDE_CAP = 50;
+const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 export interface FileScopeDeps {
   db: Kysely<DB>;
   logger?: Logger;
   now?: () => number;
+  experimentalFlag?: boolean;
+  loadAdjacencyForAnchor?: (deps: FileScopeDeps, anchorId: string) => Promise<AdjacencyEntry[]>;
 }
 
 export interface AnchorEntity {
@@ -59,6 +65,7 @@ export interface AnchorEntity {
 
 export interface FileAnchors {
   companies: AnchorEntity[];
+  persons: AnchorEntity[];
 }
 
 export interface AdjacencyEntry {
@@ -109,9 +116,11 @@ export async function resolveFileAnchors(deps: FileScopeDeps, fileId: string): P
     .execute();
 
   const companyMap = new Map<string, AnchorEntity>();
+  const participantEmails: string[] = [];
   for (const row of attendees) {
     const email = row.subject_email;
     if (!email) continue;
+    participantEmails.push(email);
     const domain = domainsRepo.normalizeEmailDomain(email);
     if (!domain) continue;
     if (isRoleAccountEmail(email)) continue;
@@ -130,7 +139,42 @@ export async function resolveFileAnchors(deps: FileScopeDeps, fileId: string): P
   const companies = Array.from(companyMap.values())
     .sort((a, b) => b.hotness - a.hotness)
     .slice(0, MAX_ANCHORS_PER_SIDE);
-  return { companies };
+  if (!deps.experimentalFlag) return { companies, persons: [] };
+
+  const entityRepo = createEntityRepository(deps.db);
+  const personsByEmail = await entityRepo.getPersonEntitiesByEmails(participantEmails);
+  const personMap = new Map<string, AnchorEntity>();
+  for (const matches of personsByEmail.values()) {
+    const candidates = matches.filter((person) => person.id !== TEST_ACCOUNT_ENTITY_ID);
+    if (candidates.length !== 1) continue;
+    const person = candidates[0];
+    if (personMap.has(person.id)) continue;
+    personMap.set(person.id, {
+      id: person.id,
+      name: person.name,
+      sourceType: person.source_type,
+      hotness: Number(person.hotness ?? 0),
+    });
+  }
+
+  const nonHubIds = await loadNonHubPersonIds(deps, [...personMap.keys()]);
+  const persons = Array.from(personMap.values())
+    .filter((person) => nonHubIds.has(person.id))
+    .sort((a, b) => b.hotness - a.hotness)
+    .slice(0, MAX_PERSON_ANCHORS);
+  return { companies, persons };
+}
+
+async function loadNonHubPersonIds(deps: FileScopeDeps, personIds: string[]): Promise<Set<string>> {
+  if (personIds.length === 0) return new Set();
+  const rows = await deps.db
+    .selectFrom("entity_mentions")
+    .select(["entity_id", deps.db.fn.count<number>("indexed_file_id").distinct().as("file_degree")])
+    .where("entity_id", "in", personIds)
+    .groupBy("entity_id")
+    .execute();
+  const degreeById = new Map(rows.map((row) => [row.entity_id, Number(row.file_degree)]));
+  return new Set(personIds.filter((id) => (degreeById.get(id) ?? 0) <= HUB_PERSON_DEGREE_CAP));
 }
 
 /**
@@ -212,8 +256,8 @@ export async function buildFileScopedKnownEntities(
     if (!byKey.has(k)) byKey.set(k, { name: a.name, type: a.sourceType });
   }
 
-  for (const anchor of anchors.companies) {
-    const adj = await adjacencyForAnchor(deps, anchor.id);
+  for (const anchor of [...anchors.companies, ...anchors.persons]) {
+    const adj = await (deps.loadAdjacencyForAnchor ?? adjacencyForAnchor)(deps, anchor.id);
     const initiatives = adj
       .filter((x) => x.sourceType === "project" || x.sourceType === "product")
       .slice(0, PER_ANCHOR_INITIATIVE_CAP);
@@ -316,11 +360,19 @@ async function rankBaselineKnownEntities(
   if (scoredCandidates.length === 0) return legacy;
 
   const cap = opts.baselineRelevanceCap ?? BASELINE_RELEVANCE_CAP;
-  const alwaysInclude = scoredCandidates.filter((entity) => hasVerbatimMention(fileContent, entity));
+  const alwaysInclude = deps.experimentalFlag
+    ? scoredCandidates
+        .filter((entity) => hasVerbatimMention(fileContent, entity))
+        .sort((a, b) => {
+          const hotness = Number(b.hotness ?? 0) - Number(a.hotness ?? 0);
+          return hotness !== 0 ? hotness : a.name.localeCompare(b.name);
+        })
+        .slice(0, BASELINE_ALWAYS_INCLUDE_CAP)
+    : scoredCandidates.filter((entity) => hasVerbatimMention(fileContent, entity));
   const alwaysIds = new Set(alwaysInclude.map((entity) => entity.id));
   const candidates = scoredCandidates.filter((entity) => !alwaysIds.has(entity.id));
   const candidateIds = candidates.flatMap((entity) => (entity.id ? [entity.id] : []));
-  const anchorIds = anchors.companies.map((anchor) => anchor.id);
+  const anchorIds = [...anchors.companies.map((anchor) => anchor.id), ...anchors.persons.map((anchor) => anchor.id)];
   const [lastSeenById, overlapIds] = await Promise.all([
     loadBaselineLastSeen(deps, candidateIds),
     loadBaselineAnchorOverlap(deps, candidateIds, anchorIds),

--- a/packages/server/src/connectors/file-scope-context.ts
+++ b/packages/server/src/connectors/file-scope-context.ts
@@ -31,7 +31,7 @@ import { createEntityDomainsRepository } from "../db/repositories/entity-domains
 import { PERSON_PARTICIPANT_FACT_TYPES } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
 import { isRoleAccountEmail } from "../entities/affiliations";
-import { SYSTEM_SOURCE_TYPES } from "../entities/profile-facts";
+import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 
 export const HALF_LIFE_DAYS = 60;
 export const MIN_SCORE = 0.5;
@@ -139,7 +139,7 @@ export async function resolveFileAnchors(deps: FileScopeDeps, fileId: string): P
  * source types are excluded. Sorted by score desc.
  */
 export async function adjacencyForAnchor(deps: FileScopeDeps, anchorId: string): Promise<AdjacencyEntry[]> {
-  const systemTypes = Array.from(SYSTEM_SOURCE_TYPES);
+  const systemTypes = Array.from(HIDDEN_ENTITY_SOURCE_TYPES);
   const rows = await deps.db
     .selectFrom("entity_mentions as em1")
     .innerJoin("entity_mentions as em2", (join) =>

--- a/packages/server/src/connectors/smart-enrichment.test.ts
+++ b/packages/server/src/connectors/smart-enrichment.test.ts
@@ -17,6 +17,26 @@ import type { EmbeddingProvider } from "./embeddings/types";
 import type { GeminiGenerator } from "./gemini-generate";
 import { extractEntities, handleCandidates, smartEnrichFile } from "./smart-enrichment";
 
+const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
+
+async function countEntitiesBySourceType(db: Kysely<DB>, sourceType: string): Promise<number> {
+  const row = await db
+    .selectFrom("entities")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .where("source_type", "=", sourceType)
+    .where("id", "!=", TEST_ACCOUNT_ENTITY_ID)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function countReviewQueueRows(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entity_review_queue")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
 async function seedFile(
   db: Kysely<DB>,
   fileId: string,
@@ -179,6 +199,27 @@ describe("handleCandidates — stale seen_file_ids", () => {
     expect(storedIds).not.toContain(ghostFileId);
     expect(storedIds).toContain(liveFileId);
     expect(storedIds).toContain(secondLiveFileId);
+  });
+
+  it("A0 documents current legacy candidate promotion path creating product and project entities with no review rows until A1 flips it", async () => {
+    const firstFileId = randomUUID();
+    const secondFileId = randomUUID();
+    await seedFile(db, firstFileId);
+    await seedFile(db, secondFileId);
+
+    await handleCandidates(makeDeps(db), firstFileId, [
+      { mention: "Sketch Product", type: "product", variations: ["Sketch"] },
+      { mention: "Apollo Project", type: "project", variations: ["Apollo"] },
+    ]);
+    const promoted = await handleCandidates(makeDeps(db), secondFileId, [
+      { mention: "Sketch Product", type: "product", variations: ["Sketch"] },
+      { mention: "Apollo Project", type: "project", variations: ["Apollo"] },
+    ]);
+
+    expect(promoted).toHaveLength(2);
+    expect(await countEntitiesBySourceType(db, "product")).toBe(1);
+    expect(await countEntitiesBySourceType(db, "project")).toBe(1);
+    expect(await countReviewQueueRows(db)).toBe(0);
   });
 });
 

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -27,9 +27,11 @@ export {
   sweepDomainPromotions,
 } from "../entities/domain-promotion";
 import {
+  coerceMentionType,
   isHighConfidenceEndpoint,
   isHighConfidenceRelation,
   normalizeMentionType,
+  normalizeRelationEndpointType,
   normalizeRelationType,
 } from "../entities/graph";
 import {
@@ -38,6 +40,7 @@ import {
   cleanupRelationshipEvidenceForFacts,
   materializeUnmaterializedFacts,
 } from "../entities/materialize";
+import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 import { type ProposeEntityType, proposeEntity } from "../entities/propose";
 import { validateLearnedFact, validateLlmMention } from "../entities/validators";
 import { yieldToEventLoop } from "../lib/event-loop";
@@ -79,9 +82,12 @@ const CANDIDATE_PROMOTION_THRESHOLD = 2;
 const MIN_ENTITY_NAME_LENGTH = 3;
 const LLM_EXTRACTION_PROMPT_VERSION = "llm-extraction-v8";
 const BASE_PROPOSABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product", "team"];
+const MATCHABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product", "team", "deal"];
 
 function proposableEntityTypes(experimentalFlag = false): Set<ProposeEntityType> {
-  return new Set(BASE_PROPOSABLE_ENTITY_TYPES.filter((type) => !(experimentalFlag && type === "team")));
+  const types = BASE_PROPOSABLE_ENTITY_TYPES.filter((type) => !(experimentalFlag && type === "team"));
+  if (experimentalFlag) types.push("tool");
+  return new Set(types);
 }
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -292,6 +298,9 @@ export async function extractEntities(
   const teamFocusLine = experimentalFlag
     ? ""
     : '- **Teams**: named organizational teams (e.g., "QC team", "Content Team")\n';
+  const toolFocusLine = experimentalFlag
+    ? "- **Tools**: third-party SaaS apps/platforms the org uses (e.g., Slack, Notion, Zoom, Figma, GitHub)\n"
+    : "";
   const relationshipTypesPrompt = experimentalFlag
     ? `Valid relationship types:
 - "works_at": person -> company (the person is employed by the company)
@@ -327,6 +336,7 @@ Extract entities that a business team would want to track and reference across d
 - **Products**: named products or services your org builds or uses (e.g., "Canvas AI", "Sketch", "Meetup by Habuild")
 - **Projects**: named umbrella engagements or programs with their own scope and timeline (e.g., "OW Tourism Dashboard", "Paid Member Migration Phase 2", "K8S Migration"). A project is the umbrella, NOT a single ticket, pull request, or one feature of a product.
 ${teamFocusLine}
+${toolFocusLine}
 
 DO NOT extract:
 - Email addresses, phone numbers, URLs, or other system identifiers — these are stored separately. If a person is identifiable by name, use the name (e.g., "Sarah Chen"); never use an email address as the mention.
@@ -437,7 +447,10 @@ export async function matchEntities(
     for (const name of allNames) {
       if (name.length < MIN_ENTITY_NAME_LENGTH) continue;
 
-      const results = await entityRepo.searchEntities(name, { limit: 5 });
+      const results = await entityRepo.searchEntities(name, {
+        sourceTypes: MATCHABLE_ENTITY_TYPES.filter((type) => !HIDDEN_ENTITY_SOURCE_TYPES.has(type)),
+        limit: 5,
+      });
       if (results.length > 0) {
         // Take the best match (first result from substring search)
         const entity = results[0];
@@ -495,7 +508,11 @@ export async function handleCandidates(
   const entityRepo = createEntityRepository(db);
   const promoted: MatchedEntity[] = [];
 
-  for (const mention of unmatched) {
+  for (const rawMention of unmatched) {
+    const mention = {
+      ...rawMention,
+      type: coerceMentionType(rawMention.mention, rawMention.type, deps.experimentalFlag),
+    };
     if (!proposableEntityTypes(deps.experimentalFlag).has(mention.type as ProposeEntityType)) continue;
     if (mention.mention.length < MIN_ENTITY_NAME_LENGTH) continue;
 
@@ -961,7 +978,11 @@ async function reconcileLlmExtractionFacts(
   const writtenFactKeys: string[] = [];
 
   try {
-    for (const mention of extraction.mentions) {
+    for (const rawMention of extraction.mentions) {
+      const mention = {
+        ...rawMention,
+        type: coerceMentionType(rawMention.mention, rawMention.type, deps.experimentalFlag),
+      };
       if (!proposableEntityTypes(deps.experimentalFlag).has(mention.type as ProposeEntityType)) {
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention, entityType: mention.type },
@@ -1057,7 +1078,7 @@ async function reconcileLlmExtractionFacts(
       .execute();
 
     await deps.ensureFresh?.();
-    await materializeUnmaterializedFacts(db, deps.logger);
+    await materializeUnmaterializedFacts(db, deps.logger, { experimentalFlag: deps.experimentalFlag });
     return writtenFactKeys;
   } catch (err) {
     if (isStaleEnrichmentError(err)) {
@@ -1114,9 +1135,14 @@ function buildRelationFactInput(input: {
   const sourceName = input.relation.source.name?.trim();
   const targetName = input.relation.target.name?.trim();
   if (!sourceName || !targetName) return null;
-  const sourceType = normalizeMentionType(input.relation.source.type);
-  const targetType = normalizeMentionType(input.relation.target.type);
+  const sourceType = normalizeMentionType(
+    coerceMentionType(sourceName, input.relation.source.type, input.experimentalFlag),
+  );
+  const targetType = normalizeMentionType(
+    coerceMentionType(targetName, input.relation.target.type, input.experimentalFlag),
+  );
   if (!sourceType || !targetType) return null;
+  if (!normalizeRelationEndpointType(sourceType) || !normalizeRelationEndpointType(targetType)) return null;
   if (
     !proposableEntityTypes(input.experimentalFlag).has(sourceType as ProposeEntityType) ||
     !proposableEntityTypes(input.experimentalFlag).has(targetType as ProposeEntityType)

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -78,7 +78,11 @@ const CANDIDATE_PROMOTION_THRESHOLD = 2;
 /** Minimum entity name length for candidate matching (avoids false positives). */
 const MIN_ENTITY_NAME_LENGTH = 3;
 const LLM_EXTRACTION_PROMPT_VERSION = "llm-extraction-v8";
-const PROPOSABLE_ENTITY_TYPES = new Set<ProposeEntityType>(["person", "company", "product", "project", "team"]);
+const BASE_PROPOSABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product", "team"];
+
+function proposableEntityTypes(experimentalFlag = false): Set<ProposeEntityType> {
+  return new Set(BASE_PROPOSABLE_ENTITY_TYPES.filter((type) => !(experimentalFlag && type === "team")));
+}
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -137,6 +141,7 @@ interface SmartEnrichmentDeps {
    * attendee metadata. Caller (enrichment.ts) builds via `buildParticipantBlock`.
    */
   participantBlock?: string;
+  experimentalFlag?: boolean;
   /**
    * When set, every LLM call inside this run writes a dump file (prompt + raw
    * response + token usage) under this directory. Set only by the per-file
@@ -247,6 +252,7 @@ export async function extractEntities(
   }>,
   participantBlock?: string,
   dumpDir?: string,
+  experimentalFlag = false,
 ): Promise<EntityExtractionResult> {
   const truncatedContent = file.content.slice(0, MAX_CONTENT_CHARS);
 
@@ -281,6 +287,33 @@ export async function extractEntities(
   const threadSection = file.threadContext
     ? `\nEmail thread context for resolving references only. Do not emit entities or relationships that appear only in this context; emitted mentions and relationships must be supported by the current message content below.\n${file.threadContext}\n`
     : "";
+  const validTypes = [...proposableEntityTypes(experimentalFlag)];
+  const validTypesPrompt = validTypes.map((type) => `"${type}"`).join(", ");
+  const teamFocusLine = experimentalFlag
+    ? ""
+    : '- **Teams**: named organizational teams (e.g., "QC team", "Content Team")\n';
+  const relationshipTypesPrompt = experimentalFlag
+    ? `Valid relationship types:
+- "works_at": person -> company (the person is employed by the company)
+- "engaged_with": person -> company (the person is working with, for, or delivered to an external company without being employed by it — vendor, consultancy, or client-engagement context)
+- "leads": person -> project | product
+- "contributes_to": person -> project | product
+- "builds": company -> product
+- "part_of": project -> project, project -> product, product -> product
+- "engagement_for": project -> company (the project is a client engagement delivered for that company)
+- "partner_of": company -> company`
+    : `Valid relationship types:
+- "works_at": person -> company (the person is employed by the company)
+- "engaged_with": person | team -> company (the person/team is working with, for, or delivered to an external company without being employed by it — vendor, consultancy, or client-engagement context)
+- "leads": person -> project | product | team
+- "contributes_to": person | team -> project | product
+- "builds": company -> product
+- "part_of": project -> project, project -> product, product -> product, team -> company
+- "engagement_for": project -> company (the project is a client engagement delivered for that company)
+- "partner_of": company -> company`;
+  const engagementHint = experimentalFlag
+    ? 'Use "engagement_for" for a PROJECT delivered for a client company; use "engaged_with" for a PERSON working with a company.'
+    : 'Use "engagement_for" for a PROJECT delivered for a client company; use "engaged_with" for a PERSON or TEAM working with a company.';
 
   const prompt = `You are analyzing a document to identify meaningful business entities mentioned in it.
 ${orgSection}${knownSection}${participantSection}${threadSection}
@@ -293,7 +326,7 @@ Extract entities that a business team would want to track and reference across d
 - **Companies**: external businesses, clients, partners, vendors
 - **Products**: named products or services your org builds or uses (e.g., "Canvas AI", "Sketch", "Meetup by Habuild")
 - **Projects**: named umbrella engagements or programs with their own scope and timeline (e.g., "OW Tourism Dashboard", "Paid Member Migration Phase 2", "K8S Migration"). A project is the umbrella, NOT a single ticket, pull request, or one feature of a product.
-- **Teams**: named organizational teams (e.g., "QC team", "Content Team")
+${teamFocusLine}
 
 DO NOT extract:
 - Email addresses, phone numbers, URLs, or other system identifiers — these are stored separately. If a person is identifiable by name, use the name (e.g., "Sarah Chen"); never use an email address as the mention.
@@ -331,22 +364,14 @@ For each entity, provide the primary name, type, name variations, and a confiden
 
 If email thread context is provided, use it only to resolve references in the current message. Do not extract an entity or relationship unless the current message refers to it directly or indirectly.
 
-Most relationships in a business corpus follow this hierarchy, top down: **Companies** (clients, partners, vendors) own engagements → **Projects** are named umbrella engagements with a defined scope → **Products** are named offerings or tools → **People and Teams** work on those projects and products, either internally for their own team or on behalf of a client engagement. Prefer extracting from the top down.
+Most relationships in a business corpus follow this hierarchy, top down: **Companies** (clients, partners, vendors) own engagements → **Projects** are named umbrella engagements with a defined scope → **Products** are named offerings or tools → **People${experimentalFlag ? "" : " and Teams"}** work on those projects and products, either internally for their own team or on behalf of a client engagement. Prefer extracting from the top down.
 
 Also extract direct relationships only when the text explicitly supports them.
 
-Valid relationship types:
-- "works_at": person -> company (the person is employed by the company)
-- "engaged_with": person | team -> company (the person/team is working with, for, or delivered to an external company without being employed by it — vendor, consultancy, or client-engagement context)
-- "leads": person -> project | product | team
-- "contributes_to": person | team -> project | product
-- "builds": company -> product
-- "part_of": project -> project, project -> product, product -> product, team -> company
-- "engagement_for": project -> company (the project is a client engagement delivered for that company)
-- "partner_of": company -> company
+${relationshipTypesPrompt}
 
 Use "engaged_with" (not "works_at") whenever the person's employer is a different company from the one named on the right. Example: a Canvas engineer meeting with Oliver Wyman is engaged_with Oliver Wyman, not works_at Oliver Wyman.
-Use "engagement_for" for a PROJECT delivered for a client company; use "engaged_with" for a PERSON or TEAM working with a company.
+${engagementHint}
 Do not extract "member_of", "deal_for", or "primary_contact" from prose; those are connector-sourced relationships.
 
 When a "Meeting participants" block is present above and lists attendees from multiple companies, the cross-company link is itself relationship evidence even when the prose never names the external company. Emit \`engaged_with\` edges from home-company participants who are marked \`[action-item owner]\` to each external company present in the participants block. Treat silent external attendees (no action items) with caution — only emit when the prose corroborates it. Use the participant name and the external company name exactly as they appear in the block as the relation endpoints.
@@ -368,7 +393,7 @@ Return one JSON object:
   ]
 }
 
-Valid types: "person", "project", "company", "product", "team"
+Valid types: ${validTypesPrompt}
 
 If no notable entities or relations are found, return { "mentions": [], "relations": [] }.
 
@@ -471,7 +496,7 @@ export async function handleCandidates(
   const promoted: MatchedEntity[] = [];
 
   for (const mention of unmatched) {
-    if (!PROPOSABLE_ENTITY_TYPES.has(mention.type as ProposeEntityType)) continue;
+    if (!proposableEntityTypes(deps.experimentalFlag).has(mention.type as ProposeEntityType)) continue;
     if (mention.mention.length < MIN_ENTITY_NAME_LENGTH) continue;
 
     // Check if candidate already exists (case-insensitive name match)
@@ -519,6 +544,9 @@ export async function handleCandidates(
             reviewRepo: materializeDeps.reviewRepo,
             domainsRepo: materializeDeps.domainsRepo,
             lookup: materializeDeps.lookup,
+            logger: materializeDeps.logger,
+            birthGateTypes: materializeDeps.birthGateTypes,
+            birthGateDryRun: materializeDeps.birthGateDryRun,
             readEmail: materializeDeps.readEmail,
           },
           {
@@ -755,6 +783,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
       deps.knownEntities,
       deps.participantBlock,
       deps.debugDumpDir,
+      deps.experimentalFlag,
     );
   } catch (err) {
     logger.error({ ...fileMeta, stage: "extractEntities", err }, "smartEnrichFile: stage failed");
@@ -933,7 +962,7 @@ async function reconcileLlmExtractionFacts(
 
   try {
     for (const mention of extraction.mentions) {
-      if (!PROPOSABLE_ENTITY_TYPES.has(mention.type as ProposeEntityType)) {
+      if (!proposableEntityTypes(deps.experimentalFlag).has(mention.type as ProposeEntityType)) {
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention, entityType: mention.type },
           "Dropped LLM mention with unsupported type",
@@ -993,6 +1022,7 @@ async function reconcileLlmExtractionFacts(
         contentHash,
         relation,
         mentions: extraction.mentions,
+        experimentalFlag: deps.experimentalFlag,
       });
       if (!input) continue;
       const factKey = buildIndexedFileFactKey(input);
@@ -1077,6 +1107,7 @@ function buildRelationFactInput(input: {
   contentHash: string;
   relation: ExtractedRelation;
   mentions: ExtractedMention[];
+  experimentalFlag?: boolean;
 }): UpsertIndexedFileFactInput | null {
   const relationType = normalizeRelationType(input.relation.type);
   if (!relationType || !isHighConfidenceRelation(input.relation.confidence)) return null;
@@ -1087,8 +1118,8 @@ function buildRelationFactInput(input: {
   const targetType = normalizeMentionType(input.relation.target.type);
   if (!sourceType || !targetType) return null;
   if (
-    !PROPOSABLE_ENTITY_TYPES.has(sourceType as ProposeEntityType) ||
-    !PROPOSABLE_ENTITY_TYPES.has(targetType as ProposeEntityType)
+    !proposableEntityTypes(input.experimentalFlag).has(sourceType as ProposeEntityType) ||
+    !proposableEntityTypes(input.experimentalFlag).has(targetType as ProposeEntityType)
   ) {
     return null;
   }

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -80,7 +80,7 @@ const CANDIDATE_PROMOTION_THRESHOLD = 2;
  */
 /** Minimum entity name length for candidate matching (avoids false positives). */
 const MIN_ENTITY_NAME_LENGTH = 3;
-const LLM_EXTRACTION_PROMPT_VERSION = "llm-extraction-v8";
+const LLM_EXTRACTION_PROMPT_VERSION = "llm-extraction-v9";
 const BASE_PROPOSABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product", "team"];
 const MATCHABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product", "team", "deal"];
 

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -489,6 +489,7 @@ export interface SyncSchedulerDeps {
       | "FEATURE_ARCHIVE_MAX_PER_RUN"
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
+      | "EXPERIMENTAL_FLAG"
       | "OUTLOOK_INITIAL_LOOKBACK_DAYS"
       | "OUTLOOK_MAX_INFLIGHT"
       | "TEAMS_INITIAL_LOOKBACK_DAYS"
@@ -631,6 +632,7 @@ export async function runScheduledEnrichment(db: Kysely<DB>, logger: Logger, dep
       geminiApiKey: settings?.gemini_api_key,
       geminiMaxRpm: deps?.appConfig?.GEMINI_MAX_RPM,
       geminiMaxRetries: deps?.appConfig?.GEMINI_MAX_RETRIES,
+      experimentalFlag: deps?.appConfig?.EXPERIMENTAL_FLAG,
       downloadImage: deps?.downloadImage,
       maxFilesPerRun: SCHEDULED_ENRICHMENT_MAX_FILES_PER_RUN,
       timeBudgetMs: SCHEDULED_ENRICHMENT_TIME_BUDGET_MS,

--- a/packages/server/src/db/repositories/entities.integration.test.ts
+++ b/packages/server/src/db/repositories/entities.integration.test.ts
@@ -93,4 +93,19 @@ describe("createEntityRepository deleteEntitiesForFiles postgres", () => {
     await expect(repo.deleteEntitiesForFiles(["pg-file-1"])).resolves.toBe(2);
     await expect(repo.getEntity(target.id)).resolves.toBeUndefined();
   });
+
+  it("finds batched people by metadata email fallback in postgres", async () => {
+    const repo = createEntityRepository(db);
+    const metadataOnly = await repo.upsertPersonEntity({
+      name: "PG Metadata Person",
+      email: "pg-metadata@example.com",
+      subtype: "external",
+      source: "seed",
+      sourceId: "pg-seed:metadata",
+    });
+
+    const matches = await repo.getPersonEntitiesByEmails(["PG-METADATA@example.com"]);
+
+    expect(matches.get("pg-metadata@example.com")).toMatchObject([{ id: metadataOnly.id }]);
+  });
 });

--- a/packages/server/src/db/repositories/entities.test.ts
+++ b/packages/server/src/db/repositories/entities.test.ts
@@ -641,5 +641,11 @@ describe("createEntityRepository contact points", () => {
       { id: metadataOnly.id },
     ]);
     await expect(repo.getPersonEntitiesByEmail("CONTACT@example.com")).resolves.toMatchObject([{ id: contactOnly.id }]);
+    await expect(repo.getPersonEntitiesByEmails(["METADATA@example.com", "CONTACT@example.com"])).resolves.toEqual(
+      new Map([
+        ["metadata@example.com", [expect.objectContaining({ id: metadataOnly.id })]],
+        ["contact@example.com", [expect.objectContaining({ id: contactOnly.id })]],
+      ]),
+    );
   });
 });

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Kysely, RawBuilder, Selectable } from "kysely";
 import { sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
+import { HIDDEN_ENTITY_SOURCE_TYPES } from "../../entities/profile-facts";
 import { resolveLiveEntity, resolveLiveEntityId, resolveSourceRefToLiveEntityId } from "../../entities/redirect";
 import { parseTimestampMs } from "../../timestamps";
 import { isPg } from "../dialect";
@@ -346,8 +347,12 @@ export function createEntityRepository(db: Kysely<DB>) {
         .execute();
     },
 
-    async getEntitiesByStatus(status: string) {
-      return db.selectFrom("entities").selectAll().where("status", "=", status).where(whereLiveEntity()).execute();
+    async getEntitiesByStatus(status: string, opts?: { excludeSourceTypes?: string[] }) {
+      let query = db.selectFrom("entities").selectAll().where("status", "=", status).where(whereLiveEntity());
+      if (opts?.excludeSourceTypes && opts.excludeSourceTypes.length > 0) {
+        query = query.where("source_type", "not in", opts.excludeSourceTypes);
+      }
+      return query.execute();
     },
 
     async updateEntity(
@@ -714,6 +719,9 @@ export function createEntityRepository(db: Kysely<DB>) {
 
       if (opts?.sourceTypes && opts.sourceTypes.length > 0) {
         q = q.where("source_type", "in", opts.sourceTypes);
+      } else {
+        const hiddenTypes = Array.from(HIDDEN_ENTITY_SOURCE_TYPES);
+        if (hiddenTypes.length > 0) q = q.where("source_type", "not in", hiddenTypes);
       }
 
       if (opts?.sortBy === "recency") {
@@ -749,11 +757,13 @@ export function createEntityRepository(db: Kysely<DB>) {
     // ── Hotness ──
 
     async getHotEntities(limit: number) {
+      const hiddenTypes = Array.from(HIDDEN_ENTITY_SOURCE_TYPES);
       return db
         .selectFrom("entities")
         .selectAll()
         .where("status", "!=", "archived")
         .where(whereLiveEntity())
+        .where("source_type", "not in", hiddenTypes.length > 0 ? hiddenTypes : [""])
         .orderBy("hotness", "desc")
         .limit(limit)
         .execute();

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -704,6 +704,52 @@ export function createEntityRepository(db: Kysely<DB>) {
       return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
     },
 
+    async getPersonEntitiesByEmails(rawEmails: string[]): Promise<Map<string, Selectable<EntitiesTable>[]>> {
+      const emails = Array.from(new Set(rawEmails.map((email) => normalizeContactPointValue("email", email))));
+      const out = new Map<string, Selectable<EntitiesTable>[]>();
+      if (emails.length === 0) return out;
+
+      const byContactPoint = await db
+        .selectFrom("entity_contact_points")
+        .innerJoin("entities", "entities.id", "entity_contact_points.entity_id")
+        .selectAll("entities")
+        .select("entity_contact_points.value as matched_email")
+        .where("entity_contact_points.kind", "=", "email")
+        .where("entity_contact_points.value", "in", emails)
+        .where("entities.source_type", "=", "person")
+        .where(whereLiveEntity())
+        .execute();
+      const byMetadata = await db
+        .selectFrom("entities")
+        .selectAll()
+        .select(
+          (isPg(db) ? sql<string>`(metadata::jsonb ->> 'email')` : sql<string>`json_extract(metadata, '$.email')`).as(
+            "matched_email",
+          ),
+        )
+        .where("source_type", "=", "person")
+        .where(whereLiveEntity())
+        .where(isPg(db) ? sql`(metadata::jsonb ->> 'email')` : sql`json_extract(metadata, '$.email')`, "in", emails)
+        .execute();
+
+      const byEmailAndId = new Map<string, Map<string, Selectable<EntitiesTable>>>();
+      for (const row of [...byContactPoint, ...byMetadata]) {
+        const matchedEmail = row.matched_email;
+        if (!matchedEmail) continue;
+        const normalized = normalizeContactPointValue("email", matchedEmail);
+        const entities = byEmailAndId.get(normalized) ?? new Map<string, Selectable<EntitiesTable>>();
+        entities.set(row.id, row);
+        byEmailAndId.set(normalized, entities);
+      }
+      for (const [email, entities] of byEmailAndId) {
+        out.set(
+          email,
+          [...entities.values()].sort((a, b) => a.id.localeCompare(b.id)),
+        );
+      }
+      return out;
+    },
+
     // ── Search ──
 
     async searchEntities(

--- a/packages/server/src/entities/graph.ts
+++ b/packages/server/src/entities/graph.ts
@@ -1,6 +1,7 @@
 import type { EntityRelationshipType } from "../db/repositories/entity-domains";
 
-export const NON_PERSON_MENTION_TYPES = ["project", "company", "product", "team", "deal"] as const;
+export const NON_PERSON_MENTION_TYPES = ["project", "company", "product", "team", "deal", "tool"] as const;
+export const RELATION_ENDPOINT_TYPES = ["person", "project", "company", "product", "team", "deal"] as const;
 export const ENTITY_GRAPH_RELATION_TYPES = [
   "works_at",
   "engaged_with",
@@ -20,6 +21,7 @@ export const LLM_RELATION_ENDPOINT_CONFIDENCE_THRESHOLD = 0.8;
 
 export type NonPersonMentionType = (typeof NON_PERSON_MENTION_TYPES)[number];
 export type MentionType = "person" | NonPersonMentionType;
+export type RelationEndpointType = (typeof RELATION_ENDPOINT_TYPES)[number];
 export type EntityGraphMentionType = MentionType;
 export type EntityGraphRelationType = (typeof ENTITY_GRAPH_RELATION_TYPES)[number];
 
@@ -30,9 +32,26 @@ export type EntityGraphRelationTypeExhaustivenessCheck = AssertNever<
 
 export interface EntityGraphRelationEndpoint {
   name: string;
-  type: MentionType;
+  type: RelationEndpointType;
   variations: string[];
 }
+
+export const TOOL_NAME_DENYLIST = new Set([
+  "airtable",
+  "asana",
+  "clickup",
+  "figma",
+  "github",
+  "google drive",
+  "hubspot",
+  "jira",
+  "linear",
+  "notion",
+  "salesforce",
+  "slack",
+  "trello",
+  "zoom",
+]);
 
 export function normalizeMentionType(raw: unknown): MentionType | null {
   if (typeof raw !== "string") return null;
@@ -42,6 +61,17 @@ export function normalizeMentionType(raw: unknown): MentionType | null {
     return lowered as NonPersonMentionType;
   }
   return null;
+}
+
+export function normalizeRelationEndpointType(raw: unknown): RelationEndpointType | null {
+  const type = normalizeMentionType(raw);
+  if (!type) return null;
+  return (RELATION_ENDPOINT_TYPES as readonly string[]).includes(type) ? (type as RelationEndpointType) : null;
+}
+
+export function coerceMentionType(name: string, type: string, experimentalFlag = false): string {
+  if (!experimentalFlag) return type;
+  return TOOL_NAME_DENYLIST.has(name.trim().toLowerCase()) ? "tool" : type;
 }
 
 export function normalizeRelationType(raw: unknown): EntityRelationshipType | null {
@@ -60,7 +90,7 @@ export function readRelationEndpoint(
   if (!endpoint || typeof endpoint !== "object" || Array.isArray(endpoint)) return null;
   const record = endpoint as Record<string, unknown>;
   if (typeof record.name !== "string") return null;
-  const type = normalizeMentionType(record.type);
+  const type = normalizeRelationEndpointType(record.type);
   if (!type) return null;
   const variations = Array.isArray(record.variations)
     ? record.variations.filter((value): value is string => typeof value === "string")
@@ -70,8 +100,8 @@ export function readRelationEndpoint(
 
 export function relationDirectionAllowed(
   relationType: EntityRelationshipType,
-  sourceType: MentionType,
-  targetType: MentionType,
+  sourceType: RelationEndpointType,
+  targetType: RelationEndpointType,
 ): boolean {
   if (relationType === "works_at") return sourceType === "person" && targetType === "company";
   if (relationType === "engaged_with") {

--- a/packages/server/src/entities/materialize-birth-gate.test.ts
+++ b/packages/server/src/entities/materialize-birth-gate.test.ts
@@ -1,0 +1,236 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import type { DB } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { materializeUnmaterializedFacts } from "./materialize";
+import type { ProposeEntityType } from "./propose";
+import { confirmReview } from "./resolve";
+
+const USER_ID = "user-1";
+const CONNECTOR_ID = "connector-1";
+const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
+const A1_BIRTH_GATE_TYPES: Set<ProposeEntityType> = new Set(["project", "product", "team"]);
+
+async function seedConnector(db: Kysely<DB>, source = "google_drive"): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: USER_ID,
+      name: "User One",
+      email: "user@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: source,
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: USER_ID,
+    })
+    .execute();
+}
+
+async function seedFile(db: Kysely<DB>, id: string, source = "google_drive"): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      file_name: `${id}.md`,
+      file_type: "doc",
+      content_category: "document",
+      source,
+      content_hash: `hash-${id}`,
+      is_archived: 0,
+      synced_at: now,
+    })
+    .execute();
+}
+
+async function upsertLlmMention(db: Kysely<DB>, fileId: string, name: string, type: string): Promise<void> {
+  const repo = createIndexedFileFactRepository(db);
+  await repo.upsertFact({
+    indexedFileId: fileId,
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    contentHash: `hash-${fileId}`,
+    source: "llm_extraction",
+    factType: "llm_extracted",
+    relation: "mentioned",
+    subjectName: name,
+    subjectSource: "llm_extraction",
+    subjectSourceId: `${fileId}:hash-${fileId}:llm-extraction-v8:${name}`,
+    raw: {
+      contentHash: `hash-${fileId}`,
+      promptVersion: "llm-extraction-v8",
+      model: "gemini",
+      mention: name,
+      type,
+      variations: [],
+    },
+  });
+}
+
+async function upsertStructuralSeed(
+  db: Kysely<DB>,
+  input: { fileId: string; sourceType: string; name: string; sourceId: string; source?: string },
+): Promise<void> {
+  const source = input.source ?? "linear";
+  const repo = createIndexedFileFactRepository(db);
+  await repo.upsertFact({
+    indexedFileId: input.fileId,
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    source,
+    factType: "structural_seed",
+    relation: "seeded",
+    subjectName: input.name,
+    subjectSource: source,
+    subjectSourceId: input.sourceId,
+    raw: {
+      sourceType: input.sourceType,
+      providerFileId: input.sourceId,
+      sourcePath: `${source}/${input.sourceId}`,
+    },
+  });
+}
+
+async function countEntitiesByType(db: Kysely<DB>, sourceType: string): Promise<number> {
+  const row = await db
+    .selectFrom("entities")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .where("source_type", "=", sourceType)
+    .where("id", "!=", TEST_ACCOUNT_ENTITY_ID)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function countQueueRows(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entity_review_queue")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+describe("A1 birth gate", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("queues a conversational product birth gate and confirmReview creates the entity", async () => {
+    await seedConnector(db);
+    await seedFile(db, "file-1");
+    await upsertLlmMention(db, "file-1", "Canvas Copilot", "product");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: A1_BIRTH_GATE_TYPES,
+      birthGateDryRun: false,
+    });
+
+    expect(await countEntitiesByType(db, "product")).toBe(0);
+    expect(await countQueueRows(db)).toBe(1);
+    const row = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(row.candidate_reason).toBe("birth-gated");
+    expect(row.source).toBe("llm_extraction");
+    expect(row.source_id).toBe("file-1:hash-file-1:llm-extraction-v8:Canvas Copilot");
+    if (!row.candidate_generated_at) throw new Error("missing candidate_generated_at");
+
+    const result = await confirmReview({ db, userId: USER_ID }, row.id, {
+      candidateGeneratedAt: row.candidate_generated_at,
+    });
+
+    expect(result.targetEntityId).toBeTruthy();
+    expect(await countEntitiesByType(db, "product")).toBe(1);
+  });
+
+  it("drops conversational team mentions and queues Linear team structural seeds", async () => {
+    await seedConnector(db, "linear");
+    await seedFile(db, "file-1", "linear");
+    await seedFile(db, "file-2", "linear");
+    await upsertLlmMention(db, "file-1", "Platform Team", "team");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: A1_BIRTH_GATE_TYPES,
+      birthGateDryRun: false,
+    });
+
+    expect(await countEntitiesByType(db, "team")).toBe(0);
+    expect(await countQueueRows(db)).toBe(0);
+
+    await upsertStructuralSeed(db, {
+      fileId: "file-2",
+      sourceType: "team",
+      name: "Platform Team",
+      sourceId: "team-1",
+      source: "linear",
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      birthGateTypes: A1_BIRTH_GATE_TYPES,
+      birthGateDryRun: false,
+    });
+
+    expect(await countEntitiesByType(db, "team")).toBe(0);
+    expect(await countQueueRows(db)).toBe(1);
+    const row = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(row).toMatchObject({
+      entity_type: "team",
+      seed_source: "linear",
+      seed_source_id: "team-1",
+    });
+  });
+
+  it("links exact product matches under the gate and flag-off product mentions still auto-create", async () => {
+    await seedConnector(db);
+    await seedFile(db, "file-1");
+    const entityRepo = createEntityRepository(db);
+    await entityRepo.upsertEntity({
+      name: "Canvas Copilot",
+      sourceType: "product",
+      status: "confirmed",
+    });
+    await upsertLlmMention(db, "file-1", "Canvas Copilot", "product");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: A1_BIRTH_GATE_TYPES,
+      birthGateDryRun: false,
+    });
+
+    expect(await countEntitiesByType(db, "product")).toBe(1);
+    expect(await countQueueRows(db)).toBe(0);
+
+    await db.destroy();
+    db = await createTestDb();
+    await seedConnector(db);
+    await seedFile(db, "file-1");
+    await upsertLlmMention(db, "file-1", "Canvas Copilot", "product");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: new Set(),
+      birthGateDryRun: false,
+    });
+
+    expect(await countEntitiesByType(db, "product")).toBe(1);
+    expect(await countQueueRows(db)).toBe(0);
+  });
+});

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -22,6 +22,8 @@ import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
 
 const DEFAULT_LLM_PROMOTION_THRESHOLD = 2;
 let configuredLlmPromotionThreshold = DEFAULT_LLM_PROMOTION_THRESHOLD;
+let configuredBirthGateTypes = new Set<ProposeEntityType>();
+let configuredBirthGateDryRun = true;
 
 /**
  * Set the default `llmPromotionThreshold` used by entry points
@@ -29,10 +31,16 @@ let configuredLlmPromotionThreshold = DEFAULT_LLM_PROMOTION_THRESHOLD;
  * `buildMaterializeDeps`) when the caller doesn't pass one. Production
  * callers should invoke this once at boot with `config.LLM_PROMOTION_THRESHOLD`.
  */
-export function configureMaterializeDefaults(opts: { llmPromotionThreshold?: number }): void {
+export function configureMaterializeDefaults(opts: {
+  llmPromotionThreshold?: number;
+  birthGateTypes?: Set<ProposeEntityType>;
+  birthGateDryRun?: boolean;
+}): void {
   if (typeof opts.llmPromotionThreshold === "number" && opts.llmPromotionThreshold >= 1) {
     configuredLlmPromotionThreshold = Math.floor(opts.llmPromotionThreshold);
   }
+  if (opts.birthGateTypes) configuredBirthGateTypes = new Set(opts.birthGateTypes);
+  if (typeof opts.birthGateDryRun === "boolean") configuredBirthGateDryRun = opts.birthGateDryRun;
 }
 
 export function normalizeEntityMatchName(entityType: string, name: string): string {
@@ -234,6 +242,8 @@ export async function refreshResolvedEntityIndex(db: Kysely<DB>, index: LookupIn
 export interface BuildMaterializeDepsOptions {
   llmPromotionThreshold?: number;
   logger?: Logger;
+  birthGateTypes?: Set<ProposeEntityType>;
+  birthGateDryRun?: boolean;
 }
 
 export async function buildMaterializeDeps(
@@ -249,6 +259,8 @@ export async function buildMaterializeDeps(
     typeof opts.llmPromotionThreshold === "number" && opts.llmPromotionThreshold >= 1
       ? Math.floor(opts.llmPromotionThreshold)
       : configuredLlmPromotionThreshold;
+  const birthGateTypes = new Set(opts.birthGateTypes ?? configuredBirthGateTypes);
+  const birthGateDryRun = opts.birthGateDryRun ?? configuredBirthGateDryRun;
 
   const lookup: EntityLookup = {
     getByNormalizedName: (n) => index.byNormalizedName.get(n) ?? [],
@@ -306,6 +318,8 @@ export async function buildMaterializeDeps(
     lookup,
     index,
     llmPromotionThreshold,
+    birthGateTypes,
+    birthGateDryRun,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),
     onEntityResolved: (entity: Entity) => refreshResolvedEntityIndex(db, index, entity),
     resolveOwner: (fact: IndexedFileFactRow) => {

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -24,6 +24,7 @@ const DEFAULT_LLM_PROMOTION_THRESHOLD = 2;
 let configuredLlmPromotionThreshold = DEFAULT_LLM_PROMOTION_THRESHOLD;
 let configuredBirthGateTypes = new Set<ProposeEntityType>();
 let configuredBirthGateDryRun = true;
+let configuredExperimentalFlag = false;
 
 /**
  * Set the default `llmPromotionThreshold` used by entry points
@@ -35,12 +36,14 @@ export function configureMaterializeDefaults(opts: {
   llmPromotionThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
+  experimentalFlag?: boolean;
 }): void {
   if (typeof opts.llmPromotionThreshold === "number" && opts.llmPromotionThreshold >= 1) {
     configuredLlmPromotionThreshold = Math.floor(opts.llmPromotionThreshold);
   }
   if (opts.birthGateTypes) configuredBirthGateTypes = new Set(opts.birthGateTypes);
   if (typeof opts.birthGateDryRun === "boolean") configuredBirthGateDryRun = opts.birthGateDryRun;
+  if (typeof opts.experimentalFlag === "boolean") configuredExperimentalFlag = opts.experimentalFlag;
 }
 
 export function normalizeEntityMatchName(entityType: string, name: string): string {
@@ -54,7 +57,7 @@ export function normalizeEntityMatchName(entityType: string, name: string): stri
 }
 
 async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
-  const supportedTypes: ProposeEntityType[] = ["person", "company", "product", "project", "team", "deal"];
+  const supportedTypes: ProposeEntityType[] = ["person", "company", "product", "project", "team", "deal", "tool"];
   const entities = await db
     .selectFrom("entities")
     .selectAll()
@@ -244,6 +247,7 @@ export interface BuildMaterializeDepsOptions {
   logger?: Logger;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
+  experimentalFlag?: boolean;
 }
 
 export async function buildMaterializeDeps(
@@ -261,6 +265,7 @@ export async function buildMaterializeDeps(
       : configuredLlmPromotionThreshold;
   const birthGateTypes = new Set(opts.birthGateTypes ?? configuredBirthGateTypes);
   const birthGateDryRun = opts.birthGateDryRun ?? configuredBirthGateDryRun;
+  const experimentalFlag = opts.experimentalFlag ?? configuredExperimentalFlag;
 
   const lookup: EntityLookup = {
     getByNormalizedName: (n) => index.byNormalizedName.get(n) ?? [],
@@ -320,6 +325,7 @@ export async function buildMaterializeDeps(
     llmPromotionThreshold,
     birthGateTypes,
     birthGateDryRun,
+    experimentalFlag,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),
     onEntityResolved: (entity: Entity) => refreshResolvedEntityIndex(db, index, entity),
     resolveOwner: (fact: IndexedFileFactRow) => {

--- a/packages/server/src/entities/materialize-llm-mentions.ts
+++ b/packages/server/src/entities/materialize-llm-mentions.ts
@@ -1,6 +1,6 @@
 import type { Kysely } from "kysely";
 import type { DB } from "../db/schema";
-import { type MentionType, type NonPersonMentionType, normalizeMentionType } from "./graph";
+import { type MentionType, type NonPersonMentionType, coerceMentionType, normalizeMentionType } from "./graph";
 import { normalizeEntityMatchName, registerEntity } from "./materialize-deps";
 import { isString, readJsonObject } from "./materialize-json";
 import { createMentionFromFact } from "./materialize-mentions";
@@ -12,6 +12,7 @@ async function countActiveLlmFilesForName(
   db: Kysely<DB>,
   normalized: string,
   mentionType: MentionType,
+  experimentalFlag: boolean,
 ): Promise<number> {
   const rows = await db
     .selectFrom("indexed_file_facts")
@@ -24,7 +25,8 @@ async function countActiveLlmFilesForName(
   for (const row of rows) {
     if (!row.indexed_file_id || !row.subject_name) continue;
     const raw = readJsonObject(row.raw);
-    if (normalizeMentionType(raw.type) !== mentionType) continue;
+    const rowType = normalizeMentionType(coerceMentionType(row.subject_name, String(raw.type ?? ""), experimentalFlag));
+    if (rowType !== mentionType) continue;
     if (normalizeEntityMatchName(mentionType, row.subject_name) !== normalized) continue;
     seen.add(row.indexed_file_id);
   }
@@ -39,7 +41,9 @@ export async function materializeLlmExtractedFact(
     return { kind: "skipped", reason: "missing_llm_subject" };
   }
   const raw = readJsonObject(fact.raw);
-  const mentionType = normalizeMentionType(raw.type);
+  const mentionType = normalizeMentionType(
+    coerceMentionType(fact.subject_name, String(raw.type ?? ""), deps.experimentalFlag),
+  );
   if (!mentionType) {
     return { kind: "skipped", reason: "missing_or_invalid_mention_type" };
   }
@@ -50,7 +54,7 @@ export async function materializeLlmExtractedFact(
   if (!normalized) {
     return { kind: "skipped", reason: "missing_llm_subject" };
   }
-  const fileCount = await countActiveLlmFilesForName(deps.db, normalized, mentionType);
+  const fileCount = await countActiveLlmFilesForName(deps.db, normalized, mentionType, deps.experimentalFlag);
   if (fileCount < deps.llmPromotionThreshold) {
     return { kind: "deferred_below_threshold", reason: "below_promotion_threshold" };
   }

--- a/packages/server/src/entities/materialize-llm-mentions.ts
+++ b/packages/server/src/entities/materialize-llm-mentions.ts
@@ -43,6 +43,9 @@ export async function materializeLlmExtractedFact(
   if (!mentionType) {
     return { kind: "skipped", reason: "missing_or_invalid_mention_type" };
   }
+  if (mentionType === "team" && deps.birthGateTypes.has("team")) {
+    return { kind: "skipped", reason: "team_conversational_birth_gated" };
+  }
   const normalized = normalizeEntityMatchName(mentionType, fact.subject_name);
   if (!normalized) {
     return { kind: "skipped", reason: "missing_llm_subject" };
@@ -81,6 +84,9 @@ export async function materializeNonPersonLlmEntity(
       reviewRepo: deps.reviewRepo,
       domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
+      logger: deps.logger,
+      birthGateTypes: deps.birthGateTypes,
+      birthGateDryRun: deps.birthGateDryRun,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,
     },

--- a/packages/server/src/entities/materialize-project.ts
+++ b/packages/server/src/entities/materialize-project.ts
@@ -1,5 +1,6 @@
 import { registerEntity } from "./materialize-deps";
 import { readJsonObject } from "./materialize-json";
+import { materializeSpineCandidate } from "./materialize-spine-candidate";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
 import { proposeEntity } from "./propose";
 
@@ -17,12 +18,25 @@ export async function materializeProjectSeed(
   const metadata =
     raw.metadata && typeof raw.metadata === "object" ? (raw.metadata as Record<string, unknown>) : undefined;
 
+  if (deps.birthGateTypes.has("project")) {
+    return materializeSpineCandidate(deps, fact, {
+      subjectSource,
+      subjectSourceId,
+      sourceType: "project",
+      raw,
+      metadata,
+    });
+  }
+
   const result = await proposeEntity(
     {
       entityRepo: deps.entityRepo,
       reviewRepo: deps.reviewRepo,
       domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
+      logger: deps.logger,
+      birthGateTypes: deps.birthGateTypes,
+      birthGateDryRun: deps.birthGateDryRun,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,
     },

--- a/packages/server/src/entities/materialize-relations.ts
+++ b/packages/server/src/entities/materialize-relations.ts
@@ -1,10 +1,11 @@
 import {
   type EntityGraphRelationEndpoint,
+  coerceMentionType,
   isHighConfidenceEndpoint,
   isHighConfidenceRelation,
   normalizeMentionType,
+  normalizeRelationEndpointType,
   normalizeRelationType,
-  readRelationEndpoint,
   relationDirectionAllowed,
 } from "./graph";
 import { normalizeEntityMatchName, registerEntity } from "./materialize-deps";
@@ -26,8 +27,8 @@ export async function materializeLlmRelationFact(
 ): Promise<MaterializeResult> {
   const raw = readJsonObject(fact.raw);
   const relationType = normalizeRelationType(raw.relationType ?? fact.relation);
-  const source = readRelationEndpoint(raw, "source");
-  const target = readRelationEndpoint(raw, "target");
+  const source = readCoercedRelationEndpoint(raw, "source", deps.experimentalFlag);
+  const target = readCoercedRelationEndpoint(raw, "target", deps.experimentalFlag);
   const confidenceScore = typeof raw.confidence === "number" ? raw.confidence : 0;
   const sourceConfidence = typeof raw.sourceConfidence === "number" ? raw.sourceConfidence : 0;
   const targetConfidence = typeof raw.targetConfidence === "number" ? raw.targetConfidence : 0;
@@ -192,9 +193,27 @@ function readCrmRelationEndpoint(raw: Record<string, unknown>, key: "source" | "
   if (typeof record.source !== "string" || typeof record.sourceId !== "string" || typeof record.name !== "string") {
     return null;
   }
-  const type = normalizeMentionType(record.type);
+  const type = normalizeRelationEndpointType(record.type);
   if (!type) return null;
   return { source: record.source, sourceId: record.sourceId, name: record.name, type };
+}
+
+function readCoercedRelationEndpoint(
+  raw: Record<string, unknown>,
+  key: "source" | "target",
+  experimentalFlag: boolean,
+): EntityGraphRelationEndpoint | null {
+  const endpoint = raw[key];
+  if (!endpoint || typeof endpoint !== "object" || Array.isArray(endpoint)) return null;
+  const record = endpoint as Record<string, unknown>;
+  if (typeof record.name !== "string") return null;
+  const coercedType = coerceMentionType(record.name, String(record.type ?? ""), experimentalFlag);
+  const type = normalizeRelationEndpointType(coercedType);
+  if (!type) return null;
+  const variations = Array.isArray(record.variations)
+    ? record.variations.filter((value): value is string => typeof value === "string")
+    : [];
+  return { name: record.name, type, variations };
 }
 
 async function resolveCrmEndpoint(deps: MaterializeDeps, endpoint: CrmRelationEndpoint): Promise<EntityRow | null> {
@@ -221,6 +240,8 @@ async function materializeRelationEndpoint(
   | { kind: "suppressed_endpoint" }
 > {
   const raw = readJsonObject(fact.raw);
+  const coercedType = normalizeMentionType(coerceMentionType(endpoint.name, endpoint.type, deps.experimentalFlag));
+  if (coercedType === "tool") return { kind: "suppressed_endpoint" };
   const normalized = normalizeEntityMatchName(endpoint.type, endpoint.name);
   if (await deps.suppressionRepo.isSuppressed(normalized, endpoint.type)) {
     return { kind: "suppressed_endpoint" };

--- a/packages/server/src/entities/materialize-relations.ts
+++ b/packages/server/src/entities/materialize-relations.ts
@@ -32,6 +32,9 @@ export async function materializeLlmRelationFact(
   const sourceConfidence = typeof raw.sourceConfidence === "number" ? raw.sourceConfidence : 0;
   const targetConfidence = typeof raw.targetConfidence === "number" ? raw.targetConfidence : 0;
   if (!relationType || !source || !target) return { kind: "skipped", reason: "invalid_llm_relation" };
+  if (deps.birthGateTypes.has("team") && (source.type === "team" || target.type === "team")) {
+    return { kind: "skipped", reason: "team_conversational_birth_gated" };
+  }
   if (!isHighConfidenceRelation(confidenceScore)) return { kind: "skipped", reason: "low_confidence_relation" };
   if (!isHighConfidenceEndpoint(sourceConfidence) || !isHighConfidenceEndpoint(targetConfidence)) {
     return { kind: "skipped", reason: "low_endpoint_confidence" };
@@ -228,6 +231,9 @@ async function materializeRelationEndpoint(
       reviewRepo: deps.reviewRepo,
       domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
+      logger: deps.logger,
+      birthGateTypes: deps.birthGateTypes,
+      birthGateDryRun: deps.birthGateDryRun,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,
     },

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -127,6 +127,7 @@ export async function replaySourceFacts(
     logger,
     birthGateTypes: opts.birthGateTypes,
     birthGateDryRun: opts.birthGateDryRun,
+    experimentalFlag: opts.experimentalFlag,
   });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));
   const facts = (await db.selectFrom("indexed_file_facts").selectAll().where("deleted_at", "is", null).execute())
@@ -196,6 +197,7 @@ async function materializeUnmaterializedFactsInner(
     logger,
     birthGateTypes: opts.birthGateTypes,
     birthGateDryRun: opts.birthGateDryRun,
+    experimentalFlag: opts.experimentalFlag,
   });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));
   let factsQuery = db

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -122,7 +122,12 @@ export async function replaySourceFacts(
     skipped: 0,
   };
 
-  const deps = await buildMaterializeDeps(db, { llmPromotionThreshold: opts.llmPromotionThreshold, logger });
+  const deps = await buildMaterializeDeps(db, {
+    llmPromotionThreshold: opts.llmPromotionThreshold,
+    logger,
+    birthGateTypes: opts.birthGateTypes,
+    birthGateDryRun: opts.birthGateDryRun,
+  });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));
   const facts = (await db.selectFrom("indexed_file_facts").selectAll().where("deleted_at", "is", null).execute())
     .filter((f) => orderRank.has(f.fact_type))
@@ -186,7 +191,12 @@ async function materializeUnmaterializedFactsInner(
     deferredBelowThreshold: 0,
   };
 
-  const deps = await buildMaterializeDeps(db, { llmPromotionThreshold: opts.llmPromotionThreshold, logger });
+  const deps = await buildMaterializeDeps(db, {
+    llmPromotionThreshold: opts.llmPromotionThreshold,
+    logger,
+    birthGateTypes: opts.birthGateTypes,
+    birthGateDryRun: opts.birthGateDryRun,
+  });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));
   let factsQuery = db
     .selectFrom("indexed_file_facts")

--- a/packages/server/src/entities/materialize-spine-candidate.ts
+++ b/packages/server/src/entities/materialize-spine-candidate.ts
@@ -1,0 +1,146 @@
+import { normalizeEntityMatchName, registerEntity } from "./materialize-deps";
+import { createMentionFromFact } from "./materialize-mentions";
+import { buildSeedProvenanceNote, isProjectCandidateSeed } from "./materialize-structural-gate";
+import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+import type { ProposeEntityType } from "./propose";
+
+export function canonicalSpineTypeForStructuralSource(sourceType: string): ProposeEntityType | null {
+  if (sourceType === "project" || isProjectCandidateSeed(sourceType)) return "project";
+  if (sourceType === "team") return "team";
+  if (sourceType === "product") return "product";
+  return null;
+}
+
+export async function materializeSpineCandidate(
+  deps: MaterializeDeps,
+  fact: IndexedFileFactRow,
+  args: {
+    subjectSource: string;
+    subjectSourceId: string;
+    sourceType: string;
+    sourceUrl?: string;
+    raw: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+    forceQueue?: boolean;
+  },
+): Promise<MaterializeResult> {
+  const spineType = canonicalSpineTypeForStructuralSource(args.sourceType);
+  if (!spineType) {
+    const entity = (await deps.entityRepo.upsertEntityFromTool({
+      name: fact.subject_name as string,
+      sourceType: args.sourceType,
+      source: args.subjectSource,
+      sourceId: args.subjectSourceId,
+      sourceUrl: args.sourceUrl,
+      sourceRefId: fact.indexed_file_id ?? undefined,
+      metadata: args.metadata,
+    })) as unknown as EntityRow;
+    registerEntity(deps.index, entity);
+    deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
+    return { kind: "structural", entity };
+  }
+
+  const existing = await deps.entityRepo.getEntityBySourceRef(args.subjectSource, args.subjectSourceId);
+  if (existing && existing.source_type === spineType) {
+    const entity = existing as unknown as EntityRow;
+    if (fact.indexed_file_id) {
+      await createMentionFromFact(deps, {
+        entityId: entity.id,
+        indexedFileId: fact.indexed_file_id,
+        contextSnippet: fact.context_snippet ?? null,
+        confidence: "EXTRACTED",
+        source: `${fact.source}_structural_seed`,
+        relation: "mentioned",
+      });
+    }
+    deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
+    return { kind: "entity_linked", entity, mentionWritten: Boolean(fact.indexed_file_id), countEntity: false };
+  }
+
+  if (spineType === "project" && existing && isProjectCandidateSeed(existing.source_type)) {
+    const entity = await promoteLegacyProjectContainer(deps, existing as unknown as EntityRow, fact, args.metadata);
+    if (fact.indexed_file_id) {
+      await createMentionFromFact(deps, {
+        entityId: entity.id,
+        indexedFileId: fact.indexed_file_id,
+        contextSnippet: fact.context_snippet ?? null,
+        confidence: "EXTRACTED",
+        source: `${fact.source}_structural_seed`,
+        relation: "mentioned",
+      });
+    }
+    deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
+    return { kind: "entity_linked", entity, mentionWritten: Boolean(fact.indexed_file_id), countEntity: false };
+  }
+
+  if (args.forceQueue || deps.birthGateTypes.has(spineType)) {
+    const owner = deps.resolveOwner(fact);
+    if (!owner) return { kind: "skipped_missing_owner", reason: "missing_fact_owner" };
+
+    const subjectName = fact.subject_name as string;
+    const { row, skipEvidence } = await deps.reviewRepo.upsertSeedReviewRow({
+      proposedName: subjectName,
+      normalizedName: normalizeEntityMatchName(spineType, subjectName),
+      entityType: spineType,
+      seedSource: args.subjectSource,
+      seedSourceId: args.subjectSourceId,
+      candidateEntityId: null,
+      triggeredByUserId: owner,
+      metadata: args.metadata,
+    });
+
+    if (skipEvidence) {
+      return { kind: "skipped", reason: row.status === "rejected" ? "seed_durably_rejected" : "seed_already_resolved" };
+    }
+
+    if (fact.indexed_file_id) {
+      await deps.reviewRepo.upsertEvidence({
+        reviewId: row.id,
+        indexedFileId: fact.indexed_file_id,
+        source: `${fact.source}_structural_seed`,
+        note: buildSeedProvenanceNote(args.raw, args.sourceType),
+      });
+    }
+    return { kind: "queued", reviewId: row.id };
+  }
+
+  const entity = (await deps.entityRepo.upsertEntityFromTool({
+    name: fact.subject_name as string,
+    sourceType: spineType,
+    source: args.subjectSource,
+    sourceId: args.subjectSourceId,
+    sourceUrl: args.sourceUrl,
+    sourceRefId: fact.indexed_file_id ?? undefined,
+    metadata: args.metadata,
+  })) as unknown as EntityRow;
+  registerEntity(deps.index, entity);
+  deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
+  return { kind: "structural", entity };
+}
+
+async function promoteLegacyProjectContainer(
+  deps: MaterializeDeps,
+  existing: EntityRow,
+  fact: IndexedFileFactRow,
+  metadata?: Record<string, unknown>,
+): Promise<EntityRow> {
+  const now = new Date().toISOString();
+  const nextMetadata = metadata ? JSON.stringify(metadata) : existing.metadata;
+  await deps.db
+    .updateTable("entities")
+    .set({
+      name: fact.subject_name ?? existing.name,
+      source_type: "project",
+      metadata: nextMetadata,
+      updated_at: now,
+    })
+    .where("id", "=", existing.id)
+    .execute();
+  return {
+    ...existing,
+    name: fact.subject_name ?? existing.name,
+    source_type: "project",
+    metadata: nextMetadata,
+    updated_at: now,
+  };
+}

--- a/packages/server/src/entities/materialize-structural-gate.test.ts
+++ b/packages/server/src/entities/materialize-structural-gate.test.ts
@@ -4,14 +4,33 @@ import { createEntityRepository } from "../db/repositories/entities";
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
 import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
-import { createTestDb } from "../test-utils";
-import { buildMaterializeDeps } from "./materialize";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { buildMaterializeDeps, materializeUnmaterializedFacts } from "./materialize";
 import { materializeStructuralSeed } from "./materialize-structural";
 import type { IndexedFileFactRow } from "./materialize-types";
 
 const USER_ID = "user-1";
 const CONNECTOR_ID = "connector-1";
 const FILE_ID = "file-1";
+const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
+
+async function countEntitiesBySourceType(db: Kysely<DB>, sourceType: string): Promise<number> {
+  const row = await db
+    .selectFrom("entities")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .where("source_type", "=", sourceType)
+    .where("id", "!=", TEST_ACCOUNT_ENTITY_ID)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function countReviewQueueRows(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entity_review_queue")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
 
 async function seedConnectorFile(db: Kysely<DB>, source = "linear"): Promise<void> {
   const now = new Date().toISOString();
@@ -213,5 +232,50 @@ describe("materializeStructuralSeed project birth gate", () => {
     const entity = await db.selectFrom("entities").selectAll().executeTakeFirstOrThrow();
     expect(entity).toMatchObject({ name: "Workspace", source_type: "clickup_workspace" });
     await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(0);
+  });
+
+  it("A0 documents current structural seed path creating replay-dispatched project and team seeds but queueing linear_project containers until A1 flips it", async () => {
+    await seedConnectorFile(db);
+    await seedStructuralFact(db, {
+      sourceType: "project",
+      subjectName: "Apollo",
+      subjectSourceId: "P-live",
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(await countEntitiesBySourceType(db, "project")).toBe(1);
+    expect(await countReviewQueueRows(db)).toBe(0);
+
+    await db.destroy();
+    db = await createTestDb();
+
+    await seedConnectorFile(db);
+    const containerFact = await seedStructuralFact(db, {
+      subjectName: "Zephyr",
+      subjectSourceId: "P-container",
+    });
+    const containerDeps = await buildMaterializeDeps(db);
+
+    await materializeStructuralSeed(containerDeps, containerFact);
+
+    expect(await countEntitiesBySourceType(db, "project")).toBe(0);
+    expect(await countReviewQueueRows(db)).toBe(1);
+
+    await db.destroy();
+    db = await createTestDb();
+
+    await seedConnectorFile(db);
+    const teamFact = await seedStructuralFact(db, {
+      sourceType: "team",
+      subjectName: "Engineering",
+      subjectSourceId: "T1",
+    });
+    const teamDeps = await buildMaterializeDeps(db);
+
+    await materializeStructuralSeed(teamDeps, teamFact);
+
+    expect(await countEntitiesBySourceType(db, "team")).toBe(1);
+    expect(await countReviewQueueRows(db)).toBe(0);
   });
 });

--- a/packages/server/src/entities/materialize-structural.ts
+++ b/packages/server/src/entities/materialize-structural.ts
@@ -1,7 +1,7 @@
-import { normalizeEntityMatchName } from "./materialize-deps";
 import { readJsonObject } from "./materialize-json";
 import { createMentionFromFact } from "./materialize-mentions";
-import { buildSeedProvenanceNote, isProjectCandidateSeed } from "./materialize-structural-gate";
+import { materializeSpineCandidate } from "./materialize-spine-candidate";
+import { isProjectCandidateSeed } from "./materialize-structural-gate";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
 
 function readCrmAccountDomains(metadata: Record<string, unknown> | undefined): string[] {
@@ -33,8 +33,16 @@ export async function materializeStructuralSeed(
     raw.metadata && typeof raw.metadata === "object" ? (raw.metadata as Record<string, unknown>) : undefined;
   const metadata = metadataFromRaw ?? (sourcePath ? { path: sourcePath } : undefined);
 
-  if (isProjectCandidateSeed(sourceType)) {
-    return materializeProjectCandidate(deps, fact, { subjectSource, subjectSourceId, sourceType, raw, metadata });
+  if (isProjectCandidateSeed(sourceType) || sourceType === "team" || sourceType === "product") {
+    return materializeSpineCandidate(deps, fact, {
+      subjectSource,
+      subjectSourceId,
+      sourceType,
+      sourceUrl,
+      raw,
+      metadata,
+      forceQueue: isProjectCandidateSeed(sourceType),
+    });
   }
 
   const entity = (await deps.entityRepo.upsertEntityFromTool({
@@ -80,113 +88,6 @@ export async function materializeStructuralSeed(
   }
   deps.index.bySourceRef.set(`${subjectSource}:${subjectSourceId}`, entity);
   return { kind: "structural", entity };
-}
-
-/**
- * Project birth gate. A connector container (Linear project, ClickUp
- * space/folder) does not auto-create a `project` entity — it is proposed for
- * human review keyed on its stable `(source, source_id)` handle, which
- * survives container renames. Confirm creates the entity (see
- * `confirmReview` create-on-confirm); reject is a durable sticky memo.
- */
-async function materializeProjectCandidate(
-  deps: MaterializeDeps,
-  fact: IndexedFileFactRow,
-  args: {
-    subjectSource: string;
-    subjectSourceId: string;
-    sourceType: string;
-    raw: Record<string, unknown>;
-    metadata?: Record<string, unknown>;
-  },
-): Promise<MaterializeResult> {
-  const owner = deps.resolveOwner(fact);
-  if (!owner) return { kind: "skipped_missing_owner", reason: "missing_fact_owner" };
-
-  const existing = await deps.entityRepo.getEntityBySourceRef(args.subjectSource, args.subjectSourceId);
-  if (existing && existing.source_type === "project") {
-    const entity = existing as unknown as EntityRow;
-    if (fact.indexed_file_id) {
-      await createMentionFromFact(deps, {
-        entityId: entity.id,
-        indexedFileId: fact.indexed_file_id,
-        contextSnippet: fact.context_snippet ?? null,
-        confidence: "EXTRACTED",
-        source: `${fact.source}_structural_seed`,
-        relation: "mentioned",
-      });
-    }
-    deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
-    return { kind: "entity_linked", entity, mentionWritten: Boolean(fact.indexed_file_id), countEntity: false };
-  }
-  if (existing && isProjectCandidateSeed(existing.source_type)) {
-    const entity = await promoteLegacyProjectContainer(deps, existing as unknown as EntityRow, fact, args.metadata);
-    if (fact.indexed_file_id) {
-      await createMentionFromFact(deps, {
-        entityId: entity.id,
-        indexedFileId: fact.indexed_file_id,
-        contextSnippet: fact.context_snippet ?? null,
-        confidence: "EXTRACTED",
-        source: `${fact.source}_structural_seed`,
-        relation: "mentioned",
-      });
-    }
-    deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
-    return { kind: "entity_linked", entity, mentionWritten: Boolean(fact.indexed_file_id), countEntity: false };
-  }
-
-  const subjectName = fact.subject_name as string;
-  const { row, skipEvidence } = await deps.reviewRepo.upsertSeedReviewRow({
-    proposedName: subjectName,
-    normalizedName: normalizeEntityMatchName("project", subjectName),
-    entityType: "project",
-    seedSource: args.subjectSource,
-    seedSourceId: args.subjectSourceId,
-    candidateEntityId: null,
-    triggeredByUserId: owner,
-    metadata: args.metadata,
-  });
-
-  if (skipEvidence) {
-    return { kind: "skipped", reason: row.status === "rejected" ? "seed_durably_rejected" : "seed_already_resolved" };
-  }
-
-  if (fact.indexed_file_id) {
-    await deps.reviewRepo.upsertEvidence({
-      reviewId: row.id,
-      indexedFileId: fact.indexed_file_id,
-      source: `${fact.source}_structural_seed`,
-      note: buildSeedProvenanceNote(args.raw, args.sourceType),
-    });
-  }
-  return { kind: "queued", reviewId: row.id };
-}
-
-async function promoteLegacyProjectContainer(
-  deps: MaterializeDeps,
-  existing: EntityRow,
-  fact: IndexedFileFactRow,
-  metadata?: Record<string, unknown>,
-): Promise<EntityRow> {
-  const now = new Date().toISOString();
-  const nextMetadata = metadata ? JSON.stringify(metadata) : existing.metadata;
-  await deps.db
-    .updateTable("entities")
-    .set({
-      name: fact.subject_name ?? existing.name,
-      source_type: "project",
-      metadata: nextMetadata,
-      updated_at: now,
-    })
-    .where("id", "=", existing.id)
-    .execute();
-  return {
-    ...existing,
-    name: fact.subject_name ?? existing.name,
-    source_type: "project",
-    metadata: nextMetadata,
-    updated_at: now,
-  };
 }
 
 export async function materializeParentEntity(

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -53,6 +53,7 @@ export interface MaterializeDeps {
   llmPromotionThreshold: number;
   birthGateTypes: Set<ProposeEntityType>;
   birthGateDryRun: boolean;
+  experimentalFlag: boolean;
 }
 
 export type MaterializeResult =
@@ -76,6 +77,7 @@ export interface ReplaySourceFactsOptions {
   llmPromotionThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
+  experimentalFlag?: boolean;
 }
 
 export interface MaterializeProgress {
@@ -88,6 +90,7 @@ export interface MaterializeUnmaterializedOptions {
   llmPromotionThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
+  experimentalFlag?: boolean;
   factTypes?: IndexedFileFactType[];
   /**
    * Fires before processing each fact with `completed = index, total = facts.length`

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -51,6 +51,8 @@ export interface MaterializeDeps {
   onEntityResolved: (entity: Entity) => void | Promise<void>;
   resolveOwner: (fact: IndexedFileFactRow) => string | null;
   llmPromotionThreshold: number;
+  birthGateTypes: Set<ProposeEntityType>;
+  birthGateDryRun: boolean;
 }
 
 export type MaterializeResult =
@@ -72,6 +74,8 @@ export type MaterializeResult =
 
 export interface ReplaySourceFactsOptions {
   llmPromotionThreshold?: number;
+  birthGateTypes?: Set<ProposeEntityType>;
+  birthGateDryRun?: boolean;
 }
 
 export interface MaterializeProgress {
@@ -82,6 +86,8 @@ export interface MaterializeProgress {
 
 export interface MaterializeUnmaterializedOptions {
   llmPromotionThreshold?: number;
+  birthGateTypes?: Set<ProposeEntityType>;
+  birthGateDryRun?: boolean;
   factTypes?: IndexedFileFactType[];
   /**
    * Fires before processing each fact with `completed = index, total = facts.length`

--- a/packages/server/src/entities/materialize.test.ts
+++ b/packages/server/src/entities/materialize.test.ts
@@ -17,6 +17,25 @@ import { normalizeEntityMatchName } from "./materialize-deps";
 
 const ADMIN_ID = "admin-1";
 const CONNECTOR_ID = "cfg";
+const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
+
+async function countEntitiesBySourceType(db: Kysely<DB>, sourceType: string): Promise<number> {
+  const row = await db
+    .selectFrom("entities")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .where("source_type", "=", sourceType)
+    .where("id", "!=", TEST_ACCOUNT_ENTITY_ID)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function countReviewQueueRows(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entity_review_queue")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
 
 async function seedFiles(db: Kysely<DB>, count: number): Promise<string[]> {
   const now = new Date().toISOString();
@@ -229,6 +248,18 @@ describe("materializeFromFact — llm_extracted threshold + type fidelity", () =
     expect(queue).toHaveLength(0);
   });
 
+  it("A0 documents current LLM mention path creating product and project entities with no review rows until A1 flips it", async () => {
+    await seedFiles(db, 2);
+    await upsertLlmFact(db, "file-1", "Sketch", "product");
+    await upsertLlmFact(db, "file-2", "Apollo", "project");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { llmPromotionThreshold: 1 });
+
+    expect(await countEntitiesBySourceType(db, "product")).toBe(1);
+    expect(await countEntitiesBySourceType(db, "project")).toBe(1);
+    expect(await countReviewQueueRows(db)).toBe(0);
+  });
+
   it("promotes legacy project container source refs before queueing review", async () => {
     const [fileId] = await seedFiles(db, 1);
     const entityRepo = createEntityRepository(db);
@@ -282,6 +313,38 @@ describe("materializeFromFact — llm_extracted threshold + type fidelity", () =
     expect(rels).toHaveLength(0);
     const fact = await db.selectFrom("indexed_file_facts").selectAll().executeTakeFirstOrThrow();
     expect(fact.materialized_at).toBeNull();
+  });
+
+  it("A0 documents current relation endpoint path queueing project endpoints but creating company and product endpoints until A1 flips it", async () => {
+    await seedFiles(db, 1);
+    await upsertLlmRelationFact(db, {
+      fileId: "file-1",
+      relationType: "part_of",
+      source: { name: "Zephyr", type: "project" },
+      target: { name: "Atlas", type: "project" },
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { llmPromotionThreshold: 1 });
+
+    expect(await countEntitiesBySourceType(db, "project")).toBe(0);
+    expect(await countReviewQueueRows(db)).toBe(1);
+
+    await db.destroy();
+    db = await createTestDb();
+
+    await seedFiles(db, 1);
+    await upsertLlmRelationFact(db, {
+      fileId: "file-1",
+      relationType: "builds",
+      source: { name: "Acme", type: "company" },
+      target: { name: "Sketch", type: "product" },
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { llmPromotionThreshold: 1 });
+
+    expect(await countEntitiesBySourceType(db, "company")).toBe(1);
+    expect(await countEntitiesBySourceType(db, "product")).toBe(1);
+    expect(await countReviewQueueRows(db)).toBe(0);
   });
 
   it("links an existing project relation endpoint and writes the relation", async () => {

--- a/packages/server/src/entities/profile-facts.ts
+++ b/packages/server/src/entities/profile-facts.ts
@@ -6,9 +6,10 @@
  */
 import type { RelationListEntry } from "../db/repositories/entity-relationships";
 
-export type DrawerEntityType = "person" | "company" | "product" | "project" | "team" | "system" | "other";
+export type DrawerEntityType = "person" | "company" | "product" | "project" | "team" | "tool" | "system" | "other";
 
 export const SYSTEM_SOURCE_TYPES = new Set(["clickup_workspace", "clickup_space"]);
+export const HIDDEN_ENTITY_SOURCE_TYPES = new Set([...SYSTEM_SOURCE_TYPES, "tool"]);
 
 export function mapSourceTypeToEntityType(sourceType: string): DrawerEntityType {
   switch (sourceType) {
@@ -22,6 +23,8 @@ export function mapSourceTypeToEntityType(sourceType: string): DrawerEntityType 
       return "project";
     case "team":
       return "team";
+    case "tool":
+      return "tool";
     default:
       return SYSTEM_SOURCE_TYPES.has(sourceType) ? "system" : "other";
   }
@@ -119,6 +122,8 @@ export function buildWhatRow(facts: EntityProfileFacts): string {
     }
     case "team":
       return `Team · ${facts.mentionCount} mentions · last seen ${lastSeen}`;
+    case "tool":
+      return `Tool · ${facts.mentionCount} mentions`;
     case "system":
       return `System container · ${facts.mentionCount} mentions`;
     default:

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -19,6 +19,7 @@
  * preserves duplicates.
  */
 import type { Selectable } from "kysely";
+import type { Logger } from "pino";
 import { normalizeName } from "../connectors/name-normalize";
 import type { UpsertPersonEntityData, createEntityRepository } from "../db/repositories/entities";
 import type { EntityDomainsRepository } from "../db/repositories/entity-domains";
@@ -124,6 +125,9 @@ export interface ProposeDeps {
   reviewRepo: EntityReviewRepository;
   domainsRepo?: EntityDomainsRepository;
   lookup: EntityLookup;
+  logger?: Logger;
+  birthGateTypes?: Set<ProposeEntityType>;
+  birthGateDryRun?: boolean;
   /** Read an entity's email from its metadata JSON. */
   readEmail: (entity: Entity) => string | null;
   onEntityResolved?: (entity: Entity) => void | Promise<void>;
@@ -409,6 +413,27 @@ async function queueProposal(
   };
 }
 
+async function birthGateOrCreate(
+  deps: ProposeDeps,
+  input: ProposeInput,
+  normalized: string,
+  branch: "skipFuzzy" | "ranked_empty",
+): Promise<ProposeResult> {
+  if (deps.birthGateTypes?.has(input.entityType)) {
+    if (deps.birthGateDryRun ?? true) {
+      deps.logger?.info(
+        { event: "would_birth_gate", type: input.entityType, name: input.name, path: input.source, branch },
+        "would_birth_gate",
+      );
+    } else {
+      return queueProposal(deps, input, normalized, [], "birth-gated");
+    }
+  }
+  if (input.queueInsteadOfCreate) return queueProposal(deps, input, normalized, [], "birth-gated");
+  const { entity } = await persistEntity(deps, input);
+  return { kind: "created", entity };
+}
+
 async function decideScopedPersonCandidates(
   deps: ProposeDeps,
   input: ProposeInput,
@@ -625,9 +650,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
   }
 
   if (input.skipFuzzy) {
-    if (input.queueInsteadOfCreate) return queueProposal(deps, input, normalized, [], "birth-gated");
-    const { entity } = await persistEntity(deps, input);
-    return { kind: "created", entity };
+    return birthGateOrCreate(deps, input, normalized, "skipFuzzy");
   }
 
   // 4) Fuzzy-rank against same-type entities.
@@ -646,9 +669,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
 
   // 6) Decide.
   if (ranked.length === 0) {
-    if (input.queueInsteadOfCreate) return queueProposal(deps, input, normalized, [], "birth-gated");
-    const { entity } = await persistEntity(deps, input);
-    return { kind: "created", entity };
+    return birthGateOrCreate(deps, input, normalized, "ranked_empty");
   }
   if (input.entityType === "person") return decideScopedPersonCandidates(deps, input, normalized, ranked);
   return queueProposal(deps, input, normalized, ranked, ranked[0].reason);

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -29,7 +29,7 @@ import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "./aff
 
 export type Entity = Selectable<EntitiesTable>;
 
-export type ProposeEntityType = "person" | "company" | "product" | "project" | "team" | "deal";
+export type ProposeEntityType = "person" | "company" | "product" | "project" | "team" | "deal" | "tool";
 export type CandidateReason =
   | "token-superset"
   | "prefix"

--- a/packages/server/src/entities/reenrich.test.ts
+++ b/packages/server/src/entities/reenrich.test.ts
@@ -317,6 +317,34 @@ describe("entity re-enrich", () => {
     expect(newEntity?.name).toBe("New Person");
   });
 
+  it("threads experimentalFlag into the re-enrich extraction phase", async () => {
+    const seenFlags: Array<boolean | undefined> = [];
+    const capture = async (deps: EnrichmentDeps) => {
+      seenFlags.push(deps.experimentalFlag);
+      return { filesProcessed: 1, filesSkipped: 0, filesFailed: 0, errors: [] };
+    };
+
+    await runReenrichJob({
+      db,
+      logger,
+      triggeredByUserId: "owner",
+      fileIds: ["file-1"],
+      runAfter: false,
+      experimentalFlag: true,
+      runEnrichmentImpl: capture,
+    });
+    await runReenrichJob({
+      db,
+      logger,
+      triggeredByUserId: "owner",
+      fileIds: ["file-1"],
+      runAfter: false,
+      runEnrichmentImpl: capture,
+    });
+
+    expect(seenFlags).toEqual([true, undefined]);
+  });
+
   it("uses caller-provided fact types for the rebuild replay", async () => {
     let capturedFactTypes: string[] | undefined;
 

--- a/packages/server/src/entities/reenrich.ts
+++ b/packages/server/src/entities/reenrich.ts
@@ -70,6 +70,14 @@ export interface ReenrichDeps {
   geminiMaxRpm?: number;
   geminiMaxRetries?: number;
   /**
+   * Threads the experimental gate into the re-enrich extraction phase so the
+   * flag-gated extraction-time spine features (tool classification,
+   * person-anchored file scope) run on re-extracted files exactly as they do
+   * on the live sync path. Materialization-time gating (the birth gate) reads
+   * its own module-level config and is unaffected by this flag.
+   */
+  experimentalFlag?: boolean;
+  /**
    * Set when the caller already promoted a pending recreate lock (two-step
    * rebuild flow). Skips the internal beginRecreateLock/endRecreateLock so
    * we don't double-acquire; the caller's `finally` is responsible for
@@ -516,6 +524,7 @@ export async function runReenrichJob(deps: ReenrichDeps): Promise<ReenrichSummar
         geminiApiKey: settings?.gemini_api_key,
         geminiMaxRpm: deps.geminiMaxRpm,
         geminiMaxRetries: deps.geminiMaxRetries,
+        experimentalFlag: deps.experimentalFlag,
         runEnrichmentImpl: deps.runEnrichmentImpl,
         onProgress: deps.onProgress,
         shouldCancel: deps.shouldCancel,

--- a/packages/server/src/entities/resolve.ts
+++ b/packages/server/src/entities/resolve.ts
@@ -692,20 +692,30 @@ export async function confirmReview(ctx: ResolveCtx, reviewId: string, opts: Con
     let target: Entity;
     if (!targetId) {
       if (!row.seed_source || !row.seed_source_id) {
-        throw new ResolveError(
-          "CANDIDATE_MISSING",
-          "row has no candidate_entity_id and no mergeIntoEntityId provided",
-          {
-            currentRow: row,
-          },
-        );
+        if (row.candidate_reason === "birth-gated" && row.source && row.source_id) {
+          target = await trxCtx.entityRepo.upsertEntityFromTool({
+            name: row.proposed_name,
+            sourceType: row.entity_type,
+            source: row.source,
+            sourceId: row.source_id,
+          });
+        } else {
+          throw new ResolveError(
+            "CANDIDATE_MISSING",
+            "row has no candidate_entity_id and no mergeIntoEntityId provided",
+            {
+              currentRow: row,
+            },
+          );
+        }
+      } else {
+        target = await trxCtx.entityRepo.upsertEntityFromTool({
+          name: row.proposed_name,
+          sourceType: row.entity_type,
+          source: row.seed_source,
+          sourceId: row.seed_source_id,
+        });
       }
-      target = await trxCtx.entityRepo.upsertEntityFromTool({
-        name: row.proposed_name,
-        sourceType: row.entity_type,
-        source: row.seed_source,
-        sourceId: row.seed_source_id,
-      });
     } else {
       const fetchedTarget = await fetchEntity(trxCtx, targetId);
       if (!fetchedTarget) {

--- a/packages/server/src/entities/tool-type.test.ts
+++ b/packages/server/src/entities/tool-type.test.ts
@@ -1,0 +1,328 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleSearch, handleSearchEntities } from "../agent/tools/search";
+import { UploadCollector } from "../agent/tools/types";
+import { connectorRoutes } from "../api/connectors";
+import { createEntityProfileRoutes } from "../api/entities/profile-routes";
+import { linkEntitiesByDeterministicMatch } from "../connectors/enrichment";
+import type { GeminiGenerator } from "../connectors/gemini-generate";
+import { matchEntities, smartEnrichFile } from "../connectors/smart-enrichment";
+import { createConnectorRepository } from "../db/repositories/connectors";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import type { DB } from "../db/schema";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import { coerceMentionType, normalizeMentionType } from "./graph";
+import { materializeUnmaterializedFacts } from "./materialize";
+import type { ProposeEntityType } from "./propose";
+
+const USER_ID = "user-tool";
+const CONNECTOR_ID = "connector-tool";
+const A1_BIRTH_GATE_TYPES: Set<ProposeEntityType> = new Set(["project", "product", "team"]);
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: USER_ID,
+      name: "Tool User",
+      email: "tool@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "google_drive",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: USER_ID,
+    })
+    .execute();
+}
+
+async function seedFile(db: Kysely<DB>, id: string, content: string): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      file_name: `${id}.md`,
+      file_type: "doc",
+      content_category: "document",
+      source: "google_drive",
+      source_path: `drive/${id}.md`,
+      content,
+      summary: content,
+      content_hash: `hash-${id}`,
+      is_archived: 0,
+      synced_at: now,
+      source_updated_at: now,
+    })
+    .execute();
+}
+
+async function seedEntity(db: Kysely<DB>, id: string, name: string, sourceType: string): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: sourceType,
+      subtype: null,
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 1,
+      created_at: now,
+      updated_at: now,
+      ai_brief: null,
+    })
+    .execute();
+}
+
+async function seedMention(db: Kysely<DB>, id: string, entityId: string, fileId: string): Promise<void> {
+  await db
+    .insertInto("entity_mentions")
+    .values({
+      id,
+      entity_id: entityId,
+      indexed_file_id: fileId,
+      chunk_index: null,
+      context_snippet: null,
+      confidence: "EXTRACTED",
+      source: "llm_extraction",
+      relation: "mentioned",
+      mentioned_at: new Date().toISOString(),
+    })
+    .execute();
+}
+
+function fakeGenerator(): GeminiGenerator {
+  return {
+    async generate() {
+      return "Slack and Acme were discussed.";
+    },
+    async generateJSON<T>(_prompt: string, opts?: { label?: string }) {
+      if (opts?.label?.startsWith("extractEntities")) {
+        return {
+          mentions: [
+            { mention: "Slack", type: "product", variations: [], confidence: 0.95 },
+            { mention: "Acme Corp", type: "company", variations: ["Acme"], confidence: 0.95 },
+          ],
+          relations: [
+            {
+              type: "builds",
+              source: { name: "Acme Corp", type: "company", variations: ["Acme"] },
+              target: { name: "Slack", type: "product", variations: [] },
+              confidence: 0.95,
+              context: "Acme Corp builds Slack",
+            },
+          ],
+        } as T;
+      }
+      return {} as T;
+    },
+  } as GeminiGenerator;
+}
+
+function adminApp(routes: Hono): Hono {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("sub", USER_ID);
+    c.set("email", "tool@example.com");
+    c.set("role", "admin");
+    c.set("adminCanReadAllFiles", true);
+    await next();
+  });
+  app.route("/", routes);
+  return app;
+}
+
+describe("tool entity type", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedBase(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("classifies and materializes Slack mentions as tool while dropping tool relation endpoints", async () => {
+    await seedFile(db, "file-tool-classify", "Slack and Acme Corp were discussed.");
+    await seedFile(db, "file-tool-classify-2", "Slack and Acme Corp were discussed again.");
+
+    expect(coerceMentionType("Slack", "product", true)).toBe("tool");
+    expect(normalizeMentionType("tool")).toBe("tool");
+
+    for (const fileId of ["file-tool-classify", "file-tool-classify-2"]) {
+      await smartEnrichFile(
+        {
+          db,
+          logger: createTestLogger(),
+          generator: fakeGenerator(),
+          embeddingProvider: null,
+          experimentalFlag: true,
+        },
+        {
+          id: fileId,
+          fileName: `${fileId}.md`,
+          content: fileId.endsWith("-2")
+            ? "Slack and Acme Corp were discussed again."
+            : "Slack and Acme Corp were discussed.",
+          contentCategory: "document",
+          source: "google_drive",
+          sourcePath: `drive/${fileId}.md`,
+          contentHash: `hash-${fileId}`,
+          connectorConfigId: CONNECTOR_ID,
+          sourceCreatedAt: null,
+          sourceUpdatedAt: null,
+        },
+      );
+    }
+
+    const slack = await db
+      .selectFrom("entities")
+      .select(["id", "source_type"])
+      .where("name", "=", "Slack")
+      .executeTakeFirstOrThrow();
+    expect(slack.source_type).toBe("tool");
+    expect(
+      await db
+        .selectFrom("entities")
+        .select("id")
+        .where("name", "=", "Slack")
+        .where("source_type", "=", "product")
+        .execute(),
+    ).toHaveLength(0);
+    expect(
+      await db.selectFrom("indexed_file_facts").select("id").where("fact_type", "=", "llm_relation").execute(),
+    ).toHaveLength(0);
+    expect(await db.selectFrom("entity_relationships").select("id").execute()).toHaveLength(0);
+
+    const factRepo = createIndexedFileFactRepository(db);
+    await factRepo.upsertFact({
+      indexedFileId: "file-tool-classify",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      contentHash: "hash-file-tool-classify",
+      source: "llm_extraction",
+      factType: "llm_relation",
+      relation: "builds",
+      subjectName: "Acme Corp",
+      subjectSource: "llm_extraction",
+      subjectSourceId: "file-tool-classify:hash-file-tool-classify:relation:Acme:Slack",
+      raw: {
+        contentHash: "hash-file-tool-classify",
+        promptVersion: "llm-extraction-v8",
+        model: "gemini",
+        relationType: "builds",
+        confidence: 0.95,
+        sourceConfidence: 0.95,
+        targetConfidence: 0.95,
+        source: { name: "Acme Corp", type: "company", variations: ["Acme"] },
+        target: { name: "Slack", type: "product", variations: [] },
+      },
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: A1_BIRTH_GATE_TYPES,
+      birthGateDryRun: false,
+      experimentalFlag: true,
+    });
+
+    expect(await db.selectFrom("entity_relationships").select("id").execute()).toHaveLength(0);
+    expect(
+      await db
+        .selectFrom("entities")
+        .select("id")
+        .where("name", "=", "Slack")
+        .where("source_type", "=", "product")
+        .execute(),
+    ).toHaveLength(0);
+  });
+
+  it("excludes tools from default search, API, graph, deterministic linking, file detail, and matching", async () => {
+    await seedFile(db, "file-tool-hidden", "Slack and Project Apollo are in this document.");
+    await seedEntity(db, "entity-tool-slack", "Slack", "tool");
+    await seedEntity(db, "entity-project-apollo", "Project Apollo", "project");
+    await seedMention(db, "mention-tool-slack", "entity-tool-slack", "file-tool-hidden");
+    await seedMention(db, "mention-project-apollo", "entity-project-apollo", "file-tool-hidden");
+
+    const deps = {
+      uploadCollector: new UploadCollector(),
+      workspaceDir: "/tmp",
+      db,
+    };
+    const searchResult = await handleSearch({ query: "Slack" }, deps);
+    expect(searchResult.content[0]?.text ?? "").not.toContain("**Matching entities**: Slack");
+
+    const defaultEntities = await handleSearchEntities({ queries: ["Slack"] }, deps);
+    expect(defaultEntities.content[0]?.text ?? "").not.toContain("Slack");
+    const explicitTools = await handleSearchEntities({ queries: ["Slack"], types: ["tool"] }, deps);
+    expect(explicitTools.content[0]?.text ?? "").toContain("Slack");
+
+    const entityApp = adminApp(
+      createEntityProfileRoutes(db, { logger: createTestLogger(), config: createTestConfig() }),
+    );
+    const listRes = await entityApp.request("/?search=Slack");
+    const listBody = (await listRes.json()) as { entities: Array<{ name: string }> };
+    expect(listBody.entities.map((entity) => entity.name)).not.toContain("Slack");
+    const explicitListRes = await entityApp.request("/?type=tool&search=Slack");
+    const explicitListBody = (await explicitListRes.json()) as { entities: Array<{ name: string }> };
+    expect(explicitListBody.entities.map((entity) => entity.name)).toContain("Slack");
+    const graphRes = await entityApp.request("/graph");
+    const graphBody = (await graphRes.json()) as { nodes: Array<{ name: string }> };
+    expect(graphBody.nodes.map((node) => node.name)).not.toContain("Slack");
+
+    await linkEntitiesByDeterministicMatch(db, createTestLogger());
+    const deterministicToolMentions = await db
+      .selectFrom("entity_mentions")
+      .select("id")
+      .where("entity_id", "=", "entity-tool-slack")
+      .where("source", "=", "deterministic_substring")
+      .execute();
+    expect(deterministicToolMentions).toHaveLength(0);
+
+    const connectorApp = adminApp(connectorRoutes(createConnectorRepository(db), db, createTestLogger()));
+    const fileRes = await connectorApp.request("/files/file-tool-hidden/content");
+    const fileBody = (await fileRes.json()) as { entities: Array<{ name: string }> };
+    expect(fileBody.entities.map((entity) => entity.name)).not.toContain("Slack");
+    expect(fileBody.entities.map((entity) => entity.name)).toContain("Project Apollo");
+
+    const matched = await matchEntities(db, [{ mention: "Slack", type: "product", variations: [] }]);
+    expect(matched.matched).toHaveLength(0);
+    expect(matched.unmatched.map((mention) => mention.mention)).toContain("Slack");
+  });
+
+  it("does not reclassify an existing product named like a tool", async () => {
+    const entityRepo = createEntityRepository(db);
+    await entityRepo.upsertEntity({
+      name: "Slack",
+      sourceType: "product",
+      status: "confirmed",
+    });
+
+    const product = await db
+      .selectFrom("entities")
+      .select(["name", "source_type"])
+      .where("name", "=", "Slack")
+      .where("source_type", "=", "product")
+      .executeTakeFirstOrThrow();
+
+    expect(product).toMatchObject({ name: "Slack", source_type: "product" });
+  });
+});

--- a/packages/server/src/scripts/entity-dedup-backfill.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.ts
@@ -102,7 +102,7 @@ interface PersonScopes {
   byEntityId: Map<string, Set<string>>;
 }
 
-const SUPPORTED_TYPES: ProposeEntityType[] = ["person", "company", "product", "project", "team", "deal"];
+const SUPPORTED_TYPES: ProposeEntityType[] = ["person", "company", "product", "project", "team", "deal", "tool"];
 const DEFAULT_FUZZY_THRESHOLD = 0.85;
 const DEFAULT_ADJACENCY_THRESHOLD = 0.5;
 const DEFAULT_ADJACENCY_MIN_SHARED = 2;

--- a/packages/server/src/test-utils.ts
+++ b/packages/server/src/test-utils.ts
@@ -163,6 +163,7 @@ export function createTestConfig(overrides: Partial<Config> = {}): Config {
     MAX_FILE_SIZE_MB: 20,
     MAX_UPLOAD_SIZE_MB: 50,
     EXPERIMENTAL_FLAG: false,
+    BIRTH_GATE_DRY_RUN: true,
     LLM_PROMOTION_THRESHOLD: 2,
     CO_MENTION_CONTRIBUTES_TO_THRESHOLD: 3,
     FLOOR_RETRY_MAX_FILES_PER_DOMAIN: 5000,

--- a/packages/shared/src/agent-tools.ts
+++ b/packages/shared/src/agent-tools.ts
@@ -169,7 +169,7 @@ export const AGENT_TOOL_CATALOG: AgentToolCatalogEntry[] = [
   {
     name: "mcp__sketch__SearchEntities",
     label: "Search entities",
-    description: "Find projects, people, teams, and databases across connected sources.",
+    description: "Find projects, people, teams, companies, and products across connected sources.",
     category: "sketch",
   },
   {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -348,7 +348,7 @@ export interface EntityListItem {
   updatedAt: string;
 }
 
-export type DrawerEntityType = "person" | "company" | "product" | "project" | "team" | "system" | "other";
+export type DrawerEntityType = "person" | "company" | "product" | "project" | "team" | "tool" | "system" | "other";
 
 export interface EntityProfileSummary {
   identity: string;

--- a/packages/web/src/lib/entity-ui.tsx
+++ b/packages/web/src/lib/entity-ui.tsx
@@ -84,6 +84,7 @@ const ACCENTS: Record<DrawerEntityType, string> = {
   product: "#0f766e",
   project: "#6d28d9",
   team: "#475569",
+  tool: "#525252",
   system: "#525252",
   other: "#3f3f46",
 };
@@ -101,6 +102,8 @@ function normalizeType(input: EntityIdentity): DrawerEntityType {
       return "project";
     case "team":
       return "team";
+    case "tool":
+      return "tool";
     case "clickup_workspace":
     case "clickup_space":
       return "system";

--- a/packages/web/src/routes/files/knowledge-graph.tsx
+++ b/packages/web/src/routes/files/knowledge-graph.tsx
@@ -15,7 +15,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ForceGraph2D, { type ForceGraphMethods, type LinkObject, type NodeObject } from "react-force-graph-2d";
 
-type CoarseType = "person" | "company" | "project" | "product" | "team" | "system" | "other";
+type CoarseType = "person" | "company" | "project" | "product" | "team" | "tool" | "system" | "other";
 
 function coarseType(sourceType: string): CoarseType {
   if (sourceType === "person") return "person";
@@ -23,6 +23,7 @@ function coarseType(sourceType: string): CoarseType {
   if (sourceType === "product") return "product";
   if (sourceType === "project" || sourceType === "linear_project") return "project";
   if (sourceType === "team") return "team";
+  if (sourceType === "tool") return "tool";
   if (sourceType.startsWith("clickup_") || sourceType.startsWith("notion_")) return "system";
   return "other";
 }
@@ -34,6 +35,7 @@ const NODE_COLOR: Record<CoarseType, string> = {
   project: "#b794f6",
   product: "#2dd4bf",
   team: "#9aa7b8",
+  tool: "#8b8f96",
   system: "#8b8f96",
   other: "#a8a29e",
 };
@@ -46,6 +48,7 @@ const TYPE_LABEL: Record<CoarseType, string> = {
   project: "Projects",
   product: "Products",
   team: "Teams",
+  tool: "Tools",
   system: "Spaces",
   other: "Other",
 };


### PR DESCRIPTION
Stack position: 5/12
Base: feat/entity-dedup-adjudicator-adjacency
Head: feat/entity-creation-gating
Migrations introduced: none

A0-A3 creation gating: birth gate, tool classification sink, person-anchored context, and experimental flag threading.

Split from superseded entity-spine stack (#260/#261/#262). Verified locally with pnpm typecheck and pnpm build at this branch tip.