### PR TITLE
feat: sub-entities commitment and decision spine

### DIFF
--- a/packages/server/src/connectors/sync-facts.ts
+++ b/packages/server/src/connectors/sync-facts.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from "kysely";
 import { upsertCommitmentFact } from "../db/repositories/commitments";
+import { upsertDecisionFactsForFile } from "../db/repositories/decisions";
 import { type createIndexedFileFactRepository, upsertLlmTaskFact } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
 import { normalizeRelationType } from "../entities/graph";
@@ -237,6 +238,20 @@ export async function emitFactsForSyncedItem({
         contextSnippet: item.sourcePath,
       });
     }
+  }
+
+  if (item.decisions && db) {
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag,
+      indexedFileId,
+      connectorConfigId: factContext.connectorConfigId,
+      createdByUserId: factContext.createdByUserId,
+      lastSeenSyncRunId: factContext.lastSeenSyncRunId,
+      contentHash: item.contentHash,
+      source: connectorType,
+      decisions: item.decisions,
+      contextSnippet: item.sourcePath,
+    });
   }
 
   if (experimentalFlag && db && contentChanged && item.contentCategory === "document" && item.content) {

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -117,6 +117,7 @@ export interface SyncedItem {
     assignee?: { name: string; email?: string; source?: string; sourceId?: string };
   };
   commitments?: CommitmentSeed[];
+  decisions?: DecisionSeed[];
   /**
    * People meaningfully attached to this item (meeting speakers, doc authors).
    * Sync seeds person entities from entries where `name` is present; entries
@@ -201,6 +202,19 @@ export interface CommitmentSeed {
   evidence: { fileIds: string[]; entityIds: string[] };
 }
 
+export interface DecisionSeed {
+  decisionId?: string;
+  topic: string;
+  statement: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  decidedBy?: string;
+  decidedAt?: string;
+  rationale?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  promptVersion?: string;
+}
+
 export interface LlmTaskCandidate {
   title: string;
   owner?: { name?: string; email?: string };
@@ -239,6 +253,7 @@ export type IndexedFileFactRaw =
       task: NonNullable<SyncedItem["task"]>;
     }
   | CommitmentSeed
+  | DecisionSeed
   | LlmTaskFactRaw
   | { providerFileId: string; contactPoint: ContactPointSeed }
   | { sourceType: string; sourceUrl?: string; sourcePath?: string; metadata?: Record<string, unknown> }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -108,6 +108,7 @@ import * as m105 from "./migrations/105-normalize-indexed-file-source-timestamps
 import * as m106 from "./migrations/106-agents";
 import * as m107 from "./migrations/107-tasks";
 import * as m108 from "./migrations/108-tasks-owner";
+import * as m109 from "./migrations/109-sub-entities";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -220,6 +221,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "106-agents": m106,
           "107-tasks": m107,
           "108-tasks-owner": m108,
+          "109-sub-entities": m109,
         };
       },
     },

--- a/packages/server/src/db/migrations/109-sub-entities.ts
+++ b/packages/server/src/db/migrations/109-sub-entities.ts
@@ -1,0 +1,56 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("sub_entities")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("parent_entity_id", "text", (col) => col.references("entities.id").onDelete("set null"))
+    .addColumn("parent_scope_key", "text", (col) => col.notNull())
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("normalized_name", "text", (col) => col.notNull())
+    .addColumn("display_name", "text", (col) => col.notNull())
+    .addColumn("status", "text", (col) => col.notNull())
+    .addColumn("status_authority", "text", (col) => col.notNull().defaultTo("local"))
+    .addColumn("valid_from", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("valid_to", "text")
+    .addColumn("provenance", "text", (col) => col.notNull())
+    .addColumn("due_at", "text")
+    .addColumn("created_by_user_id", "text", (col) => col.references("users.id"))
+    .addColumn("source_fact_id", "text")
+    .addColumn("metadata_json", "text")
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createTable("sub_entity_evidence")
+    .addColumn("sub_entity_id", "text", (col) => col.notNull().references("sub_entities.id").onDelete("cascade"))
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("ref_id", "text", (col) => col.notNull())
+    .addPrimaryKeyConstraint("sub_entity_evidence_pkey", ["sub_entity_id", "kind", "ref_id"])
+    .execute();
+
+  await sql`
+    CREATE UNIQUE INDEX idx_sub_entities_current_scope_kind_name
+    ON sub_entities(parent_scope_key, kind, normalized_name)
+    WHERE valid_to IS NULL
+  `.execute(db);
+  await db.schema
+    .createIndex("idx_sub_entities_parent_kind_status")
+    .on("sub_entities")
+    .columns(["parent_entity_id", "kind", "status"])
+    .execute();
+  await db.schema
+    .createIndex("idx_sub_entity_evidence_kind_ref")
+    .on("sub_entity_evidence")
+    .columns(["kind", "ref_id"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_sub_entity_evidence_kind_ref").ifExists().execute();
+  await db.schema.dropIndex("idx_sub_entities_parent_kind_status").ifExists().execute();
+  await sql`DROP INDEX IF EXISTS idx_sub_entities_current_scope_kind_name`.execute(db);
+  await db.schema.dropTable("sub_entity_evidence").execute();
+  await db.schema.dropTable("sub_entities").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 102;
+const EXPECTED_MIGRATION_COUNT = 105;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -135,6 +135,83 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[99]).toBe("104-daily-brief-item-metadata");
     expect(names[100]).toBe("105-normalize-indexed-file-source-timestamps");
     expect(names[101]).toBe("106-agents");
+    expect(names[102]).toBe("107-tasks");
+    expect(names[103]).toBe("108-tasks-owner");
+    expect(names[104]).toBe("109-sub-entities");
+  });
+
+  it("creates the sub-entities table and current-row partial unique index", async () => {
+    const columns = await sql<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>`
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'sub_entities'
+    `.execute(db);
+    expect(columns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ column_name: "parent_entity_id", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "parent_scope_key", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "kind", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "normalized_name", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "source_fact_id", data_type: "text", is_nullable: "YES" }),
+      ]),
+    );
+
+    const indexes = await sql<{ indexname: string; indexdef: string }>`
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'sub_entities'
+    `.execute(db);
+    const currentIndex = indexes.rows.find((row) => row.indexname === "idx_sub_entities_current_scope_kind_name");
+    expect(currentIndex?.indexdef).toContain("UNIQUE INDEX");
+    expect(currentIndex?.indexdef).toContain("parent_scope_key");
+    expect(currentIndex?.indexdef).toContain("kind");
+    expect(currentIndex?.indexdef).toContain("normalized_name");
+    expect(currentIndex?.indexdef).toContain("WHERE (valid_to IS NULL)");
+
+    const foreignKeys = await sql<{
+      column_name: string;
+      foreign_table_name: string;
+      foreign_column_name: string;
+      delete_rule: string;
+    }>`
+      SELECT kcu.column_name, ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name
+       AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name
+       AND rc.constraint_schema = tc.table_schema
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'sub_entities'
+        AND tc.constraint_type = 'FOREIGN KEY'
+    `.execute(db);
+    expect(foreignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column_name: "parent_entity_id",
+          foreign_table_name: "entities",
+          foreign_column_name: "id",
+          delete_rule: "SET NULL",
+        }),
+        expect.objectContaining({
+          column_name: "created_by_user_id",
+          foreign_table_name: "users",
+          foreign_column_name: "id",
+        }),
+      ]),
+    );
+    expect(foreignKeys.rows.some((row) => row.column_name === "source_fact_id")).toBe(false);
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 102;
+const EXPECTED_MIGRATION_COUNT = 105;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -158,6 +158,59 @@ describe("runMigrations — full sequence", () => {
     expect(names[99]).toBe("104-daily-brief-item-metadata");
     expect(names[100]).toBe("105-normalize-indexed-file-source-timestamps");
     expect(names[101]).toBe("106-agents");
+    expect(names[102]).toBe("107-tasks");
+    expect(names[103]).toBe("108-tasks-owner");
+    expect(names[104]).toBe("109-sub-entities");
+  });
+
+  it("creates the sub-entities table and current-row partial unique index", async () => {
+    await runMigrations(db, { quiet: true });
+
+    const columns = await sql<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>`PRAGMA table_info(sub_entities)`.execute(db);
+    expect(columns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "parent_entity_id", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "parent_scope_key", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "kind", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "normalized_name", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "status_authority", type: "TEXT", notnull: 1, dflt_value: "'local'" }),
+        expect.objectContaining({ name: "source_fact_id", type: "TEXT", notnull: 0 }),
+      ]),
+    );
+
+    const indexes = await sql<{
+      name: string;
+      unique: number;
+      partial: number;
+    }>`PRAGMA index_list(sub_entities)`.execute(db);
+    expect(indexes.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "idx_sub_entities_current_scope_kind_name",
+          unique: 1,
+          partial: 1,
+        }),
+      ]),
+    );
+
+    const foreignKeys = await sql<{
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>`PRAGMA foreign_key_list(sub_entities)`.execute(db);
+    expect(foreignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ table: "entities", from: "parent_entity_id", to: "id", on_delete: "SET NULL" }),
+        expect.objectContaining({ table: "users", from: "created_by_user_id", to: "id" }),
+      ]),
+    );
+    expect(foreignKeys.rows.some((row) => row.from === "source_fact_id")).toBe(false);
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {

--- a/packages/server/src/db/repositories/commitments.integration.test.ts
+++ b/packages/server/src/db/repositories/commitments.integration.test.ts
@@ -1,8 +1,10 @@
 import { type Kysely, sql } from "kysely";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { getSharedPgDb } from "../../test-utils";
+import { materializeUnmaterializedFacts } from "../../entities/materialize";
+import { createTestLogger, createTestPgDb, getSharedPgDb } from "../../test-utils";
 import type { DB } from "../schema";
 import { markCommitmentDone, measureCommitmentStomp, upsertCommitmentFact } from "./commitments";
+import { createEntityRepository } from "./entities";
 import { createIndexedFileFactRepository } from "./indexed-file-facts";
 
 const USER_ID = "commitment-pg-user";
@@ -45,6 +47,96 @@ describe("commitment stomp measurement postgres", () => {
 
     expect(result).toEqual({ overwritten: 2, tombstoned: 2, survived: 0, reconcileSkipped: false });
   });
+});
+
+describe("commitment sub-entities postgres", () => {
+  it("preserves local status across re-materialization with the partial unique index", async () => {
+    const freshDb = await createTestPgDb();
+    try {
+      await seedBase(freshDb);
+      const project = await seedProject(freshDb, { id: "commitment-pg-project", name: "Commitment PG Project" });
+
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-1",
+        source: "linear",
+        commitmentId: "pg-survives",
+        parentEntityId: project.id,
+        title: "Send the PG follow-up",
+        status: "open",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await expect(markCommitmentDone(freshDb, "pg-survives")).resolves.toBe(true);
+
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-2",
+        source: "linear",
+        commitmentId: "pg-survives",
+        parentEntityId: project.id,
+        title: "Send the PG follow-up",
+        status: "open",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await createIndexedFileFactRepository(freshDb).reconcileStaleFacts(
+        { kind: "connector", connectorConfigId: CONNECTOR_ID, syncRunId: "sync-2" },
+        null,
+      );
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+
+      const rows = await freshDb
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("kind", "=", "commitment")
+        .where("normalized_name", "=", "send the pg follow-up")
+        .where("valid_to", "is", null)
+        .execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ status: "done", status_authority: "local", parent_scope_key: project.id });
+
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-3",
+        source: "linear",
+        commitmentId: "pg-external",
+        parentEntityId: project.id,
+        title: "Track external status",
+        status: "open",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-4",
+        source: "linear",
+        commitmentId: "pg-external",
+        parentEntityId: project.id,
+        title: "Track external status",
+        status: "dropped",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      const external = await freshDb
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("kind", "=", "commitment")
+        .where("normalized_name", "=", "track external status")
+        .where("valid_to", "is", null)
+        .executeTakeFirstOrThrow();
+      expect(external).toMatchObject({ status: "dropped", status_authority: "external" });
+    } finally {
+      await freshDb.destroy();
+    }
+  }, 30000);
 });
 
 async function seedBase(db: Kysely<DB>): Promise<void> {
@@ -91,4 +183,27 @@ async function seedOtherFact(db: Kysely<DB>, id: string): Promise<void> {
     subjectSourceId: id,
     raw: { sourceType: "project", sourcePath: id },
   });
+}
+
+async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) {
+  const repo = createEntityRepository(db);
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await repo.upsertSourceRef({ entityId: input.id, source: "linear", sourceId: `${input.id}-source` });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
 }

--- a/packages/server/src/db/repositories/commitments.test.ts
+++ b/packages/server/src/db/repositories/commitments.test.ts
@@ -1,24 +1,18 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { emitFactsForSyncedItem } from "../../connectors/sync-facts";
-import type { Connector, SyncedItem } from "../../connectors/types";
-import {
-  buildMaterializeDeps,
-  materializeFromFact,
-  materializeUnmaterializedFacts,
-  shouldMarkMaterialized,
-} from "../../entities/materialize";
+import { buildMaterializeDeps, materializeFromFact, materializeUnmaterializedFacts } from "../../entities/materialize";
 import { createTestDb, createTestLogger } from "../../test-utils";
 import type { DB } from "../schema";
 import { listOpenCommitments, markCommitmentDone, upsertCommitmentFact } from "./commitments";
 import { createEntityRepository } from "./entities";
 import { createIndexedFileFactRepository } from "./indexed-file-facts";
+import { createSubEntityRepository } from "./sub-entities";
 import { TEST_ACCOUNT_ENTITY_ID } from "./tasks";
 
 const USER_ID = "commitment-user";
 const CONNECTOR_ID = "commitment-config";
 
-describe("commitment facts", () => {
+describe("commitment sub-entities", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
@@ -29,66 +23,48 @@ describe("commitment facts", () => {
     await db.destroy();
   });
 
-  it("materializes with parent and due date while flag-gating emission and materialization counters", async () => {
+  it("keeps local commitment status across re-sync while external rows track source status", async () => {
     await seedBase(db);
     const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
     await seedProject(db, { id: TEST_ACCOUNT_ENTITY_ID, name: "Test Account" });
-    const connector = { type: "linear" } as Connector;
-    const item = commitmentItem(project.id);
 
-    await emitFactsForSyncedItem({
-      db,
-      factRepo: createIndexedFileFactRepository(db),
-      connector,
-      connectorType: "linear",
-      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-off" },
-      item,
-      indexedFileId: "commitment-file-1",
+    await upsertCommitmentFact(db, {
       experimentalFlag: false,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-off",
+      source: "linear",
+      commitmentId: "flag-off",
+      parentRef: { source: "linear", sourceId: `${project.id}-source` },
+      title: "Flag-off commitment",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
     });
-    let count = await db
-      .selectFrom("indexed_file_facts")
-      .select((eb) => eb.fn.countAll<number>().as("count"))
-      .where("fact_type", "=", "commitment")
-      .executeTakeFirstOrThrow();
-    expect(Number(count.count)).toBe(0);
+    expect(await countRows(db, "indexed_file_facts", "commitment")).toBe(0);
+    expect(await countRows(db, "sub_entities", "commitment")).toBe(0);
 
-    await emitFactsForSyncedItem({
-      db,
-      factRepo: createIndexedFileFactRepository(db),
-      connector,
-      connectorType: "linear",
-      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-on" },
-      item,
-      indexedFileId: "commitment-file-1",
+    await upsertCommitmentFact(db, {
       experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-1",
+      source: "linear",
+      commitmentId: "commitment-1",
+      parentRef: { source: "linear", sourceId: `${project.id}-source` },
+      title: "Send the follow-up",
+      status: "open",
+      dueAt: "2026-07-01T00:00:00.000Z",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
     });
     const fact = await db
       .selectFrom("indexed_file_facts")
       .selectAll()
-      .where("fact_type", "=", "commitment")
+      .where("subject_source_id", "=", "commitment-1")
       .executeTakeFirstOrThrow();
-    const depsOff = await buildMaterializeDeps(db, { experimentalFlag: false });
-    const offResult = await materializeFromFact(depsOff, fact);
+    const offResult = await materializeFromFact(await buildMaterializeDeps(db, { experimentalFlag: false }), fact);
     expect(offResult).toEqual({ kind: "skipped", reason: "experimental_off" });
-    expect(shouldMarkMaterialized(offResult)).toBe(true);
+    expect(await countRows(db, "sub_entities", "commitment")).toBe(0);
 
     const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
-    const materializedFact = await db
-      .selectFrom("indexed_file_facts")
-      .selectAll()
-      .where("fact_type", "=", "commitment")
-      .executeTakeFirstOrThrow();
-    const raw = JSON.parse(materializedFact.raw ?? "{}");
-    expect(raw).toMatchObject({
-      commitmentId: "commitment-1",
-      parentEntityId: project.id,
-      parent_entity_id: project.id,
-      dueAt: "2026-07-01T00:00:00.000Z",
-      status: "open",
-    });
-    expect(raw.parentEntityId).not.toBe(TEST_ACCOUNT_ENTITY_ID);
-    expect(materializedFact.materialized_at).not.toBeNull();
     expect(summary).toMatchObject({
       factsRead: 1,
       entitiesCreated: 0,
@@ -101,35 +77,158 @@ describe("commitment facts", () => {
       deferred: 0,
       deferredBelowThreshold: 0,
     });
-    count = await db
-      .selectFrom("tasks")
-      .select((eb) => eb.fn.countAll<number>().as("count"))
-      .executeTakeFirstOrThrow();
-    expect(Number(count.count)).toBe(0);
-  });
-
-  it("mark-done persists within a run and removes the row from open commitments", async () => {
-    await seedBase(db);
-    const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
-    await upsertCommitmentFact(db, {
-      experimentalFlag: true,
-      indexedFileId: "commitment-file-1",
-      connectorConfigId: CONNECTOR_ID,
-      createdByUserId: USER_ID,
-      lastSeenSyncRunId: "sync-1",
-      source: "linear",
-      commitmentId: "commitment-1",
-      parentEntityId: project.id,
-      title: "Send the follow-up",
-      dueAt: "2026-07-01T00:00:00.000Z",
-      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    let row = await currentCommitmentRow(db, "Send the follow-up");
+    expect(row).toMatchObject({
+      parent_entity_id: project.id,
+      parent_scope_key: project.id,
+      kind: "commitment",
+      normalized_name: "send the follow-up",
+      display_name: "Send the follow-up",
+      status: "open",
+      status_authority: "external",
+      due_at: "2026-07-01T00:00:00.000Z",
+      created_by_user_id: USER_ID,
     });
+    expect(row?.valid_to).toBeNull();
+    const rawAfterMaterialize = JSON.parse(
+      (await db.selectFrom("indexed_file_facts").select("raw").where("id", "=", fact.id).executeTakeFirstOrThrow())
+        .raw ?? "{}",
+    );
+    expect(rawAfterMaterialize).toMatchObject({ status: "open" });
+    expect(rawAfterMaterialize.parent_entity_id).toBeUndefined();
+    expect(rawAfterMaterialize.parentEntityId).toBeUndefined();
 
     await expect(listOpenCommitments(db, { parentEntityId: project.id })).resolves.toHaveLength(1);
     await expect(markCommitmentDone(db, "commitment-1")).resolves.toBe(true);
     await expect(listOpenCommitments(db, { parentEntityId: project.id })).resolves.toHaveLength(0);
-    const fact = await db.selectFrom("indexed_file_facts").selectAll().executeTakeFirstOrThrow();
-    expect(JSON.parse(fact.raw ?? "{}").status).toBe("done");
+    row = await currentCommitmentRow(db, "Send the follow-up");
+    expect(row).toMatchObject({ status: "done", status_authority: "local" });
+
+    await upsertCommitmentFact(db, {
+      experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-2",
+      source: "linear",
+      commitmentId: "commitment-1",
+      parentRef: { source: "linear", sourceId: `${project.id}-source` },
+      title: "Send the follow-up",
+      status: "open",
+      dueAt: "2026-07-01T00:00:00.000Z",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    });
+    await createIndexedFileFactRepository(db).reconcileStaleFacts(
+      { kind: "connector", connectorConfigId: CONNECTOR_ID, syncRunId: "sync-2" },
+      null,
+    );
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    row = await currentCommitmentRow(db, "Send the follow-up");
+    expect(row).toMatchObject({ status: "done", status_authority: "local", valid_to: null });
+    const rawAfterDone = JSON.parse(
+      (
+        await db
+          .selectFrom("indexed_file_facts")
+          .select("raw")
+          .where("subject_source_id", "=", "commitment-1")
+          .executeTakeFirstOrThrow()
+      ).raw ?? "{}",
+    );
+    expect(rawAfterDone.status).toBe("open");
+
+    await upsertCommitmentFact(db, {
+      experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-3",
+      source: "linear",
+      commitmentId: "commitment-2",
+      parentEntityId: project.id,
+      title: "Update the rollout note",
+      status: "open",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await upsertCommitmentFact(db, {
+      experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-4",
+      source: "linear",
+      commitmentId: "commitment-2",
+      parentEntityId: project.id,
+      title: "Update the rollout note",
+      status: "dropped",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    expect(await currentCommitmentRow(db, "Update the rollout note")).toMatchObject({
+      status: "dropped",
+      status_authority: "external",
+    });
+  });
+
+  it("deduplicates commitment sub-entities within parent scope and global scope", async () => {
+    await seedBase(db);
+    const projectA = await seedProject(db, { id: "project-a", name: "Project A" });
+    const projectB = await seedProject(db, { id: "project-b", name: "Project B" });
+
+    await seedCommitmentFact(db, "commitment-a1", projectA.id, "Send Update");
+    await seedCommitmentFact(db, "commitment-a2", projectA.id, " send   update ");
+    await seedCommitmentFact(db, "commitment-b1", projectB.id, "Send Update");
+    await seedCommitmentFact(db, "commitment-global-1", null, "Send Update");
+    await seedCommitmentFact(db, "commitment-global-2", null, "send update");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const rows = await db
+      .selectFrom("sub_entities")
+      .selectAll()
+      .where("kind", "=", "commitment")
+      .orderBy("parent_scope_key", "asc")
+      .execute();
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.parent_scope_key).sort()).toEqual(["global", projectA.id, projectB.id].sort());
+    expect(rows.every((row) => row.normalized_name === "send update")).toBe(true);
+
+    const projectARow = rows.find((row) => row.parent_entity_id === projectA.id);
+    expect(projectARow).toBeDefined();
+    const evidence = await db
+      .selectFrom("sub_entity_evidence")
+      .select(["kind", "ref_id"])
+      .where("sub_entity_id", "=", projectARow?.id ?? "")
+      .where("kind", "=", "fact")
+      .execute();
+    expect(evidence).toHaveLength(2);
+  });
+
+  it("keeps commitment sub-entities off entity and search indexes", async () => {
+    await seedBase(db);
+    const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
+    await seedCommitmentFact(db, "commitment-1", project.id, "Send the follow-up");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const subEntities = await createSubEntityRepository(db).listOpenSubEntities({
+      parentEntityId: project.id,
+      kind: "commitment",
+    });
+    expect(subEntities).toHaveLength(1);
+    expect(subEntities[0]).toMatchObject({
+      kind: "commitment",
+      display_name: "Send the follow-up",
+      parent_entity_id: project.id,
+    });
+
+    await expect(
+      db.selectFrom("entities").selectAll().where("name", "=", "Send the follow-up").execute(),
+    ).resolves.toHaveLength(0);
+    await expect(createEntityRepository(db).searchEntities("Send the follow-up")).resolves.toHaveLength(0);
+    await expect(
+      db.selectFrom("indexed_files").selectAll().where("id", "=", subEntities[0].id).execute(),
+    ).resolves.toHaveLength(0);
+    await expect(
+      db.selectFrom("document_chunks").selectAll().where("id", "=", subEntities[0].id).execute(),
+    ).resolves.toHaveLength(0);
   });
 });
 
@@ -203,27 +302,43 @@ async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) 
   return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
 }
 
-function commitmentItem(projectId: string): SyncedItem {
-  return {
-    providerFileId: "commitment-file-1",
-    providerUrl: null,
-    fileName: "Commitment file",
-    fileType: "issue",
-    contentCategory: "structured",
-    content: "Commitment file",
-    sourcePath: null,
-    contentHash: "hash-1",
-    sourceCreatedAt: null,
-    sourceUpdatedAt: null,
-    commitments: [
-      {
-        commitmentId: "commitment-1",
-        parentRef: { source: "linear", sourceId: `${projectId}-source` },
-        title: "Send the follow-up",
-        status: "open",
-        dueAt: "2026-07-01T00:00:00.000Z",
-        evidence: { fileIds: ["commitment-file-1"], entityIds: [projectId, TEST_ACCOUNT_ENTITY_ID] },
-      },
-    ],
-  };
+async function seedCommitmentFact(
+  db: Kysely<DB>,
+  commitmentId: string,
+  parentEntityId: string | null,
+  title: string,
+): Promise<void> {
+  await upsertCommitmentFact(db, {
+    experimentalFlag: true,
+    indexedFileId: "commitment-file-1",
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    lastSeenSyncRunId: "sync-1",
+    source: "linear",
+    commitmentId,
+    parentEntityId: parentEntityId ?? undefined,
+    title,
+    status: "open",
+    evidence: { fileIds: ["commitment-file-1"], entityIds: parentEntityId ? [parentEntityId] : [] },
+  });
+}
+
+async function currentCommitmentRow(db: Kysely<DB>, displayName: string) {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "commitment")
+    .where("display_name", "=", displayName)
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+}
+
+async function countRows(db: Kysely<DB>, table: "indexed_file_facts" | "sub_entities", kind: string): Promise<number> {
+  const column = table === "indexed_file_facts" ? "fact_type" : "kind";
+  const row = await db
+    .selectFrom(table)
+    .select((eb) => eb.fn.countAll<number>().as("count"))
+    .where(column, "=", kind)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
 }

--- a/packages/server/src/db/repositories/commitments.ts
+++ b/packages/server/src/db/repositories/commitments.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
 import type { CommitmentSeed, IndexedFileFactRaw } from "../../connectors/types";
 import type { DB, IndexedFileFactsTable } from "../schema";
 import {
@@ -6,6 +7,7 @@ import {
   type IndexedFileFactType,
   createIndexedFileFactRepository,
 } from "./indexed-file-facts";
+import { type SubEntityRow, createSubEntityRepository } from "./sub-entities";
 
 export type CommitmentStatus = "open" | "done" | "dropped";
 
@@ -88,37 +90,34 @@ export async function markCommitmentDone(db: Kysely<DB>, commitmentId: string): 
   if (!fact) return false;
   const raw = readCommitmentRaw(fact.raw);
   if (!raw) return false;
-  await db
-    .updateTable("indexed_file_facts")
-    .set({ raw: JSON.stringify({ ...raw, status: "done" }), updated_at: new Date().toISOString() })
-    .where("id", "=", fact.id)
-    .execute();
-  return true;
+  const repo = createSubEntityRepository(db);
+  const subEntityId = await findCommitmentSubEntityIdByFact(db, fact.id);
+  if (subEntityId) return repo.markSubEntityStatus(subEntityId, "done");
+  const fallback = await findCommitmentSubEntityByScopeAndName(db, readParentEntityId(raw), raw.title);
+  if (!fallback) return false;
+  return repo.markSubEntityStatus(fallback.id, "done");
 }
 
 export async function listOpenCommitments(
   db: Kysely<DB>,
   opts: { parentEntityId?: string | null } = {},
 ): Promise<OpenCommitment[]> {
-  const rows = await db
-    .selectFrom("indexed_file_facts")
-    .selectAll()
-    .where("fact_type", "=", "commitment")
-    .where("deleted_at", "is", null)
-    .execute();
+  const rows = await createSubEntityRepository(db).listOpenSubEntities({
+    parentEntityId: opts.parentEntityId,
+    kind: "commitment",
+  });
   const out: OpenCommitment[] = [];
   for (const row of rows) {
-    const raw = readCommitmentRaw(row.raw);
-    if (!raw || raw.status === "done" || raw.status === "dropped") continue;
-    const parentEntityId = readParentEntityId(raw);
-    if (opts.parentEntityId && parentEntityId !== opts.parentEntityId) continue;
+    const fact = await findSubEntityCommitmentFact(db, row.id);
+    const raw = readCommitmentRaw(fact?.raw ?? null);
+    if (!fact || !raw) continue;
     out.push({
-      factId: row.id,
+      factId: fact.id,
       commitmentId: raw.commitmentId,
-      parentEntityId,
+      parentEntityId: row.parent_entity_id,
       title: raw.title,
       status: "open",
-      dueAt: raw.dueAt ?? null,
+      dueAt: row.due_at,
       evidence: raw.evidence,
       raw,
     });
@@ -247,6 +246,47 @@ async function findActiveCommitmentFact(db: Kysely<DB>, commitmentId: string) {
     .where("fact_type", "=", "commitment")
     .where("subject_source_id", "=", commitmentId)
     .where("deleted_at", "is", null)
+    .executeTakeFirst();
+}
+
+async function findCommitmentSubEntityIdByFact(db: Kysely<DB>, factId: string): Promise<string | null> {
+  const row = await db
+    .selectFrom("sub_entity_evidence")
+    .innerJoin("sub_entities", "sub_entities.id", "sub_entity_evidence.sub_entity_id")
+    .select("sub_entities.id")
+    .where("sub_entity_evidence.kind", "=", "fact")
+    .where("sub_entity_evidence.ref_id", "=", factId)
+    .where("sub_entities.kind", "=", "commitment")
+    .where("sub_entities.valid_to", "is", null)
+    .executeTakeFirst();
+  return row?.id ?? null;
+}
+
+async function findCommitmentSubEntityByScopeAndName(
+  db: Kysely<DB>,
+  parentEntityId: string | null,
+  title: string,
+): Promise<SubEntityRow | undefined> {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("parent_scope_key", "=", parentEntityId ?? "global")
+    .where("kind", "=", "commitment")
+    .where("normalized_name", "=", normalizeName(title))
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+}
+
+async function findSubEntityCommitmentFact(db: Kysely<DB>, subEntityId: string) {
+  return db
+    .selectFrom("sub_entity_evidence")
+    .innerJoin("indexed_file_facts", "indexed_file_facts.id", "sub_entity_evidence.ref_id")
+    .selectAll("indexed_file_facts")
+    .where("sub_entity_evidence.sub_entity_id", "=", subEntityId)
+    .where("sub_entity_evidence.kind", "=", "fact")
+    .where("indexed_file_facts.fact_type", "=", "commitment")
+    .where("indexed_file_facts.deleted_at", "is", null)
+    .orderBy("indexed_file_facts.updated_at", "desc")
     .executeTakeFirst();
 }
 

--- a/packages/server/src/db/repositories/decisions.integration.test.ts
+++ b/packages/server/src/db/repositories/decisions.integration.test.ts
@@ -1,0 +1,317 @@
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+import { materializeUnmaterializedFacts } from "../../entities/materialize";
+import { createTestLogger, createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { upsertDecisionFact, upsertDecisionFactsForFile } from "./decisions";
+import { createEntityRepository } from "./entities";
+import { createSubEntityRepository } from "./sub-entities";
+import { TEST_ACCOUNT_ENTITY_ID } from "./tasks";
+
+const USER_ID = "decision-pg-user";
+const CONNECTOR_ID = "decision-pg-config";
+
+describe("decision sub-entity supersession postgres", () => {
+  let db: Kysely<DB> | undefined;
+
+  afterEach(async () => {
+    await db?.destroy();
+    db = undefined;
+  });
+
+  it("supersedes changed decisions and keeps normalized statement replays idempotent", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedProject(db, { id: "decision-project-forward", name: "Decision Project Forward" });
+    await seedProject(db, { id: TEST_ACCOUNT_ENTITY_ID, name: "Test Account" });
+    await seedFile(db, "decision-file-forward", "2026-06-22T09:00:00.000Z");
+
+    await expect(
+      upsertDecisionFact(db, {
+        experimentalFlag: false,
+        indexedFileId: "decision-file-forward",
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        source: "linear",
+        topic: "Pricing Tier",
+        statement: "Use price A",
+        parentEntityId: project.id,
+        decidedAt: "2026-06-22T09:00:00.000Z",
+        evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
+      }),
+    ).resolves.toEqual({ emitted: false });
+    expect(await countDecisionRows(db)).toBe(0);
+
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-forward",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      decisions: [
+        {
+          topic: "Pricing Tier",
+          statement: "Use price A",
+          parentEntityId: project.id,
+          decidedAt: "2026-06-22T09:00:00.000Z",
+          evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
+        },
+      ],
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-forward",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      decisions: [
+        {
+          topic: "Pricing Tier",
+          statement: "Use price B",
+          parentEntityId: project.id,
+          decidedAt: "2026-06-22T11:00:00.000Z",
+          evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id] },
+        },
+      ],
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    let rows = await decisionRows(db, project.id, "pricing tier");
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.display_name === "Use price A")).toMatchObject({
+      status: "superseded",
+      valid_from: "2026-06-22T09:00:00.000Z",
+      valid_to: "2026-06-22T11:00:00.000Z",
+    });
+    expect(rows.find((row) => row.display_name === "Use price B")).toMatchObject({
+      status: "active",
+      valid_from: "2026-06-22T11:00:00.000Z",
+      valid_to: null,
+    });
+
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-forward",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      decisions: [
+        {
+          topic: "Pricing Tier",
+          statement: " use   PRICE b ",
+          parentEntityId: project.id,
+          decidedAt: "2026-06-22T11:00:00.000Z",
+          evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id] },
+        },
+      ],
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    rows = await decisionRows(db, project.id, "pricing tier");
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((row) => row.valid_to === null)).toHaveLength(1);
+  }, 30000);
+
+  it("places out-of-order decisions into the same-day temporal interval", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedProject(db, { id: "decision-project-order", name: "Decision Project Order" });
+    await seedFile(db, "decision-file-order", "2026-06-22T10:00:00.000Z");
+
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-order",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Launch Date",
+      statement: "Launch at noon",
+      parentEntityId: project.id,
+      decidedAt: "2026-06-22T12:00:00.000Z",
+      evidence: { fileIds: ["decision-file-order"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-order",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Launch Date",
+      statement: "Launch in the morning",
+      parentEntityId: project.id,
+      decidedAt: "2026-06-22T10:00:00.000Z",
+      evidence: { fileIds: ["decision-file-order"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const asOf = await createSubEntityRepository(db).getSubEntitiesAsOf({
+      parentEntityId: project.id,
+      kind: "decision",
+      at: "2026-06-22T10:30:00.000Z",
+    });
+    const current = await createSubEntityRepository(db).listCurrentByKind({
+      parentEntityId: project.id,
+      kind: "decision",
+    });
+    const rows = await decisionRows(db, project.id, "launch date");
+
+    expect(asOf.map((row) => row.display_name)).toEqual(["Launch in the morning"]);
+    expect(current.map((row) => row.display_name)).toEqual(["Launch at noon"]);
+    expect(rows.find((row) => row.display_name === "Launch in the morning")).toMatchObject({
+      status: "superseded",
+      valid_from: "2026-06-22T10:00:00.000Z",
+      valid_to: "2026-06-22T12:00:00.000Z",
+    });
+    expect(rows.find((row) => row.display_name === "Launch at noon")).toMatchObject({
+      status: "active",
+      valid_from: "2026-06-22T12:00:00.000Z",
+      valid_to: null,
+    });
+  }, 30000);
+
+  it("deduplicates decisions within a parent while keeping parent scopes separate", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const projectA = await seedProject(db, { id: "decision-project-a", name: "Decision Project A" });
+    const projectB = await seedProject(db, { id: "decision-project-b", name: "Decision Project B" });
+    await seedFile(db, "decision-file-a1", "2026-06-22T09:00:00.000Z");
+    await seedFile(db, "decision-file-a2", "2026-06-22T09:05:00.000Z");
+    await seedFile(db, "decision-file-b1", "2026-06-22T09:10:00.000Z");
+
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-a1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Support Model",
+      statement: "Use staffed support",
+      parentEntityId: projectA.id,
+      decidedAt: "2026-06-22T09:00:00.000Z",
+      evidence: { fileIds: ["decision-file-a1"], entityIds: [projectA.id] },
+    });
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-a2",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: " support   model ",
+      statement: "use STAFFED support",
+      parentEntityId: projectA.id,
+      decidedAt: "2026-06-22T09:05:00.000Z",
+      evidence: { fileIds: ["decision-file-a2"], entityIds: [projectA.id] },
+    });
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-b1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Support Model",
+      statement: "Use staffed support",
+      parentEntityId: projectB.id,
+      decidedAt: "2026-06-22T09:10:00.000Z",
+      evidence: { fileIds: ["decision-file-b1"], entityIds: [projectB.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const projectARows = await decisionRows(db, projectA.id, "support model");
+    const projectBRows = await decisionRows(db, projectB.id, "support model");
+    expect(projectARows).toHaveLength(1);
+    expect(projectBRows).toHaveLength(1);
+    expect(projectARows[0].parent_scope_key).toBe(projectA.id);
+    expect(projectBRows[0].parent_scope_key).toBe(projectB.id);
+    expect(projectARows[0].valid_to).toBeNull();
+    expect(projectBRows[0].valid_to).toBeNull();
+  }, 30000);
+});
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: USER_ID, name: "Decision PG User", email: "decision-pg-user@example.com" })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) {
+  const repo = createEntityRepository(db);
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await repo.upsertSourceRef({ entityId: input.id, source: "linear", sourceId: `${input.id}-source` });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
+}
+
+async function seedFile(db: Kysely<DB>, id: string, sourceTime: string): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      provider_url: null,
+      file_name: id,
+      file_type: "issue",
+      content_category: "structured",
+      content: "Decision file",
+      source: "linear",
+      source_path: null,
+      content_hash: `${id}-hash`,
+      source_created_at: sourceTime,
+      source_updated_at: sourceTime,
+      synced_at: sourceTime,
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function decisionRows(db: Kysely<DB>, parentEntityId: string, normalizedName: string) {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "decision")
+    .where("parent_entity_id", "=", parentEntityId)
+    .where("normalized_name", "=", normalizedName)
+    .orderBy("valid_from", "asc")
+    .execute();
+}
+
+async function countDecisionRows(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("sub_entities")
+    .select((eb) => eb.fn.countAll<number>().as("count"))
+    .where("kind", "=", "decision")
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}

--- a/packages/server/src/db/repositories/decisions.ts
+++ b/packages/server/src/db/repositories/decisions.ts
@@ -1,0 +1,268 @@
+import { createHash } from "node:crypto";
+import type { Kysely } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+import type { DecisionSeed } from "../../connectors/types";
+import type { DB, IndexedFileFactsTable } from "../schema";
+import { buildIndexedFileFactKey, createIndexedFileFactRepository } from "./indexed-file-facts";
+import { type SubEntityRow, createSubEntityRepository } from "./sub-entities";
+
+const DECISION_ID_SEPARATOR = "\u001f";
+
+export interface DecisionFactRaw extends DecisionSeed {
+  decisionId: string;
+}
+
+export interface UpsertDecisionFactInput {
+  experimentalFlag?: boolean;
+  indexedFileId: string;
+  connectorConfigId: string;
+  createdByUserId?: string | null;
+  lastSeenSyncRunId?: string | null;
+  contentHash?: string | null;
+  source: string;
+  decisionId?: string;
+  topic: string;
+  statement: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  decidedBy?: string;
+  decidedAt?: string;
+  rationale?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  promptVersion?: string;
+  contextSnippet?: string | null;
+}
+
+export interface UpsertDecisionFactsForFileInput {
+  experimentalFlag?: boolean;
+  indexedFileId: string;
+  connectorConfigId: string;
+  createdByUserId?: string | null;
+  lastSeenSyncRunId?: string | null;
+  contentHash?: string | null;
+  source: string;
+  decisions: DecisionSeed[];
+  contextSnippet?: string | null;
+}
+
+export interface CurrentDecision {
+  factId: string;
+  decisionId: string;
+  parentEntityId: string;
+  topic: string;
+  statement: string;
+  decidedBy: string | null;
+  decidedAt: string | null;
+  rationale: string | null;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  raw: DecisionFactRaw;
+  row: SubEntityRow;
+}
+
+export async function upsertDecisionFact(
+  db: Kysely<DB>,
+  input: UpsertDecisionFactInput,
+): Promise<{ emitted: boolean; factKey?: string; decisionId?: string }> {
+  const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
+  const source = requireNonEmpty(input.source, "source");
+  const decisionId = requireNonEmpty(
+    input.decisionId ?? buildDecisionId(input.indexedFileId, input.topic, input.statement),
+    "decisionId",
+  );
+  if (!input.experimentalFlag) return { emitted: false };
+
+  const raw: DecisionFactRaw = {
+    decisionId,
+    topic: input.topic,
+    statement: input.statement,
+    parentRef: input.parentRef,
+    parentEntityId: input.parentEntityId,
+    decidedBy: input.decidedBy,
+    decidedAt: input.decidedAt,
+    rationale: input.rationale,
+    evidence: input.evidence,
+    promptVersion: input.promptVersion,
+  };
+  const factInput = {
+    indexedFileId: input.indexedFileId,
+    connectorConfigId,
+    createdByUserId: input.createdByUserId ?? null,
+    lastSeenSyncRunId: input.lastSeenSyncRunId ?? null,
+    contentHash: input.contentHash ?? null,
+    source,
+    factType: "decision" as const,
+    relation: "mentioned" as const,
+    subjectName: input.statement,
+    subjectSource: source,
+    subjectSourceId: decisionId,
+    contextSnippet: input.contextSnippet ?? null,
+    raw,
+  };
+  await createIndexedFileFactRepository(db).upsertFact(factInput);
+  return { emitted: true, factKey: buildIndexedFileFactKey(factInput), decisionId };
+}
+
+export async function upsertDecisionFactsForFile(
+  db: Kysely<DB>,
+  input: UpsertDecisionFactsForFileInput,
+): Promise<{ emitted: boolean; factKeys: Set<string> }> {
+  requireNonEmpty(input.connectorConfigId, "connectorConfigId");
+  requireNonEmpty(input.source, "source");
+  const emittedKeys = new Set<string>();
+  if (!input.experimentalFlag) return { emitted: false, factKeys: emittedKeys };
+
+  for (const decision of input.decisions) {
+    const result = await upsertDecisionFact(db, {
+      experimentalFlag: input.experimentalFlag,
+      indexedFileId: input.indexedFileId,
+      connectorConfigId: input.connectorConfigId,
+      createdByUserId: input.createdByUserId,
+      lastSeenSyncRunId: input.lastSeenSyncRunId,
+      contentHash: input.contentHash,
+      source: input.source,
+      decisionId: decision.decisionId,
+      topic: decision.topic,
+      statement: decision.statement,
+      parentRef: decision.parentRef,
+      parentEntityId: decision.parentEntityId,
+      decidedBy: decision.decidedBy,
+      decidedAt: decision.decidedAt,
+      rationale: decision.rationale,
+      evidence: decision.evidence,
+      promptVersion: decision.promptVersion,
+      contextSnippet: input.contextSnippet,
+    });
+    if (result.factKey) emittedKeys.add(result.factKey);
+  }
+  await createIndexedFileFactRepository(db).reconcileStaleFacts(
+    { kind: "file", indexedFileId: input.indexedFileId, source: input.source, factType: "decision" },
+    emittedKeys,
+  );
+  return { emitted: true, factKeys: emittedKeys };
+}
+
+export function buildDecisionId(indexedFileId: string, topic: string, statement: string): string {
+  return createHash("sha256")
+    .update([indexedFileId, normalizeName(topic), normalizeName(statement)].join(DECISION_ID_SEPARATOR))
+    .digest("hex");
+}
+
+export async function listCurrentDecisions(
+  db: Kysely<DB>,
+  opts: { experimentalFlag?: boolean; parentEntityId: string },
+): Promise<CurrentDecision[]> {
+  if (!opts.experimentalFlag) return [];
+  const rows = await createSubEntityRepository(db).listCurrentByKind({
+    parentEntityId: opts.parentEntityId,
+    kind: "decision",
+  });
+  return hydrateDecisionRows(db, rows);
+}
+
+export async function getDecisionsAsOf(
+  db: Kysely<DB>,
+  opts: { experimentalFlag?: boolean; parentEntityId: string; at: string },
+): Promise<CurrentDecision[]> {
+  if (!opts.experimentalFlag) return [];
+  const rows = await createSubEntityRepository(db).getSubEntitiesAsOf({
+    parentEntityId: opts.parentEntityId,
+    kind: "decision",
+    at: opts.at,
+  });
+  return hydrateDecisionRows(db, rows);
+}
+
+async function hydrateDecisionRows(db: Kysely<DB>, rows: SubEntityRow[]): Promise<CurrentDecision[]> {
+  const out: CurrentDecision[] = [];
+  for (const row of rows) {
+    const fact = row.source_fact_id ? await findDecisionFact(db, row.source_fact_id) : undefined;
+    const raw = readDecisionRaw(fact?.raw ?? null);
+    if (!fact || !raw || !row.parent_entity_id) continue;
+    out.push({
+      factId: fact.id,
+      decisionId: raw.decisionId,
+      parentEntityId: row.parent_entity_id,
+      topic: raw.topic,
+      statement: row.display_name,
+      decidedBy: raw.decidedBy ?? null,
+      decidedAt: raw.decidedAt ?? null,
+      rationale: raw.rationale ?? null,
+      evidence: raw.evidence,
+      raw,
+      row,
+    });
+  }
+  return out;
+}
+
+async function findDecisionFact(
+  db: Kysely<DB>,
+  factId: string,
+): Promise<Pick<IndexedFileFactsTable, "id" | "raw"> | undefined> {
+  return db
+    .selectFrom("indexed_file_facts")
+    .select(["id", "raw"])
+    .where("id", "=", factId)
+    .where("fact_type", "=", "decision")
+    .executeTakeFirst();
+}
+
+function readDecisionRaw(raw: string | null): DecisionFactRaw | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  if (
+    typeof record.decisionId !== "string" ||
+    typeof record.topic !== "string" ||
+    typeof record.statement !== "string" ||
+    !isEvidence(record.evidence)
+  ) {
+    return null;
+  }
+  return {
+    decisionId: record.decisionId,
+    topic: record.topic,
+    statement: record.statement,
+    parentRef: readParentRef(record.parentRef),
+    parentEntityId: readOptionalString(record.parentEntityId),
+    decidedBy: readOptionalString(record.decidedBy),
+    decidedAt: readOptionalString(record.decidedAt),
+    rationale: readOptionalString(record.rationale),
+    evidence: { fileIds: record.evidence.fileIds, entityIds: record.evidence.entityIds },
+    promptVersion: readOptionalString(record.promptVersion),
+  };
+}
+
+function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.fileIds) &&
+    record.fileIds.every((id) => typeof id === "string") &&
+    Array.isArray(record.entityIds) &&
+    record.entityIds.every((id) => typeof id === "string")
+  );
+}
+
+function readParentRef(value: unknown): { source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || typeof record.sourceId !== "string") return undefined;
+  return { source: record.source, sourceId: record.sourceId };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function requireNonEmpty(value: string | null | undefined, name: string): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) throw new Error(`decision ${name} is required`);
+  return trimmed;
+}

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -13,6 +13,7 @@ export type IndexedFileFactType =
   | "structural_seed"
   | "structural_task"
   | "commitment"
+  | "decision"
   | "llm_task"
   | "person_seed"
   | "llm_extracted"
@@ -144,6 +145,13 @@ export function buildIndexedFileFactKey(input: UpsertIndexedFileFactInput): stri
       .update([input.connectorConfigId ?? "", input.factType, input.source, commitmentId].join("|"))
       .digest("hex");
   }
+  if (input.factType === "decision") {
+    const raw = input.raw as Record<string, unknown> | undefined;
+    const decisionId = typeof raw?.decisionId === "string" ? raw.decisionId.trim().toLowerCase() : "";
+    return createHash("sha256")
+      .update([input.connectorConfigId ?? "", input.factType, input.source, decisionId].join("|"))
+      .digest("hex");
+  }
   if (input.factType === "llm_task") {
     const raw = input.raw as Record<string, unknown> | undefined;
     const candidateId = typeof raw?.candidateId === "string" ? raw.candidateId.trim().toLowerCase() : "";
@@ -209,6 +217,9 @@ function hasString(value: Record<string, unknown>, key: string): boolean {
 }
 
 function validateRaw(input: UpsertIndexedFileFactInput): string | null {
+  if (!input.raw && input.factType === "decision") {
+    throw new Error("decision facts require raw decision data");
+  }
   if (!input.raw) return null;
   if (!isRecord(input.raw)) {
     throw new Error("indexed_file_facts.raw must be an object");
@@ -289,6 +300,39 @@ function validateRaw(input: UpsertIndexedFileFactInput): string | null {
     const parentRef = raw.parentRef as Record<string, unknown> | undefined;
     if (parentRef && (!hasString(parentRef, "source") || !hasString(parentRef, "sourceId"))) {
       throw new Error("commitment parentRef requires source and sourceId");
+    }
+  } else if (input.factType === "decision") {
+    if (
+      !input.connectorConfigId?.trim() ||
+      !input.source.trim() ||
+      !hasString(raw, "decisionId") ||
+      !hasString(raw, "topic") ||
+      !hasString(raw, "statement") ||
+      !isRecord(raw.evidence)
+    ) {
+      throw new Error("decision facts require connectorConfigId, source, decisionId, topic, statement, and evidence");
+    }
+    const evidence = raw.evidence as Record<string, unknown>;
+    if (!Array.isArray(evidence.fileIds) || !Array.isArray(evidence.entityIds)) {
+      throw new Error("decision evidence requires fileIds and entityIds arrays");
+    }
+    if (
+      !evidence.fileIds.every((id) => typeof id === "string") ||
+      !evidence.entityIds.every((id) => typeof id === "string")
+    ) {
+      throw new Error("decision evidence ids must be strings");
+    }
+    if (raw.parentRef !== undefined && !isRecord(raw.parentRef)) {
+      throw new Error("decision parentRef must be an object");
+    }
+    const parentRef = raw.parentRef as Record<string, unknown> | undefined;
+    if (parentRef && (!hasString(parentRef, "source") || !hasString(parentRef, "sourceId"))) {
+      throw new Error("decision parentRef requires source and sourceId");
+    }
+    for (const key of ["parentEntityId", "decidedBy", "decidedAt", "rationale", "promptVersion"]) {
+      if (raw[key] !== undefined && typeof raw[key] !== "string") {
+        throw new Error(`decision ${key} must be a string`);
+      }
     }
   } else if (input.factType === "llm_task") {
     if (

--- a/packages/server/src/db/repositories/sub-entities.ts
+++ b/packages/server/src/db/repositories/sub-entities.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely, Selectable } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+import type { DB, SubEntitiesTable } from "../schema";
+
+export type SubEntityStatus = "open" | "done" | "dropped" | string;
+export type SubEntityStatusAuthority = "external" | "local";
+
+export interface UpsertSubEntityInput {
+  parentEntityId?: string | null;
+  kind: string;
+  displayName: string;
+  status: SubEntityStatus;
+  provenance: string;
+  dueAt?: string | null;
+  ownerUserId?: string | null;
+  sourceFactId?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface ListOpenSubEntitiesOptions {
+  parentEntityId?: string | null;
+  kind: string;
+}
+
+export type SubEntityRow = Selectable<SubEntitiesTable>;
+
+const GLOBAL_PARENT_SCOPE_KEY = "global";
+const TERMINAL_STATUSES = ["done", "dropped"];
+
+export function createSubEntityRepository(db: Kysely<DB>) {
+  return {
+    async upsertSubEntity(input: UpsertSubEntityInput): Promise<{ subEntityId: string; created: boolean }> {
+      try {
+        return await upsertInTransaction(db, input);
+      } catch (err) {
+        if (!isUniqueConstraintError(err)) throw err;
+        return upsertInTransaction(db, input);
+      }
+    },
+
+    async markSubEntityStatus(subEntityId: string, status: SubEntityStatus): Promise<boolean> {
+      const result = await db
+        .updateTable("sub_entities")
+        .set({ status, status_authority: "local", updated_at: new Date().toISOString() })
+        .where("id", "=", subEntityId)
+        .where("valid_to", "is", null)
+        .executeTakeFirst();
+      return Number(result.numUpdatedRows ?? 0) > 0;
+    },
+
+    async listOpenSubEntities(opts: ListOpenSubEntitiesOptions): Promise<SubEntityRow[]> {
+      let query = db
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("valid_to", "is", null)
+        .where("kind", "=", opts.kind)
+        .where("status", "not in", TERMINAL_STATUSES)
+        .orderBy("updated_at", "desc");
+      if (opts.parentEntityId !== undefined) {
+        query =
+          opts.parentEntityId === null
+            ? query.where("parent_entity_id", "is", null)
+            : query.where("parent_entity_id", "=", opts.parentEntityId);
+      }
+      return query.execute();
+    },
+
+    async upsertSubEntityEvidence(subEntityId: string, kind: string, refId: string): Promise<void> {
+      await db
+        .insertInto("sub_entity_evidence")
+        .values({ sub_entity_id: subEntityId, kind, ref_id: refId })
+        .onConflict((oc) => oc.columns(["sub_entity_id", "kind", "ref_id"]).doNothing())
+        .execute();
+    },
+  };
+}
+
+async function upsertInTransaction(
+  db: Kysely<DB>,
+  input: UpsertSubEntityInput,
+): Promise<{ subEntityId: string; created: boolean }> {
+  return db.transaction().execute(async (trx) => {
+    const parentScopeKey = input.parentEntityId ?? GLOBAL_PARENT_SCOPE_KEY;
+    const normalized = normalizeName(input.displayName);
+    const existing = await selectCurrent(trx, parentScopeKey, input.kind, normalized);
+    const now = new Date().toISOString();
+    if (!existing) {
+      const id = randomUUID();
+      await trx
+        .insertInto("sub_entities")
+        .values({
+          id,
+          parent_entity_id: input.parentEntityId ?? null,
+          parent_scope_key: parentScopeKey,
+          kind: input.kind,
+          normalized_name: normalized,
+          display_name: input.displayName,
+          status: input.status,
+          status_authority: "external",
+          valid_to: null,
+          provenance: input.provenance,
+          due_at: input.dueAt ?? null,
+          created_by_user_id: input.ownerUserId ?? null,
+          source_fact_id: input.sourceFactId ?? null,
+          metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
+          updated_at: now,
+        })
+        .execute();
+      return { subEntityId: id, created: true };
+    }
+
+    await updateExisting(trx, existing, input, now);
+    return { subEntityId: existing.id, created: false };
+  });
+}
+
+async function selectCurrent(
+  db: Kysely<DB>,
+  parentScopeKey: string,
+  kind: string,
+  normalizedName: string,
+): Promise<SubEntityRow | undefined> {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("parent_scope_key", "=", parentScopeKey)
+    .where("kind", "=", kind)
+    .where("normalized_name", "=", normalizedName)
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+}
+
+async function updateExisting(
+  db: Kysely<DB>,
+  existing: SubEntityRow,
+  input: UpsertSubEntityInput,
+  now: string,
+): Promise<void> {
+  await db
+    .updateTable("sub_entities")
+    .set({
+      display_name: input.displayName,
+      status: existing.status_authority === "local" ? existing.status : input.status,
+      due_at: input.dueAt ?? null,
+      source_fact_id: input.sourceFactId ?? null,
+      metadata_json: input.metadata ? JSON.stringify(input.metadata) : existing.metadata_json,
+      updated_at: now,
+    })
+    .where("id", "=", existing.id)
+    .execute();
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = "code" in error ? String(error.code) : "";
+  if (code === "23505" || code === "SQLITE_CONSTRAINT_UNIQUE") return true;
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return message.includes("unique constraint") || message.includes("duplicate key");
+}

--- a/packages/server/src/db/repositories/sub-entities.ts
+++ b/packages/server/src/db/repositories/sub-entities.ts
@@ -9,6 +9,7 @@ export type SubEntityStatusAuthority = "external" | "local";
 export interface UpsertSubEntityInput {
   parentEntityId?: string | null;
   kind: string;
+  dedupName?: string | null;
   displayName: string;
   status: SubEntityStatus;
   provenance: string;
@@ -23,10 +24,33 @@ export interface ListOpenSubEntitiesOptions {
   kind: string;
 }
 
+export interface SupersedeSubEntityInput {
+  parentEntityId: string;
+  kind: string;
+  dedupName: string;
+  displayName: string;
+  provenance: string;
+  metadata?: Record<string, unknown> | null;
+  sourceFactId?: string | null;
+  effectiveAt: string;
+}
+
+export interface ListCurrentByKindOptions {
+  parentEntityId: string;
+  kind: string;
+}
+
+export interface GetSubEntitiesAsOfOptions {
+  parentEntityId: string;
+  kind: string;
+  at: string;
+}
+
 export type SubEntityRow = Selectable<SubEntitiesTable>;
 
-const GLOBAL_PARENT_SCOPE_KEY = "global";
+export const GLOBAL_PARENT_SCOPE_KEY = "global";
 const TERMINAL_STATUSES = ["done", "dropped"];
+const MAX_SUPERSESSION_ATTEMPTS = 3;
 
 export function createSubEntityRepository(db: Kysely<DB>) {
   return {
@@ -47,6 +71,45 @@ export function createSubEntityRepository(db: Kysely<DB>) {
         .where("valid_to", "is", null)
         .executeTakeFirst();
       return Number(result.numUpdatedRows ?? 0) > 0;
+    },
+
+    async supersedeSubEntity(
+      input: SupersedeSubEntityInput,
+    ): Promise<{ subEntityId: string; created: boolean; superseded: boolean }> {
+      let lastError: unknown;
+      for (let attempt = 0; attempt < MAX_SUPERSESSION_ATTEMPTS; attempt++) {
+        try {
+          return await supersedeInTransaction(db, input);
+        } catch (err) {
+          if (!isUniqueConstraintError(err) && !(err instanceof SupersessionRetryError)) throw err;
+          lastError = err;
+        }
+      }
+      throw lastError;
+    },
+
+    async listCurrentByKind(opts: ListCurrentByKindOptions): Promise<SubEntityRow[]> {
+      return db
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("parent_entity_id", "=", opts.parentEntityId)
+        .where("kind", "=", opts.kind)
+        .where("valid_to", "is", null)
+        .orderBy("updated_at", "desc")
+        .execute();
+    },
+
+    async getSubEntitiesAsOf(opts: GetSubEntitiesAsOfOptions): Promise<SubEntityRow[]> {
+      const at = new Date(opts.at).toISOString();
+      return db
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("parent_entity_id", "=", opts.parentEntityId)
+        .where("kind", "=", opts.kind)
+        .where("valid_from", "<=", at)
+        .where((eb) => eb.or([eb("valid_to", "is", null), eb("valid_to", ">", at)]))
+        .orderBy("valid_from", "desc")
+        .execute();
     },
 
     async listOpenSubEntities(opts: ListOpenSubEntitiesOptions): Promise<SubEntityRow[]> {
@@ -82,7 +145,7 @@ async function upsertInTransaction(
 ): Promise<{ subEntityId: string; created: boolean }> {
   return db.transaction().execute(async (trx) => {
     const parentScopeKey = input.parentEntityId ?? GLOBAL_PARENT_SCOPE_KEY;
-    const normalized = normalizeName(input.displayName);
+    const normalized = normalizeName(input.dedupName ?? input.displayName);
     const existing = await selectCurrent(trx, parentScopeKey, input.kind, normalized);
     const now = new Date().toISOString();
     if (!existing) {
@@ -113,6 +176,96 @@ async function upsertInTransaction(
     await updateExisting(trx, existing, input, now);
     return { subEntityId: existing.id, created: false };
   });
+}
+
+async function supersedeInTransaction(
+  db: Kysely<DB>,
+  input: SupersedeSubEntityInput,
+): Promise<{ subEntityId: string; created: boolean; superseded: boolean }> {
+  return db.transaction().execute(async (trx) => {
+    const parentScopeKey = input.parentEntityId;
+    const normalized = normalizeName(input.dedupName);
+    const displayNormalized = normalizeName(input.displayName);
+    const effectiveAt = new Date(input.effectiveAt).toISOString();
+    const now = new Date().toISOString();
+    const rows = await trx
+      .selectFrom("sub_entities")
+      .selectAll()
+      .where("parent_scope_key", "=", parentScopeKey)
+      .where("kind", "=", input.kind)
+      .where("normalized_name", "=", normalized)
+      .orderBy("valid_from", "asc")
+      .execute();
+    const existingAtTime = rows.find(
+      (row) => row.valid_from === effectiveAt && normalizeName(row.display_name) === displayNormalized,
+    );
+    if (existingAtTime) {
+      await refreshSupersededRow(trx, existingAtTime.id, input, now);
+      return { subEntityId: existingAtTime.id, created: false, superseded: false };
+    }
+
+    const predecessor = [...rows].reverse().find((row) => row.valid_from <= effectiveAt);
+    const successor = rows.find((row) => row.valid_from > effectiveAt);
+    if (predecessor && normalizeName(predecessor.display_name) === displayNormalized) {
+      return { subEntityId: predecessor.id, created: false, superseded: false };
+    }
+
+    if (predecessor && (predecessor.valid_to === null || predecessor.valid_to > effectiveAt)) {
+      const update = trx
+        .updateTable("sub_entities")
+        .set({ valid_to: effectiveAt, status: "superseded", updated_at: now })
+        .where("id", "=", predecessor.id);
+      const result =
+        predecessor.valid_to === null
+          ? await update.where("valid_to", "is", null).executeTakeFirst()
+          : await update.where("valid_to", "=", predecessor.valid_to).executeTakeFirst();
+      if (Number(result.numUpdatedRows ?? 0) !== 1) throw new SupersessionRetryError();
+    }
+
+    const id = randomUUID();
+    const validTo = successor?.valid_from ?? null;
+    await trx
+      .insertInto("sub_entities")
+      .values({
+        id,
+        parent_entity_id: input.parentEntityId,
+        parent_scope_key: parentScopeKey,
+        kind: input.kind,
+        normalized_name: normalized,
+        display_name: input.displayName,
+        status: validTo === null ? "active" : "superseded",
+        status_authority: "external",
+        valid_from: effectiveAt,
+        valid_to: validTo,
+        provenance: input.provenance,
+        due_at: null,
+        created_by_user_id: null,
+        source_fact_id: input.sourceFactId ?? null,
+        metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
+        updated_at: now,
+      })
+      .execute();
+    return { subEntityId: id, created: true, superseded: Boolean(predecessor) };
+  });
+}
+
+async function refreshSupersededRow(
+  db: Kysely<DB>,
+  subEntityId: string,
+  input: SupersedeSubEntityInput,
+  now: string,
+): Promise<void> {
+  await db
+    .updateTable("sub_entities")
+    .set({
+      display_name: input.displayName,
+      provenance: input.provenance,
+      source_fact_id: input.sourceFactId ?? null,
+      metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
+      updated_at: now,
+    })
+    .where("id", "=", subEntityId)
+    .execute();
 }
 
 async function selectCurrent(
@@ -151,10 +304,12 @@ async function updateExisting(
     .execute();
 }
 
-function isUniqueConstraintError(error: unknown): boolean {
+export function isUniqueConstraintError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const code = "code" in error ? String(error.code) : "";
   if (code === "23505" || code === "SQLITE_CONSTRAINT_UNIQUE") return true;
   const message = error instanceof Error ? error.message.toLowerCase() : "";
   return message.includes("unique constraint") || message.includes("duplicate key");
 }
+
+class SupersessionRetryError extends Error {}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -887,6 +887,32 @@ export interface TaskEvidenceTable {
   ref_id: string;
 }
 
+export interface SubEntitiesTable {
+  id: string;
+  parent_entity_id: string | null;
+  parent_scope_key: string;
+  kind: string;
+  normalized_name: string;
+  display_name: string;
+  status: string;
+  status_authority: Generated<string>;
+  valid_from: Generated<string>;
+  valid_to: string | null;
+  provenance: string;
+  due_at: string | null;
+  created_by_user_id: string | null;
+  source_fact_id: string | null;
+  metadata_json: string | null;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
+export interface SubEntityEvidenceTable {
+  sub_entity_id: string;
+  kind: string;
+  ref_id: string;
+}
+
 export interface DB {
   users: UsersTable;
   channels: ChannelsTable;
@@ -950,6 +976,8 @@ export interface DB {
   indexed_file_facts: IndexedFileFactsTable;
   tasks: TasksTable;
   task_evidence: TaskEvidenceTable;
+  sub_entities: SubEntitiesTable;
+  sub_entity_evidence: SubEntityEvidenceTable;
   entity_domains: EntityDomainsTable;
   entity_project_bindings: EntityProjectBindingsTable;
   entity_project_member_overrides: EntityProjectMemberOverridesTable;

--- a/packages/server/src/entities/materialize-commitment.ts
+++ b/packages/server/src/entities/materialize-commitment.ts
@@ -34,16 +34,22 @@ export async function materializeCommitment(
   return { kind: "commitment_materialized" };
 }
 
-function resolveParent(deps: MaterializeDeps, commitment: CommitmentInput): EntityRow | null {
-  if (commitment.parentRef) {
-    const byRef = deps.index.bySourceRef.get(`${commitment.parentRef.source}:${commitment.parentRef.sourceId}`);
+export interface SubEntityParentInput {
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  evidence: { entityIds: string[] };
+}
+
+export function resolveParent(deps: MaterializeDeps, input: SubEntityParentInput): EntityRow | null {
+  if (input.parentRef) {
+    const byRef = deps.index.bySourceRef.get(`${input.parentRef.source}:${input.parentRef.sourceId}`);
     if (isAllowedParent(byRef)) return byRef;
   }
-  if (commitment.parentEntityId) {
-    const byId = findEntityById(deps, commitment.parentEntityId);
+  if (input.parentEntityId) {
+    const byId = findEntityById(deps, input.parentEntityId);
     if (isAllowedParent(byId)) return byId;
   }
-  for (const entityId of commitment.evidence.entityIds) {
+  for (const entityId of input.evidence.entityIds) {
     const byId = findEntityById(deps, entityId);
     if (isAllowedParent(byId)) return byId;
   }
@@ -66,10 +72,8 @@ function isAllowedParent(entity: EntityRow | undefined): entity is EntityRow {
   );
 }
 
-interface CommitmentInput {
+interface CommitmentInput extends SubEntityParentInput {
   commitmentId: string;
-  parentRef?: { source: string; sourceId: string };
-  parentEntityId?: string;
   title: string;
   status: "open" | "done" | "dropped";
   dueAt?: string;

--- a/packages/server/src/entities/materialize-commitment.ts
+++ b/packages/server/src/entities/materialize-commitment.ts
@@ -1,3 +1,4 @@
+import { createSubEntityRepository } from "../db/repositories/sub-entities";
 import { TEST_ACCOUNT_ENTITY_ID } from "../db/repositories/tasks";
 import { readJsonObject } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
@@ -12,19 +13,24 @@ export async function materializeCommitment(
   if (!commitment) return { kind: "skipped", reason: "invalid_commitment" };
 
   const parent = resolveParent(deps, commitment);
-  await deps.db
-    .updateTable("indexed_file_facts")
-    .set({
-      raw: JSON.stringify({
-        ...raw,
-        status: commitment.status,
-        parentEntityId: parent?.id ?? null,
-        parent_entity_id: parent?.id ?? null,
-      }),
-      updated_at: new Date().toISOString(),
-    })
-    .where("id", "=", fact.id)
-    .execute();
+  const repo = createSubEntityRepository(deps.db);
+  const result = await repo.upsertSubEntity({
+    parentEntityId: parent?.id ?? null,
+    kind: "commitment",
+    displayName: commitment.title,
+    status: commitment.status,
+    provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
+    dueAt: commitment.dueAt ?? null,
+    ownerUserId: deps.resolveOwner(fact),
+    sourceFactId: fact.id,
+  });
+  await repo.upsertSubEntityEvidence(result.subEntityId, "fact", fact.id);
+  for (const fileId of commitment.evidence.fileIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "file", fileId);
+  }
+  for (const entityId of commitment.evidence.entityIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "entity", entityId);
+  }
   return { kind: "commitment_materialized" };
 }
 
@@ -64,13 +70,16 @@ interface CommitmentInput {
   commitmentId: string;
   parentRef?: { source: string; sourceId: string };
   parentEntityId?: string;
+  title: string;
   status: "open" | "done" | "dropped";
-  evidence: { entityIds: string[] };
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
 }
 
 function readCommitment(raw: Record<string, unknown>): CommitmentInput | null {
   if (
     typeof raw.commitmentId !== "string" ||
+    typeof raw.title !== "string" ||
     (raw.status !== "open" && raw.status !== "done" && raw.status !== "dropped") ||
     !isEvidence(raw.evidence)
   ) {
@@ -80,8 +89,10 @@ function readCommitment(raw: Record<string, unknown>): CommitmentInput | null {
     commitmentId: raw.commitmentId,
     parentRef: readParentRef(raw.parentRef),
     parentEntityId: readOptionalString(raw.parentEntityId),
+    title: raw.title,
     status: raw.status,
-    evidence: { entityIds: raw.evidence.entityIds },
+    dueAt: readOptionalString(raw.dueAt),
+    evidence: { fileIds: raw.evidence.fileIds, entityIds: raw.evidence.entityIds },
   };
 }
 
@@ -92,10 +103,15 @@ function readParentRef(value: unknown): { source: string; sourceId: string } | u
   return { source: record.source, sourceId: record.sourceId };
 }
 
-function isEvidence(value: unknown): value is { entityIds: string[] } {
+function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: string[] } {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
-  return Array.isArray(record.entityIds) && record.entityIds.every((id) => typeof id === "string");
+  return (
+    Array.isArray(record.fileIds) &&
+    record.fileIds.every((id) => typeof id === "string") &&
+    Array.isArray(record.entityIds) &&
+    record.entityIds.every((id) => typeof id === "string")
+  );
 }
 
 function readOptionalString(value: unknown): string | undefined {

--- a/packages/server/src/entities/materialize-decision.ts
+++ b/packages/server/src/entities/materialize-decision.ts
@@ -1,0 +1,108 @@
+import { createSubEntityRepository } from "../db/repositories/sub-entities";
+import { resolveParent } from "./materialize-commitment";
+import { readJsonObject } from "./materialize-json";
+import type { IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+
+export async function materializeDecision(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
+  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
+  const raw = readJsonObject(fact.raw);
+  const decision = readDecision(raw);
+  if (!decision) return { kind: "skipped", reason: "invalid_decision" };
+
+  const parent = resolveParent(deps, decision);
+  if (!parent) return { kind: "skipped", reason: "missing_decision_parent" };
+  const effectiveAt = await resolveEffectiveAt(deps, fact, decision);
+  if (!effectiveAt) return { kind: "skipped", reason: "missing_decision_effective_time" };
+
+  const repo = createSubEntityRepository(deps.db);
+  const result = await repo.supersedeSubEntity({
+    parentEntityId: parent.id,
+    kind: "decision",
+    dedupName: decision.topic,
+    displayName: decision.statement,
+    provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
+    metadata: {
+      decidedBy: decision.decidedBy,
+      decidedAt: decision.decidedAt,
+      rationale: decision.rationale,
+    },
+    sourceFactId: fact.id,
+    effectiveAt,
+  });
+  await repo.upsertSubEntityEvidence(result.subEntityId, "fact", fact.id);
+  for (const fileId of decision.evidence.fileIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "file", fileId);
+  }
+  for (const entityId of decision.evidence.entityIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "entity", entityId);
+  }
+  return { kind: "decision_materialized" };
+}
+
+async function resolveEffectiveAt(
+  deps: MaterializeDeps,
+  fact: IndexedFileFactRow,
+  decision: DecisionInput,
+): Promise<string | null> {
+  const sourceTimes = fact.indexed_file_id ? await deps.getIndexedFileSourceTime(fact.indexed_file_id) : null;
+  const value =
+    decision.decidedAt ?? sourceTimes?.source_updated_at ?? sourceTimes?.source_created_at ?? sourceTimes?.synced_at;
+  if (!value) return null;
+  return new Date(value).toISOString();
+}
+
+interface DecisionInput {
+  decisionId: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  topic: string;
+  statement: string;
+  decidedBy?: string;
+  decidedAt?: string;
+  rationale?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+}
+
+function readDecision(raw: Record<string, unknown>): DecisionInput | null {
+  if (
+    typeof raw.decisionId !== "string" ||
+    typeof raw.topic !== "string" ||
+    typeof raw.statement !== "string" ||
+    !isEvidence(raw.evidence)
+  ) {
+    return null;
+  }
+  return {
+    decisionId: raw.decisionId,
+    parentRef: readParentRef(raw.parentRef),
+    parentEntityId: readOptionalString(raw.parentEntityId),
+    topic: raw.topic,
+    statement: raw.statement,
+    decidedBy: readOptionalString(raw.decidedBy),
+    decidedAt: readOptionalString(raw.decidedAt),
+    rationale: readOptionalString(raw.rationale),
+    evidence: { fileIds: raw.evidence.fileIds, entityIds: raw.evidence.entityIds },
+  };
+}
+
+function readParentRef(value: unknown): { source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || typeof record.sourceId !== "string") return undefined;
+  return { source: record.source, sourceId: record.sourceId };
+}
+
+function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.fileIds) &&
+    record.fileIds.every((id) => typeof id === "string") &&
+    Array.isArray(record.entityIds) &&
+    record.entityIds.every((id) => typeof id === "string")
+  );
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -340,6 +340,13 @@ export async function buildMaterializeDeps(
     experimentalFlag,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),
     onEntityResolved: (entity: Entity) => refreshResolvedEntityIndex(db, index, entity),
+    getIndexedFileSourceTime: (indexedFileId: string) =>
+      db
+        .selectFrom("indexed_files")
+        .select(["source_created_at", "source_updated_at", "synced_at"])
+        .where("id", "=", indexedFileId)
+        .executeTakeFirst()
+        .then((row) => row ?? null),
     resolveOwner: (fact: IndexedFileFactRow) => {
       if (fact.created_by_user_id) return fact.created_by_user_id;
       const indexedFileId = fact.indexed_file_id;

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -5,6 +5,7 @@ import type { DB } from "../db/schema";
 import { yieldToEventLoop } from "../lib/event-loop";
 import { materializeCommitment } from "./materialize-commitment";
 import { materializeContactPointFact } from "./materialize-contact-points";
+import { materializeDecision } from "./materialize-decision";
 import { buildMaterializeDeps } from "./materialize-deps";
 import { readJsonObject } from "./materialize-json";
 import { materializeLlmExtractedFact } from "./materialize-llm-mentions";
@@ -38,6 +39,7 @@ const FACT_REPLAY_ORDER = [
   "llm_relation",
   "structural_task",
   "commitment",
+  "decision",
   "llm_task",
 ] as const;
 
@@ -81,6 +83,9 @@ export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFi
   if (fact.fact_type === "commitment") {
     return materializeCommitment(deps, fact);
   }
+  if (fact.fact_type === "decision") {
+    return materializeDecision(deps, fact);
+  }
   if (fact.fact_type === "llm_task") {
     return materializeLlmTask(deps, fact);
   }
@@ -118,6 +123,10 @@ function accumulate(summary: ReplayFactsSummary, result: MaterializeResult): voi
     return;
   }
   if (result.kind === "commitment_materialized") {
+    if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
+    return;
+  }
+  if (result.kind === "decision_materialized") {
     if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
     return;
   }
@@ -256,7 +265,12 @@ async function materializeUnmaterializedFactsInner(
           .set({ materialized_at: new Date().toISOString() })
           .where("id", "=", fact.id)
           .execute();
-        if (result.kind !== "task_materialized" && result.kind !== "commitment_materialized") summary.materialized++;
+        if (
+          result.kind !== "task_materialized" &&
+          result.kind !== "commitment_materialized" &&
+          result.kind !== "decision_materialized"
+        )
+          summary.materialized++;
       } else {
         summary.deferred++;
       }
@@ -282,6 +296,7 @@ export function shouldMarkMaterialized(result: MaterializeResult): boolean {
     result.kind === "relationship_materialized" ||
     result.kind === "task_materialized" ||
     result.kind === "commitment_materialized" ||
+    result.kind === "decision_materialized" ||
     result.kind === "structural"
   ) {
     return true;

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -50,6 +50,11 @@ export interface MaterializeDeps {
   readEmail: (entity: Entity) => string | null;
   onEntityResolved: (entity: Entity) => void | Promise<void>;
   resolveOwner: (fact: IndexedFileFactRow) => string | null;
+  getIndexedFileSourceTime: (indexedFileId: string) => Promise<{
+    source_created_at: string | null;
+    source_updated_at: string | null;
+    synced_at: string;
+  } | null>;
   llmPromotionThreshold: number;
   llmTaskCorroborationThreshold: number;
   birthGateTypes: Set<ProposeEntityType>;
@@ -71,6 +76,7 @@ export type MaterializeResult =
     }
   | { kind: "task_materialized"; taskId: string; created: boolean }
   | { kind: "commitment_materialized" }
+  | { kind: "decision_materialized" }
   | { kind: "structural"; entity: EntityRow }
   | { kind: "skipped_missing_owner"; reason: string }
   | { kind: "deferred_below_threshold"; reason: string }


### PR DESCRIPTION
Stack position: 7/12
Base: feat/tasks-core
Head: feat/sub-entities
Migrations introduced: 109

Sub-entities commitment status and decision supersession on the entity spine.

Split from superseded entity-spine stack (#260/#261/#262). Verified locally with pnpm typecheck and pnpm build at this branch tip.