### PR TITLE
fix: cap concurrent agent runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ DATA_DIR=./data
 # SKETCH_CONFIG_DIR=/data/.sketch
 PORT=3000
 LOG_LEVEL=info          # debug | info | warn | error
+# Process-wide cap for concurrent Claude agent executions. Additional runs wait FIFO.
+# MAX_CONCURRENT_AGENT_RUNS=4
 # In dev, the Vite server proxies /api to http://localhost:${PORT} by default.
 # Override the full target if your API runs elsewhere (e.g. a remote host):
 # VITE_API_PROXY_TARGET=http://localhost:3000

--- a/packages/server/src/agent/concurrency-limiter.test.ts
+++ b/packages/server/src/agent/concurrency-limiter.test.ts
@@ -98,6 +98,42 @@ describe("AgentRunLimiter", () => {
     expect(limiter.snapshot()).toEqual({ limit: 1, active: 0, waiting: 0 });
   });
 
+  it("lets nested agent work reuse the active slot without bypassing queued independent work", async () => {
+    const { logger, entries } = captureLogger();
+    const limiter = createAgentRunLimiter({ limit: 1, logger });
+    const releaseOuter = deferred<void>();
+    const started: string[] = [];
+
+    const outer = limiter.run(async () => {
+      started.push("outer");
+      const nested = await limiter.run(async () => {
+        started.push("nested");
+        return "nested complete";
+      });
+      expect(nested).toBe("nested complete");
+      await releaseOuter.promise;
+      return "outer complete";
+    });
+
+    const independent = limiter.run(async () => {
+      started.push("independent");
+      return "independent complete";
+    });
+
+    await vi.waitFor(() => expect(started).toEqual(["outer", "nested"]));
+    expect(limiter.snapshot()).toEqual({ limit: 1, active: 1, waiting: 1 });
+    expect(entries.some((entry) => entry.fields.event === "agent_run_limiter_start" && entry.fields.reentrant)).toBe(
+      true,
+    );
+
+    releaseOuter.resolve();
+
+    await expect(outer).resolves.toBe("outer complete");
+    await vi.waitFor(() => expect(started).toEqual(["outer", "nested", "independent"]));
+    await expect(independent).resolves.toBe("independent complete");
+    expect(limiter.snapshot()).toEqual({ limit: 1, active: 0, waiting: 0 });
+  });
+
   it("logs limiter wait, start, and finish fields", async () => {
     const { logger, entries } = captureLogger();
     const limiter = createAgentRunLimiter({ limit: 1, logger });

--- a/packages/server/src/agent/concurrency-limiter.test.ts
+++ b/packages/server/src/agent/concurrency-limiter.test.ts
@@ -134,6 +134,41 @@ describe("AgentRunLimiter", () => {
     expect(limiter.snapshot()).toEqual({ limit: 1, active: 0, waiting: 0 });
   });
 
+  it("does not keep reentrant context active for timers after the parent run finishes", async () => {
+    const { logger } = captureLogger();
+    const limiter = createAgentRunLimiter({ limit: 1, logger });
+    const releaseBlocker = deferred<void>();
+    const timerDone = deferred<void>();
+    const started: string[] = [];
+
+    await limiter.run(async () => {
+      setTimeout(() => {
+        limiter
+          .run(async () => {
+            started.push("timer");
+          })
+          .then(timerDone.resolve, timerDone.reject);
+      }, 0);
+    });
+
+    const blocker = limiter.run(async () => {
+      started.push("blocker");
+      await releaseBlocker.promise;
+    });
+
+    await vi.waitFor(() => expect(started).toEqual(["blocker"]));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(started).toEqual(["blocker"]);
+    expect(limiter.snapshot()).toEqual({ limit: 1, active: 1, waiting: 1 });
+
+    releaseBlocker.resolve();
+
+    await blocker;
+    await timerDone.promise;
+    expect(started).toEqual(["blocker", "timer"]);
+    expect(limiter.snapshot()).toEqual({ limit: 1, active: 0, waiting: 0 });
+  });
+
   it("logs limiter wait, start, and finish fields", async () => {
     const { logger, entries } = captureLogger();
     const limiter = createAgentRunLimiter({ limit: 1, logger });

--- a/packages/server/src/agent/concurrency-limiter.test.ts
+++ b/packages/server/src/agent/concurrency-limiter.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "../logger";
+import { createAgentRunLimiter } from "./concurrency-limiter";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function captureLogger() {
+  const entries: Array<{ fields: Record<string, unknown>; message: string }> = [];
+  return {
+    entries,
+    logger: {
+      info: (fields: Record<string, unknown>, message: string) => {
+        entries.push({ fields, message });
+      },
+    } as Pick<Logger, "info">,
+  };
+}
+
+describe("AgentRunLimiter", () => {
+  it("caps concurrent work and starts queued runs FIFO", async () => {
+    const { logger, entries } = captureLogger();
+    const limiter = createAgentRunLimiter({ limit: 2, logger });
+    const releases = Array.from({ length: 5 }, () => deferred<void>());
+    const started: number[] = [];
+    const finished: number[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const runs = releases.map((release, index) =>
+      limiter.run(async () => {
+        started.push(index);
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await release.promise;
+        active -= 1;
+        finished.push(index);
+        return index;
+      }),
+    );
+
+    await vi.waitFor(() => expect(started).toEqual([0, 1]));
+    expect(limiter.snapshot()).toEqual({ limit: 2, active: 2, waiting: 3 });
+
+    releases[0].resolve();
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2]));
+    expect(maxActive).toBe(2);
+    expect(limiter.snapshot()).toEqual({ limit: 2, active: 2, waiting: 2 });
+
+    releases[1].resolve();
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2, 3]));
+
+    releases[2].resolve();
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2, 3, 4]));
+
+    releases[3].resolve();
+    releases[4].resolve();
+
+    await expect(Promise.all(runs)).resolves.toEqual([0, 1, 2, 3, 4]);
+    expect(finished.sort()).toEqual([0, 1, 2, 3, 4]);
+    expect(maxActive).toBe(2);
+    expect(entries.map((entry) => entry.fields.event)).toContain("agent_run_limiter_wait");
+    expect(entries.map((entry) => entry.fields.event)).toContain("agent_run_limiter_start");
+    expect(entries.map((entry) => entry.fields.event)).toContain("agent_run_limiter_finish");
+  });
+
+  it("continues queued work after a running task fails", async () => {
+    const { logger } = captureLogger();
+    const limiter = createAgentRunLimiter({ limit: 1, logger });
+    const failFirst = deferred<void>();
+    const started: number[] = [];
+
+    const first = limiter.run(async () => {
+      started.push(0);
+      await failFirst.promise;
+      throw new Error("first failed");
+    });
+    const second = limiter.run(async () => {
+      started.push(1);
+      return "second complete";
+    });
+
+    await vi.waitFor(() => expect(started).toEqual([0]));
+    expect(limiter.snapshot()).toEqual({ limit: 1, active: 1, waiting: 1 });
+
+    failFirst.resolve();
+
+    await expect(first).rejects.toThrow("first failed");
+    await vi.waitFor(() => expect(started).toEqual([0, 1]));
+    await expect(second).resolves.toBe("second complete");
+    expect(limiter.snapshot()).toEqual({ limit: 1, active: 0, waiting: 0 });
+  });
+
+  it("logs limiter wait, start, and finish fields", async () => {
+    const { logger, entries } = captureLogger();
+    const limiter = createAgentRunLimiter({ limit: 1, logger });
+    const releaseFirst = deferred<void>();
+
+    const first = limiter.run(async () => {
+      await releaseFirst.promise;
+    });
+    const second = limiter.run(async () => undefined);
+
+    await vi.waitFor(() => expect(entries.some((entry) => entry.fields.event === "agent_run_limiter_wait")).toBe(true));
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+
+    for (const entry of entries) {
+      expect(entry.fields).toMatchObject({
+        limit: expect.any(Number),
+        active: expect.any(Number),
+        waiting: expect.any(Number),
+      });
+      if (entry.fields.event === "agent_run_limiter_start" || entry.fields.event === "agent_run_limiter_wait") {
+        expect(entry.fields.waitMs).toEqual(expect.any(Number));
+      }
+      if (entry.fields.event === "agent_run_limiter_finish") {
+        expect(entry.fields.durationMs).toEqual(expect.any(Number));
+      }
+    }
+  });
+});

--- a/packages/server/src/agent/concurrency-limiter.ts
+++ b/packages/server/src/agent/concurrency-limiter.ts
@@ -1,0 +1,99 @@
+import type { Logger } from "../logger";
+
+interface AgentRunLimiterOptions {
+  limit: number;
+  logger: Pick<Logger, "info">;
+  now?: () => number;
+}
+
+interface Waiter {
+  queuedAt: number;
+  resolve: (waitMs: number) => void;
+}
+
+export class AgentRunLimiter {
+  private active = 0;
+  private readonly waiting: Waiter[] = [];
+  private readonly limit: number;
+  private readonly logger: Pick<Logger, "info">;
+  private readonly now: () => number;
+
+  constructor(options: AgentRunLimiterOptions) {
+    this.limit = options.limit;
+    this.logger = options.logger;
+    this.now = options.now ?? Date.now;
+  }
+
+  async run<T>(work: () => Promise<T>): Promise<T> {
+    const waitMs = await this.acquire();
+    const startedAt = this.now();
+
+    this.logger.info(
+      {
+        event: "agent_run_limiter_start",
+        limit: this.limit,
+        active: this.active,
+        waiting: this.waiting.length,
+        waitMs,
+      },
+      "Agent run limiter started run",
+    );
+
+    try {
+      return await work();
+    } finally {
+      const durationMs = this.now() - startedAt;
+      this.release();
+      this.logger.info(
+        {
+          event: "agent_run_limiter_finish",
+          limit: this.limit,
+          active: this.active,
+          waiting: this.waiting.length,
+          waitMs,
+          durationMs,
+        },
+        "Agent run limiter finished run",
+      );
+    }
+  }
+
+  snapshot() {
+    return { limit: this.limit, active: this.active, waiting: this.waiting.length };
+  }
+
+  private acquire(): Promise<number> {
+    if (this.active < this.limit) {
+      this.active += 1;
+      return Promise.resolve(0);
+    }
+
+    const queuedAt = this.now();
+    return new Promise((resolve) => {
+      this.waiting.push({ queuedAt, resolve });
+      this.logger.info(
+        {
+          event: "agent_run_limiter_wait",
+          limit: this.limit,
+          active: this.active,
+          waiting: this.waiting.length,
+          waitMs: 0,
+        },
+        "Agent run limiter waiting for slot",
+      );
+    });
+  }
+
+  private release(): void {
+    this.active -= 1;
+    const next = this.waiting.shift();
+    if (!next) return;
+
+    this.active += 1;
+    next.resolve(this.now() - next.queuedAt);
+  }
+}
+
+export function createAgentRunLimiter(options: AgentRunLimiterOptions) {
+  return new AgentRunLimiter(options);
+}

--- a/packages/server/src/agent/concurrency-limiter.ts
+++ b/packages/server/src/agent/concurrency-limiter.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Logger } from "../logger";
 
 interface AgentRunLimiterOptions {
@@ -17,6 +18,7 @@ export class AgentRunLimiter {
   private readonly limit: number;
   private readonly logger: Pick<Logger, "info">;
   private readonly now: () => number;
+  private readonly activeRunContext = new AsyncLocalStorage<boolean>();
 
   constructor(options: AgentRunLimiterOptions) {
     this.limit = options.limit;
@@ -25,6 +27,10 @@ export class AgentRunLimiter {
   }
 
   async run<T>(work: () => Promise<T>): Promise<T> {
+    if (this.activeRunContext.getStore()) {
+      return this.runReentrant(work);
+    }
+
     const waitMs = await this.acquire();
     const startedAt = this.now();
 
@@ -40,7 +46,7 @@ export class AgentRunLimiter {
     );
 
     try {
-      return await work();
+      return await this.activeRunContext.run(true, work);
     } finally {
       const durationMs = this.now() - startedAt;
       this.release();
@@ -52,6 +58,40 @@ export class AgentRunLimiter {
           waiting: this.waiting.length,
           waitMs,
           durationMs,
+        },
+        "Agent run limiter finished run",
+      );
+    }
+  }
+
+  private async runReentrant<T>(work: () => Promise<T>): Promise<T> {
+    const startedAt = this.now();
+
+    this.logger.info(
+      {
+        event: "agent_run_limiter_start",
+        limit: this.limit,
+        active: this.active,
+        waiting: this.waiting.length,
+        waitMs: 0,
+        reentrant: true,
+      },
+      "Agent run limiter started run",
+    );
+
+    try {
+      return await work();
+    } finally {
+      const durationMs = this.now() - startedAt;
+      this.logger.info(
+        {
+          event: "agent_run_limiter_finish",
+          limit: this.limit,
+          active: this.active,
+          waiting: this.waiting.length,
+          waitMs: 0,
+          durationMs,
+          reentrant: true,
         },
         "Agent run limiter finished run",
       );

--- a/packages/server/src/agent/concurrency-limiter.ts
+++ b/packages/server/src/agent/concurrency-limiter.ts
@@ -12,13 +12,17 @@ interface Waiter {
   resolve: (waitMs: number) => void;
 }
 
+interface ActiveRunContext {
+  active: boolean;
+}
+
 export class AgentRunLimiter {
   private active = 0;
   private readonly waiting: Waiter[] = [];
   private readonly limit: number;
   private readonly logger: Pick<Logger, "info">;
   private readonly now: () => number;
-  private readonly activeRunContext = new AsyncLocalStorage<boolean>();
+  private readonly activeRunContext = new AsyncLocalStorage<ActiveRunContext>();
 
   constructor(options: AgentRunLimiterOptions) {
     this.limit = options.limit;
@@ -27,12 +31,13 @@ export class AgentRunLimiter {
   }
 
   async run<T>(work: () => Promise<T>): Promise<T> {
-    if (this.activeRunContext.getStore()) {
+    if (this.activeRunContext.getStore()?.active) {
       return this.runReentrant(work);
     }
 
     const waitMs = await this.acquire();
     const startedAt = this.now();
+    const runContext: ActiveRunContext = { active: true };
 
     this.logger.info(
       {
@@ -46,8 +51,9 @@ export class AgentRunLimiter {
     );
 
     try {
-      return await this.activeRunContext.run(true, work);
+      return await this.activeRunContext.run(runContext, work);
     } finally {
+      runContext.active = false;
       const durationMs = this.now() - startedAt;
       this.release();
       this.logger.info(

--- a/packages/server/src/api/workflows.ts
+++ b/packages/server/src/api/workflows.ts
@@ -63,6 +63,7 @@ interface WorkflowRouteDeps {
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   sendDm?: RunAgentParams["sendDm"];
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };
+  limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
 class WorkflowApiError extends Error {
@@ -255,6 +256,7 @@ async function executeWorkflowRun(params: ExecuteWorkflowRunParams) {
     sendDm: deps.sendDm,
     sendMessage: delivery.sendMessage,
     onEvent,
+    limitAgentExecution: deps.limitAgentExecution,
   });
 
   return {

--- a/packages/server/src/bootstrap.integration.test.ts
+++ b/packages/server/src/bootstrap.integration.test.ts
@@ -13,6 +13,14 @@ vi.mock("./agent/runner", () => ({
   runAgent: vi.fn(),
 }));
 
+vi.mock("./agent/concurrency-limiter", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./agent/concurrency-limiter")>();
+  return {
+    ...actual,
+    createAgentRunLimiter: vi.fn(actual.createAgentRunLimiter),
+  };
+});
+
 // Avoid syncing skills from remote repo during tests
 vi.mock("./skills/sync", () => ({
   syncFeaturedSkills: vi.fn(),
@@ -33,6 +41,7 @@ describe("bootstrap", () => {
       await handle.shutdown();
       handle = null;
     }
+    vi.clearAllMocks();
   });
 
   async function boot(configOverrides: Record<string, unknown> = {}) {
@@ -57,6 +66,17 @@ describe("bootstrap", () => {
   it("has no Slack bot when tokens are not configured", async () => {
     const h = await boot();
     expect(h.getSlack()).toBeNull();
+  });
+
+  it("configures the process-wide agent limiter from server config", async () => {
+    const { createAgentRunLimiter } = await import("./agent/concurrency-limiter");
+    await boot({ MAX_CONCURRENT_AGENT_RUNS: 2 });
+
+    expect(createAgentRunLimiter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 2,
+      }),
+    );
   });
 
   it("health endpoint responds 200", async () => {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -5,6 +5,7 @@
  */
 import { serve } from "@hono/node-server";
 import type { Kysely } from "kysely";
+import { createAgentRunLimiter } from "./agent/concurrency-limiter";
 import { disableSdkAttributionHeader, removeReservedAgentEnv } from "./agent/environment";
 import { applyLlmEnvFromSettings } from "./agent/llm-env";
 import { type RunAgentResult, runAgent } from "./agent/runner";
@@ -138,6 +139,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const tracer = telemetry.tracer;
   const priceMap = new OpenRouterPriceMap({ ttlMs: config.OPENROUTER_PRICE_TTL_HOURS * 60 * 60 * 1000, logger });
   const pricing = createPricingService(priceMap, logger);
+  const agentRunLimiter = createAgentRunLimiter({ limit: config.MAX_CONCURRENT_AGENT_RUNS, logger });
 
   /**
    * Current LLM provider context, refreshed at startup and on settings change
@@ -181,7 +183,9 @@ export async function createServer(config: Config, options?: CreateServerOptions
           }
         : {}),
     };
-    return instrumentAgentRun(tracer, pricing, providerCtx, enrichedParams, () => runAgent(enrichedParams));
+    return agentRunLimiter.run(() =>
+      instrumentAgentRun(tracer, pricing, providerCtx, enrichedParams, () => runAgent(enrichedParams)),
+    );
   };
 
   // 4. LLM env from DB

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -140,6 +140,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const priceMap = new OpenRouterPriceMap({ ttlMs: config.OPENROUTER_PRICE_TTL_HOURS * 60 * 60 * 1000, logger });
   const pricing = createPricingService(priceMap, logger);
   const agentRunLimiter = createAgentRunLimiter({ limit: config.MAX_CONCURRENT_AGENT_RUNS, logger });
+  const limitAgentExecution = <T>(work: () => Promise<T>): Promise<T> => agentRunLimiter.run(work);
 
   /**
    * Current LLM provider context, refreshed at startup and on settings change
@@ -183,7 +184,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
           }
         : {}),
     };
-    return agentRunLimiter.run(() =>
+    return limitAgentExecution(() =>
       instrumentAgentRun(tracer, pricing, providerCtx, enrichedParams, () => runAgent(enrichedParams)),
     );
   };
@@ -328,6 +329,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     inboxMessagesRepo,
     sendDm: sendDirectMessage,
     recordWorkflowStep,
+    limitAgentExecution,
   });
   await scheduler.start();
 
@@ -432,6 +434,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     localDeviceGateway,
     localClaudeSessionService,
     agentRunService,
+    limitAgentExecution,
   });
   const server = serve({ fetch: app.fetch, port: config.PORT });
   localDeviceGateway.attach(server);

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -29,6 +29,7 @@ describe("configSchema", () => {
         expect(result.data.SQLITE_PATH).toBe("./data/sketch.db");
         expect(result.data.SLACK_CHANNEL_HISTORY_LIMIT).toBe(5);
         expect(result.data.SLACK_THREAD_HISTORY_LIMIT).toBe(50);
+        expect(result.data.MAX_CONCURRENT_AGENT_RUNS).toBe(4);
         expect(result.data.MAX_FILE_SIZE_MB).toBe(20);
         expect(result.data.VISION_ENABLED).toBe(false);
       }
@@ -126,6 +127,14 @@ describe("configSchema", () => {
         expect(result.data.MAX_FILE_SIZE_MB).toBe(50);
       }
     });
+
+    it("coerces MAX_CONCURRENT_AGENT_RUNS string to number", () => {
+      const result = configSchema.safeParse({ MAX_CONCURRENT_AGENT_RUNS: "2" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.MAX_CONCURRENT_AGENT_RUNS).toBe(2);
+      }
+    });
   });
 
   describe("invalid configs", () => {
@@ -152,6 +161,11 @@ describe("configSchema", () => {
     it("rejects Microsoft connector concurrency outside the bounded Graph limit", () => {
       expect(configSchema.safeParse({ OUTLOOK_MAX_INFLIGHT: "32" }).success).toBe(false);
       expect(configSchema.safeParse({ TEAMS_MAX_INFLIGHT: "32" }).success).toBe(false);
+    });
+
+    it("rejects agent concurrency below one", () => {
+      const result = configSchema.safeParse({ MAX_CONCURRENT_AGENT_RUNS: "0" });
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -17,6 +17,7 @@ export const configSchema = z.object({
   // Slack context
   SLACK_CHANNEL_HISTORY_LIMIT: z.coerce.number().default(5),
   SLACK_THREAD_HISTORY_LIMIT: z.coerce.number().default(50),
+  MAX_CONCURRENT_AGENT_RUNS: z.coerce.number().int().min(1).default(4),
 
   // Files
   MAX_FILE_SIZE_MB: z.coerce.number().default(20),

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -101,6 +101,7 @@ interface AppDeps {
   localDeviceGateway?: LocalDeviceGateway;
   localClaudeSessionService?: LocalClaudeSessionService;
   agentRunService?: AgentRunService;
+  limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
 export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
@@ -301,6 +302,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       inboxMessagesRepo: inboxMessages,
       sendDm: deps?.sendDm,
       queueManager: deps?.queueManager,
+      limitAgentExecution: deps?.limitAgentExecution,
     }),
   );
   if (deps?.runAgent) {

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -95,6 +95,7 @@ function buildDeps(
     whatsapp?: ReturnType<typeof buildMockWhatsApp>;
     runAgent?: ReturnType<typeof vi.fn>;
     queueManager?: QueueManager;
+    limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
   } = {},
 ) {
   const mockRunAgent =
@@ -119,6 +120,7 @@ function buildDeps(
     runAgent: mockRunAgent,
     buildMcpServers: vi.fn().mockResolvedValue({}),
     loadIntegrationProvider: vi.fn().mockResolvedValue(null),
+    limitAgentExecution: overrides.limitAgentExecution ?? ((work) => work()),
     automationRunsRepo: {
       create: vi.fn().mockResolvedValue("run-1"),
       update: vi.fn().mockResolvedValue(undefined),
@@ -495,6 +497,7 @@ describe("executeTask() invokes automation runtime", () => {
         inboxMessagesRepo: deps.inboxMessagesRepo,
         sendDm: deps.sendDm,
         userRepo: deps.userRepo,
+        limitAgentExecution: deps.limitAgentExecution,
       }),
     );
   });

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -60,6 +60,7 @@ export interface TaskSchedulerDeps {
   inboxMessagesRepo?: ReturnType<typeof createInboxMessagesRepository>;
   sendDm?: Parameters<typeof runAgent>[0]["sendDm"];
   recordWorkflowStep?: RecordWorkflowStep;
+  limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
 export class TaskScheduler {
@@ -198,6 +199,7 @@ export class TaskScheduler {
       sendDm: this.deps.sendDm,
       sendMessage: sendMessage ?? undefined,
       recordWorkflowStep: this.deps.recordWorkflowStep,
+      limitAgentExecution: this.deps.limitAgentExecution,
     });
 
     const now = new Date().toISOString();
@@ -479,6 +481,7 @@ export class TaskScheduler {
       inboxMessagesRepo: this.deps.inboxMessagesRepo,
       sendDm: this.deps.sendDm,
       recordWorkflowStep: this.deps.recordWorkflowStep,
+      limitAgentExecution: this.deps.limitAgentExecution,
       stepId,
       input: options.input,
       useLatestUpstreamOutput: options.useLatestUpstreamOutput,

--- a/packages/server/src/test-utils.ts
+++ b/packages/server/src/test-utils.ts
@@ -160,6 +160,7 @@ export function createTestConfig(overrides: Partial<Config> = {}): Config {
     SQLITE_PATH: ":memory:",
     SLACK_CHANNEL_HISTORY_LIMIT: 5,
     SLACK_THREAD_HISTORY_LIMIT: 50,
+    MAX_CONCURRENT_AGENT_RUNS: 4,
     MAX_FILE_SIZE_MB: 20,
     MAX_UPLOAD_SIZE_MB: 50,
     EXPERIMENTAL_FLAG: false,

--- a/packages/server/src/workflows/runtime.isolated.test.ts
+++ b/packages/server/src/workflows/runtime.isolated.test.ts
@@ -285,8 +285,10 @@ describe("executeAutomation agent steps", () => {
 
   it("keeps light-mode agent steps on the lightweight SDK path", async () => {
     const runAgent = vi.fn();
+    const limitAgentExecution = vi.fn((work: () => Promise<unknown>) => work());
     const params = makeParams({
       runAgent,
+      limitAgentExecution,
       task: makeTask({
         steps: JSON.stringify([
           { id: "trigger", type: "trigger", label: "Schedule", icon: "clock", position: { x: 0, y: 0 } },
@@ -305,6 +307,7 @@ describe("executeAutomation agent steps", () => {
     await executeAutomation(params as never);
 
     expect(runAgent).not.toHaveBeenCalled();
+    expect(limitAgentExecution).toHaveBeenCalledTimes(1);
     expect(params.sendMessage).toHaveBeenCalledWith("light result");
   });
 

--- a/packages/server/src/workflows/runtime.ts
+++ b/packages/server/src/workflows/runtime.ts
@@ -47,6 +47,7 @@ export interface ExecuteAutomationParams {
   sendMessage?: (text: string) => Promise<void>;
   onEvent?: (event: AutomationExecutionEvent) => Promise<void>;
   recordWorkflowStep?: RecordWorkflowStep;
+  limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
 export type AutomationExecutionEvent =
@@ -450,6 +451,7 @@ async function executeWorkflowStep(params: {
       sendDm: runtimeParams.sendDm,
       outputPlatform: resolveWorkflowDelivery(task).platform,
       recordWorkflowStep: runtimeParams.recordWorkflowStep,
+      limitAgentExecution: runtimeParams.limitAgentExecution,
     });
   }
 
@@ -827,6 +829,7 @@ interface AgentStepParams {
   sendDm?: RunAgentParams["sendDm"];
   outputPlatform: "slack" | "whatsapp";
   recordWorkflowStep?: RecordWorkflowStep;
+  limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
 /**
@@ -870,49 +873,53 @@ async function executeAgentStep(params: AgentStepParams): Promise<unknown> {
     ...buildPlatformFormattingLines(outputPlatform),
   ];
 
-  const run = query({
-    prompt: userMessage,
-    options: {
-      maxTurns: 10,
-      ...(modelOverride ? { model: modelOverride } : {}),
-      cwd: workspaceDir,
-      systemPrompt: systemPromptLines.join("\n"),
-      permissionMode: "bypassPermissions" as const,
-      settingSources: [],
-      stderr: (chunk: string) => {
-        stderrChunks.push(chunk);
-      },
-    },
-  });
+  const limitAgentExecution = params.limitAgentExecution ?? (<T>(work: () => Promise<T>) => work());
 
   let lastText = "";
   let stepUsage: WorkflowStepUsage | null = null;
   try {
-    for await (const message of run) {
-      if (!message || typeof message !== "object" || !("type" in message)) continue;
-      if (message.type === "assistant" && "message" in message) {
-        const msg = message.message as { content?: Array<{ type: string; text?: string }> };
-        if (msg.content) {
-          for (const block of msg.content) {
-            if (block.type === "text" && block.text) {
-              lastText = block.text;
+    await limitAgentExecution(async () => {
+      const run = query({
+        prompt: userMessage,
+        options: {
+          maxTurns: 10,
+          ...(modelOverride ? { model: modelOverride } : {}),
+          cwd: workspaceDir,
+          systemPrompt: systemPromptLines.join("\n"),
+          permissionMode: "bypassPermissions" as const,
+          settingSources: [],
+          stderr: (chunk: string) => {
+            stderrChunks.push(chunk);
+          },
+        },
+      });
+
+      for await (const message of run) {
+        if (!message || typeof message !== "object" || !("type" in message)) continue;
+        if (message.type === "assistant" && "message" in message) {
+          const msg = message.message as { content?: Array<{ type: string; text?: string }> };
+          if (msg.content) {
+            for (const block of msg.content) {
+              if (block.type === "text" && block.text) {
+                lastText = block.text;
+              }
             }
           }
+        } else if (message.type === "result") {
+          const resultMsg = message as Record<string, unknown>;
+          const u = resultMsg.usage as Record<string, unknown> | undefined;
+          const modelKeys = Object.keys((resultMsg.modelUsage as Record<string, unknown>) ?? {});
+          stepUsage = {
+            model: modelKeys.length > 0 ? modelKeys[0] : (modelOverride ?? null),
+            inputTokens: (u?.input_tokens as number) ?? 0,
+            outputTokens: (u?.output_tokens as number) ?? 0,
+            cacheReadTokens: (u?.cache_read_input_tokens as number) ?? 0,
+            cacheCreationTokens: (u?.cache_creation_input_tokens as number) ?? 0,
+            sdkCostUsd: (resultMsg.total_cost_usd as number) ?? 0,
+          };
         }
-      } else if (message.type === "result") {
-        const resultMsg = message as Record<string, unknown>;
-        const u = resultMsg.usage as Record<string, unknown> | undefined;
-        const modelKeys = Object.keys((resultMsg.modelUsage as Record<string, unknown>) ?? {});
-        stepUsage = {
-          model: modelKeys.length > 0 ? modelKeys[0] : (modelOverride ?? null),
-          inputTokens: (u?.input_tokens as number) ?? 0,
-          outputTokens: (u?.output_tokens as number) ?? 0,
-          cacheReadTokens: (u?.cache_read_input_tokens as number) ?? 0,
-          cacheCreationTokens: (u?.cache_creation_input_tokens as number) ?? 0,
-          sdkCostUsd: (resultMsg.total_cost_usd as number) ?? 0,
-        };
       }
-    }
+    });
   } catch (err) {
     const stderrText = stderrChunks.join("").slice(0, 2000);
     logger.error({ err, stepId: step.id, stderrText }, "Automation agent: step failed (Claude Code subprocess error)");


### PR DESCRIPTION
## Summary

Fixes SKE-238 by adding a process-wide FIFO concurrency limiter around the shared `trackedRunAgent` path in `packages/server/src/bootstrap.ts`.

The cap defaults to `MAX_CONCURRENT_AGENT_RUNS=4` and waits queued runs instead of rejecting or timing them out. Because the limiter wraps the shared bootstrap dependency, the existing per-user/per-channel/per-group queues keep their local ordering while Slack, WhatsApp, scheduled tasks/workflows, Daily Brief, API-triggered runs, web chat, and local-device continuations all share the same process-wide execution cap.

## Validation

- `pnpm --filter @sketch/server exec vitest run src/agent/concurrency-limiter.test.ts src/config.test.ts src/bootstrap.integration.test.ts`
- `pnpm biome check .`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Manual limiter simulation with five local runs, limit `2`, one intentional failure: FIFO start order, max active `2`, queued runs continued, final snapshot `{ active: 0, waiting: 0 }`
