### PR TITLE
feat: today's meetings section in the Daily Brief

### DIFF
--- a/packages/server/src/agent/tools/agent-output.ts
+++ b/packages/server/src/agent/tools/agent-output.ts
@@ -22,6 +22,11 @@ const itemSchema = z.object({
   actionLabel: z.string().optional(),
   actionPrompt: z.string().optional(),
   sourceUrl: z.string().optional(),
+  /**
+   * Free-form section-specific structured data. The shape is documented per
+   * section in the agent instructions; each definition normalizes it downstream.
+   */
+  structuredPayload: z.record(z.string(), z.unknown()).optional(),
   knowledgeRefs: knowledgeRefsSchema,
 });
 
@@ -74,6 +79,7 @@ function mapItems(payload: WriteAgentOutputPayload): AgentOutputItemInput[] {
       actionLabel: item.actionLabel ?? null,
       actionPrompt: item.actionPrompt ?? null,
       sourceUrl: item.sourceUrl ?? null,
+      structuredPayload: item.structuredPayload ?? null,
       knowledgeRefs: normalizeRefs(item.knowledgeRefs),
       sortOrder: order,
     };

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -1,11 +1,15 @@
 import type { Kysely, Selectable } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentOutputItemInput } from "../../db/repositories/agent-outputs";
 import type { DB, UsersTable } from "../../db/schema";
 import { createTestDb } from "../../test-utils";
 import {
   DAILY_BRIEF_ENTITY_WINDOW_DAYS,
   DAILY_BRIEF_EVIDENCE_WINDOW_DAYS,
+  DAILY_BRIEF_MEETINGS_SECTION_KEY,
+  type TodaysMeeting,
   buildDailyBriefCandidateContext,
+  buildTodaysMeetings,
   dailyBriefDefinition,
 } from "./daily-brief";
 
@@ -330,5 +334,259 @@ describe("buildDailyBriefCandidateContext", () => {
     expect(context.evidenceSince).toBe("2026-05-16T18:29:59.999Z");
     expect(context.recentEntities.map((entity) => entity.id)).toEqual(["entity-historical"]);
     expect(context.hotFallbackEntities).toEqual([]);
+  });
+});
+
+async function seedCalendarEvent(
+  db: Kysely<DB>,
+  params: {
+    id: string;
+    startTime: string;
+    title?: string;
+    sourcePath?: string | null;
+    providerUrl?: string | null;
+    archived?: boolean;
+    restrictedTo?: string;
+  },
+): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: params.id,
+      connector_config_id: "config-1",
+      provider_file_id: `cal-${params.id}`,
+      file_name: params.title ?? params.id,
+      file_type: "calendar_event",
+      content_category: "document",
+      source: "google_calendar",
+      source_path: params.sourcePath ?? "Google Calendar / Work",
+      provider_url: params.providerUrl ?? `https://calendar.google.com/${params.id}`,
+      content: "calendar event",
+      is_archived: params.archived ? 1 : 0,
+      source_updated_at: params.startTime,
+      source_created_at: params.startTime,
+      synced_at: NOW.toISOString(),
+      embedding_status: "pending",
+    })
+    .execute();
+
+  if (params.restrictedTo) {
+    await db.insertInto("file_access").values({ indexed_file_id: params.id, email: params.restrictedTo }).execute();
+  }
+}
+
+async function seedAttendeeFact(
+  db: Kysely<DB>,
+  params: { id: string; fileId: string; name: string; email?: string | null },
+): Promise<void> {
+  await db
+    .insertInto("indexed_file_facts")
+    .values({
+      id: params.id,
+      indexed_file_id: params.fileId,
+      source: "google_calendar",
+      fact_type: "attendee",
+      relation: "attendee",
+      subject_name: params.name,
+      subject_email: params.email ?? null,
+      fact_key: `${params.fileId}:${params.email ?? params.name}`,
+    })
+    .execute();
+}
+
+async function seedPerson(db: Kysely<DB>, params: { id: string; name: string; email: string }): Promise<void> {
+  const now = NOW.toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: params.id,
+      name: params.name,
+      source_type: "person",
+      subtype: null,
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+      ai_brief: null,
+    })
+    .execute();
+  await db
+    .insertInto("entity_contact_points")
+    .values({ id: `cp-${params.id}`, entity_id: params.id, kind: "email", value: params.email, source: "test" })
+    .execute();
+}
+
+const MEETINGS_RUNTIME_PARAMS = {
+  outputDate: "2026-06-25",
+  timezone: "UTC",
+  now: NOW,
+  adminCanReadAllFiles: false,
+  contentUserEmails: ["agent@example.com"],
+};
+
+describe("buildTodaysMeetings", () => {
+  let db: Kysely<DB>;
+  let user: Selectable<UsersTable>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    user = await seedUser(db);
+    await seedConnectorConfig(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("builds today's meetings sorted by start, resolving attendees to person entities", async () => {
+    await seedPerson(db, { id: "person-jane", name: "Jane Doe", email: "jane@example.com" });
+    await seedCalendarEvent(db, { id: "evt-late", startTime: "2026-06-25T14:00:00.000Z", title: "Late sync" });
+    await seedCalendarEvent(db, { id: "evt-early", startTime: "2026-06-25T09:00:00.000Z", title: "Early standup" });
+    await seedAttendeeFact(db, { id: "f1", fileId: "evt-early", name: "Jane Doe", email: "JANE@example.com" });
+    await seedAttendeeFact(db, { id: "f2", fileId: "evt-early", name: "Bob Stone", email: "bob@example.com" });
+
+    const meetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
+
+    expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-early", "evt-late"]);
+    expect(meetings[0]).toMatchObject({
+      title: "Early standup",
+      startTime: "2026-06-25T09:00:00.000Z",
+      via: "Work",
+      sourceUrl: "https://calendar.google.com/evt-early",
+    });
+    expect(meetings[0].attendees).toEqual([
+      { name: "Jane Doe", email: "jane@example.com", entityId: "person-jane" },
+      { name: "Bob Stone", email: "bob@example.com", entityId: null },
+    ]);
+    expect(meetings[1].attendees).toEqual([]);
+  });
+
+  it("excludes archived events, events outside the day, and files the reader cannot see", async () => {
+    await seedCalendarEvent(db, { id: "evt-today", startTime: "2026-06-25T10:00:00.000Z" });
+    await seedCalendarEvent(db, { id: "evt-archived", startTime: "2026-06-25T11:00:00.000Z", archived: true });
+    await seedCalendarEvent(db, { id: "evt-tomorrow", startTime: "2026-06-26T10:00:00.000Z" });
+    await seedCalendarEvent(db, {
+      id: "evt-restricted",
+      startTime: "2026-06-25T12:00:00.000Z",
+      restrictedTo: "someone-else@example.com",
+    });
+
+    const meetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
+
+    expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-today"]);
+  });
+});
+
+describe("dailyBriefDefinition.reconcileItems", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  const skeleton: TodaysMeeting[] = [
+    {
+      fileId: "evt-1",
+      startTime: "2026-06-25T09:00:00.000Z",
+      title: "Standup",
+      via: "Work",
+      sourceUrl: "https://calendar.google.com/evt-1",
+      attendees: [{ name: "Jane Doe", email: "jane@example.com", entityId: "person-jane" }],
+    },
+    {
+      fileId: "evt-2",
+      startTime: "2026-06-25T14:00:00.000Z",
+      title: "Customer call",
+      via: null,
+      sourceUrl: null,
+      attendees: [],
+    },
+  ];
+
+  function meetingItem(fileId: string, payload: AgentOutputItemInput["structuredPayload"]): AgentOutputItemInput {
+    return {
+      sectionKey: DAILY_BRIEF_MEETINGS_SECTION_KEY,
+      title: "Model title",
+      summary: "model summary",
+      priority: "medium",
+      label: "meeting",
+      structuredPayload: payload,
+      knowledgeRefs: { entityIds: [], fileIds: [fileId] },
+      sortOrder: 0,
+    };
+  }
+
+  it("uses the skeleton as truth: enriches matches, backfills skipped, drops invented meetings", async () => {
+    const items: AgentOutputItemInput[] = [
+      meetingItem("evt-1", {
+        context: "Kickoff for the new sprint.",
+        attendees: [{ entityId: "person-jane", role: "EM", note: "Owns delivery", emphasis: true }],
+      }),
+      meetingItem("ghost", { context: "Invented meeting." }),
+      {
+        sectionKey: "todos",
+        title: "Ship the thing",
+        summary: "do it",
+        priority: "high",
+        label: "todo",
+        knowledgeRefs: { entityIds: [], fileIds: [] },
+        sortOrder: 0,
+      },
+    ];
+
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items,
+        runtimeContext: { sections: ["meetings", "todos"], todaysMeetings: skeleton },
+      })) ?? [];
+
+    const meetings = result.filter((item) => item.sectionKey === DAILY_BRIEF_MEETINGS_SECTION_KEY);
+    expect(meetings.map((item) => item.title)).toEqual(["Standup", "Customer call"]);
+    expect(meetings.map((item) => item.knowledgeRefs.fileIds)).toEqual([["evt-1"], ["evt-2"]]);
+
+    expect(meetings[0].summary).toBe("Kickoff for the new sprint.");
+    expect(meetings[0].sourceUrl).toBe("https://calendar.google.com/evt-1");
+    expect(meetings[0].structuredPayload).toMatchObject({
+      startTime: "2026-06-25T09:00:00.000Z",
+      via: "Work",
+      attendees: [{ name: "Jane Doe", entityId: "person-jane", role: "EM", note: "Owns delivery", emphasis: true }],
+    });
+    expect(meetings[0].knowledgeRefs.entityIds).toEqual(["person-jane"]);
+
+    expect(meetings[1].structuredPayload).toMatchObject({ startTime: "2026-06-25T14:00:00.000Z", attendees: [] });
+    expect(meetings[1].summary).toBe("On your calendar today.");
+
+    expect(result.some((item) => item.knowledgeRefs.fileIds.includes("ghost"))).toBe(false);
+    expect(result.some((item) => item.sectionKey === "todos")).toBe(true);
+  });
+
+  it("drops all meeting items when the skeleton is empty", async () => {
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items: [meetingItem("evt-1", null)],
+        runtimeContext: { sections: ["meetings"], todaysMeetings: [] },
+      })) ?? [];
+
+    expect(result).toEqual([]);
+  });
+
+  it("leaves items untouched when the meetings section is disabled", async () => {
+    const items = [meetingItem("evt-1", null)];
+    const result = await dailyBriefDefinition.reconcileItems?.({
+      db,
+      items,
+      runtimeContext: { sections: ["todos"], todaysMeetings: skeleton },
+    });
+
+    expect(result).toBe(items);
   });
 });

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -349,6 +349,7 @@ async function seedCalendarEvent(
     restrictedTo?: string;
     connectorConfigId?: string;
     threadId?: string;
+    allDay?: boolean;
   },
 ): Promise<void> {
   await db
@@ -366,6 +367,7 @@ async function seedCalendarEvent(
       provider_url: params.providerUrl ?? `https://calendar.google.com/${params.id}`,
       content: "calendar event",
       is_archived: params.archived ? 1 : 0,
+      is_all_day: params.allDay ? 1 : 0,
       source_updated_at: params.startTime,
       source_created_at: params.startTime,
       synced_at: NOW.toISOString(),
@@ -482,12 +484,22 @@ describe("buildTodaysMeetings", () => {
     expect(meetings[1].attendees).toEqual([]);
   });
 
-  it("excludes all-day events (UTC-midnight sentinel) regardless of timezone", async () => {
-    await seedCalendarEvent(db, { id: "evt-all-day", startTime: "2026-06-25T00:00:00.000Z", title: "Team offsite" });
+  it("excludes all-day events by flag but keeps timed meetings that start at UTC midnight", async () => {
+    await seedCalendarEvent(db, {
+      id: "evt-all-day",
+      startTime: "2026-06-25T00:00:00.000Z",
+      title: "Team offsite",
+      allDay: true,
+    });
+    await seedCalendarEvent(db, {
+      id: "evt-midnight-utc",
+      startTime: "2026-06-25T00:00:00.000Z",
+      title: "5:30 AM IST standup",
+    });
     await seedCalendarEvent(db, { id: "evt-timed", startTime: "2026-06-25T09:00:00.000Z", title: "Standup" });
 
     const utcMeetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
-    expect(utcMeetings.map((meeting) => meeting.fileId)).toEqual(["evt-timed"]);
+    expect(utcMeetings.map((meeting) => meeting.fileId)).toEqual(["evt-midnight-utc", "evt-timed"]);
 
     const istMeetings = await buildTodaysMeetings({
       db,
@@ -495,7 +507,7 @@ describe("buildTodaysMeetings", () => {
       ...MEETINGS_RUNTIME_PARAMS,
       timezone: "Asia/Kolkata",
     });
-    expect(istMeetings.map((meeting) => meeting.fileId)).toEqual(["evt-timed"]);
+    expect(istMeetings.map((meeting) => meeting.fileId)).toEqual(["evt-midnight-utc", "evt-timed"]);
   });
 
   it("excludes archived events, events outside the day, and files the reader cannot see", async () => {

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -497,7 +497,11 @@ describe("buildTodaysMeetings", () => {
 
   it("scopes an admin's meetings to their own calendar even with the read-all bypass", async () => {
     const admin = await seedUser(db, { id: "admin-1", email: "admin@example.com", authRole: "admin" });
-    await seedCalendarEvent(db, { id: "evt-mine", startTime: "2026-06-25T09:00:00.000Z" });
+    await seedCalendarEvent(db, {
+      id: "evt-mine",
+      startTime: "2026-06-25T09:00:00.000Z",
+      restrictedTo: "admin@example.com",
+    });
     await seedCalendarEvent(db, {
       id: "evt-someone-else",
       startTime: "2026-06-25T10:00:00.000Z",
@@ -511,7 +515,7 @@ describe("buildTodaysMeetings", () => {
       timezone: "UTC",
       now: NOW,
       adminCanReadAllFiles: true,
-      contentUserEmails: ["admin@example.com"],
+      contentUserEmails: undefined,
     });
 
     expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-mine"]);

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -464,22 +464,20 @@ describe("buildTodaysMeetings", () => {
     expect(meetings[1].attendees).toEqual([]);
   });
 
-  it("keeps all-day events on their calendar date in a negative-UTC timezone", async () => {
+  it("excludes all-day events (UTC-midnight sentinel) regardless of timezone", async () => {
     await seedCalendarEvent(db, { id: "evt-all-day", startTime: "2026-06-25T00:00:00.000Z", title: "Team offsite" });
-    await seedCalendarEvent(db, {
-      id: "evt-prev-evening",
-      startTime: "2026-06-25T02:00:00.000Z",
-      title: "Late call (prev local day)",
-    });
+    await seedCalendarEvent(db, { id: "evt-timed", startTime: "2026-06-25T09:00:00.000Z", title: "Standup" });
 
-    const meetings = await buildTodaysMeetings({
+    const utcMeetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
+    expect(utcMeetings.map((meeting) => meeting.fileId)).toEqual(["evt-timed"]);
+
+    const istMeetings = await buildTodaysMeetings({
       db,
       user,
       ...MEETINGS_RUNTIME_PARAMS,
-      timezone: "America/Los_Angeles",
+      timezone: "Asia/Kolkata",
     });
-
-    expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-all-day"]);
+    expect(istMeetings.map((meeting) => meeting.fileId)).toEqual(["evt-timed"]);
   });
 
   it("excludes archived events, events outside the day, and files the reader cannot see", async () => {
@@ -495,6 +493,28 @@ describe("buildTodaysMeetings", () => {
     const meetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
 
     expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-today"]);
+  });
+
+  it("scopes an admin's meetings to their own calendar even with the read-all bypass", async () => {
+    const admin = await seedUser(db, { id: "admin-1", email: "admin@example.com", authRole: "admin" });
+    await seedCalendarEvent(db, { id: "evt-mine", startTime: "2026-06-25T09:00:00.000Z" });
+    await seedCalendarEvent(db, {
+      id: "evt-someone-else",
+      startTime: "2026-06-25T10:00:00.000Z",
+      restrictedTo: "other-person@example.com",
+    });
+
+    const meetings = await buildTodaysMeetings({
+      db,
+      user: admin,
+      outputDate: "2026-06-25",
+      timezone: "UTC",
+      now: NOW,
+      adminCanReadAllFiles: true,
+      contentUserEmails: ["admin@example.com"],
+    });
+
+    expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-mine"]);
   });
 });
 

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -355,7 +355,7 @@ async function seedCalendarEvent(
     .insertInto("indexed_files")
     .values({
       id: params.id,
-      connector_config_id: params.connectorConfigId ?? "config-1",
+      connector_config_id: params.connectorConfigId ?? "cal-reader",
       provider_file_id: `cal-${params.id}`,
       thread_id: params.threadId ?? null,
       file_name: params.title ?? params.id,
@@ -452,6 +452,7 @@ describe("buildTodaysMeetings", () => {
     db = await createTestDb();
     user = await seedUser(db);
     await seedConnectorConfig(db);
+    await seedCalendarConnector(db, { id: "cal-reader", createdBy: "user-1" });
   });
 
   afterEach(async () => {
@@ -512,9 +513,8 @@ describe("buildTodaysMeetings", () => {
     expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-today"]);
   });
 
-  it("collapses duplicate calendar copies of one event, preferring the reader-owned copy", async () => {
+  it("collapses duplicate calendar copies of one event, keeping the reader-owned copy", async () => {
     await seedUser(db, { id: "coworker", email: "coworker@example.com" });
-    await seedCalendarConnector(db, { id: "cal-reader", createdBy: "user-1" });
     await seedCalendarConnector(db, { id: "cal-coworker", createdBy: "coworker" });
 
     await seedCalendarEvent(db, {
@@ -540,11 +540,31 @@ describe("buildTodaysMeetings", () => {
     expect(meetings[0].fileId).toBe("evt-reader-copy");
   });
 
+  it("drops a meeting visible only through a coworker's calendar copy (declined / not on my calendar)", async () => {
+    await seedUser(db, { id: "coworker", email: "coworker@example.com" });
+    await seedCalendarConnector(db, { id: "cal-coworker", createdBy: "coworker" });
+
+    await seedCalendarEvent(db, {
+      id: "evt-declined-coworker-copy",
+      startTime: "2026-06-25T09:00:00.000Z",
+      title: "Invite the reader declined",
+      threadId: "declined-invite@google.com",
+      connectorConfigId: "cal-coworker",
+      restrictedTo: "agent@example.com",
+    });
+
+    const meetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
+
+    expect(meetings).toEqual([]);
+  });
+
   it("scopes an admin's meetings to their own calendar even with the read-all bypass", async () => {
     const admin = await seedUser(db, { id: "admin-1", email: "admin@example.com", authRole: "admin" });
+    await seedCalendarConnector(db, { id: "cal-admin", createdBy: "admin-1" });
     await seedCalendarEvent(db, {
       id: "evt-mine",
       startTime: "2026-06-25T09:00:00.000Z",
+      connectorConfigId: "cal-admin",
       restrictedTo: "admin@example.com",
     });
     await seedCalendarEvent(db, {

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -464,6 +464,24 @@ describe("buildTodaysMeetings", () => {
     expect(meetings[1].attendees).toEqual([]);
   });
 
+  it("keeps all-day events on their calendar date in a negative-UTC timezone", async () => {
+    await seedCalendarEvent(db, { id: "evt-all-day", startTime: "2026-06-25T00:00:00.000Z", title: "Team offsite" });
+    await seedCalendarEvent(db, {
+      id: "evt-prev-evening",
+      startTime: "2026-06-25T02:00:00.000Z",
+      title: "Late call (prev local day)",
+    });
+
+    const meetings = await buildTodaysMeetings({
+      db,
+      user,
+      ...MEETINGS_RUNTIME_PARAMS,
+      timezone: "America/Los_Angeles",
+    });
+
+    expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-all-day"]);
+  });
+
   it("excludes archived events, events outside the day, and files the reader cannot see", async () => {
     await seedCalendarEvent(db, { id: "evt-today", startTime: "2026-06-25T10:00:00.000Z" });
     await seedCalendarEvent(db, { id: "evt-archived", startTime: "2026-06-25T11:00:00.000Z", archived: true });

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -347,14 +347,17 @@ async function seedCalendarEvent(
     providerUrl?: string | null;
     archived?: boolean;
     restrictedTo?: string;
+    connectorConfigId?: string;
+    threadId?: string;
   },
 ): Promise<void> {
   await db
     .insertInto("indexed_files")
     .values({
       id: params.id,
-      connector_config_id: "config-1",
+      connector_config_id: params.connectorConfigId ?? "config-1",
       provider_file_id: `cal-${params.id}`,
+      thread_id: params.threadId ?? null,
       file_name: params.title ?? params.id,
       file_type: "calendar_event",
       content_category: "document",
@@ -373,6 +376,20 @@ async function seedCalendarEvent(
   if (params.restrictedTo) {
     await db.insertInto("file_access").values({ indexed_file_id: params.id, email: params.restrictedTo }).execute();
   }
+}
+
+async function seedCalendarConnector(db: Kysely<DB>, params: { id: string; createdBy: string }): Promise<void> {
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: params.id,
+      connector_type: "google_calendar",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: params.createdBy,
+      scope_config: "{}",
+    })
+    .execute();
 }
 
 async function seedAttendeeFact(
@@ -493,6 +510,34 @@ describe("buildTodaysMeetings", () => {
     const meetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
 
     expect(meetings.map((meeting) => meeting.fileId)).toEqual(["evt-today"]);
+  });
+
+  it("collapses duplicate calendar copies of one event, preferring the reader-owned copy", async () => {
+    await seedUser(db, { id: "coworker", email: "coworker@example.com" });
+    await seedCalendarConnector(db, { id: "cal-reader", createdBy: "user-1" });
+    await seedCalendarConnector(db, { id: "cal-coworker", createdBy: "coworker" });
+
+    await seedCalendarEvent(db, {
+      id: "evt-coworker-copy",
+      startTime: "2026-06-25T09:00:00.000Z",
+      title: "Shared sync",
+      threadId: "shared-invite@google.com",
+      connectorConfigId: "cal-coworker",
+      restrictedTo: "agent@example.com",
+    });
+    await seedCalendarEvent(db, {
+      id: "evt-reader-copy",
+      startTime: "2026-06-25T09:00:00.000Z",
+      title: "Shared sync",
+      threadId: "shared-invite@google.com",
+      connectorConfigId: "cal-reader",
+      restrictedTo: "agent@example.com",
+    });
+
+    const meetings = await buildTodaysMeetings({ db, user, ...MEETINGS_RUNTIME_PARAMS });
+
+    expect(meetings).toHaveLength(1);
+    expect(meetings[0].fileId).toBe("evt-reader-copy");
   });
 
   it("scopes an admin's meetings to their own calendar even with the read-all bypass", async () => {

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -245,6 +245,30 @@ function meetingViaFromSourcePath(sourcePath: string | null): string | null {
 }
 
 /**
+ * The reader's own email addresses (primary + linked provider identities). The
+ * meetings section is always scoped to these, even for admins with the read-all
+ * bypass (whose `contentUserEmails` is intentionally nulled upstream), so the
+ * personal meetings view never includes other people's calendar events.
+ */
+async function readerEmailsForUser(db: Kysely<DB>, userId: string): Promise<string[]> {
+  const [user, identities] = await Promise.all([
+    db.selectFrom("users").select("email").where("id", "=", userId).executeTakeFirst(),
+    db
+      .selectFrom("user_provider_identities")
+      .select("provider_email")
+      .where("user_id", "=", userId)
+      .where("provider_email", "is not", null)
+      .execute(),
+  ]);
+  const emails: string[] = [];
+  if (user?.email) emails.push(user.email);
+  for (const row of identities) {
+    if (row.provider_email && !emails.includes(row.provider_email)) emails.push(row.provider_email);
+  }
+  return emails;
+}
+
+/**
  * Deterministic skeleton for the meetings section: every non-archived calendar
  * event whose start lands on `outputDate` in the user's timezone, with attendees
  * resolved to person entities. This is the canonical list the model enriches;
@@ -259,9 +283,9 @@ function meetingViaFromSourcePath(sourcePath: string | null): string | null {
  */
 export async function buildTodaysMeetings({
   db,
+  user,
   outputDate,
   timezone,
-  contentUserEmails,
 }: AgentRuntimeContextParams): Promise<TodaysMeeting[]> {
   const dayStart = new Date(outputDateWindowStartMs(outputDate, timezone)).toISOString();
   const dayEnd = new Date(outputDateWindowEndMs(outputDate, timezone)).toISOString();
@@ -278,10 +302,11 @@ export async function buildTodaysMeetings({
     .execute();
   if (files.length === 0) return [];
 
+  const readerEmails = await readerEmailsForUser(db, user.id);
   const visibleFileIds = await filterVisibleCandidateFileIds(
     db,
     files.map((file) => file.id),
-    contentUserEmails,
+    readerEmails,
   );
   const visibleFiles = files.filter((file) => visibleFileIds.has(file.id) && file.source_created_at);
   if (visibleFiles.length === 0) return [];

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -1,7 +1,11 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import { filterAccessibleFileIds } from "../../connectors/search";
-import type { AgentKnowledgeRefs, AgentOutputItemInput } from "../../db/repositories/agent-outputs";
+import type {
+  AgentKnowledgeRefs,
+  AgentOutputItemInput,
+  AgentStructuredPayload,
+} from "../../db/repositories/agent-outputs";
 import { whereLiveEntity } from "../../db/repositories/entities";
 import type { DB } from "../../db/schema";
 import { parseOnceSchedule } from "../../scheduler/parse-once";
@@ -17,12 +21,16 @@ export const DAILY_BRIEF_HOT_FALLBACK_LIMIT = 10;
 const FILE_ACCESS_FILTER_CHUNK_SIZE = 500;
 
 export const DAILY_BRIEF_SECTION_LABELS = {
+  meetings: ["meeting"],
   todos: ["todo", "in_progress", "blocked", "waiting", "done"],
   customer_updates: ["owed_follow_up", "warm", "inbound", "stuck", "cold", "at_risk"],
   active_projects: ["active", "at_risk", "blocked", "needs_attention"],
 } as const satisfies Record<string, readonly string[]>;
 
+export const DAILY_BRIEF_MEETINGS_SECTION_KEY = "meetings";
+
 export const DAILY_BRIEF_ACTION_LABELS = {
+  meetings: ["Prep with Sketch"],
   todos: ["Plan with Sketch", "Unblock with Sketch", "Review with Sketch"],
   customer_updates: [
     "Prepare with Sketch",
@@ -95,6 +103,56 @@ export type DailyBriefCandidateContext = {
   hotFallbackEntities: DailyBriefCandidateEntity[];
 };
 
+export const DAILY_BRIEF_MEETING_ATTENDEE_LIMIT = 12;
+
+const CALENDAR_SOURCE = "google_calendar";
+const CALENDAR_EVENT_FILE_TYPE = "calendar_event";
+
+export type TodaysMeetingAttendee = {
+  name: string;
+  email: string | null;
+  entityId: string | null;
+};
+
+/**
+ * Server-built canonical record of one meeting on the user's calendar today.
+ * The list is the source of truth: the model enriches each meeting (roles,
+ * context, prep prompt) but never invents, drops, or reorders them.
+ */
+export type TodaysMeeting = {
+  fileId: string;
+  startTime: string;
+  title: string;
+  via: string | null;
+  sourceUrl: string | null;
+  attendees: TodaysMeetingAttendee[];
+};
+
+/** Enrichment the model attaches to a meeting; identity stays server-owned. */
+type MeetingAttendeeEnrichment = {
+  entityId?: string;
+  name?: string;
+  role?: string;
+  note?: string;
+  emphasis?: boolean;
+};
+
+/** Per-attendee shape persisted in the meeting item's structured payload. */
+export type MeetingPayloadAttendee = {
+  name: string;
+  entityId: string | null;
+  role: string | null;
+  note: string | null;
+  emphasis: boolean;
+};
+
+/** Structured payload persisted for a meetings-section item. */
+export type MeetingStructuredPayload = {
+  startTime: string;
+  via: string | null;
+  attendees: MeetingPayloadAttendee[];
+};
+
 type CandidateAccumulator = {
   id: string;
   name: string;
@@ -158,6 +216,127 @@ function outputDateWindowEndMs(outputDate: string, timezone: string): number {
   const ms = parsed.getTime();
   if (!Number.isFinite(ms)) throw new Error(`Invalid Daily Brief output date: ${outputDate}`);
   return ms;
+}
+
+function outputDateWindowStartMs(outputDate: string, timezone: string): number {
+  const parsed = parseOnceSchedule(`${outputDate}T00:00:00.000`, timezone);
+  const ms = parsed.getTime();
+  if (!Number.isFinite(ms)) throw new Error(`Invalid Daily Brief output date: ${outputDate}`);
+  return ms;
+}
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : null;
+}
+
+function meetingViaFromSourcePath(sourcePath: string | null): string | null {
+  if (!sourcePath) return null;
+  const slash = sourcePath.indexOf(" / ");
+  const calendar = slash >= 0 ? sourcePath.slice(slash + 3).trim() : sourcePath.trim();
+  return calendar ? calendar : null;
+}
+
+/**
+ * Deterministic skeleton for the meetings section: every non-archived calendar
+ * event whose start lands on `outputDate` in the user's timezone, with attendees
+ * resolved to person entities. This is the canonical list the model enriches;
+ * declined and cancelled events are already excluded at sync time so they never
+ * reach the graph. RBAC mirrors {@link buildDailyBriefCandidateContext}.
+ */
+export async function buildTodaysMeetings({
+  db,
+  outputDate,
+  timezone,
+  adminCanReadAllFiles,
+  contentUserEmails,
+  user,
+}: AgentRuntimeContextParams): Promise<TodaysMeeting[]> {
+  const dayStart = new Date(outputDateWindowStartMs(outputDate, timezone)).toISOString();
+  const dayEnd = new Date(outputDateWindowEndMs(outputDate, timezone)).toISOString();
+  const candidateUserEmails = user.auth_role === "admin" && adminCanReadAllFiles ? undefined : contentUserEmails;
+
+  const files = await db
+    .selectFrom("indexed_files")
+    .select(["id", "file_name", "source_created_at", "provider_url", "source_path"])
+    .where("source", "=", CALENDAR_SOURCE)
+    .where("file_type", "=", CALENDAR_EVENT_FILE_TYPE)
+    .where("is_archived", "=", 0)
+    .where("source_created_at", ">=", dayStart)
+    .where("source_created_at", "<=", dayEnd)
+    .execute();
+  if (files.length === 0) return [];
+
+  const visibleFileIds = await filterVisibleCandidateFileIds(
+    db,
+    files.map((file) => file.id),
+    candidateUserEmails,
+  );
+  const visibleFiles = files.filter((file) => visibleFileIds.has(file.id) && file.source_created_at);
+  if (visibleFiles.length === 0) return [];
+
+  const fileIds = visibleFiles.map((file) => file.id);
+  const attendeeFacts = await db
+    .selectFrom("indexed_file_facts")
+    .select(["indexed_file_id", "subject_name", "subject_email"])
+    .where("fact_type", "=", "attendee")
+    .where("deleted_at", "is", null)
+    .where("indexed_file_id", "in", fileIds)
+    .execute();
+
+  const emailToEntity = await resolveAttendeeEntities(
+    db,
+    attendeeFacts.map((fact) => fact.subject_email),
+  );
+
+  const attendeesByFile = new Map<string, TodaysMeetingAttendee[]>();
+  for (const fact of attendeeFacts) {
+    if (!fact.indexed_file_id) continue;
+    const email = normalizeEmail(fact.subject_email);
+    const name = fact.subject_name?.trim() || email;
+    if (!name) continue;
+    const list = attendeesByFile.get(fact.indexed_file_id) ?? [];
+    const dedupeKey = email ?? name.toLowerCase();
+    if (list.some((existing) => (existing.email ?? existing.name.toLowerCase()) === dedupeKey)) continue;
+    if (list.length >= DAILY_BRIEF_MEETING_ATTENDEE_LIMIT) continue;
+    list.push({ name, email, entityId: (email && emailToEntity.get(email)) || null });
+    attendeesByFile.set(fact.indexed_file_id, list);
+  }
+
+  return visibleFiles
+    .map((file) => ({
+      fileId: file.id,
+      startTime: file.source_created_at as string,
+      title: file.file_name?.trim() || "Untitled event",
+      via: meetingViaFromSourcePath(file.source_path),
+      sourceUrl: file.provider_url,
+      attendees: attendeesByFile.get(file.id) ?? [],
+    }))
+    .sort((a, b) => a.startTime.localeCompare(b.startTime) || a.title.localeCompare(b.title));
+}
+
+async function resolveAttendeeEntities(db: Kysely<DB>, emails: Array<string | null>): Promise<Map<string, string>> {
+  const normalized = [...new Set(emails.map(normalizeEmail).filter((email): email is string => email !== null))];
+  const map = new Map<string, string>();
+  if (normalized.length === 0) return map;
+
+  const rows = await db
+    .selectFrom("entity_contact_points")
+    .innerJoin("entities", "entities.id", "entity_contact_points.entity_id")
+    .select(["entity_contact_points.value as email", "entities.id as entity_id", "entities.name as entity_name"])
+    .where("entity_contact_points.kind", "=", "email")
+    .where(sql<boolean>`lower(entity_contact_points.value) in (${sql.join(normalized)})`)
+    .where("entities.source_type", "=", "person")
+    .where("entities.status", "!=", "archived")
+    .where(whereLiveEntity())
+    .orderBy("entities.name", "asc")
+    .execute();
+
+  for (const row of rows) {
+    const email = normalizeEmail(row.email);
+    if (email && !map.has(email)) map.set(email, row.entity_id);
+  }
+  return map;
 }
 
 export async function buildDailyBriefCandidateContext({
@@ -268,12 +447,14 @@ function normalizeStoredLabel(sectionKey: string, value: string | null): string 
     | readonly string[]
     | undefined;
   if (labels?.includes(value ?? "")) return value as string;
+  if (sectionKey === DAILY_BRIEF_MEETINGS_SECTION_KEY) return "meeting";
   if (sectionKey === "customer_updates") return "warm";
   if (sectionKey === "active_projects") return "active";
   return "todo";
 }
 
 function defaultActionLabel(sectionKey: string, label: string | null): string {
+  if (sectionKey === DAILY_BRIEF_MEETINGS_SECTION_KEY) return "Prep with Sketch";
   const normalizedLabel = normalizeStoredLabel(sectionKey, label);
   if (sectionKey === "active_projects") return "Catch me up";
   if (sectionKey === "customer_updates") {
@@ -366,6 +547,7 @@ function normalizeActionLabel(item: AgentOutputItemInput): string {
 }
 
 const SECTION_GUIDE: Record<string, string> = {
+  meetings: "meetings: today's calendar events. The list is provided; you only enrich it (see Meetings below).",
   todos: "todos: concrete follow-ups, blockers, unanswered asks, or decisions that appear actionable.",
   customer_updates: "customer_updates: customer/company/account changes, risks, asks, demos, or decisions.",
   active_projects: "active_projects: internal project/workstream/product movement and next steps.",
@@ -390,11 +572,21 @@ const DAILY_BRIEF_INSTRUCTIONS = [
   "- Emit items only for the section keys listed in the runtime context `sections` field. Emit no items for any other section.",
   "",
   "Sections:",
+  `- ${SECTION_GUIDE.meetings}`,
   `- ${SECTION_GUIDE.todos}`,
   `- ${SECTION_GUIDE.customer_updates}`,
   `- ${SECTION_GUIDE.active_projects}`,
   "",
+  "Meetings (deterministic — enrich only, never invent):",
+  "- The runtime context includes `todaysMeetings`: the exact list of the reader's meetings today, built from their calendar. It is the source of truth.",
+  "- If meetings is in the enabled `sections`, emit exactly one item per entry in `todaysMeetings`. Do not add, drop, merge, or reorder meetings, and do not invent any not in the list.",
+  "- For each meeting item: sectionKey 'meetings', title = the meeting's title, label 'meeting', and set knowledgeRefs.fileIds to exactly that meeting's `fileId`.",
+  "- Put your enrichment in `structuredPayload`: { context: one-line situational read of why this meeting matters today; attendees: [{ entityId (copy from the meeting's attendee when present), name, role: one-line role, note: one line on why they matter today, emphasis: true for the single key person }] }. Only enrich attendees listed on the meeting; never add attendees.",
+  "- summary = the same one-line context. actionPrompt = a Sketch chat prompt that preps the reader for this meeting (pull context on the attendees/topic, give talking points and questions).",
+  "- The per-section item cap does NOT apply to meetings; always emit one item per meeting. Identity (time, title, attendee identity) is fixed by the server, so focus your effort on the roles, notes, context, and prep prompt.",
+  "",
   "Labels (per sectionKey):",
+  "- meetings.label must be: meeting.",
   "- todos.label must be one of: todo, in_progress, blocked, waiting, done.",
   "- customer_updates.label must be one of: owed_follow_up, warm, inbound, stuck, cold, at_risk.",
   "- active_projects.label must be one of: active, at_risk, blocked, needs_attention.",
@@ -402,13 +594,13 @@ const DAILY_BRIEF_INSTRUCTIONS = [
   "",
   "Sketch chat actions:",
   "- Every action must start a Sketch chat only. Do not use external-agent language such as Ask Claude, Review PR, send email, or run automation.",
+  "- meetings.actionLabel must be Prep with Sketch.",
   "- todos.actionLabel must be Plan with Sketch for todo, in_progress, and waiting; Unblock with Sketch for blocked; Review with Sketch only for done items that are still worth showing.",
   "- customer_updates.actionLabel must be one of: Prepare with Sketch, Draft follow-up, Plan next step, Catch me up, Unblock with Sketch, Review risk, Plan re-engagement.",
   "- active_projects.actionLabel must always be Catch me up.",
   "- actionPrompt must be a complete instruction to Sketch chat with enough context to discuss, prepare, draft, plan, catch up, or unblock. It must not claim Sketch will perform an external side effect without user review.",
   "",
   "Rules:",
-  "- Do not create a meetings or calendar section.",
   "- Output a complete new brief snapshot, not patches.",
   "- Return at most the per-section item cap given in the runtime context `maxItemsPerSection` field.",
   "- The runtime context includes `dailyBriefCandidateContext`. Start from `recentEntities` there; then consider `hotFallbackEntities` as a safety net for important entities just outside the recent window.",
@@ -430,6 +622,139 @@ const DAILY_BRIEF_INSTRUCTIONS = [
 
 function buildInstructions(): string {
   return DAILY_BRIEF_INSTRUCTIONS;
+}
+
+function parseTodaysMeetings(value: unknown): TodaysMeeting[] {
+  if (!Array.isArray(value)) return [];
+  const meetings: TodaysMeeting[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object") continue;
+    const m = raw as Record<string, unknown>;
+    if (typeof m.fileId !== "string" || typeof m.startTime !== "string" || typeof m.title !== "string") continue;
+    const attendees = Array.isArray(m.attendees)
+      ? m.attendees.flatMap((entry): TodaysMeetingAttendee[] => {
+          if (!entry || typeof entry !== "object") return [];
+          const a = entry as Record<string, unknown>;
+          if (typeof a.name !== "string") return [];
+          return [
+            {
+              name: a.name,
+              email: typeof a.email === "string" ? a.email : null,
+              entityId: typeof a.entityId === "string" ? a.entityId : null,
+            },
+          ];
+        })
+      : [];
+    meetings.push({
+      fileId: m.fileId,
+      startTime: m.startTime,
+      title: m.title,
+      via: typeof m.via === "string" ? m.via : null,
+      sourceUrl: typeof m.sourceUrl === "string" ? m.sourceUrl : null,
+      attendees,
+    });
+  }
+  return meetings;
+}
+
+function parseMeetingEnrichment(payload: AgentStructuredPayload | null | undefined): {
+  context: string | null;
+  attendees: MeetingAttendeeEnrichment[];
+} {
+  const context = typeof payload?.context === "string" ? payload.context : null;
+  const attendees: MeetingAttendeeEnrichment[] = [];
+  const rawAttendees = payload?.attendees;
+  if (Array.isArray(rawAttendees)) {
+    for (const entry of rawAttendees) {
+      if (!entry || typeof entry !== "object") continue;
+      const a = entry as Record<string, unknown>;
+      attendees.push({
+        entityId: typeof a.entityId === "string" ? a.entityId : undefined,
+        name: typeof a.name === "string" ? a.name : undefined,
+        role: typeof a.role === "string" ? a.role : undefined,
+        note: typeof a.note === "string" ? a.note : undefined,
+        emphasis: typeof a.emphasis === "boolean" ? a.emphasis : undefined,
+      });
+    }
+  }
+  return { context, attendees };
+}
+
+function meetingFallbackSummary(meeting: TodaysMeeting): string {
+  const count = meeting.attendees.length;
+  if (count === 0) return "On your calendar today.";
+  return `${count} ${count === 1 ? "attendee" : "attendees"}.`;
+}
+
+function defaultMeetingPrompt(meeting: TodaysMeeting): string {
+  const names = meeting.attendees
+    .map((attendee) => attendee.name)
+    .slice(0, 5)
+    .join(", ");
+  const withWhom = names ? ` with ${names}` : "";
+  return `Prep me for my meeting "${meeting.title}"${withWhom}. Pull recent context on the attendees and the topic from our org knowledge, summarise what it is likely about, then give me three talking points and two questions to ask.`;
+}
+
+/**
+ * Reconciles the model's meetings items against the deterministic skeleton: the
+ * skeleton is the source of truth for which meetings exist and their identity
+ * (time, title, attendee identity); the model only supplies enrichment. Invented
+ * meetings are dropped, skipped meetings are backfilled skeleton-only, and the
+ * output is ordered by start time. When the skeleton is empty (no calendar or no
+ * meetings today) every meetings item is dropped.
+ */
+function reconcileMeetingItems(items: AgentOutputItemInput[], meetings: TodaysMeeting[]): AgentOutputItemInput[] {
+  const others = items.filter((item) => item.sectionKey !== DAILY_BRIEF_MEETINGS_SECTION_KEY);
+  if (meetings.length === 0) return others;
+
+  const meetingItems = items.filter((item) => item.sectionKey === DAILY_BRIEF_MEETINGS_SECTION_KEY);
+  const skeletonIds = new Set(meetings.map((meeting) => meeting.fileId));
+  const enrichmentByFile = new Map<string, AgentOutputItemInput>();
+  for (const item of meetingItems) {
+    const fileId = item.knowledgeRefs.fileIds.find((id) => skeletonIds.has(id));
+    if (fileId && !enrichmentByFile.has(fileId)) enrichmentByFile.set(fileId, item);
+  }
+
+  const reconciled: AgentOutputItemInput[] = meetings.map((meeting, index) => {
+    const source = enrichmentByFile.get(meeting.fileId);
+    const enrichment = parseMeetingEnrichment(source?.structuredPayload);
+    const attendees: MeetingPayloadAttendee[] = meeting.attendees.map((attendee) => {
+      const match = enrichment.attendees.find(
+        (candidate) =>
+          (candidate.entityId && attendee.entityId && candidate.entityId === attendee.entityId) ||
+          (candidate.name && candidate.name.trim().toLowerCase() === attendee.name.trim().toLowerCase()),
+      );
+      return {
+        name: attendee.name,
+        entityId: attendee.entityId,
+        role: match?.role?.trim() || null,
+        note: match?.note?.trim() || null,
+        emphasis: match?.emphasis ?? false,
+      };
+    });
+    const entityIds = [...new Set(attendees.map((a) => a.entityId).filter((id): id is string => id !== null))];
+    const structuredPayload: MeetingStructuredPayload = {
+      startTime: meeting.startTime,
+      via: meeting.via,
+      attendees,
+    };
+    return {
+      sectionKey: DAILY_BRIEF_MEETINGS_SECTION_KEY,
+      title: meeting.title,
+      summary: enrichment.context?.trim() || source?.summary?.trim() || meetingFallbackSummary(meeting),
+      priority: "medium",
+      label: "meeting",
+      actionType: "meeting",
+      actionLabel: "Prep with Sketch",
+      actionPrompt: source?.actionPrompt?.trim() || defaultMeetingPrompt(meeting),
+      sourceUrl: meeting.sourceUrl,
+      structuredPayload: structuredPayload as AgentStructuredPayload,
+      knowledgeRefs: { entityIds, fileIds: [meeting.fileId] },
+      sortOrder: index,
+    };
+  });
+
+  return [...reconciled, ...others];
 }
 
 async function enrichItems(db: Kysely<DB>, items: AgentOutputItemInput[]): Promise<AgentOutputItemInput[]> {
@@ -471,6 +796,7 @@ function toApiItem(item: AgentStoredItem): AgentApiItem {
     actionLabel: normalizeStoredActionLabel(item.section_key, item.label, item.action_label),
     actionPrompt: item.action_prompt,
     sourceUrl: item.source_url,
+    structuredPayload: item.structuredPayload,
     knowledgeRefs: item.knowledgeRefs,
     sortOrder: item.sort_order,
   };
@@ -491,6 +817,12 @@ export const dailyBriefDefinition: AgentDefinition = {
     maxItemsPerSection: 4,
   },
   sections: [
+    {
+      key: DAILY_BRIEF_MEETINGS_SECTION_KEY,
+      title: "Today's meetings",
+      enabledByDefault: true,
+      labels: DAILY_BRIEF_SECTION_LABELS.meetings,
+    },
     { key: "todos", title: "To-dos", enabledByDefault: true, labels: DAILY_BRIEF_SECTION_LABELS.todos },
     {
       key: "customer_updates",
@@ -509,9 +841,18 @@ export const dailyBriefDefinition: AgentDefinition = {
   itemsPerSectionRange: { min: 1, max: 10 },
   requiresKnowledgeRefs: true,
   buildInstructions,
-  buildRuntimeContext: async (params) => ({
-    dailyBriefCandidateContext: await buildDailyBriefCandidateContext(params),
-  }),
+  buildRuntimeContext: async (params) => {
+    const [dailyBriefCandidateContext, todaysMeetings] = await Promise.all([
+      buildDailyBriefCandidateContext(params),
+      buildTodaysMeetings(params),
+    ]);
+    return { dailyBriefCandidateContext, todaysMeetings };
+  },
+  reconcileItems: async ({ items, runtimeContext }) => {
+    const sections = Array.isArray(runtimeContext.sections) ? (runtimeContext.sections as string[]) : [];
+    if (!sections.includes(DAILY_BRIEF_MEETINGS_SECTION_KEY)) return items;
+    return reconcileMeetingItems(items, parseTodaysMeetings(runtimeContext.todaysMeetings));
+  },
   enrichItems,
   toApiItem,
 };

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -292,7 +292,7 @@ export async function buildTodaysMeetings({
 
   const files = await db
     .selectFrom("indexed_files")
-    .select(["id", "file_name", "source_created_at", "provider_url", "source_path"])
+    .select(["id", "file_name", "source_created_at", "provider_url", "source_path", "thread_id", "connector_config_id"])
     .where("source", "=", CALENDAR_SOURCE)
     .where("file_type", "=", CALENDAR_EVENT_FILE_TYPE)
     .where("is_archived", "=", 0)
@@ -311,7 +311,10 @@ export async function buildTodaysMeetings({
   const visibleFiles = files.filter((file) => visibleFileIds.has(file.id) && file.source_created_at);
   if (visibleFiles.length === 0) return [];
 
-  const fileIds = visibleFiles.map((file) => file.id);
+  const readerConnectorIds = await readerOwnedCalendarConnectorIds(db, user.id);
+  const dedupedFiles = dedupeCalendarCopies(visibleFiles, readerConnectorIds);
+
+  const fileIds = dedupedFiles.map((file) => file.id);
   const attendeeFacts = await db
     .selectFrom("indexed_file_facts")
     .select(["indexed_file_id", "subject_name", "subject_email"])
@@ -339,7 +342,7 @@ export async function buildTodaysMeetings({
     attendeesByFile.set(fact.indexed_file_id, list);
   }
 
-  return visibleFiles
+  return dedupedFiles
     .map((file) => ({
       fileId: file.id,
       startTime: file.source_created_at as string,
@@ -349,6 +352,47 @@ export async function buildTodaysMeetings({
       attendees: attendeesByFile.get(file.id) ?? [],
     }))
     .sort((a, b) => a.startTime.localeCompare(b.startTime) || a.title.localeCompare(b.title));
+}
+
+type CalendarCopyFile = {
+  id: string;
+  thread_id: string | null;
+  connector_config_id: string;
+};
+
+/** The google_calendar connector configs the reader owns (created). */
+async function readerOwnedCalendarConnectorIds(db: Kysely<DB>, userId: string): Promise<Set<string>> {
+  const rows = await db
+    .selectFrom("connector_configs")
+    .select("id")
+    .where("connector_type", "=", CALENDAR_SOURCE)
+    .where("created_by", "=", userId)
+    .execute();
+  return new Set(rows.map((row) => row.id));
+}
+
+/**
+ * Collapses duplicate calendar copies of the same event. When several attendees
+ * in an org connect their calendars, one real invite is indexed once per
+ * connector (one row per attendee's copy) and the reader can see more than one.
+ * Copies are keyed by `thread_id` (the event's iCalUID); the reader-owned copy
+ * wins, then the lowest id, so the result is stable regardless of query order.
+ */
+function dedupeCalendarCopies<T extends CalendarCopyFile>(files: T[], readerConnectorIds: Set<string>): T[] {
+  const ordered = [...files].sort((a, b) => a.id.localeCompare(b.id));
+  const byIdentity = new Map<string, T>();
+  for (const file of ordered) {
+    const key = file.thread_id ?? `file:${file.id}`;
+    const existing = byIdentity.get(key);
+    if (!existing) {
+      byIdentity.set(key, file);
+      continue;
+    }
+    const existingOwned = readerConnectorIds.has(existing.connector_config_id);
+    const candidateOwned = readerConnectorIds.has(file.connector_config_id);
+    if (candidateOwned && !existingOwned) byIdentity.set(key, file);
+  }
+  return [...byIdentity.values()];
 }
 
 async function resolveAttendeeEntities(db: Kysely<DB>, emails: Array<string | null>): Promise<Map<string, string>> {

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -312,7 +312,8 @@ export async function buildTodaysMeetings({
   if (visibleFiles.length === 0) return [];
 
   const readerConnectorIds = await readerOwnedCalendarConnectorIds(db, user.id);
-  const dedupedFiles = dedupeCalendarCopies(visibleFiles, readerConnectorIds);
+  const dedupedFiles = readerOwnedMeetingCopies(visibleFiles, readerConnectorIds);
+  if (dedupedFiles.length === 0) return [];
 
   const fileIds = dedupedFiles.map((file) => file.id);
   const attendeeFacts = await db
@@ -372,25 +373,26 @@ async function readerOwnedCalendarConnectorIds(db: Kysely<DB>, userId: string): 
 }
 
 /**
- * Collapses duplicate calendar copies of the same event. When several attendees
- * in an org connect their calendars, one real invite is indexed once per
- * connector (one row per attendee's copy) and the reader can see more than one.
- * Copies are keyed by `thread_id` (the event's iCalUID); the reader-owned copy
- * wins, then the lowest id, so the result is stable regardless of query order.
+ * Reduces calendar copies to one row per event, keeping only copies synced from
+ * the reader's own calendar connector.
+ *
+ * When several attendees connect their calendars, one real invite is indexed
+ * once per connector and calendar ACLs make every copy visible to all
+ * attendees. Requiring a reader-owned copy is what keeps the section scoped to
+ * the reader's own calendar: it both collapses the duplicates and honours the
+ * owner-declined filter, since a declined event's reader-owned copy is archived
+ * and only coworker copies would remain (those must not resurface the meeting).
+ *
+ * Deduped by `thread_id` (the event's iCalUID); the lowest id wins when the
+ * reader holds multiple copies, so the result is stable regardless of query order.
  */
-function dedupeCalendarCopies<T extends CalendarCopyFile>(files: T[], readerConnectorIds: Set<string>): T[] {
+function readerOwnedMeetingCopies<T extends CalendarCopyFile>(files: T[], readerConnectorIds: Set<string>): T[] {
   const ordered = [...files].sort((a, b) => a.id.localeCompare(b.id));
   const byIdentity = new Map<string, T>();
   for (const file of ordered) {
+    if (!readerConnectorIds.has(file.connector_config_id)) continue;
     const key = file.thread_id ?? `file:${file.id}`;
-    const existing = byIdentity.get(key);
-    if (!existing) {
-      byIdentity.set(key, file);
-      continue;
-    }
-    const existingOwned = readerConnectorIds.has(existing.connector_config_id);
-    const candidateOwned = readerConnectorIds.has(file.connector_config_id);
-    if (candidateOwned && !existingOwned) byIdentity.set(key, file);
+    if (!byIdentity.has(key)) byIdentity.set(key, file);
   }
   return [...byIdentity.values()];
 }

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -108,6 +108,13 @@ export const DAILY_BRIEF_MEETING_ATTENDEE_LIMIT = 12;
 const CALENDAR_SOURCE = "google_calendar";
 const CALENDAR_EVENT_FILE_TYPE = "calendar_event";
 
+/**
+ * All-day Google Calendar events are stored with a UTC-midnight `source_created_at`
+ * sentinel ("YYYY-MM-DDT00:00:00.000Z"). The meetings section is for timed meetings,
+ * so they are excluded with this LIKE suffix (portable across SQLite and Postgres).
+ */
+const ALL_DAY_INSTANT_SUFFIX = "%T00:00:00.000Z";
+
 export type TodaysMeetingAttendee = {
   name: string;
   email: string | null;
@@ -242,25 +249,22 @@ function meetingViaFromSourcePath(sourcePath: string | null): string | null {
  * event whose start lands on `outputDate` in the user's timezone, with attendees
  * resolved to person entities. This is the canonical list the model enriches;
  * declined and cancelled events are already excluded at sync time so they never
- * reach the graph. RBAC mirrors {@link buildDailyBriefCandidateContext}.
+ * reach the graph. Always scoped to the reader's own calendar access: unlike the
+ * knowledge candidate query it does not honor the admin "read all files" bypass,
+ * so an admin's meetings section never pulls in other people's meetings.
  *
- * Timed events match the tz day window. All-day events are stored at UTC
- * midnight with no timezone, so the window would drop them in negative-UTC
- * zones; they are matched separately by their calendar date so they always land
- * on the day they are labeled.
+ * Only timed events inside the timezone day window are included; all-day events
+ * (stored at UTC midnight) are excluded since this section is about meetings to
+ * prep for, not OOO/holiday/offsite entries. See {@link ALL_DAY_INSTANT_SUFFIX}.
  */
 export async function buildTodaysMeetings({
   db,
   outputDate,
   timezone,
-  adminCanReadAllFiles,
   contentUserEmails,
-  user,
 }: AgentRuntimeContextParams): Promise<TodaysMeeting[]> {
   const dayStart = new Date(outputDateWindowStartMs(outputDate, timezone)).toISOString();
   const dayEnd = new Date(outputDateWindowEndMs(outputDate, timezone)).toISOString();
-  const allDayInstant = `${outputDate}T00:00:00.000Z`;
-  const candidateUserEmails = user.auth_role === "admin" && adminCanReadAllFiles ? undefined : contentUserEmails;
 
   const files = await db
     .selectFrom("indexed_files")
@@ -268,19 +272,16 @@ export async function buildTodaysMeetings({
     .where("source", "=", CALENDAR_SOURCE)
     .where("file_type", "=", CALENDAR_EVENT_FILE_TYPE)
     .where("is_archived", "=", 0)
-    .where((eb) =>
-      eb.or([
-        eb.and([eb("source_created_at", ">=", dayStart), eb("source_created_at", "<=", dayEnd)]),
-        eb("source_created_at", "=", allDayInstant),
-      ]),
-    )
+    .where("source_created_at", ">=", dayStart)
+    .where("source_created_at", "<=", dayEnd)
+    .where("source_created_at", "not like", ALL_DAY_INSTANT_SUFFIX)
     .execute();
   if (files.length === 0) return [];
 
   const visibleFileIds = await filterVisibleCandidateFileIds(
     db,
     files.map((file) => file.id),
-    candidateUserEmails,
+    contentUserEmails,
   );
   const visibleFiles = files.filter((file) => visibleFileIds.has(file.id) && file.source_created_at);
   if (visibleFiles.length === 0) return [];

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -7,6 +7,7 @@ import type {
   AgentStructuredPayload,
 } from "../../db/repositories/agent-outputs";
 import { whereLiveEntity } from "../../db/repositories/entities";
+import { createUserRepository } from "../../db/repositories/users";
 import type { DB } from "../../db/schema";
 import { parseOnceSchedule } from "../../scheduler/parse-once";
 import { parseTimestampMs } from "../../timestamps";
@@ -107,13 +108,6 @@ export const DAILY_BRIEF_MEETING_ATTENDEE_LIMIT = 12;
 
 const CALENDAR_SOURCE = "google_calendar";
 const CALENDAR_EVENT_FILE_TYPE = "calendar_event";
-
-/**
- * All-day Google Calendar events are stored with a UTC-midnight `source_created_at`
- * sentinel ("YYYY-MM-DDT00:00:00.000Z"). The meetings section is for timed meetings,
- * so they are excluded with this LIKE suffix (portable across SQLite and Postgres).
- */
-const ALL_DAY_INSTANT_SUFFIX = "%T00:00:00.000Z";
 
 export type TodaysMeetingAttendee = {
   name: string;
@@ -245,30 +239,6 @@ function meetingViaFromSourcePath(sourcePath: string | null): string | null {
 }
 
 /**
- * The reader's own email addresses (primary + linked provider identities). The
- * meetings section is always scoped to these, even for admins with the read-all
- * bypass (whose `contentUserEmails` is intentionally nulled upstream), so the
- * personal meetings view never includes other people's calendar events.
- */
-async function readerEmailsForUser(db: Kysely<DB>, userId: string): Promise<string[]> {
-  const [user, identities] = await Promise.all([
-    db.selectFrom("users").select("email").where("id", "=", userId).executeTakeFirst(),
-    db
-      .selectFrom("user_provider_identities")
-      .select("provider_email")
-      .where("user_id", "=", userId)
-      .where("provider_email", "is not", null)
-      .execute(),
-  ]);
-  const emails: string[] = [];
-  if (user?.email) emails.push(user.email);
-  for (const row of identities) {
-    if (row.provider_email && !emails.includes(row.provider_email)) emails.push(row.provider_email);
-  }
-  return emails;
-}
-
-/**
  * Deterministic skeleton for the meetings section: every non-archived calendar
  * event whose start lands on `outputDate` in the user's timezone, with attendees
  * resolved to person entities. This is the canonical list the model enriches;
@@ -278,8 +248,8 @@ async function readerEmailsForUser(db: Kysely<DB>, userId: string): Promise<stri
  * so an admin's meetings section never pulls in other people's meetings.
  *
  * Only timed events inside the timezone day window are included; all-day events
- * (stored at UTC midnight) are excluded since this section is about meetings to
- * prep for, not OOO/holiday/offsite entries. See {@link ALL_DAY_INSTANT_SUFFIX}.
+ * are excluded via the `is_all_day` flag the connector sets at sync time, since
+ * this section is about meetings to prep for, not OOO/holiday/offsite entries.
  */
 export async function buildTodaysMeetings({
   db,
@@ -296,13 +266,13 @@ export async function buildTodaysMeetings({
     .where("source", "=", CALENDAR_SOURCE)
     .where("file_type", "=", CALENDAR_EVENT_FILE_TYPE)
     .where("is_archived", "=", 0)
+    .where("is_all_day", "=", 0)
     .where("source_created_at", ">=", dayStart)
     .where("source_created_at", "<=", dayEnd)
-    .where("source_created_at", "not like", ALL_DAY_INSTANT_SUFFIX)
     .execute();
   if (files.length === 0) return [];
 
-  const readerEmails = await readerEmailsForUser(db, user.id);
+  const readerEmails = await createUserRepository(db).getAllEmailsForUser(user.id);
   const visibleFileIds = await filterVisibleCandidateFileIds(
     db,
     files.map((file) => file.id),
@@ -405,7 +375,7 @@ async function resolveAttendeeEntities(db: Kysely<DB>, emails: Array<string | nu
   const rows = await db
     .selectFrom("entity_contact_points")
     .innerJoin("entities", "entities.id", "entity_contact_points.entity_id")
-    .select(["entity_contact_points.value as email", "entities.id as entity_id", "entities.name as entity_name"])
+    .select(["entity_contact_points.value as email", "entities.id as entity_id"])
     .where("entity_contact_points.kind", "=", "email")
     .where(sql<boolean>`lower(entity_contact_points.value) in (${sql.join(normalized)})`)
     .where("entities.source_type", "=", "person")

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -243,6 +243,11 @@ function meetingViaFromSourcePath(sourcePath: string | null): string | null {
  * resolved to person entities. This is the canonical list the model enriches;
  * declined and cancelled events are already excluded at sync time so they never
  * reach the graph. RBAC mirrors {@link buildDailyBriefCandidateContext}.
+ *
+ * Timed events match the tz day window. All-day events are stored at UTC
+ * midnight with no timezone, so the window would drop them in negative-UTC
+ * zones; they are matched separately by their calendar date so they always land
+ * on the day they are labeled.
  */
 export async function buildTodaysMeetings({
   db,
@@ -254,6 +259,7 @@ export async function buildTodaysMeetings({
 }: AgentRuntimeContextParams): Promise<TodaysMeeting[]> {
   const dayStart = new Date(outputDateWindowStartMs(outputDate, timezone)).toISOString();
   const dayEnd = new Date(outputDateWindowEndMs(outputDate, timezone)).toISOString();
+  const allDayInstant = `${outputDate}T00:00:00.000Z`;
   const candidateUserEmails = user.auth_role === "admin" && adminCanReadAllFiles ? undefined : contentUserEmails;
 
   const files = await db
@@ -262,8 +268,12 @@ export async function buildTodaysMeetings({
     .where("source", "=", CALENDAR_SOURCE)
     .where("file_type", "=", CALENDAR_EVENT_FILE_TYPE)
     .where("is_archived", "=", 0)
-    .where("source_created_at", ">=", dayStart)
-    .where("source_created_at", "<=", dayEnd)
+    .where((eb) =>
+      eb.or([
+        eb.and([eb("source_created_at", ">=", dayStart), eb("source_created_at", "<=", dayEnd)]),
+        eb("source_created_at", "=", allDayInstant),
+      ]),
+    )
     .execute();
   if (files.length === 0) return [];
 

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import type { DB } from "../db/schema";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import type { AgentOutputApi, AgentRunService } from "./service";
 
@@ -24,6 +26,7 @@ function toBriefShape(output: AgentOutputApi | null) {
     generatedAt: output.generatedAt,
     masthead: output.masthead,
     sections: {
+      meetings: output.sections.meetings ?? [],
       todos: output.sections.todos ?? [],
       customer_updates: output.sections.customer_updates ?? [],
       active_projects: output.sections.active_projects ?? [],
@@ -31,20 +34,39 @@ function toBriefShape(output: AgentOutputApi | null) {
   };
 }
 
-export function dailyBriefRoutes(service: AgentRunService) {
+/**
+ * Whether the reader has connected their own calendar. Drives the meetings
+ * section empty state: a connect nudge when false, an "empty day" line when true.
+ */
+async function hasCalendarConnector(db: Kysely<DB>, userId: string): Promise<boolean> {
+  const row = await db
+    .selectFrom("connector_configs")
+    .select("id")
+    .where("connector_type", "=", "google_calendar")
+    .where("created_by", "=", userId)
+    .limit(1)
+    .executeTakeFirst();
+  return Boolean(row);
+}
+
+export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>) {
   const routes = new Hono();
 
   routes.get("/", async (c) => {
     const userId = await getCurrentUserId(c, service);
     if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
     const date = c.req.query("date") || undefined;
-    const result = await service.getLatestForUser(DAILY_BRIEF_AGENT_KEY, userId, date);
+    const [result, calendarConnected] = await Promise.all([
+      service.getLatestForUser(DAILY_BRIEF_AGENT_KEY, userId, date),
+      hasCalendarConnector(db, userId),
+    ]);
     return c.json({
       brief: toBriefShape(result.output),
       running: result.running,
       briefDate: result.outputDate,
       timezone: result.timezone,
       enabledSections: result.enabledSections,
+      calendarConnected,
     });
   });
 

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -479,15 +479,6 @@ export class AgentRunService {
     let saved = false;
     const config = await this.resolveConfig(def, user.id);
     const enabledSections = def.sections.filter((s) => config.enabledSections[s.key]).map((s) => s.key);
-    const writer = this.createWriter(def, {
-      outputId,
-      enabledSections: new Set(enabledSections),
-      expectedOutputDate: output.output_date,
-      expectedTimezone: output.timezone,
-      onSaved: () => {
-        saved = true;
-      },
-    });
 
     try {
       const now = new Date();
@@ -526,6 +517,16 @@ export class AgentRunService {
         previousDayOutput: this.formatOutputForContext(previousDay.output),
         ...definitionContext,
       };
+      const writer = this.createWriter(def, {
+        outputId,
+        enabledSections: new Set(enabledSections),
+        expectedOutputDate: output.output_date,
+        expectedTimezone: output.timezone,
+        runtimeContext,
+        onSaved: () => {
+          saved = true;
+        },
+      });
       const userMessage = buildSketchContext({
         messages: [],
         currentUserName: user.name,
@@ -590,6 +591,7 @@ export class AgentRunService {
       enabledSections: Set<string>;
       expectedOutputDate: string;
       expectedTimezone: string;
+      runtimeContext: Record<string, unknown>;
       onSaved: () => void;
     },
   ): AgentOutputWriter {
@@ -611,7 +613,10 @@ export class AgentRunService {
         const filtered = payload.items.filter(
           (item) => sectionKeys.has(item.sectionKey) && params.enabledSections.has(item.sectionKey),
         );
-        const items = await def.enrichItems(this.deps.db, filtered);
+        const reconciled = def.reconcileItems
+          ? await def.reconcileItems({ db: this.deps.db, items: filtered, runtimeContext: params.runtimeContext })
+          : filtered;
+        const items = await def.enrichItems(this.deps.db, reconciled);
         await this.validateItemRefs(def, items);
         await this.repo.completeOutput({
           outputId: params.outputId,

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -1,9 +1,14 @@
 import type { Kysely } from "kysely";
 import type { Selectable } from "kysely";
-import type { AgentKnowledgeRefs, AgentOutputItemInput, AgentOutputItemRow } from "../db/repositories/agent-outputs";
+import type {
+  AgentKnowledgeRefs,
+  AgentOutputItemInput,
+  AgentStoredItemRow,
+  AgentStructuredPayload,
+} from "../db/repositories/agent-outputs";
 import type { DB, UsersTable } from "../db/schema";
 
-export type AgentStoredItem = AgentOutputItemRow & { knowledgeRefs: AgentKnowledgeRefs };
+export type AgentStoredItem = AgentStoredItemRow;
 
 export interface AgentSectionDef {
   key: string;
@@ -32,6 +37,7 @@ export interface AgentApiItem {
   actionLabel: string | null;
   actionPrompt: string | null;
   sourceUrl: string | null;
+  structuredPayload: AgentStructuredPayload | null;
   knowledgeRefs: AgentKnowledgeRefs;
   sortOrder: number;
 }
@@ -76,6 +82,18 @@ export interface AgentDefinition {
   enrichItems(db: Kysely<DB>, items: AgentOutputItemInput[]): Promise<AgentOutputItemInput[]>;
   /** Optional per-definition runtime context appended to the agent run JSON. */
   buildRuntimeContext?(params: AgentRuntimeContextParams): Promise<Record<string, unknown>>;
+  /**
+   * Optional pass over the emitted items before enrichment/validation. Used by
+   * sections whose canonical content is deterministic (e.g. meetings, where the
+   * list comes from the calendar, not the model): reconcile the model's items
+   * against the server-built skeleton in `runtimeContext` so nothing is invented,
+   * dropped, or has its identity fields overwritten by the model.
+   */
+  reconcileItems?(params: {
+    db: Kysely<DB>;
+    items: AgentOutputItemInput[];
+    runtimeContext: Record<string, unknown>;
+  }): Promise<AgentOutputItemInput[]>;
   /** Normalize a stored item into its API representation (label/action/displayRef fallbacks). */
   toApiItem(item: AgentStoredItem): AgentApiItem;
 }

--- a/packages/server/src/connectors/google-calendar.test.ts
+++ b/packages/server/src/connectors/google-calendar.test.ts
@@ -577,6 +577,53 @@ describe("Google Calendar connector", () => {
     ]);
   });
 
+  it("removes a declined recurring instance by its stored series id", async () => {
+    const connector = createGoogleCalendarConnector();
+    const removals: SourceItemRemovalRecord[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+      const url = new URL(input.toString());
+
+      if (url.pathname === "/calendar/v3/users/me/calendarList") {
+        return jsonResponse({ items: [primaryCalendar] });
+      }
+
+      if (url.pathname === "/calendar/v3/calendars/primary/events") {
+        return jsonResponse({
+          items: [
+            calendarEvent("recur-declined", {
+              recurringEventId: "recur-declined-series",
+              attendees: [{ email: "owner@canvasx.ai", displayName: "Owner", self: true, responseStatus: "declined" }],
+            }),
+          ],
+          nextSyncToken: "sync-primary-new",
+        });
+      }
+
+      throw new Error(`unexpected fetch ${url.toString()}`);
+    });
+
+    await drain(
+      connector.sync({
+        credentials: validCredentials(),
+        scopeConfig: {},
+        cursor: currentCursor({ primary: "sync-primary-old" }),
+        logger,
+        ownerEmail: "owner@canvasx.ai",
+        onSourceItemRemoved: async (record) => {
+          removals.push(record);
+        },
+      }),
+    );
+
+    expect(removals).toEqual([
+      {
+        providerFileId: "primary:recurring:recur-declined@google.com",
+        reason: "google_calendar_event_declined",
+      },
+    ]);
+  });
+
   it("prunes unreadable calendars and drops their stale sync token", async () => {
     const connector = createGoogleCalendarConnector();
     const removals: SourceItemRemovalRecord[] = [];

--- a/packages/server/src/connectors/google-calendar.test.ts
+++ b/packages/server/src/connectors/google-calendar.test.ts
@@ -55,6 +55,7 @@ describe("Google Calendar connector", () => {
       sourcePath: "Google Calendar / Work",
       sourceCreatedAt: "2026-02-04T10:00:00.000Z",
       sourceUpdatedAt: "2026-02-02T10:00:00.000Z",
+      isAllDay: false,
       mimeType: "text/calendar",
       authorEmail: "owner@canvasx.ai",
       authorName: "Owner",
@@ -66,6 +67,27 @@ describe("Google Calendar connector", () => {
       { name: "Owner", email: "owner@canvasx.ai" },
       { name: "Jane Doe", email: "jane@example.com" },
     ]);
+  });
+
+  it("flags all-day events (date-only start) so the brief can tell them from a midnight-UTC meeting", () => {
+    const allDay = eventToSyncedItem(
+      calendarEvent("offsite-1", { start: { date: "2026-02-04" }, end: { date: "2026-02-05" } }),
+      primaryCalendar,
+      "owner@canvasx.ai",
+    );
+    expect(allDay?.isAllDay).toBe(true);
+    expect(allDay?.sourceCreatedAt).toBe("2026-02-04T00:00:00.000Z");
+
+    const midnightTimed = eventToSyncedItem(
+      calendarEvent("midnight-1", {
+        start: { dateTime: "2026-02-04T00:00:00Z" },
+        end: { dateTime: "2026-02-04T00:30:00Z" },
+      }),
+      primaryCalendar,
+      "owner@canvasx.ai",
+    );
+    expect(midnightTimed?.isAllDay).toBe(false);
+    expect(midnightTimed?.sourceCreatedAt).toBe("2026-02-04T00:00:00.000Z");
   });
 
   it("extracts Calendly invitees and guests from the event description when Google attendees are missing", () => {

--- a/packages/server/src/connectors/google-calendar.test.ts
+++ b/packages/server/src/connectors/google-calendar.test.ts
@@ -577,7 +577,7 @@ describe("Google Calendar connector", () => {
     ]);
   });
 
-  it("removes a declined recurring instance by its stored series id", async () => {
+  it("keeps the recurring series when a single instance is declined", async () => {
     const connector = createGoogleCalendarConnector();
     const removals: SourceItemRemovalRecord[] = [];
 
@@ -616,12 +616,7 @@ describe("Google Calendar connector", () => {
       }),
     );
 
-    expect(removals).toEqual([
-      {
-        providerFileId: "primary:recurring:recur-declined@google.com",
-        reason: "google_calendar_event_declined",
-      },
-    ]);
+    expect(removals).toEqual([]);
   });
 
   it("prunes unreadable calendars and drops their stale sync token", async () => {

--- a/packages/server/src/connectors/google-calendar.test.ts
+++ b/packages/server/src/connectors/google-calendar.test.ts
@@ -251,6 +251,35 @@ describe("Google Calendar connector", () => {
     expect(item?.attendees).toEqual([{ name: "Owner", email: "owner@canvasx.ai" }]);
   });
 
+  it("drops events the owner declined", () => {
+    const item = eventToSyncedItem(
+      calendarEvent("declined", {
+        attendees: [
+          { email: "owner@canvasx.ai", displayName: "Owner", self: true, responseStatus: "declined" },
+          { email: "jane@example.com", displayName: "Jane Doe", responseStatus: "accepted" },
+        ],
+      }),
+      primaryCalendar,
+      "owner@canvasx.ai",
+    );
+
+    expect(item).toBeNull();
+  });
+
+  it("keeps events the owner has not declined", () => {
+    for (const responseStatus of ["accepted", "tentative", "needsAction"]) {
+      const item = eventToSyncedItem(
+        calendarEvent(`rsvp-${responseStatus}`, {
+          attendees: [{ email: "owner@canvasx.ai", displayName: "Owner", self: true, responseStatus }],
+        }),
+        primaryCalendar,
+        "owner@canvasx.ai",
+      );
+
+      expect(item).not.toBeNull();
+    }
+  });
+
   it("syncs readable calendars and stores per-calendar sync tokens", async () => {
     const connector = createGoogleCalendarConnector();
     const requests: URL[] = [];

--- a/packages/server/src/connectors/google-calendar.test.ts
+++ b/packages/server/src/connectors/google-calendar.test.ts
@@ -529,6 +529,54 @@ describe("Google Calendar connector", () => {
     expect(cursor.calendars).toEqual({ primary: "sync-primary-new" });
   });
 
+  it("removes a previously synced event the owner has now declined", async () => {
+    const connector = createGoogleCalendarConnector();
+    const removals: SourceItemRemovalRecord[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+      const url = new URL(input.toString());
+
+      if (url.pathname === "/calendar/v3/users/me/calendarList") {
+        return jsonResponse({ items: [primaryCalendar] });
+      }
+
+      if (url.pathname === "/calendar/v3/calendars/primary/events") {
+        return jsonResponse({
+          items: [
+            calendarEvent("declined", {
+              attendees: [{ email: "owner@canvasx.ai", displayName: "Owner", self: true, responseStatus: "declined" }],
+            }),
+            calendarEvent("kept"),
+          ],
+          nextSyncToken: "sync-primary-new",
+        });
+      }
+
+      throw new Error(`unexpected fetch ${url.toString()}`);
+    });
+
+    const items = await drain(
+      connector.sync({
+        credentials: validCredentials(),
+        scopeConfig: {},
+        cursor: currentCursor({ primary: "sync-primary-old" }),
+        logger,
+        ownerEmail: "owner@canvasx.ai",
+        onSourceItemRemoved: async (record) => {
+          removals.push(record);
+        },
+      }),
+    );
+
+    expect(items.map((item) => item.providerFileId)).toEqual(["primary:kept"]);
+    expect(removals).toEqual([
+      {
+        providerFileId: providerFileIdForEvent("primary", "declined"),
+        reason: "google_calendar_event_declined",
+      },
+    ]);
+  });
+
   it("prunes unreadable calendars and drops their stale sync token", async () => {
     const connector = createGoogleCalendarConnector();
     const removals: SourceItemRemovalRecord[] = [];

--- a/packages/server/src/connectors/google-calendar.ts
+++ b/packages/server/src/connectors/google-calendar.ts
@@ -249,6 +249,15 @@ function eventDateToIso(value: GoogleCalendarEventDate | undefined): string | nu
   return null;
 }
 
+/**
+ * All-day events carry a `date` (no `dateTime`) on their start. They are stored
+ * at the UTC-midnight sentinel, so they need an explicit flag to be told apart
+ * from a genuine timed meeting that happens to start at exactly 00:00 UTC.
+ */
+function isAllDayEvent(event: GoogleCalendarEvent): boolean {
+  return !event.start?.dateTime && Boolean(event.start?.date);
+}
+
 function eventDateLabel(value: GoogleCalendarEventDate | undefined): string | null {
   return value?.dateTime ?? value?.date ?? null;
 }
@@ -643,6 +652,7 @@ export function eventToSyncedItem(
     contentHash: contentHash(content),
     sourceCreatedAt,
     sourceUpdatedAt,
+    isAllDay: isAllDayEvent(event),
     mimeType: "text/calendar",
     accessEmails: eventAccessEmails(event, ownerEmail, calendlyPeople),
     attendees: people.length > 0 ? people : undefined,

--- a/packages/server/src/connectors/google-calendar.ts
+++ b/packages/server/src/connectors/google-calendar.ts
@@ -762,10 +762,12 @@ async function collectEventsForCalendar(params: {
         continue;
       }
       if (ownerDeclinedEvent(event)) {
-        removals.push({
-          providerFileId: providerFileIdForSyncedEvent(params.calendar.id, event),
-          reason: "google_calendar_event_declined",
-        });
+        if (!recurringSeriesKey(event)) {
+          removals.push({
+            providerFileId: providerFileIdForEvent(params.calendar.id, event.id),
+            reason: "google_calendar_event_declined",
+          });
+        }
         continue;
       }
 

--- a/packages/server/src/connectors/google-calendar.ts
+++ b/packages/server/src/connectors/google-calendar.ts
@@ -598,12 +598,21 @@ function recurringCandidateIsBetter(
   return candidateStart > currentStart;
 }
 
+/**
+ * The calendar owner's own RSVP, when the event carries a `self` attendee.
+ * Used to skip events the owner declined, mirroring the cancelled-event guard.
+ */
+function ownerResponseStatus(event: GoogleCalendarEvent): string | null {
+  return event.attendees?.find((attendee) => attendee.self)?.responseStatus ?? null;
+}
+
 export function eventToSyncedItem(
   event: GoogleCalendarEvent,
   calendar: GoogleCalendarListEntry,
   ownerEmail: string | null | undefined,
 ): SyncedItem | null {
   if (!event.id || event.status === "cancelled") return null;
+  if (ownerResponseStatus(event) === "declined") return null;
 
   const content = eventContent(event, calendar);
   const calendlyPeople = calendlyDescriptionPeople(event);

--- a/packages/server/src/connectors/google-calendar.ts
+++ b/packages/server/src/connectors/google-calendar.ts
@@ -606,13 +606,18 @@ function ownerResponseStatus(event: GoogleCalendarEvent): string | null {
   return event.attendees?.find((attendee) => attendee.self)?.responseStatus ?? null;
 }
 
+/** True when the calendar owner declined the event (their own RSVP is "declined"). */
+export function ownerDeclinedEvent(event: GoogleCalendarEvent): boolean {
+  return ownerResponseStatus(event) === "declined";
+}
+
 export function eventToSyncedItem(
   event: GoogleCalendarEvent,
   calendar: GoogleCalendarListEntry,
   ownerEmail: string | null | undefined,
 ): SyncedItem | null {
   if (!event.id || event.status === "cancelled") return null;
-  if (ownerResponseStatus(event) === "declined") return null;
+  if (ownerDeclinedEvent(event)) return null;
 
   const content = eventContent(event, calendar);
   const calendlyPeople = calendlyDescriptionPeople(event);
@@ -749,10 +754,10 @@ async function collectEventsForCalendar(params: {
 
     for (const event of result.items ?? []) {
       if (!event.id) continue;
-      if (event.status === "cancelled") {
+      if (event.status === "cancelled" || ownerDeclinedEvent(event)) {
         removals.push({
           providerFileId: providerFileIdForEvent(params.calendar.id, event.id),
-          reason: "google_calendar_event_cancelled",
+          reason: event.status === "cancelled" ? "google_calendar_event_cancelled" : "google_calendar_event_declined",
         });
         continue;
       }

--- a/packages/server/src/connectors/google-calendar.ts
+++ b/packages/server/src/connectors/google-calendar.ts
@@ -754,10 +754,17 @@ async function collectEventsForCalendar(params: {
 
     for (const event of result.items ?? []) {
       if (!event.id) continue;
-      if (event.status === "cancelled" || ownerDeclinedEvent(event)) {
+      if (event.status === "cancelled") {
         removals.push({
           providerFileId: providerFileIdForEvent(params.calendar.id, event.id),
-          reason: event.status === "cancelled" ? "google_calendar_event_cancelled" : "google_calendar_event_declined",
+          reason: "google_calendar_event_cancelled",
+        });
+        continue;
+      }
+      if (ownerDeclinedEvent(event)) {
+        removals.push({
+          providerFileId: providerFileIdForSyncedEvent(params.calendar.id, event),
+          reason: "google_calendar_event_declined",
         });
         continue;
       }

--- a/packages/server/src/connectors/sync-item.ts
+++ b/packages/server/src/connectors/sync-item.ts
@@ -138,6 +138,7 @@ export async function processSyncedItem({
         content_category: item.contentCategory ?? undefined,
         source_created_at: sourceCreatedAt,
         source_updated_at: sourceUpdatedAt,
+        ...(item.isAllDay !== undefined ? { is_all_day: item.isAllDay ? 1 : 0 } : {}),
         mime_type: item.mimeType ?? undefined,
         rollup_group_id: item.rollupGroupId ?? null,
       })
@@ -166,6 +167,7 @@ export async function processSyncedItem({
       contentHash: item.contentHash,
       sourceCreatedAt: item.sourceCreatedAt,
       sourceUpdatedAt: item.sourceUpdatedAt,
+      isAllDay: item.isAllDay,
       mimeType: item.mimeType,
       rollupGroupId: item.rollupGroupId ?? null,
     });

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -80,6 +80,11 @@ export interface SyncedItem {
   contentHash: string | null;
   sourceCreatedAt: string | null;
   sourceUpdatedAt: string | null;
+  /**
+   * Whole-day item with no specific time of day (e.g. a Google Calendar all-day
+   * event). Calendar connectors always set this; other sources leave it unset.
+   */
+  isAllDay?: boolean;
   /** MIME type of the original file (e.g. "image/png", "application/pdf"). */
   mimeType?: string;
   /**

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -111,6 +111,7 @@ import * as m108 from "./migrations/108-scheduled-task-origin-chat";
 import * as m109 from "./migrations/109-scheduled-task-origin-message-id";
 import * as m110 from "./migrations/110-google-calendar-provider-file-scope";
 import * as m111 from "./migrations/111-settings-embedding-provider";
+import * as m112 from "./migrations/112-agent-output-structured-payload";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -226,6 +227,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "109-scheduled-task-origin-message-id": m109,
           "110-google-calendar-provider-file-scope": m110,
           "111-settings-embedding-provider": m111,
+          "112-agent-output-structured-payload": m112,
         };
       },
     },

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -112,6 +112,7 @@ import * as m109 from "./migrations/109-scheduled-task-origin-message-id";
 import * as m110 from "./migrations/110-google-calendar-provider-file-scope";
 import * as m111 from "./migrations/111-settings-embedding-provider";
 import * as m112 from "./migrations/112-agent-output-structured-payload";
+import * as m113 from "./migrations/113-indexed-file-all-day-flag";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -228,6 +229,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "110-google-calendar-provider-file-scope": m110,
           "111-settings-embedding-provider": m111,
           "112-agent-output-structured-payload": m112,
+          "113-indexed-file-all-day-flag": m113,
         };
       },
     },

--- a/packages/server/src/db/migrations/112-agent-output-structured-payload.ts
+++ b/packages/server/src/db/migrations/112-agent-output-structured-payload.ts
@@ -1,0 +1,34 @@
+import type { Kysely } from "kysely";
+
+const TABLE = "agent_output_items";
+const COLUMN = "structured_payload_json";
+
+/**
+ * Adds a per-item structured payload column so sections whose items carry
+ * section-specific structured data (e.g. the Daily Brief meetings section, with
+ * start time and attendee list) can persist it alongside the generic item shape.
+ * Nullable: sections that have no structured payload leave it null.
+ *
+ * Guarded via introspection so re-running after a partially applied upgrade
+ * (ledger row cleared but column present) is a no-op, matching the recovery
+ * behavior the migration suite exercises.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const columns = await getColumns(db);
+  if (!columns.has(COLUMN)) {
+    await db.schema.alterTable(TABLE).addColumn(COLUMN, "text").execute();
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const columns = await getColumns(db);
+  if (columns.has(COLUMN)) {
+    await db.schema.alterTable(TABLE).dropColumn(COLUMN).execute();
+  }
+}
+
+async function getColumns(db: Kysely<unknown>): Promise<Set<string>> {
+  const tables = await db.introspection.getTables();
+  const table = tables.find((candidate) => candidate.name === TABLE);
+  return new Set(table?.columns.map((column) => column.name) ?? []);
+}

--- a/packages/server/src/db/migrations/113-indexed-file-all-day-flag.ts
+++ b/packages/server/src/db/migrations/113-indexed-file-all-day-flag.ts
@@ -1,0 +1,48 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+const TABLE = "indexed_files";
+const COLUMN = "is_all_day";
+
+/**
+ * Adds an explicit all-day discriminator to calendar rows so the Daily Brief
+ * meetings section can exclude whole-day events precisely.
+ *
+ * Previously all-day events were detected by their UTC-midnight `source_created_at`
+ * sentinel, which also matched genuine timed meetings that happen to start at
+ * exactly 00:00 UTC (for example a 5:30 AM IST standup). The connector now sets
+ * this flag at sync time; the backfill classifies existing calendar rows with the
+ * old heuristic so the column is reliable immediately, and re-syncs self-correct
+ * any timed-midnight row the heuristic misclassified.
+ *
+ * Guarded via introspection so re-running after a partially applied upgrade is a
+ * no-op, matching the recovery behavior the migration suite exercises.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const columns = await getColumns(db);
+  if (!columns.has(COLUMN)) {
+    await db.schema
+      .alterTable(TABLE)
+      .addColumn(COLUMN, "integer", (col) => col.notNull().defaultTo(0))
+      .execute();
+    await sql`
+      UPDATE ${sql.table(TABLE)}
+      SET ${sql.ref(COLUMN)} = 1
+      WHERE source = 'google_calendar'
+        AND source_created_at LIKE '%T00:00:00.000Z'
+    `.execute(db);
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const columns = await getColumns(db);
+  if (columns.has(COLUMN)) {
+    await db.schema.alterTable(TABLE).dropColumn(COLUMN).execute();
+  }
+}
+
+async function getColumns(db: Kysely<unknown>): Promise<Set<string>> {
+  const tables = await db.introspection.getTables();
+  const table = tables.find((candidate) => candidate.name === TABLE);
+  return new Set(table?.columns.map((column) => column.name) ?? []);
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 107;
+const EXPECTED_MIGRATION_COUNT = 108;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -140,6 +140,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[104]).toBe("109-scheduled-task-origin-message-id");
     expect(names[105]).toBe("110-google-calendar-provider-file-scope");
     expect(names[106]).toBe("111-settings-embedding-provider");
+    expect(names[107]).toBe("112-agent-output-structured-payload");
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 108;
+const EXPECTED_MIGRATION_COUNT = 109;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -141,6 +141,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[105]).toBe("110-google-calendar-provider-file-scope");
     expect(names[106]).toBe("111-settings-embedding-provider");
     expect(names[107]).toBe("112-agent-output-structured-payload");
+    expect(names[108]).toBe("113-indexed-file-all-day-flag");
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 107;
+const EXPECTED_MIGRATION_COUNT = 108;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -163,6 +163,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[104]).toBe("109-scheduled-task-origin-message-id");
     expect(names[105]).toBe("110-google-calendar-provider-file-scope");
     expect(names[106]).toBe("111-settings-embedding-provider");
+    expect(names[107]).toBe("112-agent-output-structured-payload");
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {
@@ -527,7 +528,8 @@ describe("runMigrations — incremental upgrade", () => {
         '108-scheduled-task-origin-chat',
         '109-scheduled-task-origin-message-id',
         '110-google-calendar-provider-file-scope',
-        '111-settings-embedding-provider'
+        '111-settings-embedding-provider',
+        '112-agent-output-structured-payload'
       )
     `.execute(db);
 
@@ -540,7 +542,8 @@ describe("runMigrations — incremental upgrade", () => {
         '108-scheduled-task-origin-chat',
         '109-scheduled-task-origin-message-id',
         '110-google-calendar-provider-file-scope',
-        '111-settings-embedding-provider'
+        '111-settings-embedding-provider',
+        '112-agent-output-structured-payload'
       )
       ORDER BY name ASC
     `.execute(db);
@@ -550,6 +553,7 @@ describe("runMigrations — incremental upgrade", () => {
       { name: "109-scheduled-task-origin-message-id" },
       { name: "110-google-calendar-provider-file-scope" },
       { name: "111-settings-embedding-provider" },
+      { name: "112-agent-output-structured-payload" },
     ]);
   });
 });

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 108;
+const EXPECTED_MIGRATION_COUNT = 109;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -164,6 +164,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[105]).toBe("110-google-calendar-provider-file-scope");
     expect(names[106]).toBe("111-settings-embedding-provider");
     expect(names[107]).toBe("112-agent-output-structured-payload");
+    expect(names[108]).toBe("113-indexed-file-all-day-flag");
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {
@@ -529,7 +530,8 @@ describe("runMigrations — incremental upgrade", () => {
         '109-scheduled-task-origin-message-id',
         '110-google-calendar-provider-file-scope',
         '111-settings-embedding-provider',
-        '112-agent-output-structured-payload'
+        '112-agent-output-structured-payload',
+        '113-indexed-file-all-day-flag'
       )
     `.execute(db);
 
@@ -543,7 +545,8 @@ describe("runMigrations — incremental upgrade", () => {
         '109-scheduled-task-origin-message-id',
         '110-google-calendar-provider-file-scope',
         '111-settings-embedding-provider',
-        '112-agent-output-structured-payload'
+        '112-agent-output-structured-payload',
+        '113-indexed-file-all-day-flag'
       )
       ORDER BY name ASC
     `.execute(db);
@@ -554,6 +557,7 @@ describe("runMigrations — incremental upgrade", () => {
       { name: "110-google-calendar-provider-file-scope" },
       { name: "111-settings-embedding-provider" },
       { name: "112-agent-output-structured-payload" },
+      { name: "113-indexed-file-all-day-flag" },
     ]);
   });
 });

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -21,6 +21,9 @@ export interface AgentMasthead {
   generatedFor?: string;
 }
 
+/** Section-specific structured data carried alongside the generic item shape. */
+export type AgentStructuredPayload = Record<string, unknown>;
+
 export interface AgentOutputItemInput {
   sectionKey: string;
   title: string;
@@ -32,6 +35,7 @@ export interface AgentOutputItemInput {
   actionLabel?: string | null;
   actionPrompt?: string | null;
   sourceUrl?: string | null;
+  structuredPayload?: AgentStructuredPayload | null;
   knowledgeRefs: AgentKnowledgeRefs;
   sortOrder: number;
 }
@@ -106,16 +110,22 @@ function toConfig(row: Selectable<DB["agent_user_configs"]> | undefined): AgentU
   };
 }
 
+export type AgentStoredItemRow = AgentOutputItemRow & {
+  knowledgeRefs: AgentKnowledgeRefs;
+  structuredPayload: AgentStructuredPayload | null;
+};
+
 export interface AgentOutputWithItems {
   output: AgentOutputRow;
   masthead: AgentMasthead | null;
-  items: Array<AgentOutputItemRow & { knowledgeRefs: AgentKnowledgeRefs }>;
+  items: AgentStoredItemRow[];
 }
 
-function withRefs(item: AgentOutputItemRow): AgentOutputItemRow & { knowledgeRefs: AgentKnowledgeRefs } {
+function withRefs(item: AgentOutputItemRow): AgentStoredItemRow {
   return {
     ...item,
     knowledgeRefs: parseJson<AgentKnowledgeRefs>(item.knowledge_refs_json) ?? { entityIds: [], fileIds: [] },
+    structuredPayload: parseJson<AgentStructuredPayload>(item.structured_payload_json),
   };
 }
 
@@ -356,6 +366,7 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
             action_prompt: item.actionPrompt ?? null,
             knowledge_refs_json: JSON.stringify(item.knowledgeRefs),
             source_url: item.sourceUrl ?? null,
+            structured_payload_json: item.structuredPayload ? JSON.stringify(item.structuredPayload) : null,
             sort_order: item.sortOrder,
             created_at: now,
           }));

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -384,6 +384,7 @@ export function createConnectorRepository(db: Kysely<DB>, encryptionKey?: string
       connectorConfigId: string;
       mimeType?: string | null;
       rollupGroupId?: string | null;
+      isAllDay?: boolean;
     }) {
       const now = new Date().toISOString();
       const sourceCreatedAt = normalizeSourceTimestampForStorage(data.sourceCreatedAt);
@@ -440,6 +441,7 @@ export function createConnectorRepository(db: Kysely<DB>, encryptionKey?: string
           synced_at: now,
         };
         if (data.mimeType !== undefined) updates.mime_type = data.mimeType;
+        if (data.isAllDay !== undefined) updates.is_all_day = data.isAllDay ? 1 : 0;
         if (contentChanged || categoryChanged || sourceVersionChanged) {
           updates.embedding_status = "pending";
           updates.summary_status = "pending";
@@ -475,6 +477,7 @@ export function createConnectorRepository(db: Kysely<DB>, encryptionKey?: string
           source_updated_at: sourceUpdatedAt,
           rollup_group_id: data.rollupGroupId ?? null,
           synced_at: now,
+          is_all_day: data.isAllDay ? 1 : 0,
           mime_type: data.mimeType ?? null,
           embedding_status: "pending",
           summary_status: "pending",

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -553,6 +553,8 @@ export interface AgentOutputItemsTable {
   action_prompt: string | null;
   knowledge_refs_json: string;
   source_url: string | null;
+  /** Optional section-specific structured data (e.g. meetings: start time, attendees). */
+  structured_payload_json: string | null;
   sort_order: number;
   created_at: Generated<string>;
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -129,6 +129,7 @@ export interface IndexedFilesTable {
   is_archived: Generated<number>;
   source_created_at: string | null;
   source_updated_at: string | null;
+  is_all_day: Generated<number>;
   synced_at: string;
   indexed_at: Generated<string>;
   context_note: string | null;

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -353,7 +353,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   app.route("/api/mcp-servers", mcpServerRoutes(mcpServers, users));
   app.route("/api/workspace/summary", workspaceSummaryRoutes({ db, config, users, mcpServers }));
   if (deps?.agentRunService) {
-    app.route("/api/daily-briefs", dailyBriefRoutes(deps.agentRunService));
+    app.route("/api/daily-briefs", dailyBriefRoutes(deps.agentRunService, db));
     app.route("/api/agents", agentRoutes(deps.agentRunService));
   }
   app.route("/api/workspace", createWorkspaceApi({ config }));

--- a/packages/web/src/components/brief/brief-detail-drawer.tsx
+++ b/packages/web/src/components/brief/brief-detail-drawer.tsx
@@ -1,8 +1,10 @@
-import type { DailyBriefItem } from "@/lib/api";
+import type { DailyBriefItem, DailyBriefMeetingAttendee } from "@/lib/api";
+import { EntityChip, useEntityUiOptional } from "@/lib/entity-ui";
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@sketch/ui/components/sheet";
 import { BriefActionButton } from "./brief-action-button";
 import { labelMeta, refChips, sourceLinkLabel } from "./item-metadata";
+import { formatMeetingTime } from "./meeting-row";
 
 function drawerTitle(item: DailyBriefItem): string {
   if (item.sectionKey === "todos" && item.displayRef) return `${item.displayRef} \u00b7 ${item.title}`;
@@ -23,10 +25,12 @@ function priorityLabel(priority: DailyBriefItem["priority"]): string {
 
 export function BriefDetailDrawer({
   item,
+  timezone,
   onClose,
   onOpenChat,
 }: {
   item: DailyBriefItem | null;
+  timezone: string;
   onClose: () => void;
   onOpenChat: (prompt: string) => void;
 }) {
@@ -35,7 +39,13 @@ export function BriefDetailDrawer({
       <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-[480px]">
         <SheetTitle className="sr-only">Brief detail</SheetTitle>
         <SheetDescription className="sr-only">Context and actions for the selected brief item.</SheetDescription>
-        {item ? <DrawerBody item={item} onOpenChat={onOpenChat} /> : null}
+        {item ? (
+          item.sectionKey === "meetings" ? (
+            <MeetingDrawerBody item={item} timezone={timezone} onOpenChat={onOpenChat} />
+          ) : (
+            <DrawerBody item={item} onOpenChat={onOpenChat} />
+          )
+        ) : null}
       </SheetContent>
     </Sheet>
   );
@@ -105,6 +115,134 @@ function DrawerBody({ item, onOpenChat }: { item: DailyBriefItem; onOpenChat: (p
           ) : null}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function MeetingDrawerBody({
+  item,
+  timezone,
+  onOpenChat,
+}: {
+  item: DailyBriefItem;
+  timezone: string;
+  onOpenChat: (prompt: string) => void;
+}) {
+  const payload = item.structuredPayload;
+  const attendees = payload?.attendees ?? [];
+  const time = payload?.startTime ? formatMeetingTime(payload.startTime, timezone) : "";
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex-1 overflow-y-auto px-6 pb-8 pt-12">
+        <header>
+          <span className="font-mono text-[13px] font-medium tabular-nums text-foreground">{time}</span>
+          <h2 className="mt-2 text-[18px] font-semibold leading-snug text-foreground">{item.title}</h2>
+          {payload?.via ? <p className="mt-1 text-[12px] text-muted-foreground">{payload.via}</p> : null}
+        </header>
+
+        <div className="mt-5 space-y-5">
+          {attendees.length > 0 ? (
+            <div>
+              <p className="mb-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Attendees</p>
+              <ul className="flex flex-col gap-3.5">
+                {attendees.map((attendee) => (
+                  <AttendeeRow key={`${attendee.name}-${attendee.entityId ?? ""}`} attendee={attendee} />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {item.summary ? (
+            <div>
+              <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Context</p>
+              <p className="text-[13px] leading-relaxed text-muted-foreground">{item.summary}</p>
+            </div>
+          ) : null}
+
+          <MeetingTimelines attendees={attendees} />
+        </div>
+      </div>
+
+      {item.actionPrompt || item.sourceUrl ? (
+        <div className="flex flex-wrap items-center gap-2 border-t border-border/60 px-6 py-4">
+          {item.actionPrompt ? (
+            <BriefActionButton
+              label={item.actionLabel ?? "Prep with Sketch"}
+              stopPropagation={false}
+              onClick={() => onOpenChat(item.actionPrompt as string)}
+            />
+          ) : null}
+          {item.sourceUrl ? (
+            <a
+              href={item.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-full border-[0.5px] border-border bg-transparent px-3 py-1 text-[12px] font-medium text-muted-foreground transition-colors hover:border-foreground/25 hover:bg-muted/50 hover:text-foreground"
+            >
+              <ArrowSquareOutIcon size={13} weight="bold" aria-hidden />
+              {sourceLinkLabel(item.sourceUrl)}
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function AttendeeRow({ attendee }: { attendee: DailyBriefMeetingAttendee }) {
+  const initials = attendee.name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <li className="flex gap-3">
+      <div
+        className={`mt-[1px] flex size-[28px] shrink-0 items-center justify-center rounded-full text-[10px] font-medium ${
+          attendee.emphasis
+            ? "bg-amber-400 text-amber-950"
+            : "border-[0.5px] border-border bg-muted text-muted-foreground dark:bg-muted/50"
+        }`}
+        aria-hidden
+      >
+        {initials}
+      </div>
+      <div className="min-w-0">
+        <p className="text-[13px] leading-tight text-foreground">
+          <span className="font-medium">{attendee.name}</span>
+          {attendee.role ? <span className="text-muted-foreground"> — {attendee.role}</span> : null}
+        </p>
+        {attendee.note ? (
+          <p className="mt-0.5 text-[12px] leading-relaxed text-muted-foreground">{attendee.note}</p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/** Timeline chips for attendees resolved to a graph entity; opens their drawer. */
+function MeetingTimelines({ attendees }: { attendees: DailyBriefMeetingAttendee[] }) {
+  const entityUi = useEntityUiOptional();
+  const resolved = attendees.filter((attendee) => attendee.entityId);
+  if (!entityUi || resolved.length === 0) return null;
+
+  return (
+    <div>
+      <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Timelines</p>
+      <div className="flex flex-wrap gap-1.5">
+        {resolved.map((attendee) => (
+          <EntityChip
+            key={attendee.entityId as string}
+            entity={{ id: attendee.entityId as string, name: attendee.name, sourceType: "person" }}
+            compact
+            onClick={() => entityUi.openEntity(attendee.entityId as string)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/brief/daily-brief.isolated.test.tsx
+++ b/packages/web/src/components/brief/daily-brief.isolated.test.tsx
@@ -1,0 +1,71 @@
+import type { DailyBrief as DailyBriefData, DailyBriefItem } from "@/lib/api";
+import { act, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DailyBrief } from "./daily-brief";
+
+function meetingItem(id: string, title: string, startTime: string): DailyBriefItem {
+  return {
+    id,
+    sectionKey: "meetings",
+    title,
+    summary: "",
+    priority: "medium",
+    label: "Meeting",
+    displayRef: null,
+    actionType: null,
+    actionLabel: null,
+    actionPrompt: null,
+    sourceUrl: null,
+    structuredPayload: { startTime, via: null, attendees: [] },
+    knowledgeRefs: { entityIds: [], fileIds: [] },
+    sortOrder: 0,
+  };
+}
+
+function briefWith(meetings: DailyBriefItem[]): DailyBriefData {
+  return {
+    id: "brief-1",
+    userId: "user-1",
+    briefDate: "2026-06-27",
+    timezone: "UTC",
+    status: "ready",
+    generatedAt: null,
+    masthead: null,
+    sections: { meetings, todos: [], customer_updates: [], active_projects: [] },
+  };
+}
+
+function rowWithBadge(): HTMLElement {
+  const badge = screen.getByText("Now / Next");
+  const row = badge.closest("button");
+  if (!row) throw new Error("Now / Next badge is not inside a meeting row");
+  return row;
+}
+
+describe("DailyBrief Now / Next marker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("advances the Now / Next badge as meeting start times pass", () => {
+    vi.setSystemTime(new Date("2026-06-27T08:00:00.000Z"));
+    const meetings = [
+      meetingItem("m-standup", "Standup", "2026-06-27T09:00:00.000Z"),
+      meetingItem("m-review", "Design review", "2026-06-27T11:00:00.000Z"),
+    ];
+
+    render(<DailyBrief brief={briefWith(meetings)} running={false} calendarConnected onOpenChat={() => {}} />);
+
+    expect(within(rowWithBadge()).getByText("Standup")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(61 * 60 * 1000);
+    });
+
+    expect(within(rowWithBadge()).getByText("Design review")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/brief/daily-brief.tsx
+++ b/packages/web/src/components/brief/daily-brief.tsx
@@ -1,9 +1,10 @@
-import type { DailyBrief as DailyBriefData } from "@/lib/api";
+import type { DailyBrief as DailyBriefData, DailyBriefItem } from "@/lib/api";
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { BriefDetailDrawer } from "./brief-detail-drawer";
 import { BriefItemRow } from "./brief-item-row";
 import { BriefSection } from "./brief-section";
+import { MeetingRow } from "./meeting-row";
 import { BRIEF_SECTIONS } from "./sections";
 
 function formatBriefDate(value: string): string {
@@ -16,19 +17,36 @@ function formatBriefDate(value: string): string {
   }).format(date);
 }
 
+/** The current/next meeting: the earliest one whose start is still ahead of now. */
+function computeNextMeetingId(items: DailyBriefItem[]): string | null {
+  const now = Date.now();
+  let next: { id: string; start: number } | null = null;
+  for (const item of items) {
+    const startIso = item.structuredPayload?.startTime;
+    const start = startIso ? new Date(startIso).getTime() : Number.NaN;
+    if (Number.isNaN(start) || start < now) continue;
+    if (!next || start < next.start) next = { id: item.id, start };
+  }
+  return next?.id ?? null;
+}
+
 export function DailyBrief({
   brief,
   running,
   enabledSections,
+  calendarConnected,
   onOpenChat,
 }: {
   brief: DailyBriefData;
   running: boolean;
   /** Section keys enabled in the user's config; when omitted, all sections show. */
   enabledSections?: string[];
+  /** Whether the reader has a calendar connected — drives the meetings empty state. */
+  calendarConnected?: boolean;
   onOpenChat: (prompt: string) => void;
 }) {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const nextMeetingId = computeNextMeetingId(brief.sections.meetings ?? []);
   const subtitle =
     brief.masthead?.summary ?? brief.masthead?.title ?? "Today across your to-dos, customers, and projects.";
   const visibleSections = enabledSections
@@ -58,6 +76,30 @@ export function DailyBrief({
       <div className="mt-8 flex flex-col gap-8">
         {visibleSections.map((section) => {
           const items = brief.sections[section.key];
+          if (section.key === "meetings") {
+            return (
+              <BriefSection key={section.key} label={section.label}>
+                {items.length === 0 ? (
+                  <p className="py-1.5 text-[12.5px] text-muted-foreground/70">
+                    {calendarConnected ? "Nothing on your calendar today." : "Connect a calendar to see your day."}
+                  </p>
+                ) : (
+                  <div className="flex flex-col">
+                    {items.map((item, index) => (
+                      <MeetingRow
+                        key={item.id}
+                        item={item}
+                        timezone={brief.timezone}
+                        isNext={item.id === nextMeetingId}
+                        isLast={index === items.length - 1}
+                        onOpenDetail={() => setSelectedItemId(item.id)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </BriefSection>
+            );
+          }
           return (
             <BriefSection key={section.key} label={section.label}>
               {items.length === 0 ? (
@@ -86,7 +128,12 @@ export function DailyBrief({
         </p>
       </footer>
 
-      <BriefDetailDrawer item={selectedItem} onClose={() => setSelectedItemId(null)} onOpenChat={onOpenChat} />
+      <BriefDetailDrawer
+        item={selectedItem}
+        timezone={brief.timezone}
+        onClose={() => setSelectedItemId(null)}
+        onOpenChat={onOpenChat}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/brief/daily-brief.tsx
+++ b/packages/web/src/components/brief/daily-brief.tsx
@@ -1,6 +1,6 @@
 import type { DailyBrief as DailyBriefData, DailyBriefItem } from "@/lib/api";
 import { SparkleIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { BriefDetailDrawer } from "./brief-detail-drawer";
 import { BriefItemRow } from "./brief-item-row";
 import { BriefSection } from "./brief-section";
@@ -17,9 +17,8 @@ function formatBriefDate(value: string): string {
   }).format(date);
 }
 
-/** The current/next meeting: the earliest one whose start is still ahead of now. */
-function computeNextMeetingId(items: DailyBriefItem[]): string | null {
-  const now = Date.now();
+/** The current/next meeting: the earliest one whose start is still ahead of `now`. */
+function computeNextMeetingId(items: DailyBriefItem[], now: number): string | null {
   let next: { id: string; start: number } | null = null;
   for (const item of items) {
     const startIso = item.structuredPayload?.startTime;
@@ -28,6 +27,34 @@ function computeNextMeetingId(items: DailyBriefItem[]): string | null {
     if (!next || start < next.start) next = { id: item.id, start };
   }
   return next?.id ?? null;
+}
+
+/**
+ * Tracks the current/next meeting and advances it as start times pass.
+ *
+ * `nextMeetingId` is time-dependent, so without a clock the badge would freeze
+ * on a meeting that is no longer next once Home stays open across its start. A
+ * timeout scheduled to the current marker's start re-evaluates exactly when it
+ * elapses, then reschedules for the following meeting; it idles once none remain.
+ */
+function useNextMeetingId(items: DailyBriefItem[]): string | null {
+  const [now, setNow] = useState(() => Date.now());
+  const nextMeetingId = computeNextMeetingId(items, now);
+  const nextStart = useMemo(() => {
+    const current = items.find((item) => item.id === nextMeetingId);
+    const startIso = current?.structuredPayload?.startTime;
+    const start = startIso ? new Date(startIso).getTime() : Number.NaN;
+    return Number.isNaN(start) ? null : start;
+  }, [items, nextMeetingId]);
+
+  useEffect(() => {
+    if (nextStart === null) return;
+    const delay = Math.max(0, nextStart - Date.now()) + 1000;
+    const timer = window.setTimeout(() => setNow(Date.now()), delay);
+    return () => window.clearTimeout(timer);
+  }, [nextStart]);
+
+  return nextMeetingId;
 }
 
 export function DailyBrief({
@@ -46,7 +73,7 @@ export function DailyBrief({
   onOpenChat: (prompt: string) => void;
 }) {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
-  const nextMeetingId = computeNextMeetingId(brief.sections.meetings ?? []);
+  const nextMeetingId = useNextMeetingId(brief.sections.meetings ?? []);
   const subtitle =
     brief.masthead?.summary ?? brief.masthead?.title ?? "Today across your to-dos, customers, and projects.";
   const visibleSections = enabledSections

--- a/packages/web/src/components/brief/item-metadata.ts
+++ b/packages/web/src/components/brief/item-metadata.ts
@@ -4,6 +4,9 @@ export const LABEL_META: Record<
   DailyBriefItem["sectionKey"],
   Record<string, { label: string; dot: string; eyebrow: string }>
 > = {
+  meetings: {
+    meeting: { label: "Meeting", dot: "bg-muted-foreground/40", eyebrow: "Meeting" },
+  },
   todos: {
     todo: { label: "Todo", dot: "bg-muted-foreground/40", eyebrow: "Task" },
     in_progress: { label: "In Progress", dot: "bg-amber-400", eyebrow: "Task" },

--- a/packages/web/src/components/brief/meeting-row.tsx
+++ b/packages/web/src/components/brief/meeting-row.tsx
@@ -1,0 +1,103 @@
+import type { DailyBriefItem, DailyBriefMeetingAttendee } from "@/lib/api";
+import { CaretRightIcon } from "@phosphor-icons/react";
+import { cn } from "@sketch/ui/lib/utils";
+
+/** Formats a meeting start time in the brief's timezone, e.g. "9:30 AM". */
+export function formatMeetingTime(iso: string, timezone: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit", timeZone: timezone }).format(date);
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+/**
+ * A compact meeting row — time, title, attendee avatars. Clicking opens the full
+ * prep detail in the drawer. The next meeting carries a "Now / Next" pill, which
+ * the parent computes from the current time so it stays correct through the day.
+ */
+export function MeetingRow({
+  item,
+  timezone,
+  isNext,
+  isLast,
+  onOpenDetail,
+}: {
+  item: DailyBriefItem;
+  timezone: string;
+  isNext: boolean;
+  isLast: boolean;
+  onOpenDetail: () => void;
+}) {
+  const payload = item.structuredPayload;
+  const attendees = payload?.attendees ?? [];
+  const time = payload?.startTime ? formatMeetingTime(payload.startTime, timezone) : "";
+
+  return (
+    <button
+      type="button"
+      onClick={onOpenDetail}
+      className={cn("group flex w-full items-center gap-3 py-3 text-left", !isLast && "border-b border-border/50")}
+    >
+      <time className="w-[64px] shrink-0 font-mono text-[12px] font-medium tabular-nums text-foreground">{time}</time>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-[13.5px] font-medium text-foreground">{item.title}</span>
+          {isNext ? (
+            <span className="shrink-0 rounded-full bg-amber-400 px-2 py-[1px] font-mono text-[9px] font-semibold uppercase tracking-[0.1em] text-amber-950">
+              Now / Next
+            </span>
+          ) : null}
+        </div>
+        {payload?.via ? <p className="mt-0.5 truncate text-[11.5px] text-muted-foreground">{payload.via}</p> : null}
+      </div>
+
+      <AvatarStack attendees={attendees} />
+
+      <CaretRightIcon
+        size={14}
+        className="shrink-0 text-muted-foreground/50 transition-colors group-hover:text-muted-foreground"
+        aria-hidden
+      />
+    </button>
+  );
+}
+
+function AvatarStack({ attendees }: { attendees: DailyBriefMeetingAttendee[] }) {
+  const shown = attendees.slice(0, 3);
+  const overflow = attendees.length - shown.length;
+
+  return (
+    <div className="hidden items-center sm:flex">
+      {shown.map((attendee, index) => (
+        <span
+          key={`${attendee.name}-${index}`}
+          className={cn(
+            "flex size-[22px] items-center justify-center rounded-full text-[8px] font-medium ring-2 ring-background",
+            index > 0 && "-ml-2",
+            attendee.emphasis
+              ? "bg-amber-400 text-amber-950"
+              : "border-[0.5px] border-border bg-muted text-muted-foreground dark:bg-muted/50",
+          )}
+          aria-hidden
+        >
+          {initialsOf(attendee.name)}
+        </span>
+      ))}
+      {overflow > 0 ? (
+        <span className="-ml-2 flex size-[22px] items-center justify-center rounded-full border-[0.5px] border-border bg-muted text-[8px] font-medium text-muted-foreground ring-2 ring-background dark:bg-muted/50">
+          +{overflow}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/components/brief/sections.ts
+++ b/packages/web/src/components/brief/sections.ts
@@ -10,6 +10,11 @@ export interface BriefSectionMeta {
 
 export const BRIEF_SECTIONS: BriefSectionMeta[] = [
   {
+    key: "meetings",
+    label: "Today's meetings",
+    promise: "Your calendar for today, with who's in the room and why they matter.",
+  },
+  {
     key: "todos",
     label: "Top to-dos",
     promise: "Your most pressing tasks, pulled from your tools and ranked for today.",

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -961,9 +961,24 @@ export interface DailyBriefKnowledgeRefs {
   factIds?: string[];
 }
 
+export interface DailyBriefMeetingAttendee {
+  name: string;
+  entityId: string | null;
+  role: string | null;
+  note: string | null;
+  emphasis: boolean;
+}
+
+/** Structured payload carried by meetings-section items (start time, attendees). */
+export interface DailyBriefMeetingPayload {
+  startTime: string;
+  via: string | null;
+  attendees: DailyBriefMeetingAttendee[];
+}
+
 export interface DailyBriefItem {
   id: string;
-  sectionKey: "todos" | "customer_updates" | "active_projects";
+  sectionKey: "meetings" | "todos" | "customer_updates" | "active_projects";
   title: string;
   summary: string;
   priority: "high" | "medium" | "low";
@@ -973,6 +988,7 @@ export interface DailyBriefItem {
   actionLabel: string | null;
   actionPrompt: string | null;
   sourceUrl: string | null;
+  structuredPayload: DailyBriefMeetingPayload | null;
   knowledgeRefs: DailyBriefKnowledgeRefs;
   sortOrder: number;
 }
@@ -990,6 +1006,7 @@ export interface DailyBrief {
     generatedFor?: string;
   } | null;
   sections: {
+    meetings: DailyBriefItem[];
     todos: DailyBriefItem[];
     customer_updates: DailyBriefItem[];
     active_projects: DailyBriefItem[];
@@ -1003,6 +1020,8 @@ export interface DailyBriefResponse {
   timezone: string;
   /** Section keys currently enabled in the user's config. Disabled sections are hidden on Home. */
   enabledSections?: string[];
+  /** Whether the reader has connected a calendar — drives the meetings empty state. */
+  calendarConnected?: boolean;
 }
 
 export interface AgentSummary {

--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -340,18 +340,20 @@ describe("AutomationBuilderPage", () => {
 
     renderBuilder();
 
-    await screen.findByLabelText("Message Sketch");
+    const input = await screen.findByLabelText("Message Sketch");
     expect(screen.queryByText("Alice: Create a Trustpilot review automation")).not.toBeInTheDocument();
     expect(mocks.loadMessages).toHaveBeenCalledWith(expect.stringMatching(/^builder-task-123-/));
     expect(mocks.originChatMessages).not.toHaveBeenCalled();
 
-    const input = screen.getByLabelText("Message Sketch");
+    await waitFor(() => expect(input).not.toBeDisabled());
     await user.type(input, "Tighten the filter");
     await user.click(screen.getByLabelText("Send message"));
 
-    expect(mocks.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: "Tighten the filter" }), {
-      body: { automationTaskId: "task-123" },
-    });
+    await waitFor(() =>
+      expect(mocks.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: "Tighten the filter" }), {
+        body: { automationTaskId: "task-123" },
+      }),
+    );
   });
 
   it("can stop a stuck builder chat run", async () => {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -45,6 +45,7 @@ export function HomePage() {
           brief={brief}
           running={running}
           enabledSections={briefQuery.data?.enabledSections}
+          calendarConnected={briefQuery.data?.calendarConnected}
           onOpenChat={(prompt) => {
             void navigate(chatPrefillTargetFromPrompt(prompt));
           }}


### PR DESCRIPTION
## What & Why

Adds a **Today's meetings** section to the top of the Daily Brief, driven by the reader's calendar in the knowledge graph. Closes the gap where the brief covered to-dos, customers, and projects but not the day's actual schedule. Linear: SKE-240.

The section leads the brief with the day's meetings: time, title, who's in the room (with roles and why they matter), a one-line context read, and a one-click **Prep with Sketch** action.

## How

**Design: deterministic skeleton + LLM enrichment + writer reconciliation.**

- The **server** builds the canonical list of today's calendar events (the ground truth for which meetings exist and their identity: time, title, attendee identity).
- The **agent** only enriches each meeting (attendee roles/notes, an emphasis person, a context line, a prep prompt). It cannot invent, drop, merge, or reorder meetings.
- The **writer** reconciles model output against the skeleton: invented meetings are dropped, skipped meetings are backfilled skeleton-only, identity always comes from the skeleton. Reconciliation respects the run's enabled sections (no backfill when the section is off).

This keeps the calendar authoritative while letting the LLM add the judgment (who matters today, what to prep) that a calendar can't.

### Server
- New nullable `agent_output_items.structured_payload_json` column (migration 111) carries per-item structured data (meeting start time + attendees). Threaded through the repo, the `WriteAgentOutput` tool schema, and `AgentApiItem`.
- `AgentDefinition` gains an optional `reconcileItems` hook, run in the writer after section filtering and before enrich/validate, with the run's `runtimeContext`.
- `daily-brief`: `buildTodaysMeetings` skeleton query (today's `calendar_event` files in the user's tz window, RBAC-filtered like the existing candidate query, attendees resolved to person entities via contact points), `reconcileMeetingItems`, meeting-aware labels/instructions. Meetings are exempt from the per-section item cap.
- **Declined meetings**: the Google Calendar connector now drops events the owner declined at sync time, mirroring the existing cancelled-event guard. Simpler than filtering downstream and keeps declined events out of search too (consistent with cancelled).
- The daily-brief route returns the `meetings` section plus a `calendarConnected` signal for the empty state (connect nudge vs "nothing on your calendar today").

### Web
- Meetings render first on Home via a compact `MeetingRow` (time, title, attendee avatars, a `Now / Next` pill computed client-side from start time so it stays correct through the day) and a meeting detail drawer (attendees with roles/notes, context, entity-chip timelines for resolved attendees, `Prep with Sketch` action).

## Acceptance
- [x] Meetings section appears at the top of the brief, one row per today's meeting, ordered by start time.
- [x] Next upcoming meeting is marked `Now / Next`.
- [x] Attendees resolve to person entities where known; drawer shows roles/notes and opens entity timelines.
- [x] Owner-declined and cancelled events never appear.
- [x] Reconciliation drops invented meetings, backfills skipped, takes identity from the skeleton, and is a no-op when the section is disabled.
- [x] Not behind the experimental flag.

## Testing
- Unit: skeleton query (tz window / RBAC / archived / attendee resolution), reconciliation (enrich / backfill / drop-invented / empty-skeleton / section-disabled), connector declined-event drop.
- Manual: rendered Home + meeting drawer against realistic data (meetings list with `Now / Next`, emphasis avatars, attendee roles/notes, entity-chip timelines, prep + source actions).
- Gates: `pnpm biome check`, `pnpm typecheck`, `pnpm test`, `pnpm build` all green; pre-push hook passed.