### PR TITLE
fix: use DB model for agent SDK defaults

### DIFF
--- a/packages/server/src/agent/llm-env.test.ts
+++ b/packages/server/src/agent/llm-env.test.ts
@@ -13,6 +13,8 @@ const ENV_KEYS = [
   "AWS_REGION",
   "ANTHROPIC_API_KEY",
   "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
 ] as const;
 
 function snapshotEnv() {
@@ -56,6 +58,8 @@ describe("applyLlmEnvFromSettings", () => {
     process.env.AWS_SECRET_ACCESS_KEY = "aws-secret";
     process.env.AWS_REGION = "us-east-1";
     process.env.ANTHROPIC_AUTH_TOKEN = "legacy";
+    process.env.ANTHROPIC_SMALL_FAST_MODEL = "claude-haiku-4-5-20251001";
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
     const logger = { warn: vi.fn(), info: vi.fn() };
 
     applyLlmEnvFromSettings(
@@ -71,6 +75,9 @@ describe("applyLlmEnvFromSettings", () => {
     );
 
     expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-live");
+    expect(process.env.ANTHROPIC_MODEL).toBe("claude-sonnet-4-6");
+    expect(process.env.ANTHROPIC_SMALL_FAST_MODEL).toBe("claude-sonnet-4-6");
+    expect(process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-sonnet-4-6");
     expect(process.env.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
     expect(process.env.AWS_ACCESS_KEY_ID).toBeUndefined();
     expect(process.env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
@@ -108,6 +115,8 @@ describe("applyLlmEnvFromSettings", () => {
   it("configures bedrock and clears anthropic env", () => {
     process.env.ANTHROPIC_API_KEY = "sk-ant-existing";
     process.env.ANTHROPIC_BASE_URL = "https://proxy.example.com";
+    process.env.ANTHROPIC_SMALL_FAST_MODEL = "claude-haiku-4-5-20251001";
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
     const logger = { warn: vi.fn(), info: vi.fn() };
 
     applyLlmEnvFromSettings(
@@ -126,6 +135,9 @@ describe("applyLlmEnvFromSettings", () => {
     expect(process.env.AWS_ACCESS_KEY_ID).toBe("AKIA...");
     expect(process.env.AWS_SECRET_ACCESS_KEY).toBe("secret");
     expect(process.env.AWS_REGION).toBe("us-west-2");
+    expect(process.env.ANTHROPIC_MODEL).toBe("us.anthropic.claude-sonnet-4-6");
+    expect(process.env.ANTHROPIC_SMALL_FAST_MODEL).toBe("us.anthropic.claude-sonnet-4-6");
+    expect(process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("us.anthropic.claude-sonnet-4-6");
     expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
     expect(logger.info).toHaveBeenCalledWith(
@@ -168,6 +180,8 @@ describe("applyLlmEnvFromSettings", () => {
     process.env.AWS_SECRET_ACCESS_KEY = "aws-secret";
     process.env.AWS_REGION = "us-east-1";
     process.env.ANTHROPIC_API_KEY = "sk-ant-existing";
+    process.env.ANTHROPIC_SMALL_FAST_MODEL = "claude-haiku-4-5-20251001";
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
     const logger = { warn: vi.fn(), info: vi.fn() };
 
     applyLlmEnvFromSettings(
@@ -186,6 +200,8 @@ describe("applyLlmEnvFromSettings", () => {
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("sk-or-v1-tenant-key");
     expect(process.env.ANTHROPIC_API_KEY).toBe("");
     expect(process.env.ANTHROPIC_MODEL).toBe("anthropic/claude-sonnet-4.6@preset/sketch-bedrock");
+    expect(process.env.ANTHROPIC_SMALL_FAST_MODEL).toBe("anthropic/claude-sonnet-4.6@preset/sketch-bedrock");
+    expect(process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("anthropic/claude-sonnet-4.6@preset/sketch-bedrock");
     expect(process.env.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
     expect(process.env.AWS_ACCESS_KEY_ID).toBeUndefined();
     expect(process.env.AWS_SECRET_ACCESS_KEY).toBeUndefined();

--- a/packages/server/src/agent/llm-env.ts
+++ b/packages/server/src/agent/llm-env.ts
@@ -21,7 +21,15 @@ function clearProviderRoutingEnv() {
     "ANTHROPIC_BASE_URL",
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
   );
+}
+
+function setModelRoutingEnv(model: string) {
+  process.env.ANTHROPIC_MODEL = model;
+  process.env.ANTHROPIC_SMALL_FAST_MODEL = model;
+  process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = model;
 }
 
 export function applyLlmEnvFromSettings(settings: LlmSettings | null, logger?: Logger): void {
@@ -42,7 +50,7 @@ export function applyLlmEnvFromSettings(settings: LlmSettings | null, logger?: L
     clearProviderRoutingEnv();
     unsetEnv("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION");
     process.env.ANTHROPIC_API_KEY = settings.anthropic_api_key;
-    process.env.ANTHROPIC_MODEL = settings.model_id || "claude-sonnet-4-6";
+    setModelRoutingEnv(settings.model_id || "claude-sonnet-4-6");
     logger?.info({ llmProvider: "anthropic", source: "db" }, "Configured LLM provider from DB settings");
     return;
   }
@@ -67,7 +75,7 @@ export function applyLlmEnvFromSettings(settings: LlmSettings | null, logger?: L
     process.env.AWS_ACCESS_KEY_ID = settings.aws_access_key_id;
     process.env.AWS_SECRET_ACCESS_KEY = settings.aws_secret_access_key;
     process.env.AWS_REGION = settings.aws_region;
-    process.env.ANTHROPIC_MODEL = settings.model_id || "us.anthropic.claude-sonnet-4-6";
+    setModelRoutingEnv(settings.model_id || "us.anthropic.claude-sonnet-4-6");
     logger?.info({ llmProvider: "bedrock", source: "db" }, "Configured LLM provider from DB settings");
     return;
   }
@@ -90,7 +98,7 @@ export function applyLlmEnvFromSettings(settings: LlmSettings | null, logger?: L
     process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
     process.env.ANTHROPIC_AUTH_TOKEN = settings.anthropic_api_key;
     process.env.ANTHROPIC_API_KEY = "";
-    process.env.ANTHROPIC_MODEL = settings.model_id;
+    setModelRoutingEnv(settings.model_id);
     logger?.info({ llmProvider: "openrouter", source: "db" }, "Configured LLM provider from DB settings");
     return;
   }


### PR DESCRIPTION
## Summary

- Route the DB-configured model through `ANTHROPIC_MODEL` and the Claude SDK small-fast/Haiku override env vars.
- Clear those model-routing env vars during provider switches so stale SDK defaults cannot survive.
- Extend `llm-env` tests for Anthropic, Bedrock, and OpenRouter paths when stale Haiku defaults are present.

## Root Cause

Sketch already applied the DB model to `ANTHROPIC_MODEL`, but workflow agent steps can omit an explicit SDK `model`. Claude Code / Agent SDK also has small-fast/Haiku fallback env vars, so those unset-model runs could still fall through to `claude-haiku-4-5-20251001` instead of the tenant DB model.

## Linear

SKE-242: https://linear.app/sketch-ai/issue/SKE-242/make-agent-sdk-defaults-use-the-db-configured-model

## Validation

- `pnpm --filter @sketch/server test:unit -- src/agent/llm-env.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- pre-push hook reran lint, typecheck, test, and build successfully
