### PR TITLE
feat: work cycles and ClickUp sprints

### DIFF
--- a/packages/server/src/connectors/clickup.test.ts
+++ b/packages/server/src/connectors/clickup.test.ts
@@ -5,7 +5,68 @@
  * do not produce an infinite loop.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createClickUpConnector } from "./clickup";
+import { type ClickUpList, type ClickUpSpace, createClickUpConnector, detectSprintCycle } from "./clickup";
+
+const sprintsEnabledSpace: ClickUpSpace = {
+  id: "space-design",
+  name: "Design",
+  features: { sprints: { enabled: true } },
+};
+
+const sprintList: ClickUpList = {
+  id: "901205383311",
+  name: "[Design] Sprint 5 (5/13 - 5/26)",
+  start_date: "1747094400000",
+  due_date: "1748217600000",
+};
+
+describe("detectSprintCycle", () => {
+  it("detects a dated sprint list in a sprint-enabled space", () => {
+    const cycle = detectSprintCycle(sprintList, sprintsEnabledSpace, { id: "folder-design", name: "Design" });
+
+    expect(cycle).toEqual({
+      source: "clickup",
+      externalRef: sprintList.id,
+      name: sprintList.name,
+      scopeRef: { source: "clickup", sourceId: "folder-design" },
+      startsAt: "2025-05-13T00:00:00.000Z",
+      endsAt: "2025-05-26T00:00:00.000Z",
+      sequence: 5,
+      isSprint: true,
+    });
+  });
+
+  it("rejects lists when the space sprint feature or sprint name gate fails", () => {
+    expect(
+      detectSprintCycle(sprintList, {
+        ...sprintsEnabledSpace,
+        features: { sprints: { enabled: false } },
+      }),
+    ).toBeNull();
+    expect(
+      detectSprintCycle(
+        {
+          ...sprintList,
+          id: "901205383312",
+          name: "QA EPIC",
+        },
+        sprintsEnabledSpace,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects excluded, undated, and malformed-date sprint-like lists", () => {
+    for (const list of [
+      { ...sprintList, id: "901205383313", name: "QA Sprint Backlog" },
+      { ...sprintList, id: "901205383314", name: "Old Sprint Archive" },
+      { id: "901205383315", name: "Delight Sprint", start_date: null, due_date: null },
+      { ...sprintList, id: "901205383316", name: "Sprint 6", start_date: "0" },
+      { ...sprintList, id: "901205383317", name: "Sprint 7", due_date: "123abc" },
+    ]) {
+      expect(detectSprintCycle(list, sprintsEnabledSpace)).toBeNull();
+    }
+  });
+});
 
 describe("ClickUp 429 retry bounded", () => {
   const token = "test-api-key";

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -211,6 +211,23 @@ function contentHash(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+type SyncedTaskCycle = NonNullable<NonNullable<SyncedItem["task"]>["cycle"]>;
+
+/**
+ * Threads ClickUp list/folder/space context for WORK_STRUCTURES PR-S part 1.
+ * Sprint metadata fetch and auto-detection are deferred until the follow-on plan
+ * verifies the required ClickUp auth scope.
+ */
+function taskCycleContext(task: ClickUpTask, folderId: string | undefined, spaceId: string): SyncedTaskCycle {
+  return {
+    source: "clickup",
+    externalRef: task.list.id,
+    name: task.list.name,
+    scopeRef: { source: "clickup", sourceId: folderId ?? spaceId },
+    isSprint: false,
+  };
+}
+
 function taskToSyncedItem(
   task: ClickUpTask,
   workspaceName: string,
@@ -297,6 +314,7 @@ function taskToSyncedItem(
             sourceId: `assignee:${primaryAssignee.username}`,
           }
         : undefined,
+      cycle: taskCycleContext(task, folderId, spaceId),
     },
     authorEmail: task.creator?.email,
     authorName: task.creator?.username,

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -52,11 +52,12 @@ interface ClickUpMember {
   user: { id: number; username: string; email?: string };
 }
 
-interface ClickUpSpace {
+export interface ClickUpSpace {
   id: string;
   name: string;
   private?: boolean;
   members?: ClickUpMember[];
+  features?: { sprints?: { enabled?: boolean } };
 }
 
 interface ClickUpFolder {
@@ -64,10 +65,12 @@ interface ClickUpFolder {
   name: string;
 }
 
-interface ClickUpList {
+export interface ClickUpList {
   id: string;
   name: string;
   task_count?: number;
+  start_date?: string | null;
+  due_date?: string | null;
 }
 
 interface ClickUpDoc {
@@ -214,18 +217,41 @@ function contentHash(content: string): string {
 type SyncedTaskCycle = NonNullable<NonNullable<SyncedItem["task"]>["cycle"]>;
 
 /**
- * Threads ClickUp list/folder/space context for WORK_STRUCTURES PR-S part 1.
- * Sprint metadata fetch and auto-detection are deferred until the follow-on plan
- * verifies the required ClickUp auth scope.
+ * Detects ClickUp sprints structurally because lists and folders do not expose
+ * a dedicated sprint flag. A list is treated as a sprint only when the space has
+ * sprints enabled, the list name contains sprint without backlog/archive/template
+ * wording, and both list dates are positive epoch strings. Undated sprint lists
+ * are intentionally not detected until list-level metadata support is expanded.
  */
-function taskCycleContext(task: ClickUpTask, folderId: string | undefined, spaceId: string): SyncedTaskCycle {
+export function detectSprintCycle(
+  list: ClickUpList,
+  space: ClickUpSpace,
+  folder?: { id: string; name: string },
+): SyncedTaskCycle | null {
+  if (space.features?.sprints?.enabled !== true) return null;
+  if (!/\bsprint\b/i.test(list.name)) return null;
+  if (/\b(backlog|archive|template)\b/i.test(list.name)) return null;
+  if (!isPositiveDigitString(list.start_date) || !isPositiveDigitString(list.due_date)) return null;
+  const startsAt = parseClickUpTimestamp(list.start_date);
+  const endsAt = parseClickUpTimestamp(list.due_date);
+  if (!startsAt || !endsAt) return null;
+  const sequenceMatch = /\bsprint\s*#?\s*(\d+)/i.exec(list.name);
   return {
     source: "clickup",
-    externalRef: task.list.id,
-    name: task.list.name,
-    scopeRef: { source: "clickup", sourceId: folderId ?? spaceId },
-    isSprint: false,
+    externalRef: list.id,
+    name: list.name,
+    scopeRef: { source: "clickup", sourceId: folder ? folder.id : space.id },
+    startsAt,
+    endsAt,
+    sequence: sequenceMatch ? Number(sequenceMatch[1]) : undefined,
+    isSprint: true,
   };
+}
+
+function isPositiveDigitString(value: string | null | undefined): value is string {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) return false;
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0;
 }
 
 function taskToSyncedItem(
@@ -238,6 +264,7 @@ function taskToSyncedItem(
   folderId: string | undefined,
   listProjectParent: { id: string; name: string } | undefined,
   accessScope?: SyncedItem["accessScope"],
+  cycle?: SyncedTaskCycle,
 ): SyncedItem {
   const hasDescription = task.description && task.description.trim().length > 0;
 
@@ -281,6 +308,25 @@ function taskToSyncedItem(
         ? { name: listProjectParent.name, source: "clickup", sourceId: listProjectParent.id }
         : undefined;
   const primaryAssignee = task.assignees.find((assignee) => assignee.username);
+  const syncedTask: NonNullable<SyncedItem["task"]> = {
+    sourceTaskId: task.id,
+    externalRef: task.id,
+    title: task.name,
+    statusType: task.status.type,
+    statusRaw: task.status.status,
+    priority: task.priority?.priority,
+    dueAt: parseClickUpTimestamp(task.due_date) ?? undefined,
+    project: taskProject,
+    assignee: primaryAssignee
+      ? {
+          name: primaryAssignee.username,
+          email: primaryAssignee.email,
+          source: "clickup",
+          sourceId: `assignee:${primaryAssignee.username}`,
+        }
+      : undefined,
+    ...(cycle ? { cycle } : {}),
+  };
 
   return {
     providerFileId: task.id,
@@ -297,25 +343,7 @@ function taskToSyncedItem(
     assignees: task.assignees
       .filter((a) => a.username)
       .map((a) => ({ name: a.username, email: a.email, source: "clickup", sourceId: `assignee:${a.username}` })),
-    task: {
-      sourceTaskId: task.id,
-      externalRef: task.id,
-      title: task.name,
-      statusType: task.status.type,
-      statusRaw: task.status.status,
-      priority: task.priority?.priority,
-      dueAt: parseClickUpTimestamp(task.due_date) ?? undefined,
-      project: taskProject,
-      assignee: primaryAssignee
-        ? {
-            name: primaryAssignee.username,
-            email: primaryAssignee.email,
-            source: "clickup",
-            sourceId: `assignee:${primaryAssignee.username}`,
-          }
-        : undefined,
-      cycle: taskCycleContext(task, folderId, spaceId),
-    },
+    task: syncedTask,
     authorEmail: task.creator?.email,
     authorName: task.creator?.username,
     authorSourceId: task.creator?.id === undefined ? undefined : `user:${String(task.creator.id)}`,
@@ -559,6 +587,7 @@ export function createClickUpConnector(): Connector {
               );
             }
             for (const list of listsRes.lists) {
+              const cycle = detectSprintCycle(list, space, { id: folder.id, name: folder.name });
               yield* fetchTasksFromList(
                 list.id,
                 workspaceName,
@@ -573,6 +602,7 @@ export function createClickUpConnector(): Connector {
                 spaceScope,
                 seenAssignees,
                 sinceMs,
+                cycle ?? undefined,
               );
             }
           }
@@ -592,6 +622,7 @@ export function createClickUpConnector(): Connector {
                 }),
               );
             }
+            const cycle = detectSprintCycle(list, space, undefined);
             yield* fetchTasksFromList(
               list.id,
               workspaceName,
@@ -606,6 +637,7 @@ export function createClickUpConnector(): Connector {
               spaceScope,
               seenAssignees,
               sinceMs,
+              cycle ?? undefined,
             );
           }
         }
@@ -669,6 +701,7 @@ async function* fetchTasksFromList(
   accessScope?: SyncedItem["accessScope"],
   seenAssignees?: Map<string, { username: string; email?: string }>,
   sinceMs?: number,
+  cycle?: SyncedTaskCycle,
 ): AsyncGenerator<SyncedItem> {
   try {
     let url = `/list/${listId}/task?include_subtasks=true&subtasks=true&include_closed=true`;
@@ -696,6 +729,7 @@ async function* fetchTasksFromList(
         folderId,
         listProjectParent,
         accessScope,
+        cycle,
       );
     }
   } catch (err) {

--- a/packages/server/src/connectors/post-sync.isolated.test.ts
+++ b/packages/server/src/connectors/post-sync.isolated.test.ts
@@ -1,4 +1,8 @@
+import type { Kysely } from "kysely";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTaskRepository } from "../db/repositories/tasks";
+import { assignMembership, upsertWorkCycle } from "../db/repositories/work-cycles";
+import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
 import { floorRetryForDomains } from "./engagement-floor";
 import { runPostSyncGraphPipeline } from "./post-sync";
@@ -85,4 +89,176 @@ describe("runPostSyncGraphPipeline", () => {
       await db.destroy();
     }
   });
+
+  it("runs work cycle reconcile only for full reconciled runs", async () => {
+    const db = await createTestDb();
+    const logger = createTestLogger();
+
+    try {
+      await seedConnector(db, "connector-a");
+      const task = await seedTask(db, "task-a");
+      const cycle = await upsertWorkCycle(db, {
+        connectorConfigId: "connector-a",
+        source: "clickup",
+        externalRef: "sprint-a",
+        name: "Sprint A",
+        lastSeenSyncRunId: "sync-old",
+      });
+      await assignMembership(db, {
+        taskId: task.taskId,
+        cycleId: cycle.cycleId,
+        sourceFactId: null,
+        at: "2026-06-01T00:00:00.000Z",
+      });
+
+      await runPostSyncGraphPipeline({
+        db,
+        syncLogger: logger,
+        affectedIndexedFileIds: [],
+        connectorConfigId: "connector-a",
+        syncRunId: "sync-new",
+        experimentalFlag: true,
+        runCycleReconcile: false,
+      });
+      await expect(loadCycle(db, cycle.cycleId)).resolves.toMatchObject({ state: "active", deleted_at: null });
+      await expect(openMemberships(db, cycle.cycleId)).resolves.toBe(1);
+
+      await runPostSyncGraphPipeline({
+        db,
+        syncLogger: logger,
+        affectedIndexedFileIds: [],
+        connectorConfigId: "connector-a",
+        syncRunId: "sync-new",
+        experimentalFlag: true,
+        runCycleReconcile: true,
+      });
+      await expect(loadCycle(db, cycle.cycleId)).resolves.toMatchObject({
+        state: "closed",
+        deleted_at: expect.any(String),
+      });
+      await expect(openMemberships(db, cycle.cycleId)).resolves.toBe(0);
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("does not close pre-existing cycles when the experimental flag is off", async () => {
+    const db = await createTestDb();
+    const logger = createTestLogger();
+
+    try {
+      await seedConnector(db, "connector-a");
+      const cycle = await upsertWorkCycle(db, {
+        connectorConfigId: "connector-a",
+        source: "clickup",
+        externalRef: "sprint-flag-off",
+        name: "Sprint Flag Off",
+        lastSeenSyncRunId: "sync-old",
+      });
+
+      await runPostSyncGraphPipeline({
+        db,
+        syncLogger: logger,
+        affectedIndexedFileIds: [],
+        connectorConfigId: "connector-a",
+        syncRunId: "sync-new",
+        experimentalFlag: false,
+        runCycleReconcile: true,
+      });
+
+      await expect(loadCycle(db, cycle.cycleId)).resolves.toMatchObject({ state: "active", deleted_at: null });
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("scopes work cycle reconcile to the syncing connector config", async () => {
+    const db = await createTestDb();
+    const logger = createTestLogger();
+
+    try {
+      await seedConnector(db, "connector-a");
+      await seedConnector(db, "connector-b");
+      const cycleA = await upsertWorkCycle(db, {
+        connectorConfigId: "connector-a",
+        source: "clickup",
+        externalRef: "sprint-a",
+        name: "Sprint A",
+        lastSeenSyncRunId: "sync-old",
+      });
+      const cycleB = await upsertWorkCycle(db, {
+        connectorConfigId: "connector-b",
+        source: "clickup",
+        externalRef: "sprint-b",
+        name: "Sprint B",
+        lastSeenSyncRunId: "sync-old",
+      });
+
+      await runPostSyncGraphPipeline({
+        db,
+        syncLogger: logger,
+        affectedIndexedFileIds: [],
+        connectorConfigId: "connector-a",
+        syncRunId: "sync-new",
+        experimentalFlag: true,
+        runCycleReconcile: true,
+      });
+
+      await expect(loadCycle(db, cycleA.cycleId)).resolves.toMatchObject({ state: "closed" });
+      await expect(loadCycle(db, cycleB.cycleId)).resolves.toMatchObject({ state: "active", deleted_at: null });
+    } finally {
+      await db.destroy();
+    }
+  });
 });
+
+async function seedConnector(db: Kysely<DB>, connectorConfigId: string): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: `${connectorConfigId}-user`, name: connectorConfigId, email: `${connectorConfigId}@example.com` })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: connectorConfigId,
+      connector_type: "clickup",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: `${connectorConfigId}-user`,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedTask(db: Kysely<DB>, sourceTaskId: string): Promise<{ taskId: string; created: boolean }> {
+  return createTaskRepository(db).upsertTask({
+    parentEntityId: null,
+    parentSourceRef: null,
+    parentName: null,
+    source: "clickup",
+    externalRef: sourceTaskId,
+    title: sourceTaskId,
+    status: "open",
+    statusRaw: "open",
+    statusAuthority: "external",
+    assigneeEntityId: null,
+    priority: null,
+    dueAt: null,
+    provenance: "structural",
+    sourceTaskId,
+  });
+}
+
+async function loadCycle(db: Kysely<DB>, cycleId: string) {
+  return db.selectFrom("work_cycles").selectAll().where("id", "=", cycleId).executeTakeFirstOrThrow();
+}
+
+async function openMemberships(db: Kysely<DB>, cycleId: string): Promise<number> {
+  const row = await db
+    .selectFrom("task_cycle_memberships")
+    .select((eb) => eb.fn.countAll().as("count"))
+    .where("cycle_id", "=", cycleId)
+    .where("removed_at", "is", null)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}

--- a/packages/server/src/connectors/post-sync.ts
+++ b/packages/server/src/connectors/post-sync.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
 import { createTaskRepository } from "../db/repositories/tasks";
+import { reconcileWorkCycles } from "../db/repositories/work-cycles";
 import type { DB } from "../db/schema";
 import { sweepCoMentionContributesTo } from "../entities/co-mention-sweep";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
@@ -14,6 +15,10 @@ export interface PostSyncGraphPipelineParams {
   coMentionContributesToThreshold?: number;
   floorRetryMaxFilesPerDomain?: number;
   source?: string;
+  syncRunId?: string;
+  connectorConfigId?: string;
+  experimentalFlag?: boolean;
+  runCycleReconcile?: boolean;
 }
 
 export async function runPostSyncGraphPipeline({
@@ -23,6 +28,10 @@ export async function runPostSyncGraphPipeline({
   coMentionContributesToThreshold,
   floorRetryMaxFilesPerDomain,
   source,
+  syncRunId,
+  connectorConfigId,
+  experimentalFlag,
+  runCycleReconcile,
 }: PostSyncGraphPipelineParams): Promise<void> {
   const materializeSummary = await materializeUnmaterializedFacts(db, syncLogger);
   if (materializeSummary.factsRead > 0) {
@@ -33,6 +42,16 @@ export async function runPostSyncGraphPipeline({
   const expiredTasks = await taskRepo.expireOrphanedTasks(source);
   if (reanchoredTasks > 0 || expiredTasks > 0) {
     syncLogger.info({ reanchoredTasks, expiredTasks }, "Post-sync task sweep complete");
+  }
+  if (experimentalFlag && runCycleReconcile && connectorConfigId && syncRunId) {
+    const closedWorkCycles = await reconcileWorkCycles(db, {
+      connectorConfigId,
+      syncRunId,
+      at: new Date().toISOString(),
+    });
+    if (closedWorkCycles > 0) {
+      syncLogger.info({ closedWorkCycles }, "Post-sync work cycle reconcile complete");
+    }
   }
 
   const domainSweep = await sweepDomainPromotions(db, syncLogger.child({ component: "domain-sweep" }));

--- a/packages/server/src/connectors/sync-reconcile.test.ts
+++ b/packages/server/src/connectors/sync-reconcile.test.ts
@@ -1,0 +1,67 @@
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import type { DB } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { reconcileConnectorSync } from "./sync-reconcile";
+
+type FactRepo = ReturnType<typeof createIndexedFileFactRepository>;
+
+describe("reconcileConnectorSync", () => {
+  let db: Kysely<DB> | undefined;
+
+  afterEach(async () => {
+    await db?.destroy();
+    db = undefined;
+  });
+
+  it("reports reconciled true on the normal path", async () => {
+    db = await createTestDb();
+    const factRepo = {
+      reconcileStaleFacts: vi.fn().mockResolvedValue({
+        skipped: null,
+        tombstonedFactIds: [],
+        affectedIndexedFileIds: [],
+      }),
+      clearMaterializedAtForActiveFacts: vi.fn(),
+    } as unknown as FactRepo;
+
+    const result = await reconcileConnectorSync({
+      db,
+      factRepo,
+      connectorConfigId: "connector-normal",
+      connectorType: "google_drive",
+      syncRunId: "sync-1",
+      seenSyncIdentityKeys: new Set(["file:seen"]),
+      logger: createTestLogger(),
+    });
+
+    expect(result).toMatchObject({ reconciled: true, itemsArchived: 0, affectedIndexedFileIds: [] });
+  });
+
+  it("reports reconciled false when the large-delta guard skips", async () => {
+    db = await createTestDb();
+    const factRepo = {
+      reconcileStaleFacts: vi.fn().mockResolvedValue({
+        skipped: { ratio: 0.95, threshold: 0.5 },
+        activeBefore: 100,
+        wouldTombstone: 95,
+        tombstonedFactIds: [],
+        affectedIndexedFileIds: [],
+      }),
+      clearMaterializedAtForActiveFacts: vi.fn(),
+    } as unknown as FactRepo;
+
+    const result = await reconcileConnectorSync({
+      db,
+      factRepo,
+      connectorConfigId: "connector-skip",
+      connectorType: "google_drive",
+      syncRunId: "sync-1",
+      seenSyncIdentityKeys: new Set(["file:seen"]),
+      logger: createTestLogger(),
+    });
+
+    expect(result).toMatchObject({ reconciled: false, itemsArchived: 0, affectedIndexedFileIds: [] });
+  });
+});

--- a/packages/server/src/connectors/sync-reconcile.ts
+++ b/packages/server/src/connectors/sync-reconcile.ts
@@ -48,7 +48,11 @@ export async function reconcileConnectorSync({
   maxReconcileRatio,
   encryptionKey,
   logger,
-}: ReconcileConnectorSyncParams): Promise<{ itemsArchived: number; affectedIndexedFileIds: string[] }> {
+}: ReconcileConnectorSyncParams): Promise<{
+  itemsArchived: number;
+  affectedIndexedFileIds: string[];
+  reconciled: boolean;
+}> {
   const repo = createConnectorRepository(db, encryptionKey);
   const entityRepo = createEntityRepository(db);
   const reconcileResult = await factRepo.reconcileStaleFacts(
@@ -72,7 +76,7 @@ export async function reconcileConnectorSync({
       },
       "Stale-fact reconcile skipped: delta exceeds threshold",
     );
-    return { itemsArchived: 0, affectedIndexedFileIds: [] };
+    return { itemsArchived: 0, affectedIndexedFileIds: [], reconciled: false };
   }
 
   const itemsArchived = await repo.archiveStaleFiles(connectorConfigId, seenSyncIdentityKeys);
@@ -88,7 +92,7 @@ export async function reconcileConnectorSync({
     await factRepo.clearMaterializedAtForActiveFacts(reconcileResult.affectedIndexedFileIds);
   }
 
-  return { itemsArchived, affectedIndexedFileIds: reconcileResult.affectedIndexedFileIds };
+  return { itemsArchived, affectedIndexedFileIds: reconcileResult.affectedIndexedFileIds, reconciled: true };
 }
 
 export async function removeConnectorSourceItems({

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -221,6 +221,7 @@ export async function runConnectorSync(
     const seenSyncIdentityKeys = new Set<string>();
     const affectedIndexedFileIds = new Set<string>();
     const dirtyCrmRollupGroupIds = new Set<string>();
+    let syncReconciled = false;
 
     const connectorType = config.connector_type as ConnectorType;
     const existingHashes = await loadExistingContentHashes(db, connectorType, config.id);
@@ -374,6 +375,7 @@ export async function runConnectorSync(
         encryptionKey: appConfig?.ENCRYPTION_KEY,
         logger: syncLogger,
       });
+      syncReconciled = reconcileResult.reconciled;
       result.itemsArchived = reconcileResult.itemsArchived;
       for (const indexedFileId of reconcileResult.affectedIndexedFileIds) affectedIndexedFileIds.add(indexedFileId);
     }
@@ -385,6 +387,10 @@ export async function runConnectorSync(
       coMentionContributesToThreshold: appConfig?.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
       floorRetryMaxFilesPerDomain: appConfig?.FLOOR_RETRY_MAX_FILES_PER_DOMAIN,
       source: connectorType,
+      syncRunId,
+      connectorConfigId: config.id,
+      experimentalFlag: appConfig?.EXPERIMENTAL_FLAG ?? false,
+      runCycleReconcile: syncReconciled,
     });
 
     if (connectorType === "zoho_crm") {

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -115,6 +115,16 @@ export interface SyncedItem {
     dueAt?: string;
     project?: { name: string; source: string; sourceId: string };
     assignee?: { name: string; email?: string; source?: string; sourceId?: string };
+    cycle?: {
+      source: string;
+      externalRef: string;
+      name: string;
+      scopeRef?: { source: string; sourceId: string };
+      startsAt?: string;
+      endsAt?: string;
+      sequence?: number;
+      isSprint: boolean;
+    };
   };
   commitments?: CommitmentSeed[];
   decisions?: DecisionSeed[];

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -111,6 +111,7 @@ import * as m108 from "./migrations/108-tasks-owner";
 import * as m109 from "./migrations/109-sub-entities";
 import * as m110 from "./migrations/110-tasks-assignee-name";
 import * as m111 from "./migrations/111-milestone-series-and-value-signature";
+import * as m112 from "./migrations/112-work-cycles";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -226,6 +227,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "109-sub-entities": m109,
           "110-tasks-assignee-name": m110,
           "111-milestone-series-and-value-signature": m111,
+          "112-work-cycles": m112,
         };
       },
     },

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -112,6 +112,7 @@ import * as m109 from "./migrations/109-sub-entities";
 import * as m110 from "./migrations/110-tasks-assignee-name";
 import * as m111 from "./migrations/111-milestone-series-and-value-signature";
 import * as m112 from "./migrations/112-work-cycles";
+import * as m113 from "./migrations/113-work-cycles-connector";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -228,6 +229,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "110-tasks-assignee-name": m110,
           "111-milestone-series-and-value-signature": m111,
           "112-work-cycles": m112,
+          "113-work-cycles-connector": m113,
         };
       },
     },

--- a/packages/server/src/db/migrations/112-work-cycles.ts
+++ b/packages/server/src/db/migrations/112-work-cycles.ts
@@ -1,0 +1,64 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("work_cycles")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("scope_entity_id", "text", (col) => col.references("entities.id").onDelete("set null"))
+    .addColumn("source", "text", (col) => col.notNull())
+    .addColumn("external_ref", "text", (col) => col.notNull())
+    .addColumn("name", "text", (col) => col.notNull())
+    .addColumn("sequence", "integer")
+    .addColumn("starts_at", "text")
+    .addColumn("ends_at", "text")
+    .addColumn("state", "text", (col) => col.notNull().defaultTo("planned"))
+    .addColumn("last_seen_sync_run_id", "text")
+    .addColumn("deleted_at", "text")
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createTable("task_cycle_memberships")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("task_id", "text", (col) => col.notNull().references("tasks.id").onDelete("cascade"))
+    .addColumn("cycle_id", "text", (col) => col.notNull().references("work_cycles.id").onDelete("cascade"))
+    .addColumn("assigned_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("removed_at", "text")
+    .addColumn("source_fact_id", "text", (col) => col.references("indexed_file_facts.id").onDelete("set null"))
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createIndex("idx_work_cycles_source_ref")
+    .unique()
+    .on("work_cycles")
+    .columns(["source", "external_ref"])
+    .execute();
+  await db.schema.createIndex("idx_work_cycles_last_seen").on("work_cycles").column("last_seen_sync_run_id").execute();
+  await sql`
+    CREATE UNIQUE INDEX idx_task_cycle_current
+    ON task_cycle_memberships(task_id)
+    WHERE removed_at IS NULL
+  `.execute(db);
+  await db.schema
+    .createIndex("idx_task_cycle_memberships_cycle")
+    .on("task_cycle_memberships")
+    .column("cycle_id")
+    .execute();
+  await db.schema
+    .createIndex("idx_task_cycle_memberships_task")
+    .on("task_cycle_memberships")
+    .column("task_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_task_cycle_memberships_task").ifExists().execute();
+  await db.schema.dropIndex("idx_task_cycle_memberships_cycle").ifExists().execute();
+  await sql`DROP INDEX IF EXISTS idx_task_cycle_current`.execute(db);
+  await db.schema.dropIndex("idx_work_cycles_last_seen").ifExists().execute();
+  await db.schema.dropIndex("idx_work_cycles_source_ref").ifExists().execute();
+  await db.schema.dropTable("task_cycle_memberships").execute();
+  await db.schema.dropTable("work_cycles").execute();
+}

--- a/packages/server/src/db/migrations/113-work-cycles-connector.ts
+++ b/packages/server/src/db/migrations/113-work-cycles-connector.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("work_cycles")
+    .addColumn("connector_config_id", "text", (col) => col.references("connector_configs.id").onDelete("cascade"))
+    .execute();
+
+  await db.schema.createIndex("idx_work_cycles_connector").on("work_cycles").column("connector_config_id").execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_work_cycles_connector").ifExists().execute();
+  await db.schema.alterTable("work_cycles").dropColumn("connector_config_id").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 108;
+const EXPECTED_MIGRATION_COUNT = 109;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -141,6 +141,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[105]).toBe("110-tasks-assignee-name");
     expect(names[106]).toBe("111-milestone-series-and-value-signature");
     expect(names[107]).toBe("112-work-cycles");
+    expect(names[108]).toBe("113-work-cycles-connector");
   });
 
   it("creates the task assignee_name column", async () => {
@@ -268,6 +269,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(cycleColumns.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ column_name: "scope_entity_id", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "connector_config_id", data_type: "text", is_nullable: "YES" }),
         expect.objectContaining({ column_name: "source", data_type: "text", is_nullable: "NO" }),
         expect.objectContaining({ column_name: "external_ref", data_type: "text", is_nullable: "NO" }),
         expect.objectContaining({ column_name: "name", data_type: "text", is_nullable: "NO" }),
@@ -310,6 +312,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(sourceRefIndex?.indexdef).toContain("source");
     expect(sourceRefIndex?.indexdef).toContain("external_ref");
     expect(cycleIndexes.rows.map((row) => row.indexname)).toContain("idx_work_cycles_last_seen");
+    expect(cycleIndexes.rows.map((row) => row.indexname)).toContain("idx_work_cycles_connector");
 
     const cycleForeignKeys = await sql<{
       column_name: string;
@@ -339,6 +342,12 @@ describe("runMigrations on Postgres — full sequence", () => {
           foreign_table_name: "entities",
           foreign_column_name: "id",
           delete_rule: "SET NULL",
+        }),
+        expect.objectContaining({
+          column_name: "connector_config_id",
+          foreign_table_name: "connector_configs",
+          foreign_column_name: "id",
+          delete_rule: "CASCADE",
         }),
       ]),
     );

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 107;
+const EXPECTED_MIGRATION_COUNT = 108;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -140,6 +140,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[104]).toBe("109-sub-entities");
     expect(names[105]).toBe("110-tasks-assignee-name");
     expect(names[106]).toBe("111-milestone-series-and-value-signature");
+    expect(names[107]).toBe("112-work-cycles");
   });
 
   it("creates the task assignee_name column", async () => {
@@ -250,6 +251,155 @@ describe("runMigrations on Postgres — full sequence", () => {
         AND tablename = 'tasks'
     `.execute(db);
     expect(taskIndexes.rows.map((row) => row.indexname)).toContain("idx_tasks_milestone_series_key");
+  });
+
+  it("creates work cycle tables and indexes", async () => {
+    const cycleColumns = await sql<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>`
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'work_cycles'
+    `.execute(db);
+    expect(cycleColumns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ column_name: "scope_entity_id", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "source", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "external_ref", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "name", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "sequence", data_type: "integer", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "state", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "last_seen_sync_run_id", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "deleted_at", data_type: "text", is_nullable: "YES" }),
+      ]),
+    );
+    expect(cycleColumns.rows.find((row) => row.column_name === "state")?.column_default).toContain("'planned'");
+
+    const membershipColumns = await sql<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+    }>`
+      SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'task_cycle_memberships'
+    `.execute(db);
+    expect(membershipColumns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ column_name: "task_id", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "cycle_id", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "assigned_at", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "removed_at", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "source_fact_id", data_type: "text", is_nullable: "YES" }),
+      ]),
+    );
+
+    const cycleIndexes = await sql<{ indexname: string; indexdef: string }>`
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'work_cycles'
+    `.execute(db);
+    const sourceRefIndex = cycleIndexes.rows.find((row) => row.indexname === "idx_work_cycles_source_ref");
+    expect(sourceRefIndex?.indexdef).toContain("UNIQUE INDEX");
+    expect(sourceRefIndex?.indexdef).toContain("source");
+    expect(sourceRefIndex?.indexdef).toContain("external_ref");
+    expect(cycleIndexes.rows.map((row) => row.indexname)).toContain("idx_work_cycles_last_seen");
+
+    const cycleForeignKeys = await sql<{
+      column_name: string;
+      foreign_table_name: string;
+      foreign_column_name: string;
+      delete_rule: string;
+    }>`
+      SELECT kcu.column_name, ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name
+       AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name
+       AND rc.constraint_schema = tc.table_schema
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'work_cycles'
+        AND tc.constraint_type = 'FOREIGN KEY'
+    `.execute(db);
+    expect(cycleForeignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column_name: "scope_entity_id",
+          foreign_table_name: "entities",
+          foreign_column_name: "id",
+          delete_rule: "SET NULL",
+        }),
+      ]),
+    );
+
+    const membershipIndexes = await sql<{ indexname: string; indexdef: string }>`
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'task_cycle_memberships'
+    `.execute(db);
+    const currentIndex = membershipIndexes.rows.find((row) => row.indexname === "idx_task_cycle_current");
+    expect(currentIndex?.indexdef).toContain("UNIQUE INDEX");
+    expect(currentIndex?.indexdef).toContain("task_id");
+    expect(currentIndex?.indexdef).toContain("WHERE (removed_at IS NULL)");
+    expect(membershipIndexes.rows.map((row) => row.indexname)).toEqual(
+      expect.arrayContaining(["idx_task_cycle_memberships_cycle", "idx_task_cycle_memberships_task"]),
+    );
+
+    const foreignKeys = await sql<{
+      column_name: string;
+      foreign_table_name: string;
+      foreign_column_name: string;
+      delete_rule: string;
+    }>`
+      SELECT kcu.column_name, ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name
+       AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name
+       AND rc.constraint_schema = tc.table_schema
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'task_cycle_memberships'
+        AND tc.constraint_type = 'FOREIGN KEY'
+    `.execute(db);
+    expect(foreignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column_name: "task_id",
+          foreign_table_name: "tasks",
+          foreign_column_name: "id",
+          delete_rule: "CASCADE",
+        }),
+        expect.objectContaining({
+          column_name: "cycle_id",
+          foreign_table_name: "work_cycles",
+          foreign_column_name: "id",
+          delete_rule: "CASCADE",
+        }),
+        expect.objectContaining({
+          column_name: "source_fact_id",
+          foreign_table_name: "indexed_file_facts",
+          foreign_column_name: "id",
+          delete_rule: "SET NULL",
+        }),
+      ]),
+    );
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 107;
+const EXPECTED_MIGRATION_COUNT = 108;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -163,6 +163,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[104]).toBe("109-sub-entities");
     expect(names[105]).toBe("110-tasks-assignee-name");
     expect(names[106]).toBe("111-milestone-series-and-value-signature");
+    expect(names[107]).toBe("112-work-cycles");
   });
 
   it("creates the task assignee_name column", async () => {
@@ -240,6 +241,94 @@ describe("runMigrations — full sequence", () => {
 
     const taskIndexes = await sql<{ name: string }>`PRAGMA index_list(tasks)`.execute(db);
     expect(taskIndexes.rows.map((row) => row.name)).toContain("idx_tasks_milestone_series_key");
+  });
+
+  it("creates work cycle tables and indexes", async () => {
+    await runMigrations(db, { quiet: true });
+
+    const cycleColumns = await sql<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>`PRAGMA table_info(work_cycles)`.execute(db);
+    expect(cycleColumns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "scope_entity_id", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "source", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "external_ref", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "name", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "sequence", type: "INTEGER", notnull: 0 }),
+        expect.objectContaining({ name: "state", type: "TEXT", notnull: 1, dflt_value: "'planned'" }),
+        expect.objectContaining({ name: "last_seen_sync_run_id", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "deleted_at", type: "TEXT", notnull: 0 }),
+      ]),
+    );
+
+    const membershipColumns = await sql<{
+      name: string;
+      type: string;
+      notnull: number;
+    }>`PRAGMA table_info(task_cycle_memberships)`.execute(db);
+    expect(membershipColumns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "task_id", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "cycle_id", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "assigned_at", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "removed_at", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "source_fact_id", type: "TEXT", notnull: 0 }),
+      ]),
+    );
+
+    const cycleIndexes = await sql<{ name: string; unique: number }>`PRAGMA index_list(work_cycles)`.execute(db);
+    expect(cycleIndexes.rows).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "idx_work_cycles_source_ref", unique: 1 })]),
+    );
+    expect(cycleIndexes.rows.map((row) => row.name)).toContain("idx_work_cycles_last_seen");
+
+    const cycleForeignKeys = await sql<{
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>`PRAGMA foreign_key_list(work_cycles)`.execute(db);
+    expect(cycleForeignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ table: "entities", from: "scope_entity_id", to: "id", on_delete: "SET NULL" }),
+      ]),
+    );
+
+    const membershipIndexes = await sql<{
+      name: string;
+      unique: number;
+      partial: number;
+    }>`PRAGMA index_list(task_cycle_memberships)`.execute(db);
+    expect(membershipIndexes.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "idx_task_cycle_current", unique: 1, partial: 1 }),
+        expect.objectContaining({ name: "idx_task_cycle_memberships_cycle" }),
+        expect.objectContaining({ name: "idx_task_cycle_memberships_task" }),
+      ]),
+    );
+
+    const membershipForeignKeys = await sql<{
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>`PRAGMA foreign_key_list(task_cycle_memberships)`.execute(db);
+    expect(membershipForeignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ table: "tasks", from: "task_id", to: "id", on_delete: "CASCADE" }),
+        expect.objectContaining({ table: "work_cycles", from: "cycle_id", to: "id", on_delete: "CASCADE" }),
+        expect.objectContaining({
+          table: "indexed_file_facts",
+          from: "source_fact_id",
+          to: "id",
+          on_delete: "SET NULL",
+        }),
+      ]),
+    );
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 108;
+const EXPECTED_MIGRATION_COUNT = 109;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -164,6 +164,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[105]).toBe("110-tasks-assignee-name");
     expect(names[106]).toBe("111-milestone-series-and-value-signature");
     expect(names[107]).toBe("112-work-cycles");
+    expect(names[108]).toBe("113-work-cycles-connector");
   });
 
   it("creates the task assignee_name column", async () => {
@@ -255,6 +256,7 @@ describe("runMigrations — full sequence", () => {
     expect(cycleColumns.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "scope_entity_id", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "connector_config_id", type: "TEXT", notnull: 0 }),
         expect.objectContaining({ name: "source", type: "TEXT", notnull: 1 }),
         expect.objectContaining({ name: "external_ref", type: "TEXT", notnull: 1 }),
         expect.objectContaining({ name: "name", type: "TEXT", notnull: 1 }),
@@ -285,6 +287,7 @@ describe("runMigrations — full sequence", () => {
       expect.arrayContaining([expect.objectContaining({ name: "idx_work_cycles_source_ref", unique: 1 })]),
     );
     expect(cycleIndexes.rows.map((row) => row.name)).toContain("idx_work_cycles_last_seen");
+    expect(cycleIndexes.rows.map((row) => row.name)).toContain("idx_work_cycles_connector");
 
     const cycleForeignKeys = await sql<{
       table: string;
@@ -295,6 +298,12 @@ describe("runMigrations — full sequence", () => {
     expect(cycleForeignKeys.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ table: "entities", from: "scope_entity_id", to: "id", on_delete: "SET NULL" }),
+        expect.objectContaining({
+          table: "connector_configs",
+          from: "connector_config_id",
+          to: "id",
+          on_delete: "CASCADE",
+        }),
       ]),
     );
 

--- a/packages/server/src/db/repositories/work-cycles.integration.test.ts
+++ b/packages/server/src/db/repositories/work-cycles.integration.test.ts
@@ -72,6 +72,7 @@ describe("work cycle sink postgres", () => {
       state: "active",
       deleted_at: null,
       last_seen_sync_run_id: "sync-1",
+      connector_config_id: CONNECTOR_ID,
     });
     expect(await tableCount(db, "work_cycles")).toBe(1);
     expect(await openMembershipCount(db, "work-cycle-task-sprint")).toBe(1);
@@ -179,13 +180,16 @@ describe("work cycle sink postgres", () => {
 
   it("reconciles unseen cycles and returns current task rollups", async () => {
     db = await createTestPgDb();
+    await seedBase(db);
     const cycleA = await upsertWorkCycle(db, {
+      connectorConfigId: CONNECTOR_ID,
       source: "linear",
       externalRef: "sprint-rollup-a",
       name: "Sprint 10",
       lastSeenSyncRunId: "sync-1",
     });
     const cycleB = await upsertWorkCycle(db, {
+      connectorConfigId: CONNECTOR_ID,
       source: "linear",
       externalRef: "sprint-rollup-b",
       name: "Sprint 11",
@@ -216,6 +220,7 @@ describe("work cycle sink postgres", () => {
       at: "2026-06-01T00:00:00.000Z",
     });
     await upsertWorkCycle(db, {
+      connectorConfigId: CONNECTOR_ID,
       source: "linear",
       externalRef: "sprint-rollup-a",
       name: "Sprint 10",
@@ -223,7 +228,7 @@ describe("work cycle sink postgres", () => {
     });
 
     const closed = await reconcileWorkCycles(db, {
-      source: "linear",
+      connectorConfigId: CONNECTOR_ID,
       syncRunId: "sync-2",
       at: "2026-06-15T00:00:00.000Z",
     });

--- a/packages/server/src/db/repositories/work-cycles.integration.test.ts
+++ b/packages/server/src/db/repositories/work-cycles.integration.test.ts
@@ -1,0 +1,407 @@
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+import { materializeUnmaterializedFacts } from "../../entities/materialize";
+import { createTestLogger, createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createEntityRepository } from "./entities";
+import { createIndexedFileFactRepository } from "./indexed-file-facts";
+import { type TaskStatus, createTaskRepository } from "./tasks";
+import { assignMembership, getCycleRollup, reconcileWorkCycles, upsertWorkCycle } from "./work-cycles";
+
+const USER_ID = "work-cycle-pg-user";
+const CONNECTOR_ID = "work-cycle-pg-config";
+
+describe("work cycle sink postgres", () => {
+  let db: Kysely<DB> | undefined;
+
+  afterEach(async () => {
+    await db?.destroy();
+    db = undefined;
+  });
+
+  it("promotes sprint cycles only when flagged and preserves task materialization for non-sprints", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const scope = await seedProject(db, {
+      id: "work-cycle-scope",
+      name: "Work Cycle Scope",
+      sourceId: "scope-folder",
+    });
+    await seedFile(db, "work-cycle-file-flag");
+
+    await emitStructuralTaskFact(db, {
+      fileId: "work-cycle-file-flag",
+      sourceTaskId: "work-cycle-task-sprint",
+      title: "Finish sprint scope",
+      cycle: {
+        source: "linear",
+        externalRef: "sprint-23",
+        name: "Sprint 23",
+        scopeRef: { source: "linear", sourceId: "scope-folder" },
+        isSprint: true,
+      },
+      syncRunId: "sync-1",
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: false });
+    expect(await tableCount(db, "tasks")).toBe(0);
+    expect(await tableCount(db, "work_cycles")).toBe(0);
+    expect(await tableCount(db, "task_cycle_memberships")).toBe(0);
+
+    await emitStructuralTaskFact(db, {
+      fileId: "work-cycle-file-flag",
+      sourceTaskId: "work-cycle-task-sprint",
+      title: "Finish sprint scope",
+      cycle: {
+        source: "linear",
+        externalRef: "sprint-23",
+        name: "Sprint 23",
+        scopeRef: { source: "linear", sourceId: "scope-folder" },
+        isSprint: true,
+      },
+      syncRunId: "sync-1",
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const cycle = await db.selectFrom("work_cycles").selectAll().executeTakeFirstOrThrow();
+    expect(cycle).toMatchObject({
+      scope_entity_id: scope.id,
+      source: "linear",
+      external_ref: "sprint-23",
+      name: "Sprint 23",
+      sequence: 23,
+      state: "active",
+      deleted_at: null,
+      last_seen_sync_run_id: "sync-1",
+    });
+    expect(await tableCount(db, "work_cycles")).toBe(1);
+    expect(await openMembershipCount(db, "work-cycle-task-sprint")).toBe(1);
+
+    await emitStructuralTaskFact(db, {
+      fileId: "work-cycle-file-flag",
+      sourceTaskId: "work-cycle-task-sprint",
+      title: "Finish sprint scope",
+      cycle: {
+        source: "linear",
+        externalRef: "sprint-23",
+        name: "Sprint 23",
+        scopeRef: { source: "linear", sourceId: "scope-folder" },
+        isSprint: true,
+      },
+      syncRunId: "sync-1",
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    expect(await tableCount(db, "work_cycles")).toBe(1);
+    expect(await openMembershipCount(db, "work-cycle-task-sprint")).toBe(1);
+
+    await seedFile(db, "work-cycle-file-nonsprint");
+    await emitStructuralTaskFact(db, {
+      fileId: "work-cycle-file-nonsprint",
+      sourceTaskId: "work-cycle-task-nonsprint",
+      title: "Stay on ordinary list",
+      cycle: {
+        source: "linear",
+        externalRef: "ordinary-list",
+        name: "Ordinary List",
+        scopeRef: { source: "linear", sourceId: "scope-folder" },
+        isSprint: false,
+      },
+      syncRunId: "sync-1",
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const nonSprintTask = await db
+      .selectFrom("tasks")
+      .select(["title", "source_task_id", "status"])
+      .where("source_task_id", "=", "work-cycle-task-nonsprint")
+      .executeTakeFirstOrThrow();
+    expect(nonSprintTask).toEqual({
+      title: "Stay on ordinary list",
+      source_task_id: "work-cycle-task-nonsprint",
+      status: "open",
+    });
+    expect(await tableCount(db, "work_cycles")).toBe(1);
+    expect(await openMembershipCount(db, "work-cycle-task-nonsprint")).toBe(0);
+  }, 30000);
+
+  it("preserves carryover history and rejects a duplicate open membership", async () => {
+    db = await createTestPgDb();
+    const task = await seedTask(db, { sourceTaskId: "carryover-task", title: "Carry over", status: "open" });
+    const cycleA = await upsertWorkCycle(db, {
+      source: "linear",
+      externalRef: "sprint-a",
+      name: "Sprint 1",
+      lastSeenSyncRunId: "sync-1",
+    });
+    const cycleB = await upsertWorkCycle(db, {
+      source: "linear",
+      externalRef: "sprint-b",
+      name: "Sprint 2",
+      lastSeenSyncRunId: "sync-1",
+    });
+
+    await assignMembership(db, {
+      taskId: task.taskId,
+      cycleId: cycleA.cycleId,
+      sourceFactId: null,
+      at: "2026-06-01T00:00:00.000Z",
+    });
+    await assignMembership(db, {
+      taskId: task.taskId,
+      cycleId: cycleB.cycleId,
+      sourceFactId: null,
+      at: "2026-06-08T00:00:00.000Z",
+    });
+
+    const memberships = await db
+      .selectFrom("task_cycle_memberships")
+      .selectAll()
+      .where("task_id", "=", task.taskId)
+      .orderBy("assigned_at", "asc")
+      .execute();
+    expect(memberships).toHaveLength(2);
+    expect(memberships[0]).toMatchObject({ cycle_id: cycleA.cycleId, removed_at: "2026-06-08T00:00:00.000Z" });
+    expect(memberships[1]).toMatchObject({ cycle_id: cycleB.cycleId, removed_at: null });
+    expect(memberships.filter((row) => row.removed_at === null)).toHaveLength(1);
+
+    await expect(
+      db
+        .insertInto("task_cycle_memberships")
+        .values({
+          id: "raw-duplicate-open-membership",
+          task_id: task.taskId,
+          cycle_id: cycleA.cycleId,
+          assigned_at: "2026-06-09T00:00:00.000Z",
+          removed_at: null,
+          source_fact_id: null,
+        })
+        .execute(),
+    ).rejects.toThrow();
+  }, 30000);
+
+  it("reconciles unseen cycles and returns current task rollups", async () => {
+    db = await createTestPgDb();
+    const cycleA = await upsertWorkCycle(db, {
+      source: "linear",
+      externalRef: "sprint-rollup-a",
+      name: "Sprint 10",
+      lastSeenSyncRunId: "sync-1",
+    });
+    const cycleB = await upsertWorkCycle(db, {
+      source: "linear",
+      externalRef: "sprint-rollup-b",
+      name: "Sprint 11",
+      lastSeenSyncRunId: "sync-1",
+    });
+    const open = await seedTask(db, { sourceTaskId: "rollup-open", title: "Open", status: "open" });
+    const progress = await seedTask(db, {
+      sourceTaskId: "rollup-progress",
+      title: "Progress",
+      status: "in_progress",
+    });
+    const done = await seedTask(db, { sourceTaskId: "rollup-done", title: "Done", status: "done" });
+    const dropped = await seedTask(db, { sourceTaskId: "rollup-dropped", title: "Dropped", status: "dropped" });
+    const closedTask = await seedTask(db, { sourceTaskId: "rollup-closed-cycle", title: "Closed", status: "open" });
+
+    for (const task of [open, progress, done, dropped]) {
+      await assignMembership(db, {
+        taskId: task.taskId,
+        cycleId: cycleA.cycleId,
+        sourceFactId: null,
+        at: "2026-06-01T00:00:00.000Z",
+      });
+    }
+    await assignMembership(db, {
+      taskId: closedTask.taskId,
+      cycleId: cycleB.cycleId,
+      sourceFactId: null,
+      at: "2026-06-01T00:00:00.000Z",
+    });
+    await upsertWorkCycle(db, {
+      source: "linear",
+      externalRef: "sprint-rollup-a",
+      name: "Sprint 10",
+      lastSeenSyncRunId: "sync-2",
+    });
+
+    const closed = await reconcileWorkCycles(db, {
+      source: "linear",
+      syncRunId: "sync-2",
+      at: "2026-06-15T00:00:00.000Z",
+    });
+    expect(closed).toBe(1);
+
+    const rows = await db
+      .selectFrom("work_cycles")
+      .select(["external_ref", "state", "deleted_at"])
+      .orderBy("external_ref", "asc")
+      .execute();
+    expect(rows).toEqual([
+      { external_ref: "sprint-rollup-a", state: "active", deleted_at: null },
+      { external_ref: "sprint-rollup-b", state: "closed", deleted_at: "2026-06-15T00:00:00.000Z" },
+    ]);
+    const bMemberships = await db
+      .selectFrom("task_cycle_memberships")
+      .selectAll()
+      .where("cycle_id", "=", cycleB.cycleId)
+      .execute();
+    expect(bMemberships).toHaveLength(1);
+    expect(bMemberships[0].removed_at).toBe("2026-06-15T00:00:00.000Z");
+    await expect(getCycleRollup(db, cycleA.cycleId)).resolves.toEqual({
+      open: 1,
+      in_progress: 1,
+      done: 1,
+      dropped: 1,
+      total: 4,
+    });
+  }, 30000);
+});
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: USER_ID, name: "Work Cycle PG User", email: "work-cycle-pg-user@example.com" })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedProject(db: Kysely<DB>, input: { id: string; name: string; sourceId: string }) {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await createEntityRepository(db).upsertSourceRef({ entityId: input.id, source: "linear", sourceId: input.sourceId });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
+}
+
+async function seedFile(db: Kysely<DB>, id: string): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      provider_url: null,
+      file_name: id,
+      file_type: "issue",
+      content_category: "structured",
+      content: "Work cycle file",
+      source: "linear",
+      source_path: null,
+      content_hash: `${id}-hash`,
+      source_created_at: "2026-06-01T00:00:00.000Z",
+      source_updated_at: "2026-06-01T00:00:00.000Z",
+      synced_at: "2026-06-01T00:00:00.000Z",
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function emitStructuralTaskFact(
+  db: Kysely<DB>,
+  input: {
+    fileId: string;
+    sourceTaskId: string;
+    title: string;
+    cycle?: {
+      source: string;
+      externalRef: string;
+      name: string;
+      scopeRef?: { source: string; sourceId: string };
+      startsAt?: string;
+      endsAt?: string;
+      sequence?: number;
+      isSprint: boolean;
+    };
+    syncRunId: string;
+  },
+): Promise<void> {
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: input.fileId,
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    lastSeenSyncRunId: input.syncRunId,
+    contentHash: `${input.fileId}-${input.syncRunId}-hash`,
+    source: "linear",
+    factType: "structural_task",
+    relation: "mentioned",
+    subjectName: input.title,
+    subjectSource: "linear",
+    subjectSourceId: input.sourceTaskId,
+    contextSnippet: null,
+    raw: {
+      indexedFileId: input.fileId,
+      task: {
+        sourceTaskId: input.sourceTaskId,
+        externalRef: input.sourceTaskId,
+        title: input.title,
+        statusType: "unstarted",
+        statusRaw: "Unstarted",
+        cycle: input.cycle,
+      },
+    },
+  });
+}
+
+async function seedTask(
+  db: Kysely<DB>,
+  input: { sourceTaskId: string; title: string; status: TaskStatus },
+): Promise<{ taskId: string; created: boolean }> {
+  return createTaskRepository(db).upsertTask({
+    parentEntityId: null,
+    parentSourceRef: null,
+    parentName: null,
+    source: "linear",
+    externalRef: input.sourceTaskId,
+    title: input.title,
+    status: input.status,
+    statusRaw: input.status,
+    statusAuthority: "external",
+    assigneeEntityId: null,
+    priority: null,
+    dueAt: null,
+    provenance: "structural",
+    sourceTaskId: input.sourceTaskId,
+  });
+}
+
+async function tableCount(db: Kysely<DB>, table: "tasks" | "work_cycles" | "task_cycle_memberships"): Promise<number> {
+  const row = await db
+    .selectFrom(table)
+    .select((eb) => eb.fn.countAll().as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function openMembershipCount(db: Kysely<DB>, sourceTaskId: string): Promise<number> {
+  const row = await db
+    .selectFrom("task_cycle_memberships")
+    .innerJoin("tasks", "tasks.id", "task_cycle_memberships.task_id")
+    .select((eb) => eb.fn.countAll().as("count"))
+    .where("tasks.source_task_id", "=", sourceTaskId)
+    .where("task_cycle_memberships.removed_at", "is", null)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}

--- a/packages/server/src/db/repositories/work-cycles.ts
+++ b/packages/server/src/db/repositories/work-cycles.ts
@@ -8,6 +8,7 @@ export type WorkCycleState = "planned" | "active" | "closed";
 
 export interface UpsertWorkCycleInput {
   scopeEntityId?: string | null;
+  connectorConfigId?: string | null;
   source: string;
   externalRef: string;
   name: string;
@@ -26,8 +27,13 @@ export interface AssignMembershipInput {
 }
 
 export interface ReconcileWorkCyclesInput {
-  source: string;
+  connectorConfigId: string;
   syncRunId: string;
+  at: string;
+}
+
+export interface CloseOpenMembershipForTaskInput {
+  taskId: string;
   at: string;
 }
 
@@ -55,6 +61,7 @@ export async function upsertWorkCycle(
   const now = new Date().toISOString();
   const values = {
     scope_entity_id: input.scopeEntityId ?? null,
+    connector_config_id: input.connectorConfigId ?? null,
     name: input.name,
     sequence: input.sequence ?? null,
     starts_at: input.startsAt ?? null,
@@ -111,7 +118,7 @@ export async function reconcileWorkCycles(db: Kysely<DB>, input: ReconcileWorkCy
   const rows = await db
     .selectFrom("work_cycles")
     .select("id")
-    .where("source", "=", input.source)
+    .where("connector_config_id", "=", input.connectorConfigId)
     .where("deleted_at", "is", null)
     .where((eb) => eb.or([eb("last_seen_sync_run_id", "is", null), eb("last_seen_sync_run_id", "!=", input.syncRunId)]))
     .execute();
@@ -137,6 +144,19 @@ export async function reconcileWorkCycles(db: Kysely<DB>, input: ReconcileWorkCy
     await yieldToEventLoop();
   }
   return closed;
+}
+
+export async function closeOpenMembershipForTask(
+  db: Kysely<DB>,
+  input: CloseOpenMembershipForTaskInput,
+): Promise<number> {
+  const result = await db
+    .updateTable("task_cycle_memberships")
+    .set({ removed_at: input.at })
+    .where("task_id", "=", input.taskId)
+    .where("removed_at", "is", null)
+    .executeTakeFirst();
+  return Number(result.numUpdatedRows ?? 0);
 }
 
 export async function getCycleRollup(db: Kysely<DB>, cycleId: string): Promise<CycleRollup> {

--- a/packages/server/src/db/repositories/work-cycles.ts
+++ b/packages/server/src/db/repositories/work-cycles.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely, Selectable, Transaction } from "kysely";
+import { yieldToEventLoop } from "../../lib/event-loop";
+import type { DB, TaskCycleMembershipsTable } from "../schema";
+import { isUniqueConstraintError } from "./sub-entities";
+
+export type WorkCycleState = "planned" | "active" | "closed";
+
+export interface UpsertWorkCycleInput {
+  scopeEntityId?: string | null;
+  source: string;
+  externalRef: string;
+  name: string;
+  sequence?: number | null;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  state?: WorkCycleState;
+  lastSeenSyncRunId?: string | null;
+}
+
+export interface AssignMembershipInput {
+  taskId: string;
+  cycleId: string;
+  sourceFactId?: string | null;
+  at: string;
+}
+
+export interface ReconcileWorkCyclesInput {
+  source: string;
+  syncRunId: string;
+  at: string;
+}
+
+export interface CycleRollup {
+  open: number;
+  in_progress: number;
+  done: number;
+  dropped: number;
+  total: number;
+}
+
+type CurrentMembership = Selectable<TaskCycleMembershipsTable>;
+type WorkCycleDb = Kysely<DB> | Transaction<DB>;
+
+export async function upsertWorkCycle(
+  db: Kysely<DB>,
+  input: UpsertWorkCycleInput,
+): Promise<{ cycleId: string; created: boolean }> {
+  const existing = await db
+    .selectFrom("work_cycles")
+    .selectAll()
+    .where("source", "=", input.source)
+    .where("external_ref", "=", input.externalRef)
+    .executeTakeFirst();
+  const now = new Date().toISOString();
+  const values = {
+    scope_entity_id: input.scopeEntityId ?? null,
+    name: input.name,
+    sequence: input.sequence ?? null,
+    starts_at: input.startsAt ?? null,
+    ends_at: input.endsAt ?? null,
+    state: input.state ?? existing?.state ?? "active",
+    last_seen_sync_run_id: input.lastSeenSyncRunId ?? null,
+    deleted_at: null,
+    updated_at: now,
+  };
+
+  await db
+    .insertInto("work_cycles")
+    .values({
+      id: existing?.id ?? randomUUID(),
+      source: input.source,
+      external_ref: input.externalRef,
+      ...values,
+      state: input.state ?? "active",
+    })
+    .onConflict((oc) =>
+      oc.columns(["source", "external_ref"]).doUpdateSet({
+        ...values,
+      }),
+    )
+    .execute();
+
+  const row = await db
+    .selectFrom("work_cycles")
+    .select("id")
+    .where("source", "=", input.source)
+    .where("external_ref", "=", input.externalRef)
+    .executeTakeFirstOrThrow();
+  return { cycleId: row.id, created: !existing };
+}
+
+/**
+ * Keeps cycle assignment append-only. A concurrent duplicate-open insert is rejected
+ * by the partial unique index, after which the current row is re-read and retried once.
+ */
+export async function assignMembership(
+  db: Kysely<DB>,
+  input: AssignMembershipInput,
+): Promise<{ membershipId: string }> {
+  try {
+    return await assignMembershipInTransaction(db, input);
+  } catch (err) {
+    if (!isUniqueConstraintError(err)) throw err;
+    await selectCurrentMembership(db, input.taskId);
+    return assignMembershipInTransaction(db, input);
+  }
+}
+
+export async function reconcileWorkCycles(db: Kysely<DB>, input: ReconcileWorkCyclesInput): Promise<number> {
+  const rows = await db
+    .selectFrom("work_cycles")
+    .select("id")
+    .where("source", "=", input.source)
+    .where("deleted_at", "is", null)
+    .where((eb) => eb.or([eb("last_seen_sync_run_id", "is", null), eb("last_seen_sync_run_id", "!=", input.syncRunId)]))
+    .execute();
+
+  let closed = 0;
+  for (const row of rows) {
+    await db.transaction().execute(async (trx) => {
+      const result = await trx
+        .updateTable("work_cycles")
+        .set({ state: "closed", deleted_at: input.at, updated_at: input.at })
+        .where("id", "=", row.id)
+        .where("deleted_at", "is", null)
+        .executeTakeFirst();
+      if (Number(result.numUpdatedRows ?? 0) === 0) return;
+      await trx
+        .updateTable("task_cycle_memberships")
+        .set({ removed_at: input.at })
+        .where("cycle_id", "=", row.id)
+        .where("removed_at", "is", null)
+        .execute();
+      closed++;
+    });
+    await yieldToEventLoop();
+  }
+  return closed;
+}
+
+export async function getCycleRollup(db: Kysely<DB>, cycleId: string): Promise<CycleRollup> {
+  const rows = await db
+    .selectFrom("task_cycle_memberships")
+    .innerJoin("tasks", "tasks.id", "task_cycle_memberships.task_id")
+    .select(["tasks.status as status"])
+    .select((eb) => eb.fn.countAll().as("count"))
+    .where("task_cycle_memberships.cycle_id", "=", cycleId)
+    .where("task_cycle_memberships.removed_at", "is", null)
+    .groupBy("tasks.status")
+    .execute();
+
+  const rollup: CycleRollup = { open: 0, in_progress: 0, done: 0, dropped: 0, total: 0 };
+  for (const row of rows) {
+    const count = Number(row.count);
+    if (row.status === "open" || row.status === "in_progress" || row.status === "done" || row.status === "dropped") {
+      rollup[row.status] = count;
+    }
+    rollup.total += count;
+  }
+  return rollup;
+}
+
+async function assignMembershipInTransaction(
+  db: Kysely<DB>,
+  input: AssignMembershipInput,
+): Promise<{ membershipId: string }> {
+  return db.transaction().execute(async (trx) => {
+    const current = await selectCurrentMembership(trx, input.taskId);
+    if (current?.cycle_id === input.cycleId) return { membershipId: current.id };
+
+    if (current) {
+      await trx
+        .updateTable("task_cycle_memberships")
+        .set({ removed_at: input.at })
+        .where("id", "=", current.id)
+        .where("removed_at", "is", null)
+        .execute();
+    }
+
+    const id = randomUUID();
+    await trx
+      .insertInto("task_cycle_memberships")
+      .values({
+        id,
+        task_id: input.taskId,
+        cycle_id: input.cycleId,
+        assigned_at: input.at,
+        removed_at: null,
+        source_fact_id: input.sourceFactId ?? null,
+      })
+      .execute();
+    return { membershipId: id };
+  });
+}
+
+async function selectCurrentMembership(db: WorkCycleDb, taskId: string): Promise<CurrentMembership | undefined> {
+  return db
+    .selectFrom("task_cycle_memberships")
+    .selectAll()
+    .where("task_id", "=", taskId)
+    .where("removed_at", "is", null)
+    .executeTakeFirst();
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -892,6 +892,7 @@ export interface TaskEvidenceTable {
 export interface WorkCyclesTable {
   id: string;
   scope_entity_id: string | null;
+  connector_config_id: string | null;
   source: string;
   external_ref: string;
   name: string;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -889,6 +889,32 @@ export interface TaskEvidenceTable {
   ref_id: string;
 }
 
+export interface WorkCyclesTable {
+  id: string;
+  scope_entity_id: string | null;
+  source: string;
+  external_ref: string;
+  name: string;
+  sequence: number | null;
+  starts_at: string | null;
+  ends_at: string | null;
+  state: string;
+  last_seen_sync_run_id: string | null;
+  deleted_at: string | null;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
+export interface TaskCycleMembershipsTable {
+  id: string;
+  task_id: string;
+  cycle_id: string;
+  assigned_at: Generated<string>;
+  removed_at: string | null;
+  source_fact_id: string | null;
+  created_at: Generated<string>;
+}
+
 export interface SubEntitiesTable {
   id: string;
   parent_entity_id: string | null;
@@ -980,6 +1006,8 @@ export interface DB {
   indexed_file_facts: IndexedFileFactsTable;
   tasks: TasksTable;
   task_evidence: TaskEvidenceTable;
+  work_cycles: WorkCyclesTable;
+  task_cycle_memberships: TaskCycleMembershipsTable;
   sub_entities: SubEntitiesTable;
   sub_entity_evidence: SubEntityEvidenceTable;
   entity_domains: EntityDomainsTable;

--- a/packages/server/src/entities/materialize-task.test.ts
+++ b/packages/server/src/entities/materialize-task.test.ts
@@ -5,6 +5,7 @@ import type { Connector, SyncedItem } from "../connectors/types";
 import { createEntityRepository } from "../db/repositories/entities";
 import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
 import { TEST_ACCOUNT_ENTITY_ID, createTaskRepository } from "../db/repositories/tasks";
+import { getCycleRollup } from "../db/repositories/work-cycles";
 import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
 import {
@@ -119,6 +120,16 @@ async function upsertTaskFact(
     project?: { name: string; source: string; sourceId: string };
     assignee?: { name: string; source?: string; sourceId?: string };
     fileId?: string;
+    cycle?: {
+      source: string;
+      externalRef: string;
+      name: string;
+      scopeRef?: { source: string; sourceId: string };
+      startsAt?: string;
+      endsAt?: string;
+      sequence?: number;
+      isSprint: boolean;
+    };
   },
 ) {
   await createIndexedFileFactRepository(db).upsertFact({
@@ -142,6 +153,7 @@ async function upsertTaskFact(
         statusRaw: input.statusRaw,
         project: input.project,
         assignee: input.assignee,
+        cycle: input.cycle,
       },
     },
   });
@@ -332,5 +344,59 @@ describe("structural task materialization", () => {
     expect(expired).toBe(1);
     expect(expiredRow.valid_to).not.toBeNull();
     expect(visible).toHaveLength(0);
+  });
+
+  it("closes an open sprint membership when a task is observed outside a sprint", async () => {
+    await seedBase(db, "clickup");
+    await seedProject(db, { name: "Delivery Folder", source: "clickup", sourceId: "folder-1" });
+    await upsertTaskFact(db, {
+      source: "clickup",
+      sourceTaskId: "cu-sprint-move",
+      statusType: "custom",
+      statusRaw: "In Progress",
+      title: "Move from sprint",
+      project: { name: "Delivery Folder", source: "clickup", sourceId: "folder-1" },
+      cycle: {
+        source: "clickup",
+        externalRef: "sprint-5",
+        name: "Sprint 5",
+        scopeRef: { source: "clickup", sourceId: "folder-1" },
+        isSprint: true,
+      },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const cycle = await db.selectFrom("work_cycles").selectAll().executeTakeFirstOrThrow();
+    const openBefore = await db
+      .selectFrom("task_cycle_memberships")
+      .selectAll()
+      .where("cycle_id", "=", cycle.id)
+      .where("removed_at", "is", null)
+      .execute();
+    expect(openBefore).toHaveLength(1);
+
+    await upsertTaskFact(db, {
+      source: "clickup",
+      sourceTaskId: "cu-sprint-move",
+      statusType: "custom",
+      statusRaw: "In Progress",
+      title: "Move from sprint",
+      project: { name: "Delivery Folder", source: "clickup", sourceId: "folder-1" },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const memberships = await db
+      .selectFrom("task_cycle_memberships")
+      .selectAll()
+      .where("cycle_id", "=", cycle.id)
+      .execute();
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].removed_at).not.toBeNull();
+    await expect(db.selectFrom("work_cycles").selectAll().executeTakeFirstOrThrow()).resolves.toMatchObject({
+      id: cycle.id,
+      deleted_at: null,
+      state: "active",
+    });
+    await expect(getCycleRollup(db, cycle.id)).resolves.toMatchObject({ total: 0 });
   });
 });

--- a/packages/server/src/entities/materialize-task.ts
+++ b/packages/server/src/entities/materialize-task.ts
@@ -1,6 +1,6 @@
 import { normalizeName } from "../connectors/name-normalize";
 import { TEST_ACCOUNT_ENTITY_ID, type TaskStatus, createTaskRepository } from "../db/repositories/tasks";
-import { assignMembership, upsertWorkCycle } from "../db/repositories/work-cycles";
+import { assignMembership, closeOpenMembershipForTask, upsertWorkCycle } from "../db/repositories/work-cycles";
 import { readJsonObject } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
 
@@ -52,25 +52,31 @@ export async function materializeStructuralTask(
     sourceTaskId: task.sourceTaskId,
   });
   await repo.upsertEvidence(result.taskId, "file", indexedFileId);
-  if (deps.experimentalFlag && task.cycle?.isSprint) {
-    const scopeEntityId = resolveCycleScope(deps, task.cycle.scopeRef)?.id ?? null;
-    const cycle = await upsertWorkCycle(deps.db, {
-      scopeEntityId,
-      source: fact.source,
-      externalRef: task.cycle.externalRef,
-      name: task.cycle.name,
-      sequence: task.cycle.sequence ?? deriveSprintSequence(task.cycle.name),
-      startsAt: task.cycle.startsAt ?? null,
-      endsAt: task.cycle.endsAt ?? null,
-      state: "active",
-      lastSeenSyncRunId: fact.last_seen_sync_run_id,
-    });
-    await assignMembership(deps.db, {
-      taskId: result.taskId,
-      cycleId: cycle.cycleId,
-      sourceFactId: fact.id,
-      at: new Date().toISOString(),
-    });
+  if (deps.experimentalFlag) {
+    const now = new Date().toISOString();
+    if (task.cycle?.isSprint) {
+      const scopeEntityId = resolveCycleScope(deps, task.cycle.scopeRef)?.id ?? null;
+      const cycle = await upsertWorkCycle(deps.db, {
+        scopeEntityId,
+        connectorConfigId: fact.connector_config_id,
+        source: fact.source,
+        externalRef: task.cycle.externalRef,
+        name: task.cycle.name,
+        sequence: task.cycle.sequence ?? deriveSprintSequence(task.cycle.name),
+        startsAt: task.cycle.startsAt ?? null,
+        endsAt: task.cycle.endsAt ?? null,
+        state: "active",
+        lastSeenSyncRunId: fact.last_seen_sync_run_id,
+      });
+      await assignMembership(deps.db, {
+        taskId: result.taskId,
+        cycleId: cycle.cycleId,
+        sourceFactId: fact.id,
+        at: now,
+      });
+    } else {
+      await closeOpenMembershipForTask(deps.db, { taskId: result.taskId, at: now });
+    }
   }
   return { kind: "task_materialized", taskId: result.taskId, created: result.created };
 }

--- a/packages/server/src/entities/materialize-task.ts
+++ b/packages/server/src/entities/materialize-task.ts
@@ -1,5 +1,6 @@
 import { normalizeName } from "../connectors/name-normalize";
 import { TEST_ACCOUNT_ENTITY_ID, type TaskStatus, createTaskRepository } from "../db/repositories/tasks";
+import { assignMembership, upsertWorkCycle } from "../db/repositories/work-cycles";
 import { readJsonObject } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
 
@@ -51,6 +52,26 @@ export async function materializeStructuralTask(
     sourceTaskId: task.sourceTaskId,
   });
   await repo.upsertEvidence(result.taskId, "file", indexedFileId);
+  if (deps.experimentalFlag && task.cycle?.isSprint) {
+    const scopeEntityId = resolveCycleScope(deps, task.cycle.scopeRef)?.id ?? null;
+    const cycle = await upsertWorkCycle(deps.db, {
+      scopeEntityId,
+      source: fact.source,
+      externalRef: task.cycle.externalRef,
+      name: task.cycle.name,
+      sequence: task.cycle.sequence ?? deriveSprintSequence(task.cycle.name),
+      startsAt: task.cycle.startsAt ?? null,
+      endsAt: task.cycle.endsAt ?? null,
+      state: "active",
+      lastSeenSyncRunId: fact.last_seen_sync_run_id,
+    });
+    await assignMembership(deps.db, {
+      taskId: result.taskId,
+      cycleId: cycle.cycleId,
+      sourceFactId: fact.id,
+      at: new Date().toISOString(),
+    });
+  }
   return { kind: "task_materialized", taskId: result.taskId, created: result.created };
 }
 
@@ -82,6 +103,20 @@ function resolveAssignee(
   return matches.find((entity) => entity.source_type === "person" && entity.id !== TEST_ACCOUNT_ENTITY_ID) ?? null;
 }
 
+function resolveCycleScope(
+  deps: MaterializeDeps,
+  scopeRef: { source: string; sourceId: string } | undefined,
+): EntityRow | null {
+  if (!scopeRef) return null;
+  return deps.index.bySourceRef.get(`${scopeRef.source}:${scopeRef.sourceId}`) ?? null;
+}
+
+function deriveSprintSequence(name: string): number | undefined {
+  const match = /\bSprint\s+(\d+)\b/i.exec(name);
+  if (!match) return undefined;
+  return Number(match[1]);
+}
+
 function readTask(value: unknown): {
   sourceTaskId: string;
   externalRef?: string;
@@ -92,6 +127,16 @@ function readTask(value: unknown): {
   dueAt?: string;
   project?: { name: string; source: string; sourceId: string };
   assignee?: { name: string; email?: string; source?: string; sourceId?: string };
+  cycle?: {
+    source: string;
+    externalRef: string;
+    name: string;
+    scopeRef?: { source: string; sourceId: string };
+    startsAt?: string;
+    endsAt?: string;
+    sequence?: number;
+    isSprint: boolean;
+  };
 } | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
@@ -112,6 +157,7 @@ function readTask(value: unknown): {
     dueAt: readOptionalString(record.dueAt),
     project: readProject(record.project),
     assignee: readAssignee(record.assignee),
+    cycle: readCycle(record.cycle),
   };
 }
 
@@ -136,6 +182,47 @@ function readAssignee(
     source: readOptionalString(record.source),
     sourceId: readOptionalString(record.sourceId),
   };
+}
+
+function readCycle(value: unknown):
+  | {
+      source: string;
+      externalRef: string;
+      name: string;
+      scopeRef?: { source: string; sourceId: string };
+      startsAt?: string;
+      endsAt?: string;
+      sequence?: number;
+      isSprint: boolean;
+    }
+  | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.source !== "string" ||
+    typeof record.externalRef !== "string" ||
+    typeof record.name !== "string" ||
+    typeof record.isSprint !== "boolean"
+  ) {
+    return undefined;
+  }
+  return {
+    source: record.source,
+    externalRef: record.externalRef,
+    name: record.name,
+    scopeRef: readScopeRef(record.scopeRef),
+    startsAt: readOptionalString(record.startsAt),
+    endsAt: readOptionalString(record.endsAt),
+    sequence: typeof record.sequence === "number" ? record.sequence : undefined,
+    isSprint: record.isSprint,
+  };
+}
+
+function readScopeRef(value: unknown): { source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || typeof record.sourceId !== "string") return undefined;
+  return { source: record.source, sourceId: record.sourceId };
 }
 
 function readOptionalString(value: unknown): string | undefined {


### PR DESCRIPTION
Stack position: 10/12
Base: feat/sub-entities-feature-milestone
Head: feat/work-cycles-sprints
Migrations introduced: 112, 113

Work cycles, sprint memberships, ClickUp sprint detection, and connector-scoped cycle reconcile.

Split from superseded entity-spine stack (#260/#261/#262). Verified locally with pnpm typecheck and pnpm build at this branch tip.