### PR TITLE
feat: add Wati WhatsApp DM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ LOG_LEVEL=info          # debug | info | warn | error
 # WHATSAPP_GROUP_PROVIDER=baileys    # baileys | none
 # To route one-to-one DMs through Wati while keeping Baileys groups:
 # WHATSAPP_DM_PROVIDER=wati
-# WATI_API_ENDPOINT=https://live-mt-server.wati.io
+# WATI_API_ENDPOINT=https://live-mt-server.wati.io/<tenant-id>  # Tenant-qualified endpoint from Wati API docs.
 # WATI_ACCESS_TOKEN=
 # WATI_WEBHOOK_TOKEN=
 # WATI_CHANNEL_PHONE_NUMBER=         # Optional, digits only or E.164 when multiple Wati numbers are connected.

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,14 @@ LOG_LEVEL=info          # debug | info | warn | error
 # Defaults preserve current self-hosted behavior: Baileys for DMs and groups.
 # WHATSAPP_DM_PROVIDER=baileys
 # WHATSAPP_GROUP_PROVIDER=baileys    # baileys | none
+# To route one-to-one DMs through Wati while keeping Baileys groups:
+# WHATSAPP_DM_PROVIDER=wati
+# WATI_API_ENDPOINT=https://live-mt-server.wati.io
+# WATI_ACCESS_TOKEN=
+# WATI_WEBHOOK_TOKEN=
+# WATI_CHANNEL_PHONE_NUMBER=         # Optional, digits only or E.164 when multiple Wati numbers are connected.
+# Configure Wati to POST webhooks to ${BASE_URL}/whatsapp/wati/events with the token as Authorization: Bearer <token>
+# or as ?token=<token> if headers are not supported by the Wati webhook setup UI.
 
 # Encryption (optional, recommended for shared Postgres deployments)
 # 64 hex chars = 32 bytes for AES-256-GCM

--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,8 @@ LOG_LEVEL=info          # debug | info | warn | error
 # WATI_ACCESS_TOKEN=
 # WATI_WEBHOOK_TOKEN=
 # WATI_CHANNEL_PHONE_NUMBER=         # Optional, digits only or E.164 when multiple Wati numbers are connected.
-# Configure Wati to POST webhooks to ${BASE_URL}/whatsapp/wati/events with the token as Authorization: Bearer <token>
-# or as ?token=<token> if headers are not supported by the Wati webhook setup UI.
+# Configure Wati to POST webhooks to ${BASE_URL}/whatsapp/wati/events?token=<WATI_WEBHOOK_TOKEN>.
+# Authorization: Bearer <token> and x-wati-webhook-token are also accepted when a caller can send headers.
 
 # Encryption (optional, recommended for shared Postgres deployments)
 # 64 hex chars = 32 bytes for AES-256-GCM

--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,11 @@ LOG_LEVEL=info          # debug | info | warn | error
 # WATI_ACCESS_TOKEN=
 # WATI_WEBHOOK_TOKEN=
 # WATI_CHANNEL_PHONE_NUMBER=         # Optional, digits only or E.164 when multiple Wati numbers are connected.
-# Configure Wati to POST webhooks to ${BASE_URL}/whatsapp/wati/events?token=<WATI_WEBHOOK_TOKEN>.
+# Configure one enabled Wati webhook row for this callback:
+# ${BASE_URL}/whatsapp/wati/events?token=<WATI_WEBHOOK_TOKEN>
+# Select Message Received, Session Message Sent v2, Sent Message is DELIVERED v2,
+# Sent Message is READ v2, and Session message FAILED. Avoid the legacy non-v2
+# delivery/read events unless a Wati tenant cannot emit v2.
 # Authorization: Bearer <token> and x-wati-webhook-token are also accepted when a caller can send headers.
 
 # Encryption (optional, recommended for shared Postgres deployments)

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -134,6 +134,20 @@ The selected provider and credentials are stored in the database and applied to 
 2. Scan the QR code with WhatsApp on your phone (Linked Devices)
 3. Add team members on the Team page — only listed numbers can message the bot
 
+#### Wati DMs with Baileys groups
+
+Self-hosted installs can route one-to-one WhatsApp DMs through Wati while keeping Baileys for WhatsApp groups.
+
+1. Set `WHATSAPP_DM_PROVIDER=wati` in `.env`.
+2. Set `WATI_API_ENDPOINT` to the tenant-qualified Wati API endpoint, for example `https://live-mt-server.wati.io/<tenant-id>`.
+3. Set `WATI_ACCESS_TOKEN` from the Wati API page.
+4. Set `WATI_WEBHOOK_TOKEN` to a strong shared secret.
+5. If the Wati account has multiple connected numbers, set `WATI_CHANNEL_PHONE_NUMBER` to the Wati channel number.
+6. In Wati, create one enabled webhook row for `${BASE_URL}/whatsapp/wati/events?token=<WATI_WEBHOOK_TOKEN>`.
+7. Select only the supported Sketch DM events on that row: `Message Received`, `Session Message Sent v2`, `Sent Message is DELIVERED v2`, `Sent Message is READ v2`, and `Session message FAILED`.
+
+Wati allows multiple events on one webhook row, and live testing rejected a second row with the same callback URL. Prefer the v2 status events to avoid duplicate callbacks from the legacy delivery/read event family. Query-token auth is supported because Wati webhook setup may not allow custom Authorization headers; `Authorization: Bearer <token>` and `x-wati-webhook-token` are also accepted when headers are available.
+
 ## Troubleshooting
 
 **Port already in use** — Change `PORT` in `.env`.

--- a/packages/server/src/api/wati-webhook.test.ts
+++ b/packages/server/src/api/wati-webhook.test.ts
@@ -1,0 +1,115 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "../test-utils";
+import { extractWebhookToken, isValidWebhookToken, watiWebhookRoutes } from "./wati-webhook";
+
+function createTestApp(
+  handleWebhook = vi.fn(async () => [
+    { kind: "message" as const, providerMessageId: "wamid.1", senderPhoneE164: "+15551234567" },
+  ]),
+) {
+  const app = new Hono();
+  app.route(
+    "/whatsapp/wati",
+    watiWebhookRoutes(
+      {
+        webhookToken: "secret-token",
+        handleWebhook,
+      },
+      createTestLogger(),
+    ),
+  );
+  return { app, handleWebhook };
+}
+
+describe("watiWebhookRoutes", () => {
+  it("accepts bearer-token authenticated webhook payloads", async () => {
+    const { app, handleWebhook } = createTestApp();
+
+    const res = await app.request("/whatsapp/wati/events", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ eventType: "message" }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ ok: true, acceptedMessages: 1 });
+    expect(handleWebhook).toHaveBeenCalledWith({ eventType: "message" });
+  });
+
+  it("accepts query-token authenticated webhook payloads for Wati setups without custom headers", async () => {
+    const { app, handleWebhook } = createTestApp();
+
+    const res = await app.request("/whatsapp/wati/events?token=secret-token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ eventType: "message" }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(handleWebhook).toHaveBeenCalledOnce();
+  });
+
+  it("rejects missing or incorrect webhook tokens before processing the body", async () => {
+    const { app, handleWebhook } = createTestApp();
+
+    const res = await app.request("/whatsapp/wati/events", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer wrong-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ eventType: "message" }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(handleWebhook).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON after authentication", async () => {
+    const { app, handleWebhook } = createTestApp();
+
+    const res = await app.request("/whatsapp/wati/events", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "content-type": "application/json",
+      },
+      body: "{",
+    });
+
+    expect(res.status).toBe(400);
+    expect(handleWebhook).not.toHaveBeenCalled();
+  });
+});
+
+describe("Wati webhook token helpers", () => {
+  it("extracts bearer, custom header, and query tokens", () => {
+    expect(
+      extractWebhookToken(
+        new Request("https://sketch.test/whatsapp/wati/events", {
+          headers: { Authorization: "Bearer secret-token" },
+        }),
+      ),
+    ).toBe("secret-token");
+    expect(
+      extractWebhookToken(
+        new Request("https://sketch.test/whatsapp/wati/events", {
+          headers: { "x-wati-webhook-token": "header-token" },
+        }),
+      ),
+    ).toBe("header-token");
+    expect(extractWebhookToken(new Request("https://sketch.test/whatsapp/wati/events?token=query-token"))).toBe(
+      "query-token",
+    );
+  });
+
+  it("compares webhook tokens safely", () => {
+    expect(isValidWebhookToken("secret-token", "secret-token")).toBe(true);
+    expect(isValidWebhookToken("wrong", "secret-token")).toBe(false);
+    expect(isValidWebhookToken(null, "secret-token")).toBe(false);
+  });
+});

--- a/packages/server/src/api/wati-webhook.test.ts
+++ b/packages/server/src/api/wati-webhook.test.ts
@@ -23,7 +23,21 @@ function createTestApp(
 }
 
 describe("watiWebhookRoutes", () => {
-  it("accepts bearer-token authenticated webhook payloads", async () => {
+  it("accepts query-token authenticated webhook payloads for Wati setups without custom headers", async () => {
+    const { app, handleWebhook } = createTestApp();
+
+    const res = await app.request("/whatsapp/wati/events?token=secret-token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ eventType: "message" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, acceptedMessages: 1 });
+    expect(handleWebhook).toHaveBeenCalledWith({ eventType: "message" });
+  });
+
+  it("accepts bearer-token authenticated webhook payloads when headers are available", async () => {
     const { app, handleWebhook } = createTestApp();
 
     const res = await app.request("/whatsapp/wati/events", {
@@ -35,21 +49,7 @@ describe("watiWebhookRoutes", () => {
       body: JSON.stringify({ eventType: "message" }),
     });
 
-    expect(res.status).toBe(202);
-    expect(await res.json()).toEqual({ ok: true, acceptedMessages: 1 });
-    expect(handleWebhook).toHaveBeenCalledWith({ eventType: "message" });
-  });
-
-  it("accepts query-token authenticated webhook payloads for Wati setups without custom headers", async () => {
-    const { app, handleWebhook } = createTestApp();
-
-    const res = await app.request("/whatsapp/wati/events?token=secret-token", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ eventType: "message" }),
-    });
-
-    expect(res.status).toBe(202);
+    expect(res.status).toBe(200);
     expect(handleWebhook).toHaveBeenCalledOnce();
   });
 

--- a/packages/server/src/api/wati-webhook.ts
+++ b/packages/server/src/api/wati-webhook.ts
@@ -25,7 +25,7 @@ export function watiWebhookRoutes(
 
     const results = await provider.handleWebhook(payload);
     const acceptedMessages = results.filter((result) => result.kind === "message").length;
-    return c.json({ ok: true, acceptedMessages }, 202);
+    return c.json({ ok: true, acceptedMessages }, 200);
   });
 
   return routes;

--- a/packages/server/src/api/wati-webhook.ts
+++ b/packages/server/src/api/wati-webhook.ts
@@ -1,0 +1,55 @@
+import { timingSafeEqual } from "node:crypto";
+import { Hono } from "hono";
+import type { Logger } from "../logger";
+import type { WatiWhatsAppProvider } from "../whatsapp/providers/wati";
+
+export function watiWebhookRoutes(
+  provider: Pick<WatiWhatsAppProvider, "handleWebhook" | "webhookToken">,
+  logger: Logger,
+) {
+  const routes = new Hono();
+
+  routes.post("/events", async (c) => {
+    if (!isValidWebhookToken(extractWebhookToken(c.req.raw), provider.webhookToken)) {
+      return c.json({ error: { code: "UNAUTHORIZED", message: "Invalid webhook token" } }, 401);
+    }
+
+    const payload = await c.req.json().catch((err) => {
+      logger.warn({ err }, "Invalid Wati webhook JSON");
+      return undefined;
+    });
+
+    if (payload === undefined) {
+      return c.json({ error: { code: "INVALID_JSON", message: "Invalid JSON body" } }, 400);
+    }
+
+    const results = await provider.handleWebhook(payload);
+    const acceptedMessages = results.filter((result) => result.kind === "message").length;
+    return c.json({ ok: true, acceptedMessages }, 202);
+  });
+
+  return routes;
+}
+
+export function extractWebhookToken(request: Request): string | null {
+  const authorization = request.headers.get("authorization");
+  if (authorization?.toLowerCase().startsWith("bearer ")) {
+    const token = authorization.slice("bearer ".length).trim();
+    if (token) return token;
+  }
+
+  for (const header of ["x-wati-webhook-token", "x-sketch-wati-webhook-token", "x-webhook-token"]) {
+    const token = request.headers.get(header)?.trim();
+    if (token) return token;
+  }
+
+  const url = new URL(request.url);
+  return url.searchParams.get("token")?.trim() || null;
+}
+
+export function isValidWebhookToken(actual: string | null, expected: string): boolean {
+  if (!actual || !expected) return false;
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+}

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -56,6 +56,7 @@ import { wireWhatsAppHandlers } from "./whatsapp/adapter";
 import { WhatsAppBot } from "./whatsapp/bot";
 import { phoneE164ToWhatsAppJid } from "./whatsapp/provider";
 import { createBaileysWhatsAppProviders } from "./whatsapp/providers/baileys";
+import { WHATSAPP_WATI_PROVIDER_ID, createWatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import { createWhatsAppRuntime } from "./whatsapp/runtime";
 
 export interface ServerHandle {
@@ -231,12 +232,22 @@ export async function createServer(config: Config, options?: CreateServerOptions
   // 8. WhatsApp
   const whatsapp = new WhatsAppBot({ db, logger, groupMetadataStore: whatsappGroupsRepo });
   const baileysWhatsApp = createBaileysWhatsAppProviders(whatsapp, logger);
+  const watiWhatsApp =
+    config.WHATSAPP_DM_PROVIDER === WHATSAPP_WATI_PROVIDER_ID
+      ? createWatiWhatsAppProvider({
+          apiEndpoint: config.WATI_API_ENDPOINT ?? "",
+          accessToken: config.WATI_ACCESS_TOKEN ?? "",
+          webhookToken: config.WATI_WEBHOOK_TOKEN ?? "",
+          channelPhoneNumber: config.WATI_CHANNEL_PHONE_NUMBER,
+          logger,
+        })
+      : null;
   const whatsappRuntime = createWhatsAppRuntime({
     dmProviderId: config.WHATSAPP_DM_PROVIDER,
     groupProviderId: config.WHATSAPP_GROUP_PROVIDER,
-    dmProviders: [baileysWhatsApp.dmProvider],
+    dmProviders: [baileysWhatsApp.dmProvider, ...(watiWhatsApp ? [watiWhatsApp.dmProvider] : [])],
     groupProviders: [baileysWhatsApp.groupProvider],
-    inboundProviders: [baileysWhatsApp.inboundProvider],
+    inboundProviders: [baileysWhatsApp.inboundProvider, ...(watiWhatsApp ? [watiWhatsApp.inboundProvider] : [])],
     logger,
   });
 
@@ -431,6 +442,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const app = createApp(db, config, {
     whatsapp,
     whatsappRuntime,
+    watiWebhook: watiWhatsApp ?? undefined,
     getSlack: () => slack,
     scheduler,
     runAgent: trackedRunAgent,

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -41,11 +41,19 @@ describe("configSchema", () => {
       const result = configSchema.safeParse({
         WHATSAPP_DM_PROVIDER: "wati",
         WHATSAPP_GROUP_PROVIDER: "none",
+        WATI_API_ENDPOINT: "https://tenant.wati.io",
+        WATI_ACCESS_TOKEN: "access-token",
+        WATI_WEBHOOK_TOKEN: "webhook-token",
+        WATI_CHANNEL_PHONE_NUMBER: "+15551234567",
       });
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.WHATSAPP_DM_PROVIDER).toBe("wati");
         expect(result.data.WHATSAPP_GROUP_PROVIDER).toBe("none");
+        expect(result.data.WATI_API_ENDPOINT).toBe("https://tenant.wati.io");
+        expect(result.data.WATI_ACCESS_TOKEN).toBe("access-token");
+        expect(result.data.WATI_WEBHOOK_TOKEN).toBe("webhook-token");
+        expect(result.data.WATI_CHANNEL_PHONE_NUMBER).toBe("+15551234567");
       }
     });
 
@@ -181,6 +189,11 @@ describe("configSchema", () => {
       const result = configSchema.safeParse({ MAX_CONCURRENT_AGENT_RUNS: "0" });
       expect(result.success).toBe(false);
     });
+
+    it("rejects invalid Wati endpoint URLs", () => {
+      const result = configSchema.safeParse({ WATI_API_ENDPOINT: "not-a-url" });
+      expect(result.success).toBe(false);
+    });
   });
 });
 
@@ -293,6 +306,60 @@ describe("validateConfig", () => {
     it("does not exit when SLACK_MODE is absent (defaults to socket)", () => {
       const exitSpy = mockProcessExit();
       const config = makeConfig();
+      validateConfig(config);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Wati validation", () => {
+    it("does not require Wati credentials unless Wati is the configured DM provider", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({ WHATSAPP_DM_PROVIDER: "baileys" });
+      validateConfig(config);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("exits when Wati is configured without an API endpoint", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({
+        WHATSAPP_DM_PROVIDER: "wati",
+        WATI_ACCESS_TOKEN: "access-token",
+        WATI_WEBHOOK_TOKEN: "webhook-token",
+      });
+      expect(() => validateConfig(config)).toThrow("exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("exits when Wati is configured without an access token", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({
+        WHATSAPP_DM_PROVIDER: "wati",
+        WATI_API_ENDPOINT: "https://tenant.wati.io",
+        WATI_WEBHOOK_TOKEN: "webhook-token",
+      });
+      expect(() => validateConfig(config)).toThrow("exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("exits when Wati is configured without a webhook token", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({
+        WHATSAPP_DM_PROVIDER: "wati",
+        WATI_API_ENDPOINT: "https://tenant.wati.io",
+        WATI_ACCESS_TOKEN: "access-token",
+      });
+      expect(() => validateConfig(config)).toThrow("exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("accepts complete Wati configuration", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({
+        WHATSAPP_DM_PROVIDER: "wati",
+        WATI_API_ENDPOINT: "https://tenant.wati.io",
+        WATI_ACCESS_TOKEN: "access-token",
+        WATI_WEBHOOK_TOKEN: "webhook-token",
+      });
       validateConfig(config);
       expect(exitSpy).not.toHaveBeenCalled();
     });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -60,6 +60,10 @@ export const configSchema = z.object({
   // WhatsApp providers
   WHATSAPP_DM_PROVIDER: z.preprocess((v) => (v === "" ? undefined : v), z.string().default("baileys")),
   WHATSAPP_GROUP_PROVIDER: z.preprocess((v) => (v === "" ? undefined : v), z.string().default("baileys")),
+  WATI_API_ENDPOINT: z.preprocess((v) => (v === "" ? undefined : v), z.string().url().optional()),
+  WATI_ACCESS_TOKEN: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
+  WATI_WEBHOOK_TOKEN: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
+  WATI_CHANNEL_PHONE_NUMBER: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
 
   // Security
   ENCRYPTION_KEY: z.string().optional(),
@@ -158,5 +162,19 @@ export function validateConfig(config: Config): void {
   if (config.SLACK_MODE === "http" && !config.SLACK_SIGNING_SECRET) {
     console.error("SLACK_MODE=http requires SLACK_SIGNING_SECRET");
     process.exit(1);
+  }
+  if (config.WHATSAPP_DM_PROVIDER === "wati") {
+    if (!config.WATI_API_ENDPOINT) {
+      console.error("WHATSAPP_DM_PROVIDER=wati requires WATI_API_ENDPOINT");
+      process.exit(1);
+    }
+    if (!config.WATI_ACCESS_TOKEN) {
+      console.error("WHATSAPP_DM_PROVIDER=wati requires WATI_ACCESS_TOKEN");
+      process.exit(1);
+    }
+    if (!config.WATI_WEBHOOK_TOKEN) {
+      console.error("WHATSAPP_DM_PROVIDER=wati requires WATI_WEBHOOK_TOKEN");
+      process.exit(1);
+    }
   }
 }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -36,6 +36,7 @@ import { oauthRoutes } from "./api/oauth";
 import { systemRoutes } from "./api/system";
 import { usageRoutes } from "./api/usage";
 import { userRoutes } from "./api/users";
+import { watiWebhookRoutes } from "./api/wati-webhook";
 import { webChatRoutes } from "./api/web-chat";
 import { whatsappRoutes } from "./api/whatsapp";
 import { workflowRoutes } from "./api/workflows";
@@ -77,11 +78,13 @@ import type { TaskScheduler } from "./scheduler/service";
 import type { SlackBot } from "./slack/bot";
 import type { WhatsAppBot } from "./whatsapp/bot";
 import { phoneE164ToWhatsAppJid } from "./whatsapp/provider";
+import type { WatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import type { WhatsAppRuntime } from "./whatsapp/runtime";
 
 interface AppDeps {
   whatsapp?: WhatsAppBot;
   whatsappRuntime?: WhatsAppRuntime;
+  watiWebhook?: WatiWhatsAppProvider;
   getSlack?: () => SlackBot | null;
   logger?: Logger;
   onSlackTokensUpdated?: (tokens?: { botToken: string; appToken: string }) => Promise<void>;
@@ -191,6 +194,10 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
         return c.json({ error: "Invalid request" }, 401);
       }
     });
+  }
+
+  if (deps?.watiWebhook) {
+    app.route("/whatsapp/wati", watiWebhookRoutes(deps.watiWebhook, logger));
   }
 
   app.use(

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -139,7 +139,32 @@ describe("Wati webhook parsing", () => {
         providerConversationId: "conversation-1",
         eventType: "messageStatus",
         status: "READ",
+        failureCode: null,
+        failureDetail: null,
         providerTimestamp: "2025-11-27T10:14:13.000Z",
+      },
+    });
+  });
+
+  it("keeps Wati delivery failure metadata without logging message content", () => {
+    const parsed = parseWatiDeliveryStatusEvent({
+      eventType: "templateMessageFailed",
+      whatsappMessageId: "wamid.failed",
+      conversationId: "conversation-1",
+      statusString: "Failed",
+      failedCode: "131026",
+      failedDetail: "Message undeliverable",
+    });
+
+    expect(parsed).toMatchObject({
+      kind: "delivery_status",
+      event: {
+        providerMessageId: "wamid.failed",
+        providerConversationId: "conversation-1",
+        eventType: "templateMessageFailed",
+        status: "Failed",
+        failureCode: "131026",
+        failureDetail: "Message undeliverable",
       },
     });
   });
@@ -156,6 +181,13 @@ describe("Wati webhook parsing", () => {
       reason: "unsupported_event_type",
       eventType: "ticketAssigned",
       messageType: null,
+    });
+  });
+
+  it("ignores BSUID-only inbound events until Sketch supports username identities", () => {
+    expect(parseWatiWebhookEvent(documentedMessagePayload({ waId: null, bsuid: "bsuid-1" }))).toEqual({
+      kind: "ignored",
+      reason: "unsupported_sender_identity",
     });
   });
 
@@ -218,6 +250,39 @@ describe("Wati outbound provider", () => {
         },
       },
     });
+  });
+
+  it("sends files through the v1 session file endpoint when no channel is configured", async () => {
+    const requestFetch = vi.fn(async () => new Response(JSON.stringify({ ok: true, result: "success" })));
+    const provider = createWatiWhatsAppProvider({
+      apiEndpoint: "https://tenant.wati.io",
+      accessToken: "wati-token",
+      webhookToken: "webhook-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    const tmpDir = await mkdtemp(join(tmpdir(), "wati-send-file-v1-"));
+    const filePath = join(tmpDir, "note.txt");
+    await writeFile(filePath, "file body");
+
+    try {
+      await provider.dmProvider.sendFile?.(
+        { kind: "dm", phoneE164: "+15551234567" },
+        filePath,
+        "text/plain",
+        "note.txt",
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+
+    const [url, init] = firstFetchCall(requestFetch);
+    expect(url.toString()).toBe("https://tenant.wati.io/api/v1/sendSessionFile/15551234567");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ Authorization: "Bearer wati-token" });
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("target")).toBeNull();
   });
 
   it("sends files through the v3 Wati file endpoint with channel-qualified targets", async () => {
@@ -289,6 +354,48 @@ describe("Wati outbound provider", () => {
       expect(await readFile(attachments?.[0]?.localPath ?? "", "utf8")).toBe("image-bytes");
       const [url] = firstFetchCall(requestFetch);
       expect(url.pathname).toBe("/api/ext/v3/conversations/messages/file/wati-internal-id");
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries Wati media download with the WhatsApp message id after an internal id miss", async () => {
+    const requestFetch = vi.fn(async (url: URL) => {
+      if (url.pathname.endsWith("/wati-internal-id")) {
+        return new Response("missing", { status: 404 });
+      }
+
+      return new Response("image-bytes", {
+        headers: {
+          "content-type": "image/png",
+          "content-disposition": 'attachment; filename="photo.png"',
+        },
+      });
+    });
+    const provider = createWatiWhatsAppProvider({
+      apiEndpoint: "https://tenant.wati.io",
+      accessToken: "wati-token",
+      webhookToken: "webhook-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+    const parsed = parseWatiWebhookEvent(
+      documentedMessagePayload({ id: "wati-internal-id", whatsappMessageId: "wamid.media", type: "image" }),
+    );
+    if (parsed.kind !== "message") throw new Error("expected message");
+    const workspaceDir = await mkdtemp(join(tmpdir(), "wati-download-fallback-"));
+
+    try {
+      const attachments = await provider.dmProvider.downloadMedia?.(parsed.message, workspaceDir, {
+        maxFileBytes: 1024,
+      });
+
+      expect(attachments).toEqual([expect.objectContaining({ originalName: "photo.png" })]);
+      expect(requestFetch).toHaveBeenCalledTimes(2);
+      expect(requestFetch.mock.calls.map(([url]) => (url as URL).pathname)).toEqual([
+        "/api/ext/v3/conversations/messages/file/wati-internal-id",
+        "/api/ext/v3/conversations/messages/file/wamid.media",
+      ]);
     } finally {
       await rm(workspaceDir, { recursive: true, force: true });
     }

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -218,7 +218,7 @@ describe("Wati outbound provider", () => {
       );
     });
     const provider = createWatiWhatsAppProvider({
-      apiEndpoint: "https://tenant.wati.io/",
+      apiEndpoint: "https://live-mt-server.wati.io/tenant-1/",
       accessToken: "wati-token",
       webhookToken: "webhook-token",
       channelPhoneNumber: "+17435002445",
@@ -231,7 +231,7 @@ describe("Wati outbound provider", () => {
     });
 
     const [url, init] = firstFetchCall(requestFetch);
-    expect(url.toString()).toBe("https://tenant.wati.io/api/v1/sendSessionMessage/15551234567");
+    expect(url.toString()).toBe("https://live-mt-server.wati.io/tenant-1/api/v1/sendSessionMessage/15551234567");
     expect(init.headers).toEqual({
       Authorization: "Bearer wati-token",
       "Content-Type": "application/x-www-form-urlencoded",
@@ -292,7 +292,7 @@ describe("Wati outbound provider", () => {
   it("sends files through the v3 Wati file endpoint with channel-qualified targets", async () => {
     const requestFetch = vi.fn(async () => new Response(JSON.stringify({ message: { id: "sent-file" } })));
     const provider = createWatiWhatsAppProvider({
-      apiEndpoint: "https://tenant.wati.io",
+      apiEndpoint: "https://live-mt-server.wati.io/tenant-1",
       accessToken: "wati-token",
       webhookToken: "webhook-token",
       channelPhoneNumber: "17435002445",
@@ -316,7 +316,7 @@ describe("Wati outbound provider", () => {
     }
 
     const [url, init] = firstFetchCall(requestFetch);
-    expect(url.toString()).toBe("https://tenant.wati.io/api/ext/v3/conversations/messages/file");
+    expect(url.toString()).toBe("https://live-mt-server.wati.io/api/ext/v3/conversations/messages/file");
     expect(init.method).toBe("POST");
     expect(init.headers).toEqual({ Authorization: "Bearer wati-token" });
     expect(init.body).toBeInstanceOf(FormData);

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -231,11 +231,15 @@ describe("Wati outbound provider", () => {
     });
 
     const [url, init] = firstFetchCall(requestFetch);
-    expect(url.toString()).toContain("https://tenant.wati.io/api/v1/sendSessionMessage/15551234567");
-    expect(url.searchParams.get("messageText")).toBe("hello");
-    expect(url.searchParams.get("replyContextId")).toBe("wamid.inbound");
-    expect(url.searchParams.get("channelPhoneNumber")).toBe("17435002445");
-    expect(init.headers).toEqual({ Authorization: "Bearer wati-token" });
+    expect(url.toString()).toBe("https://tenant.wati.io/api/v1/sendSessionMessage/15551234567");
+    expect(init.headers).toEqual({
+      Authorization: "Bearer wati-token",
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+    expect(init.body).toBeInstanceOf(URLSearchParams);
+    expect((init.body as URLSearchParams).get("messageText")).toBe("hello");
+    expect((init.body as URLSearchParams).get("replyContextId")).toBe("wamid.inbound");
+    expect((init.body as URLSearchParams).get("channelPhoneNumber")).toBe("17435002445");
     expect(sent).toEqual({
       providerMessageId: "wamid.sent",
       providerConversationId: "conversation-2",

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -1,0 +1,320 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "../../test-utils";
+import type { WhatsAppInboundMessage } from "../provider";
+import {
+  createWatiWhatsAppProvider,
+  normalizeWatiPhoneNumber,
+  parseWatiDeliveryStatusEvent,
+  parseWatiWebhookEvent,
+} from "./wati";
+
+function documentedMessagePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "69282478274a880fe782b2d9",
+    created: "2025-11-27T10:14:16.6268572Z",
+    whatsappMessageId: "wamid.inbound",
+    conversationId: "conversation-1",
+    ticketId: "ticket-1",
+    text: "hello",
+    type: "text",
+    data: null,
+    timestamp: "1764238453",
+    owner: false,
+    eventType: "message",
+    statusString: "SENT",
+    waId: "8618719149214",
+    senderName: "Alice",
+    replyContextId: "wamid.parent",
+    channelPhoneNumber: "17435002445",
+    ...overrides,
+  };
+}
+
+function quotedMessage(): WhatsAppInboundMessage {
+  return {
+    kind: "dm",
+    providerId: "wati",
+    providerMessageId: "wamid.inbound",
+    providerConversationId: "conversation-1",
+    canonicalConversationId: "dm:+15551234567",
+    providerTimestamp: null,
+    senderName: "Alice",
+    senderProviderId: "15551234567",
+    senderPhoneE164: "+15551234567",
+    target: { kind: "dm", phoneE164: "+15551234567", providerConversationId: "conversation-1" },
+    text: "hello",
+  };
+}
+
+function firstFetchCall(requestFetch: { mock: { calls: unknown[][] } }): [URL, RequestInit] {
+  const call = requestFetch.mock.calls[0];
+  if (!call) throw new Error("expected fetch call");
+  return [call[0] as URL, call[1] as RequestInit];
+}
+
+describe("Wati webhook parsing", () => {
+  it("normalizes documented inbound message payloads into WhatsApp DM events", () => {
+    const parsed = parseWatiWebhookEvent(documentedMessagePayload(), { channelPhoneNumber: "+17435002445" });
+
+    expect(parsed).toMatchObject({
+      kind: "message",
+      message: {
+        kind: "dm",
+        providerId: "wati",
+        providerMessageId: "wamid.inbound",
+        providerConversationId: "conversation-1",
+        canonicalConversationId: "dm:+8618719149214",
+        providerTimestamp: "2025-11-27T10:14:13.000Z",
+        senderName: "Alice",
+        senderProviderId: "8618719149214",
+        senderPhoneE164: "+8618719149214",
+        target: { kind: "dm", phoneE164: "+8618719149214", providerConversationId: "conversation-1" },
+        text: "hello",
+        quotedMessage: { providerMessageId: "wamid.parent", participantJid: null, text: "" },
+      },
+    });
+    expect(parsed.kind === "message" ? parsed.message.rawProviderPayload : null).toEqual(documentedMessagePayload());
+  });
+
+  it("accepts media message variants without requiring text", () => {
+    const parsed = parseWatiWebhookEvent(
+      documentedMessagePayload({
+        whatsappMessageId: "wamid.media",
+        text: null,
+        type: "image",
+        replyContextId: "",
+      }),
+    );
+
+    expect(parsed).toMatchObject({
+      kind: "message",
+      message: {
+        providerMessageId: "wamid.media",
+        text: "",
+        mediaType: "image",
+      },
+    });
+  });
+
+  it("ignores owner, reaction, and channel-mismatched events without crashing", () => {
+    expect(parseWatiWebhookEvent(documentedMessagePayload({ owner: true }))).toMatchObject({
+      kind: "delivery_status",
+      event: { providerMessageId: "wamid.inbound", status: "SENT" },
+    });
+    expect(parseWatiWebhookEvent(documentedMessagePayload({ type: "reaction" }))).toEqual({
+      kind: "ignored",
+      reason: "unsupported_message_type",
+    });
+    expect(parseWatiWebhookEvent(documentedMessagePayload(), { channelPhoneNumber: "+15551234567" })).toEqual({
+      kind: "ignored",
+      reason: "channel_mismatch",
+    });
+    expect(
+      parseWatiWebhookEvent(documentedMessagePayload({ channelPhoneNumber: null }), {
+        channelPhoneNumber: "+15551234567",
+      }),
+    ).toEqual({
+      kind: "ignored",
+      reason: "channel_mismatch",
+    });
+  });
+
+  it("parses delivery/status payloads without treating them as inbound messages", () => {
+    const parsed = parseWatiDeliveryStatusEvent({
+      eventType: "messageStatus",
+      whatsappMessageId: "wamid.status",
+      conversationId: "conversation-1",
+      statusString: "READ",
+      timestamp: "1764238453",
+    });
+
+    expect(parsed).toMatchObject({
+      kind: "delivery_status",
+      event: {
+        providerId: "wati",
+        providerMessageId: "wamid.status",
+        providerConversationId: "conversation-1",
+        eventType: "messageStatus",
+        status: "READ",
+        providerTimestamp: "2025-11-27T10:14:13.000Z",
+      },
+    });
+  });
+
+  it("returns metadata-only unrecognized results for unsafe message shapes", () => {
+    expect(parseWatiWebhookEvent({ eventType: "message", type: "text", text: "missing ids" })).toEqual({
+      kind: "unrecognized",
+      reason: "missing_required_message_fields",
+      eventType: "message",
+      messageType: "text",
+    });
+    expect(parseWatiWebhookEvent({ eventType: "ticketAssigned", ticketId: "t1" })).toEqual({
+      kind: "unrecognized",
+      reason: "unsupported_event_type",
+      eventType: "ticketAssigned",
+      messageType: null,
+    });
+  });
+
+  it("normalizes Wati phone variants to strict E.164", () => {
+    expect(normalizeWatiPhoneNumber("8618719149214")).toBe("+8618719149214");
+    expect(normalizeWatiPhoneNumber("+1 (555) 123-4567")).toBe("+15551234567");
+    expect(normalizeWatiPhoneNumber("0000")).toBeNull();
+  });
+});
+
+describe("Wati outbound provider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends quoted session text messages through the v1 Wati endpoint", async () => {
+    const requestFetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          result: "success",
+          message: {
+            whatsappMessageId: "wamid.sent",
+            conversationId: "conversation-2",
+            time: "1764238453",
+          },
+        }),
+      );
+    });
+    const provider = createWatiWhatsAppProvider({
+      apiEndpoint: "https://tenant.wati.io/",
+      accessToken: "wati-token",
+      webhookToken: "webhook-token",
+      channelPhoneNumber: "+17435002445",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    const sent = await provider.dmProvider.sendText({ kind: "dm", phoneE164: "+15551234567" }, "hello", {
+      quotedMessage: quotedMessage(),
+    });
+
+    const [url, init] = firstFetchCall(requestFetch);
+    expect(url.toString()).toContain("https://tenant.wati.io/api/v1/sendSessionMessage/15551234567");
+    expect(url.searchParams.get("messageText")).toBe("hello");
+    expect(url.searchParams.get("replyContextId")).toBe("wamid.inbound");
+    expect(url.searchParams.get("channelPhoneNumber")).toBe("17435002445");
+    expect(init.headers).toEqual({ Authorization: "Bearer wati-token" });
+    expect(sent).toEqual({
+      providerMessageId: "wamid.sent",
+      providerConversationId: "conversation-2",
+      providerTimestamp: "2025-11-27T10:14:13.000Z",
+      rawProviderPayload: {
+        ok: true,
+        result: "success",
+        message: {
+          whatsappMessageId: "wamid.sent",
+          conversationId: "conversation-2",
+          time: "1764238453",
+        },
+      },
+    });
+  });
+
+  it("sends files through the v3 Wati file endpoint with channel-qualified targets", async () => {
+    const requestFetch = vi.fn(async () => new Response(JSON.stringify({ message: { id: "sent-file" } })));
+    const provider = createWatiWhatsAppProvider({
+      apiEndpoint: "https://tenant.wati.io",
+      accessToken: "wati-token",
+      webhookToken: "webhook-token",
+      channelPhoneNumber: "17435002445",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    const tmpDir = await mkdtemp(join(tmpdir(), "wati-send-file-"));
+    const filePath = join(tmpDir, "note.txt");
+    await writeFile(filePath, "file body");
+
+    try {
+      await provider.dmProvider.sendFile?.(
+        { kind: "dm", phoneE164: "+15551234567" },
+        filePath,
+        "text/plain",
+        "note.txt",
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+
+    const [url, init] = firstFetchCall(requestFetch);
+    expect(url.toString()).toBe("https://tenant.wati.io/api/ext/v3/conversations/messages/file");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ Authorization: "Bearer wati-token" });
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("target")).toBe("17435002445:15551234567");
+  });
+
+  it("downloads Wati media into the workspace attachment directory", async () => {
+    const requestFetch = vi.fn(async () => {
+      return new Response("image-bytes", {
+        headers: {
+          "content-type": "image/png",
+          "content-disposition": 'attachment; filename="photo.png"',
+        },
+      });
+    });
+    const provider = createWatiWhatsAppProvider({
+      apiEndpoint: "https://tenant.wati.io",
+      accessToken: "wati-token",
+      webhookToken: "webhook-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+    const parsed = parseWatiWebhookEvent(documentedMessagePayload({ id: "wati-internal-id", type: "image" }));
+    if (parsed.kind !== "message") throw new Error("expected message");
+    const workspaceDir = await mkdtemp(join(tmpdir(), "wati-download-"));
+
+    try {
+      const attachments = await provider.dmProvider.downloadMedia?.(parsed.message, workspaceDir, {
+        maxFileBytes: 1024,
+      });
+
+      expect(attachments).toEqual([
+        expect.objectContaining({
+          originalName: "photo.png",
+          mimeType: "image/png",
+          sizeBytes: "image-bytes".length,
+        }),
+      ]);
+      expect(await readFile(attachments?.[0]?.localPath ?? "", "utf8")).toBe("image-bytes");
+      const [url] = firstFetchCall(requestFetch);
+      expect(url.pathname).toBe("/api/ext/v3/conversations/messages/file/wati-internal-id");
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits only normalized inbound messages from handleWebhook", async () => {
+    const provider = createWatiWhatsAppProvider({
+      apiEndpoint: "https://tenant.wati.io",
+      accessToken: "wati-token",
+      webhookToken: "webhook-token",
+      logger: createTestLogger(),
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+    const handler = vi.fn();
+    provider.inboundProvider.onMessage(handler);
+
+    const results = await provider.handleWebhook([
+      documentedMessagePayload({ whatsappMessageId: "wamid.one" }),
+      documentedMessagePayload({ owner: true, whatsappMessageId: "wamid.owner" }),
+    ]);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ providerMessageId: "wamid.one" }));
+    expect(results).toEqual([
+      { kind: "message", providerMessageId: "wamid.one", senderPhoneE164: "+8618719149214" },
+      expect.objectContaining({ kind: "delivery_status" }),
+    ]);
+  });
+});

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "../../test-utils";
-import type { WhatsAppInboundMessage } from "../provider";
+import { type WhatsAppInboundMessage, whatsappDeliveryTargetFromTarget } from "../provider";
 import {
   createWatiWhatsAppProvider,
   normalizeWatiPhoneNumber,
@@ -44,7 +44,7 @@ function quotedMessage(): WhatsAppInboundMessage {
     senderName: "Alice",
     senderProviderId: "15551234567",
     senderPhoneE164: "+15551234567",
-    target: { kind: "dm", phoneE164: "+15551234567", providerConversationId: "conversation-1" },
+    target: { kind: "dm", phoneE164: "+15551234567" },
     text: "hello",
   };
 }
@@ -71,11 +71,13 @@ describe("Wati webhook parsing", () => {
         senderName: "Alice",
         senderProviderId: "8618719149214",
         senderPhoneE164: "+8618719149214",
-        target: { kind: "dm", phoneE164: "+8618719149214", providerConversationId: "conversation-1" },
+        target: { kind: "dm", phoneE164: "+8618719149214" },
         text: "hello",
         quotedMessage: { providerMessageId: "wamid.parent", participantJid: null, text: "" },
       },
     });
+    if (parsed.kind !== "message") throw new Error("expected message");
+    expect(whatsappDeliveryTargetFromTarget(parsed.message.target)).toBe("dm:+8618719149214");
     expect(parsed.kind === "message" ? parsed.message.rawProviderPayload : null).toEqual(documentedMessagePayload());
   });
 

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -87,15 +87,16 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
   ): Promise<WhatsAppSendResult | null> => {
     const phone = targetPhoneDigits(target);
     const url = new URL(`${endpoint}/api/v1/sendSessionMessage/${encodeURIComponent(phone)}`);
-    url.searchParams.set("messageText", text);
+    const bodyParams = new URLSearchParams({ messageText: text });
 
     const replyContextId = options?.quotedMessage?.providerMessageId;
-    if (replyContextId) url.searchParams.set("replyContextId", replyContextId);
-    if (channelPhoneDigits) url.searchParams.set("channelPhoneNumber", channelPhoneDigits);
+    if (replyContextId) bodyParams.set("replyContextId", replyContextId);
+    if (channelPhoneDigits) bodyParams.set("channelPhoneNumber", channelPhoneDigits);
 
     const body = await fetchJson(requestFetch, url, {
       method: "POST",
-      headers: authorizationHeaders(config.accessToken),
+      headers: { ...authorizationHeaders(config.accessToken), "Content-Type": "application/x-www-form-urlencoded" },
+      body: bodyParams,
     });
 
     return sendResultFromWatiBody(body, target);

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -76,6 +76,7 @@ type WatiParsedWebhookEvent =
 
 export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhatsAppProvider {
   const endpoint = normalizeApiEndpoint(config.apiEndpoint);
+  const v3Endpoint = normalizeApiEndpoint(new URL(endpoint).origin);
   const requestFetch = config.fetch ?? fetch;
   const channelPhoneDigits = phoneDigits(config.channelPhoneNumber ?? null);
   const handlers = new Set<WhatsAppMessageHandler>();
@@ -120,7 +121,7 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
 
     form.set("target", `${channelPhoneDigits}:${phone}`);
 
-    await fetchJson(requestFetch, new URL(`${endpoint}/api/ext/v3/conversations/messages/file`), {
+    await fetchJson(requestFetch, new URL(`${v3Endpoint}/api/ext/v3/conversations/messages/file`), {
       method: "POST",
       headers: authorizationHeaders(config.accessToken),
       body: form,
@@ -145,7 +146,7 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
 
     let response: Response | null = null;
     for (const [index, fileMessageId] of fileMessageIds.entries()) {
-      const url = new URL(`${endpoint}/api/ext/v3/conversations/messages/file/${encodeURIComponent(fileMessageId)}`);
+      const url = new URL(`${v3Endpoint}/api/ext/v3/conversations/messages/file/${encodeURIComponent(fileMessageId)}`);
       const attempt = await requestFetch(url, {
         headers: authorizationHeaders(config.accessToken),
       });

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -350,7 +350,7 @@ export function parseWatiWebhookEvent(
       senderName: optionalString(payload.senderName) ?? senderPhoneE164,
       senderProviderId: optionalString(payload.waId) ?? senderPhoneE164,
       senderPhoneE164,
-      target: { kind: "dm", phoneE164: senderPhoneE164, providerConversationId },
+      target: { kind: "dm", phoneE164: senderPhoneE164 },
       text,
       rawProviderPayload: payload,
       ...(mediaType ? { mediaType } : {}),

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -62,6 +62,8 @@ export interface WatiDeliveryStatusEvent {
   providerConversationId: string | null;
   eventType: string | null;
   status: string | null;
+  failureCode: string | null;
+  failureDetail: string | null;
   providerTimestamp: string | null;
   rawProviderPayload: unknown;
 }
@@ -103,10 +105,19 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
     const phone = targetPhoneDigits(target);
     const form = new FormData();
     const fileBytes = await readFile(filePath);
-    const targetId = channelPhoneDigits ? `${channelPhoneDigits}:${phone}` : phone;
 
-    form.set("target", targetId);
     form.set("file", new Blob([new Uint8Array(fileBytes)], { type: mimeType }), fileName);
+
+    if (!channelPhoneDigits) {
+      await fetchJson(requestFetch, new URL(`${endpoint}/api/v1/sendSessionFile/${encodeURIComponent(phone)}`), {
+        method: "POST",
+        headers: authorizationHeaders(config.accessToken),
+        body: form,
+      });
+      return;
+    }
+
+    form.set("target", `${channelPhoneDigits}:${phone}`);
 
     await fetchJson(requestFetch, new URL(`${endpoint}/api/ext/v3/conversations/messages/file`), {
       method: "POST",
@@ -122,8 +133,8 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
   ): Promise<Attachment[]> => {
     if (!message.mediaType) return [];
 
-    const fileMessageId = fileMessageIdForDownload(message);
-    if (!fileMessageId) {
+    const fileMessageIds = fileMessageIdsForDownload(message);
+    if (!fileMessageIds.length) {
       config.logger.warn(
         { providerMessageId: message.providerMessageId, mediaType: message.mediaType },
         "Wati media message has no downloadable id",
@@ -131,14 +142,30 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
       return [];
     }
 
-    const url = new URL(`${endpoint}/api/ext/v3/conversations/messages/file/${encodeURIComponent(fileMessageId)}`);
-    const response = await requestFetch(url, {
-      headers: authorizationHeaders(config.accessToken),
-    });
+    let response: Response | null = null;
+    for (const [index, fileMessageId] of fileMessageIds.entries()) {
+      const url = new URL(`${endpoint}/api/ext/v3/conversations/messages/file/${encodeURIComponent(fileMessageId)}`);
+      const attempt = await requestFetch(url, {
+        headers: authorizationHeaders(config.accessToken),
+      });
 
-    if (!response.ok) {
+      const isLastAttempt = index === fileMessageIds.length - 1;
+      if (attempt.ok || isLastAttempt || !shouldTryNextMediaDownloadId(attempt.status)) {
+        response = attempt;
+        break;
+      }
+
+      await attempt.arrayBuffer().catch(() => undefined);
+    }
+
+    if (!response?.ok) {
       config.logger.warn(
-        { status: response.status, providerMessageId: message.providerMessageId, mediaType: message.mediaType },
+        {
+          status: response?.status ?? null,
+          attempts: fileMessageIds.length,
+          providerMessageId: message.providerMessageId,
+          mediaType: message.mediaType,
+        },
         "Failed to download Wati media",
       );
       return [];
@@ -291,6 +318,9 @@ export function parseWatiWebhookEvent(
 
   const senderPhoneE164 = normalizeWatiPhoneNumber(payload.waId);
   const providerMessageId = optionalString(payload.whatsappMessageId) ?? optionalString(payload.id);
+  if (!senderPhoneE164 && hasWatiUsernameOnlyIdentity(payload)) {
+    return { kind: "ignored", reason: "unsupported_sender_identity" };
+  }
   if (!senderPhoneE164 || !providerMessageId) {
     return {
       kind: "unrecognized",
@@ -356,6 +386,8 @@ export function parseWatiDeliveryStatusEvent(
       providerConversationId: optionalString(payload.conversationId) ?? optionalString(payload.conversation_id),
       eventType,
       status,
+      failureCode: optionalString(payload.failedCode) ?? optionalString(payload.failed_code),
+      failureDetail: optionalString(payload.failedDetail) ?? optionalString(payload.failed_detail),
       providerTimestamp:
         parseWatiTimestamp(payload.timestamp) ??
         parseWatiTimestamp(payload.created) ??
@@ -428,9 +460,27 @@ function sendResultFromWatiBody(body: unknown, target: WhatsAppTarget): WhatsApp
   };
 }
 
-function fileMessageIdForDownload(message: WhatsAppDmInboundMessage): string | null {
+function fileMessageIdsForDownload(message: WhatsAppDmInboundMessage): string[] {
   const raw = isRecord(message.rawProviderPayload) ? message.rawProviderPayload : null;
-  return optionalString(raw?.id) ?? message.providerMessageId;
+  return uniqueStrings([optionalString(raw?.id), optionalString(raw?.whatsappMessageId), message.providerMessageId]);
+}
+
+function shouldTryNextMediaDownloadId(status: number): boolean {
+  return status === 400 || status === 403 || status === 404;
+}
+
+function uniqueStrings(values: Array<string | null>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+function hasWatiUsernameOnlyIdentity(payload: Record<string, unknown>): boolean {
+  return Boolean(
+    optionalString(payload.bsuid) ??
+      optionalString(payload.senderBsuid) ??
+      optionalString(payload.senderBSUID) ??
+      optionalString(payload.whatsappUsername) ??
+      optionalString(payload.whatsappUserName),
+  );
 }
 
 function fileNameFromHeaders(headers: Headers): string | null {

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -1,0 +1,493 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import type { Attachment } from "../../files";
+import { mimeToExtension } from "../../files";
+import type { Logger } from "../../logger";
+import {
+  type WhatsAppCapabilities,
+  type WhatsAppDmInboundMessage,
+  type WhatsAppDmProvider,
+  type WhatsAppInboundProvider,
+  type WhatsAppMessageHandler,
+  type WhatsAppSendOptions,
+  type WhatsAppSendResult,
+  type WhatsAppTarget,
+  canonicalDmConversationId,
+} from "../provider";
+
+export const WHATSAPP_WATI_PROVIDER_ID = "wati";
+
+const WATI_CAPABILITIES: WhatsAppCapabilities = {
+  text: true,
+  media: true,
+  quotedReply: true,
+  templates: true,
+  templateProvisioning: "api",
+  interactive: true,
+  deliveryStatus: true,
+  typing: false,
+  reactions: false,
+  edit: false,
+  groups: false,
+};
+
+const MEDIA_MESSAGE_TYPES = new Set(["image", "document", "voice", "audio", "video", "sticker", "media_placeholder"]);
+const UNSUPPORTED_INBOUND_MESSAGE_TYPES = new Set(["reaction"]);
+
+export interface WatiWhatsAppConfig {
+  apiEndpoint: string;
+  accessToken: string;
+  webhookToken: string;
+  channelPhoneNumber?: string | null;
+  logger: Logger;
+  fetch?: typeof fetch;
+}
+
+export interface WatiWhatsAppProvider {
+  dmProvider: WhatsAppDmProvider;
+  inboundProvider: WhatsAppInboundProvider;
+  webhookToken: string;
+  handleWebhook(payload: unknown): Promise<WatiWebhookHandleResult[]>;
+}
+
+export type WatiWebhookHandleResult =
+  | { kind: "message"; providerMessageId: string; senderPhoneE164: string }
+  | { kind: "delivery_status"; event: WatiDeliveryStatusEvent }
+  | { kind: "ignored"; reason: string }
+  | { kind: "unrecognized"; reason: string; eventType: string | null; messageType: string | null };
+
+export interface WatiDeliveryStatusEvent {
+  providerId: typeof WHATSAPP_WATI_PROVIDER_ID;
+  providerMessageId: string | null;
+  providerConversationId: string | null;
+  eventType: string | null;
+  status: string | null;
+  providerTimestamp: string | null;
+  rawProviderPayload: unknown;
+}
+
+type WatiParsedWebhookEvent =
+  | { kind: "message"; message: WhatsAppDmInboundMessage }
+  | { kind: "delivery_status"; event: WatiDeliveryStatusEvent }
+  | { kind: "ignored"; reason: string }
+  | { kind: "unrecognized"; reason: string; eventType: string | null; messageType: string | null };
+
+export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhatsAppProvider {
+  const endpoint = normalizeApiEndpoint(config.apiEndpoint);
+  const requestFetch = config.fetch ?? fetch;
+  const channelPhoneDigits = phoneDigits(config.channelPhoneNumber ?? null);
+  const handlers = new Set<WhatsAppMessageHandler>();
+
+  const sendText = async (
+    target: WhatsAppTarget,
+    text: string,
+    options?: WhatsAppSendOptions,
+  ): Promise<WhatsAppSendResult | null> => {
+    const phone = targetPhoneDigits(target);
+    const url = new URL(`${endpoint}/api/v1/sendSessionMessage/${encodeURIComponent(phone)}`);
+    url.searchParams.set("messageText", text);
+
+    const replyContextId = options?.quotedMessage?.providerMessageId;
+    if (replyContextId) url.searchParams.set("replyContextId", replyContextId);
+    if (channelPhoneDigits) url.searchParams.set("channelPhoneNumber", channelPhoneDigits);
+
+    const body = await fetchJson(requestFetch, url, {
+      method: "POST",
+      headers: authorizationHeaders(config.accessToken),
+    });
+
+    return sendResultFromWatiBody(body, target);
+  };
+
+  const sendFile = async (target: WhatsAppTarget, filePath: string, mimeType: string, fileName: string) => {
+    const phone = targetPhoneDigits(target);
+    const form = new FormData();
+    const fileBytes = await readFile(filePath);
+    const targetId = channelPhoneDigits ? `${channelPhoneDigits}:${phone}` : phone;
+
+    form.set("target", targetId);
+    form.set("file", new Blob([new Uint8Array(fileBytes)], { type: mimeType }), fileName);
+
+    await fetchJson(requestFetch, new URL(`${endpoint}/api/ext/v3/conversations/messages/file`), {
+      method: "POST",
+      headers: authorizationHeaders(config.accessToken),
+      body: form,
+    });
+  };
+
+  const downloadMedia = async (
+    message: WhatsAppDmInboundMessage,
+    workspaceDir: string,
+    params: { maxFileBytes: number },
+  ): Promise<Attachment[]> => {
+    if (!message.mediaType) return [];
+
+    const fileMessageId = fileMessageIdForDownload(message);
+    if (!fileMessageId) {
+      config.logger.warn(
+        { providerMessageId: message.providerMessageId, mediaType: message.mediaType },
+        "Wati media message has no downloadable id",
+      );
+      return [];
+    }
+
+    const url = new URL(`${endpoint}/api/ext/v3/conversations/messages/file/${encodeURIComponent(fileMessageId)}`);
+    const response = await requestFetch(url, {
+      headers: authorizationHeaders(config.accessToken),
+    });
+
+    if (!response.ok) {
+      config.logger.warn(
+        { status: response.status, providerMessageId: message.providerMessageId, mediaType: message.mediaType },
+        "Failed to download Wati media",
+      );
+      return [];
+    }
+
+    const contentLength = Number(response.headers.get("content-length") ?? "0");
+    if (contentLength > params.maxFileBytes) {
+      config.logger.warn(
+        { sizeBytes: contentLength, maxFileBytes: params.maxFileBytes, mediaType: message.mediaType },
+        "Wati media exceeds size limit",
+      );
+      return [];
+    }
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.length > params.maxFileBytes) {
+      config.logger.warn(
+        { sizeBytes: bytes.length, maxFileBytes: params.maxFileBytes, mediaType: message.mediaType },
+        "Wati media exceeds size limit",
+      );
+      return [];
+    }
+
+    const mimeType = response.headers.get("content-type")?.split(";")[0]?.trim() || "application/octet-stream";
+    const originalName =
+      fileNameFromHeaders(response.headers) ?? `${message.providerMessageId}.${mimeToExtension(mimeType)}`;
+    const safeName = sanitizeFilename(originalName);
+    const attachmentsDir = join(workspaceDir, "attachments");
+    await mkdir(attachmentsDir, { recursive: true });
+    const localPath = join(attachmentsDir, `${Date.now()}_${safeName}`);
+    await writeFile(localPath, bytes);
+
+    return [
+      {
+        originalName: safeName,
+        mimeType,
+        localPath,
+        sizeBytes: bytes.length,
+      },
+    ];
+  };
+
+  const provider: WatiWhatsAppProvider = {
+    dmProvider: {
+      id: WHATSAPP_WATI_PROVIDER_ID,
+      role: "dm",
+      capabilities: WATI_CAPABILITIES,
+      get isConnected() {
+        return Boolean(endpoint && config.accessToken);
+      },
+      sendText,
+      sendFile,
+      downloadMedia: (message, workspaceDir, params) =>
+        message.kind === "dm" ? downloadMedia(message, workspaceDir, params) : Promise.resolve([]),
+    },
+    inboundProvider: {
+      id: WHATSAPP_WATI_PROVIDER_ID,
+      onMessage(handler) {
+        handlers.add(handler);
+      },
+    },
+    webhookToken: config.webhookToken,
+    async handleWebhook(payload) {
+      const events = Array.isArray(payload) ? payload : [payload];
+      const results: WatiWebhookHandleResult[] = [];
+
+      for (const eventPayload of events) {
+        const parsed = parseWatiWebhookEvent(eventPayload, { channelPhoneNumber: config.channelPhoneNumber });
+        if (parsed.kind === "message") {
+          for (const handler of handlers) {
+            await handler(parsed.message);
+          }
+          results.push({
+            kind: "message",
+            providerMessageId: parsed.message.providerMessageId,
+            senderPhoneE164: parsed.message.senderPhoneE164,
+          });
+          continue;
+        }
+
+        if (parsed.kind === "delivery_status") {
+          config.logger.debug(
+            {
+              providerMessageId: parsed.event.providerMessageId,
+              providerConversationId: parsed.event.providerConversationId,
+              eventType: parsed.event.eventType,
+              status: parsed.event.status,
+            },
+            "Parsed Wati delivery/status webhook event",
+          );
+          results.push(parsed);
+          continue;
+        }
+
+        if (parsed.kind === "unrecognized") {
+          config.logger.warn(
+            { eventType: parsed.eventType, messageType: parsed.messageType, reason: parsed.reason },
+            "Unrecognized Wati webhook event",
+          );
+        }
+
+        results.push(parsed);
+      }
+
+      return results;
+    },
+  };
+
+  return provider;
+}
+
+export function parseWatiWebhookEvent(
+  payload: unknown,
+  options: { channelPhoneNumber?: string | null } = {},
+): WatiParsedWebhookEvent {
+  if (!isRecord(payload)) {
+    return { kind: "unrecognized", reason: "payload_not_object", eventType: null, messageType: null };
+  }
+
+  const eventType = optionalString(payload.eventType);
+  const messageType = optionalString(payload.type);
+  const owner = optionalBoolean(payload.owner);
+
+  if (owner === true) {
+    const delivery = parseWatiDeliveryStatusEvent(payload);
+    return delivery ?? { kind: "ignored", reason: "owner_event" };
+  }
+
+  if (eventType && eventType !== "message") {
+    const delivery = parseWatiDeliveryStatusEvent(payload);
+    return (
+      delivery ?? {
+        kind: "unrecognized",
+        reason: "unsupported_event_type",
+        eventType,
+        messageType,
+      }
+    );
+  }
+
+  if (messageType && UNSUPPORTED_INBOUND_MESSAGE_TYPES.has(messageType)) {
+    return { kind: "ignored", reason: "unsupported_message_type" };
+  }
+
+  const configuredChannel = phoneDigits(options.channelPhoneNumber ?? null);
+  const eventChannel = phoneDigits(optionalString(payload.channelPhoneNumber));
+  if (configuredChannel && eventChannel !== configuredChannel) {
+    return { kind: "ignored", reason: "channel_mismatch" };
+  }
+
+  const senderPhoneE164 = normalizeWatiPhoneNumber(payload.waId);
+  const providerMessageId = optionalString(payload.whatsappMessageId) ?? optionalString(payload.id);
+  if (!senderPhoneE164 || !providerMessageId) {
+    return {
+      kind: "unrecognized",
+      reason: "missing_required_message_fields",
+      eventType,
+      messageType,
+    };
+  }
+
+  const providerConversationId =
+    optionalString(payload.conversationId) ?? optionalString(payload.ticketId) ?? `wati:${senderPhoneE164}`;
+  const replyContextId = optionalString(payload.replyContextId);
+  const text = optionalString(payload.text) ?? textFromInteractiveReply(payload) ?? "";
+  const mediaType = messageType && MEDIA_MESSAGE_TYPES.has(messageType) ? messageType : undefined;
+
+  return {
+    kind: "message",
+    message: {
+      kind: "dm",
+      providerId: WHATSAPP_WATI_PROVIDER_ID,
+      providerMessageId,
+      providerConversationId,
+      canonicalConversationId: canonicalDmConversationId(senderPhoneE164),
+      providerTimestamp: parseWatiTimestamp(payload.timestamp) ?? parseWatiTimestamp(payload.created),
+      senderName: optionalString(payload.senderName) ?? senderPhoneE164,
+      senderProviderId: optionalString(payload.waId) ?? senderPhoneE164,
+      senderPhoneE164,
+      target: { kind: "dm", phoneE164: senderPhoneE164, providerConversationId },
+      text,
+      rawProviderPayload: payload,
+      ...(mediaType ? { mediaType } : {}),
+      ...(replyContextId
+        ? { quotedMessage: { providerMessageId: replyContextId, participantJid: null, text: "" } }
+        : {}),
+    },
+  };
+}
+
+export function parseWatiDeliveryStatusEvent(
+  payload: unknown,
+): { kind: "delivery_status"; event: WatiDeliveryStatusEvent } | null {
+  if (!isRecord(payload)) return null;
+
+  const eventType = optionalString(payload.eventType);
+  const status =
+    optionalString(payload.statusString) ??
+    optionalString(payload.status) ??
+    optionalString(payload.status_string) ??
+    optionalString(payload.event);
+  const providerMessageId =
+    optionalString(payload.whatsappMessageId) ??
+    optionalString(payload.messageId) ??
+    optionalString(payload.message_id) ??
+    optionalString(payload.id);
+
+  if (!status && !providerMessageId) return null;
+
+  return {
+    kind: "delivery_status",
+    event: {
+      providerId: WHATSAPP_WATI_PROVIDER_ID,
+      providerMessageId,
+      providerConversationId: optionalString(payload.conversationId) ?? optionalString(payload.conversation_id),
+      eventType,
+      status,
+      providerTimestamp:
+        parseWatiTimestamp(payload.timestamp) ??
+        parseWatiTimestamp(payload.created) ??
+        parseWatiTimestamp(payload.updatedAt),
+      rawProviderPayload: payload,
+    },
+  };
+}
+
+export function normalizeWatiPhoneNumber(value: unknown): string | null {
+  const digits = phoneDigits(value);
+  if (!digits || !/^[1-9]\d{7,14}$/.test(digits)) return null;
+  return `+${digits}`;
+}
+
+function normalizeApiEndpoint(value: string): string {
+  return value.replace(/\/+$/u, "");
+}
+
+function targetPhoneDigits(target: WhatsAppTarget): string {
+  if (target.kind !== "dm") throw new Error("Wati cannot send WhatsApp group messages");
+  const digits = phoneDigits(target.phoneE164);
+  if (!digits) throw new Error("Wati target phone number is invalid");
+  return digits;
+}
+
+function phoneDigits(value: unknown): string | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const digits = String(value).replace(/\D/gu, "");
+  return digits || null;
+}
+
+function authorizationHeaders(accessToken: string): Record<string, string> {
+  return { Authorization: `Bearer ${accessToken}` };
+}
+
+async function fetchJson(requestFetch: typeof fetch, url: URL, init: RequestInit): Promise<unknown> {
+  const response = await requestFetch(url, init);
+  if (!response.ok) {
+    throw new Error(`Wati API request failed: HTTP ${response.status}`);
+  }
+  const text = await response.text();
+  return text ? (JSON.parse(text) as unknown) : null;
+}
+
+function sendResultFromWatiBody(body: unknown, target: WhatsAppTarget): WhatsAppSendResult | null {
+  const record = isRecord(body) ? body : {};
+  const message = isRecord(record.message) ? record.message : record;
+  const fallbackConversationId =
+    target.kind === "dm" ? (target.providerConversationId ?? `wati:${target.phoneE164}`) : target.groupId;
+
+  return {
+    providerMessageId:
+      optionalString(message.whatsappMessageId) ??
+      optionalString(message.id) ??
+      optionalString(record.whatsappMessageId) ??
+      optionalString(record.id),
+    providerConversationId:
+      optionalString(message.conversationId) ??
+      optionalString(message.conversation_id) ??
+      optionalString(record.conversationId) ??
+      optionalString(record.conversation_id) ??
+      fallbackConversationId,
+    providerTimestamp:
+      parseWatiTimestamp(message.time) ??
+      parseWatiTimestamp(message.timestamp) ??
+      parseWatiTimestamp(message.created) ??
+      parseWatiTimestamp(record.created),
+    rawProviderPayload: body,
+  };
+}
+
+function fileMessageIdForDownload(message: WhatsAppDmInboundMessage): string | null {
+  const raw = isRecord(message.rawProviderPayload) ? message.rawProviderPayload : null;
+  return optionalString(raw?.id) ?? message.providerMessageId;
+}
+
+function fileNameFromHeaders(headers: Headers): string | null {
+  const contentDisposition = headers.get("content-disposition");
+  if (!contentDisposition) return null;
+  const match = /filename\*?=(?:UTF-8''|")?([^";]+)/iu.exec(contentDisposition);
+  if (!match?.[1]) return null;
+  try {
+    return basename(decodeURIComponent(match[1]));
+  } catch {
+    return basename(match[1]);
+  }
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/gu, "_");
+}
+
+function parseWatiTimestamp(value: unknown): string | null {
+  const input = optionalString(value);
+  if (!input) return null;
+
+  if (/^\d+$/u.test(input)) {
+    const seconds = Number(input);
+    if (!Number.isFinite(seconds) || seconds <= 0) return null;
+    return new Date(seconds * 1000).toISOString();
+  }
+
+  const millis = Date.parse(input);
+  if (!Number.isFinite(millis)) return null;
+  return new Date(millis).toISOString();
+}
+
+function textFromInteractiveReply(payload: Record<string, unknown>): string | null {
+  for (const key of ["listReply", "interactiveButtonReply", "buttonReply"]) {
+    const value = payload[key];
+    if (!isRecord(value)) continue;
+
+    const text =
+      optionalString(value.title) ??
+      optionalString(value.text) ??
+      optionalString(value.name) ??
+      optionalString(value.id) ??
+      optionalString(value.value);
+    if (text) return text;
+  }
+  return null;
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function optionalBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/packages/server/src/whatsapp/runtime.test.ts
+++ b/packages/server/src/whatsapp/runtime.test.ts
@@ -163,5 +163,6 @@ describe("createWhatsAppRuntime", () => {
     expect(handler).toHaveBeenCalledTimes(2);
     expect(handler).toHaveBeenNthCalledWith(1, expect.objectContaining({ kind: "group", providerId: "baileys" }));
     expect(handler).toHaveBeenNthCalledWith(2, expect.objectContaining({ kind: "dm", providerId: "wati" }));
+    expect(handler).not.toHaveBeenCalledWith(expect.objectContaining({ kind: "dm", providerId: "baileys" }));
   });
 });


### PR DESCRIPTION
## What

Adds Wati as the self-hosted WhatsApp DM provider behind the provider-neutral runtime from SKE-244. When `WHATSAPP_DM_PROVIDER=wati`, one-to-one DMs route through Wati while Baileys remains responsible for groups, and Baileys DMs are ignored to avoid duplicate processing.

## Details

- Adds Wati configuration and authenticated `/whatsapp/wati/events` webhook routing.
- Normalizes Wati inbound DM payloads into the existing WhatsApp agent pipeline using `users.whatsapp_number` lookup behavior.
- Implements Wati text sends, quoted replies, media send/fetch, template capability representation, and delivery/status parsing.
- Preserves WhatsApp final-answer-only behavior and does not reintroduce textual progress transport.
- Documents Wati env setup in `.env.example`, including query-token webhook auth as the primary Wati-compatible setup.

## Validation

- `pnpm --filter @sketch/server exec vitest run src/whatsapp/providers/wati.test.ts src/api/wati-webhook.test.ts src/whatsapp/runtime.test.ts src/config.test.ts --project unit --passWithNoTests`
- `pnpm exec biome check .`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Live Wati confirmations still needed

- Confirm whether media fetch prefers Wati internal `id` or WAMID in the tenant; implementation tries internal id first, then WAMID on invalid/not-found responses.
- Confirm v3 file-send availability for the tenant plan when `WATI_CHANNEL_PHONE_NUMBER` is configured.
- Confirm exact Wati webhook callback auth options in the tenant UI; implementation supports query token plus bearer/custom headers.
- Confirm whether BSUID-only webhook payloads are enabled for the tenant; SKE-245 intentionally ignores those until Sketch has a username identity model.

Refs SKE-245.