### PR TITLE
SKE-232: Otter Connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:unit": "pnpm -r test:unit",
     "test:integration": "pnpm -r --workspace-concurrency=1 test:integration",
     "test:changed": "pnpm -r test:changed",
+    "otter:check": "tsx scripts/otter-check.ts",
     "recompute:entity-hotness": "tsx scripts/recompute-entity-hotness.ts",
     "worktree:create": "tsx scripts/worktree.ts create",
     "worktree:remove": "tsx scripts/worktree.ts remove",

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -312,6 +312,7 @@ const SOURCE_LABELS: Record<string, { label: string; noun: string }> = {
   notion: { label: "Notion", noun: "pages" },
   linear: { label: "Linear", noun: "issues" },
   fireflies: { label: "Fireflies", noun: "meeting transcripts" },
+  otter: { label: "Otter", noun: "meeting transcripts" },
   conversation: { label: "Conversations", noun: "messages" },
   local: { label: "Workspace Files", noun: "files" },
 };

--- a/packages/server/src/api/connectors-authz.test.ts
+++ b/packages/server/src/api/connectors-authz.test.ts
@@ -83,6 +83,7 @@ async function insertConfig(
       | "outlook"
       | "teams"
       | "fireflies"
+      | "otter"
       | "clickup"
       | "notion"
       | "linear"
@@ -381,6 +382,38 @@ describe("Connectors API — authorization", () => {
         body: JSON.stringify({ api_key: "new-key" }),
       });
       expect(res.status).toBe(200);
+    });
+
+    it("owner → 200 rotating Otter email/password credentials", async () => {
+      const cfg = await insertConfig(db, { connectorType: "otter", createdBy: memberId });
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = input instanceof URL ? input : new URL(String(input));
+        if (url.pathname.endsWith("/login")) {
+          return new Response(JSON.stringify({ userid: 123 }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ email: "person@example.com" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+      const res = await app.request(`/api/connectors/${cfg.id}/rotate-key`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: memberCookie },
+        body: JSON.stringify({ credentials: { email: "person@example.com", password: "new-password" } }),
+      });
+
+      expect(res.status).toBe(200);
+      const updated = await createConnectorRepository(db).findConfigById(cfg.id);
+      expect(updated?.credential_hint).toBe("person@example.com");
+      expect(JSON.parse(updated?.credentials ?? "{}")).toMatchObject({
+        type: "api_key",
+        email: "person@example.com",
+        password: "new-password",
+      });
     });
   });
 

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -27,6 +27,7 @@ import {
 import { buildCredentialHint } from "../connectors/fireflies";
 import { ensureValidToken, listFolderContents, listMyDriveFolders, listSharedDrives } from "../connectors/google-drive";
 import { browseNotionRootPages, getBrowseStatus, startNotionBrowse } from "../connectors/notion";
+import { buildOtterCredentialHint } from "../connectors/otter";
 import { VALID_CONNECTOR_TYPES, getConnector } from "../connectors/registry";
 import {
   browseFiles,
@@ -207,6 +208,13 @@ const createConnectorSchema = z.object({
   scopeConfig: z.record(z.string(), z.unknown()).optional(),
 });
 
+const rotateCredentialsSchema = z
+  .object({
+    api_key: z.string().trim().min(1).optional(),
+    credentials: z.record(z.string(), z.unknown()).optional(),
+  })
+  .refine((value) => value.api_key || value.credentials, "Credentials are required");
+
 const searchSchema = z.object({
   query: z.string().min(1, "Search query is required"),
   source: z.string().optional(),
@@ -307,6 +315,18 @@ export function connectorRoutes(
 
   function configEnabled(config: { connector_type: string; sync_status?: string }): boolean {
     return configVisible(config) && config.sync_status !== "disabled";
+  }
+
+  function credentialHintForConnector(connectorType: ConnectorType, credentials: ConnectorCredentials): string | null {
+    if (connectorType === "otter") return buildOtterCredentialHint(credentials);
+    return credentials.type === "api_key" && credentials.api_key ? buildCredentialHint(credentials.api_key) : null;
+  }
+
+  function validationLogError(err: unknown) {
+    if (err instanceof Error) {
+      return { name: err.name, message: err.message };
+    }
+    return { message: String(err) };
   }
 
   async function getUserEmails(c: { get: (key: string) => unknown }): Promise<string[]> {
@@ -425,15 +445,17 @@ export function connectorRoutes(
       await connectorMeta.validateCredentials(credentials);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Invalid credentials";
-      logger.warn({ err, connectorType: parsed.data.connectorType }, "Credential validation failed");
+      logger.warn(
+        { error: validationLogError(err), connectorType: parsed.data.connectorType },
+        "Credential validation failed",
+      );
       return c.json(
         { error: { code: "INVALID_CREDENTIALS", message: `Credential validation failed: ${message}` } },
         400,
       );
     }
 
-    const credentialHint =
-      credentials.type === "api_key" && credentials.api_key ? buildCredentialHint(credentials.api_key) : null;
+    const credentialHint = credentialHintForConnector(connectorType, credentials);
 
     const config = await connectorRepo.createConfig({
       connectorType,
@@ -1663,7 +1685,7 @@ export function connectorRoutes(
   });
 
   /**
-   * Rotate the API key for an existing connector. Per-user rows are owner-only;
+   * Rotate local credentials for an existing connector. Per-user rows are owner-only;
    * org-wide rows are admin-managed.
    */
   routes.post("/:id/rotate-key", async (c) => {
@@ -1676,7 +1698,7 @@ export function connectorRoutes(
     const denied = denyUnless(c, permissions.canUpdateCredentials);
     if (denied) return denied;
 
-    const parsed = z.object({ api_key: z.string().min(1) }).safeParse(await c.req.json());
+    const parsed = rotateCredentialsSchema.safeParse(await c.req.json());
     if (!parsed.success) {
       return c.json(
         { error: { code: "VALIDATION_ERROR", message: parsed.error.issues[0]?.message ?? "Invalid request" } },
@@ -1684,17 +1706,24 @@ export function connectorRoutes(
       );
     }
 
-    const credentials: ApiKeyCredentials = { type: "api_key", api_key: parsed.data.api_key };
+    const credentials = {
+      type: config.auth_type,
+      ...(parsed.data.credentials ?? { api_key: parsed.data.api_key }),
+    } as ConnectorCredentials;
     try {
       await getConnector(config.connector_type as ConnectorType).validateCredentials(credentials);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Invalid key";
+      const message = err instanceof Error ? err.message : "Invalid credentials";
+      logger.warn(
+        { error: validationLogError(err), connectorType: config.connector_type },
+        "Credential rotation validation failed",
+      );
       return c.json({ error: { code: "INVALID_CREDENTIALS", message } }, 400);
     }
 
     await connectorRepo.updateConfig(config.id, {
       credentials: JSON.stringify(credentials),
-      credentialHint: buildCredentialHint(parsed.data.api_key),
+      credentialHint: credentialHintForConnector(config.connector_type as ConnectorType, credentials),
       syncStatus: "active",
       errorMessage: null,
     });

--- a/packages/server/src/connectors/index.ts
+++ b/packages/server/src/connectors/index.ts
@@ -15,5 +15,6 @@ export { createClickUpConnector } from "./clickup";
 export { createNotionConnector } from "./notion";
 export { createLinearConnector } from "./linear";
 export { createFirefliesConnector } from "./fireflies";
+export { createOtterConnector } from "./otter";
 export { runConnectorSync, runAllSyncs, runScheduledEnrichment, startSyncScheduler } from "./sync";
 export { searchFiles, getFileContent, listIndexedSources } from "./search";

--- a/packages/server/src/connectors/otter.test.ts
+++ b/packages/server/src/connectors/otter.test.ts
@@ -1,0 +1,247 @@
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  OtterApiError,
+  createOtterClient,
+  createOtterConnector,
+  extractOtterTranscriptSegments,
+  otterSpeechToSyncedItem,
+} from "./otter";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  const headers = new Headers(init.headers);
+  if (!headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers,
+    ...init,
+  });
+}
+
+describe("Otter client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs in with basic auth and reuses the returned cookies for speech listing", async () => {
+    const calls: Array<{ url: URL; headers: Record<string, string> }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = input instanceof URL ? input : new URL(String(input));
+      const headers = init?.headers as Record<string, string>;
+      calls.push({ url, headers });
+
+      if (url.pathname.endsWith("/login")) {
+        const headers = new Headers();
+        headers.append("Set-Cookie", "csrftoken=csrf-123; Path=/");
+        headers.append("Set-Cookie", "sessionid=session-456; Path=/");
+        return jsonResponse({ userid: 42038968 }, { headers });
+      }
+
+      if (url.pathname.endsWith("/speeches")) {
+        return jsonResponse({
+          speeches: [{ otid: "speech-1", title: "Transcript one" }],
+        });
+      }
+
+      return jsonResponse({});
+    });
+
+    const client = createOtterClient({
+      credentials: { email: "person@example.com", password: "secret" },
+      maxRetries: 0,
+      timeoutMs: 0,
+    });
+
+    await client.login();
+    const speeches = await client.listSpeeches({ pageSize: 10, source: "all" });
+
+    expect(speeches).toEqual([{ otid: "speech-1", title: "Transcript one" }]);
+    expect(calls[0].headers.Authorization).toBe(`Basic ${Buffer.from("person@example.com:secret").toString("base64")}`);
+    expect(calls[0].url.searchParams.get("username")).toBe("person@example.com");
+    expect(calls[1].url.searchParams.get("userid")).toBe("42038968");
+    expect(calls[1].url.searchParams.get("page_size")).toBe("10");
+    expect(calls[1].url.searchParams.get("source")).toBe("all");
+    expect(calls[1].headers.Cookie).toContain("csrftoken=csrf-123");
+    expect(calls[1].headers.Cookie).toContain("sessionid=session-456");
+  });
+
+  it("falls back to the user profile when login omits userid", async () => {
+    const paths: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input : new URL(String(input));
+      paths.push(url.pathname);
+
+      if (url.pathname.endsWith("/login")) {
+        const headers = new Headers();
+        headers.append("Set-Cookie", "sessionid=session-456; Path=/");
+        return jsonResponse({ status: "ok" }, { headers });
+      }
+
+      if (url.pathname.endsWith("/user")) {
+        return jsonResponse({ user_id: "profile-user-123", email: "person@example.com" });
+      }
+
+      if (url.pathname.endsWith("/speeches")) {
+        expect(url.searchParams.get("userid")).toBe("profile-user-123");
+        return jsonResponse({ speeches: [] });
+      }
+
+      return jsonResponse({});
+    });
+
+    const client = createOtterClient({
+      credentials: { email: "person@example.com", password: "secret" },
+      maxRetries: 0,
+      timeoutMs: 0,
+    });
+
+    await client.login();
+    await client.listSpeeches();
+
+    expect(paths.some((path) => path.endsWith("/user"))).toBe(true);
+    expect(client.getUserId()).toBe("profile-user-123");
+  });
+
+  it("extracts transcripts when Otter returns them at the top level", () => {
+    const segments = extractOtterTranscriptSegments({
+      speech: { otid: "speech-1", title: "Transcript one" },
+      transcripts: [{ speaker_name: "Alex", transcript: "Hello" }],
+    });
+
+    expect(segments).toEqual([{ speaker_name: "Alex", transcript: "Hello" }]);
+  });
+
+  it("returns a safe invalid-login message without exposing the provider body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(
+        { status: "failed", message: "User not logged in", code: 1, email: "person@example.com" },
+        { status: 401 },
+      ),
+    );
+
+    const client = createOtterClient({
+      credentials: { email: "person@example.com", password: "wrong" },
+      maxRetries: 0,
+      timeoutMs: 0,
+    });
+
+    try {
+      await client.login();
+      throw new Error("Expected login to fail");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OtterApiError);
+      expect((err as Error).message).toContain("Otter rejected this email/password");
+      expect((err as Error).message).not.toContain("person@example.com");
+      expect((err as OtterApiError).bodySummary).toBe('{"status":"failed","code":1,"message":"User not logged in"}');
+    }
+  });
+});
+
+describe("Otter speech mapping", () => {
+  it("maps a fetched speech into a Sketch meeting transcript item", () => {
+    const item = otterSpeechToSyncedItem(
+      {
+        speech: {
+          otid: "otid-123",
+          title: "Customer sync",
+          summary: "Discussed launch blockers.",
+          created_at: 1_783_000_000,
+          start_time: 1_783_000_100,
+          transcript_updated_at: 1_783_000_900,
+          duration: 125,
+          speakers: [
+            { id: 1, speaker_name: "Tanush" },
+            { id: 2, speaker_name: "Himanshu" },
+          ],
+          transcripts: [
+            { speaker_id: 1, transcript: "We need the transcript connector." },
+            { speaker_id: 2, transcript: "The Otter endpoint returns segments." },
+          ],
+        },
+      },
+      {
+        ownerEmail: "Owner@Example.com",
+        resolveNameToEmail: (name) => (name === "Tanush" ? { email: "tanush@example.com", source: "users" } : null),
+      },
+    );
+
+    expect(item.providerFileId).toBe("otid-123");
+    expect(item.providerUrl).toBe("https://otter.ai/u/otid-123");
+    expect(item.fileName).toBe("Customer sync");
+    expect(item.fileType).toBe("meeting_transcript");
+    expect(item.contentCategory).toBe("document");
+    expect(item.sourceCreatedAt).toBe("2026-07-02T13:46:40.000Z");
+    expect(item.sourceUpdatedAt).toBe("2026-07-02T14:01:40.000Z");
+    expect(item.accessEmails).toEqual(["owner@example.com", "tanush@example.com"]);
+    expect(item.attendees).toEqual([{ name: "Tanush", email: "tanush@example.com" }, { name: "Himanshu" }]);
+    expect(item.content).toContain("## Summary\nDiscussed launch blockers.");
+    expect(item.content).toContain("## Transcript");
+    expect(item.content).toContain("Tanush: We need the transcript connector.");
+    expect(item.contentHash).toEqual(expect.any(String));
+  });
+});
+
+describe("Otter connector", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("validates email/password credentials and syncs fetched speeches", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input : new URL(String(input));
+
+      if (url.pathname.endsWith("/login")) {
+        const headers = new Headers();
+        headers.append("Set-Cookie", "csrftoken=csrf-123; Path=/");
+        return jsonResponse({ userid: "user-123" }, { headers });
+      }
+
+      if (url.pathname.endsWith("/user")) {
+        return jsonResponse({ email: "person@example.com" });
+      }
+
+      if (url.pathname.endsWith("/speeches")) {
+        return jsonResponse({
+          speeches: [{ otid: "otid-123", title: "Customer sync" }],
+        });
+      }
+
+      if (url.pathname.endsWith("/speech")) {
+        return jsonResponse({
+          speech: {
+            otid: "otid-123",
+            title: "Customer sync",
+            created_at: 1_783_000_000,
+            speakers: [{ id: 1, speaker_name: "Tanush" }],
+            transcripts: [{ speaker_id: 1, transcript: "Ship the Otter connector." }],
+          },
+        });
+      }
+
+      return jsonResponse({});
+    });
+
+    const connector = createOtterConnector({ pageSize: 10 });
+    const credentials = { type: "api_key" as const, api_key: "", email: "person@example.com", password: "secret" };
+
+    await connector.validateCredentials(credentials);
+    const items = [];
+    for await (const item of connector.sync({
+      credentials,
+      cursor: null,
+      scopeConfig: {},
+      ownerEmail: "owner@example.com",
+      logger: pino({ level: "silent" }),
+    })) {
+      items.push(item);
+    }
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      providerFileId: "otid-123",
+      fileName: "Customer sync",
+      accessEmails: ["owner@example.com"],
+    });
+    expect(items[0]?.content).toContain("Tanush: Ship the Otter connector.");
+  });
+});

--- a/packages/server/src/connectors/otter.ts
+++ b/packages/server/src/connectors/otter.ts
@@ -1,0 +1,708 @@
+import { createHash } from "node:crypto";
+import type { Connector, ConnectorCredentials, NameResolver, SyncedItem } from "./types";
+
+const DEFAULT_API_BASE_URL = "https://otter.ai/forward/api/v1/";
+const DEFAULT_WEB_BASE_URL = "https://otter.ai";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_BASE_MS = 1_000;
+const DEFAULT_RETRY_MAX_MS = 16_000;
+const DEFAULT_SYNC_PAGE_SIZE = 50;
+const MAX_SYNC_PAGE_SIZE = 200;
+
+type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export type OtterSpeechSource = "owned" | "shared" | "all";
+
+export interface OtterLoginCredentials {
+  email: string;
+  password: string;
+}
+
+export interface OtterClientOptions {
+  credentials: OtterLoginCredentials;
+  fetchFn?: FetchFn;
+  apiBaseUrl?: string;
+  webBaseUrl?: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+  retryBaseMs?: number;
+  retryMaxMs?: number;
+}
+
+export interface OtterConnectorOptions {
+  fetchFn?: FetchFn;
+  apiBaseUrl?: string;
+  webBaseUrl?: string;
+  pageSize?: number;
+  source?: OtterSpeechSource;
+}
+
+export interface OtterLoginResponse extends Record<string, unknown> {
+  userid?: string | number;
+}
+
+export interface OtterUserResponse extends Record<string, unknown> {}
+
+export interface OtterSpeaker extends Record<string, unknown> {
+  id?: string | number;
+  speaker_id?: string | number;
+  speaker_name?: string;
+  name?: string;
+}
+
+export interface OtterTranscriptSegment extends Record<string, unknown> {
+  speaker_id?: string | number;
+  speaker_name?: string;
+  speaker_model_label?: string;
+  transcript?: string;
+}
+
+export interface OtterSpeechSummary extends Record<string, unknown> {
+  otid?: string;
+  speech_otid?: string;
+  speech_id?: string;
+  title?: string;
+  summary?: unknown;
+  created_at?: number;
+  start_time?: number;
+  end_time?: number;
+  transcript_updated_at?: number;
+  duration?: number;
+  speakers?: OtterSpeaker[];
+}
+
+export interface OtterSpeechResponse extends Record<string, unknown> {
+  speech?: OtterSpeechSummary;
+  transcripts?: OtterTranscriptSegment[];
+}
+
+export interface OtterListSpeechesOptions {
+  folder?: number | string;
+  pageSize?: number;
+  source?: OtterSpeechSource;
+}
+
+export interface OtterSearchOptions {
+  query: string;
+  size?: number;
+  otid?: string;
+}
+
+export interface OtterSearchResponse extends Record<string, unknown> {
+  hits?: unknown[];
+}
+
+interface RequestOptions {
+  query?: Record<string, string | number | boolean | null | undefined>;
+  basicAuth?: boolean;
+}
+
+export class OtterApiError extends Error {
+  readonly bodySummary: string | null;
+
+  constructor(
+    message: string,
+    readonly status: number | null,
+    readonly path: string,
+    body: unknown,
+  ) {
+    super(message);
+    this.name = "OtterApiError";
+    this.bodySummary = body === null ? null : summarizeBody(body);
+  }
+}
+
+export class OtterClient {
+  private readonly credentials: OtterLoginCredentials;
+  private readonly fetchFn: FetchFn;
+  private readonly apiBaseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly maxRetries: number;
+  private readonly retryBaseMs: number;
+  private readonly retryMaxMs: number;
+  private readonly cookies = new Map<string, string>();
+  private userId: string | null = null;
+
+  constructor(options: OtterClientOptions) {
+    this.credentials = options.credentials;
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.apiBaseUrl = withTrailingSlash(options.apiBaseUrl ?? DEFAULT_API_BASE_URL);
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.retryBaseMs = options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS;
+    this.retryMaxMs = options.retryMaxMs ?? DEFAULT_RETRY_MAX_MS;
+  }
+
+  getUserId() {
+    return this.userId;
+  }
+
+  async login(): Promise<OtterLoginResponse> {
+    const response = await this.request<OtterLoginResponse>("login", {
+      query: { username: this.credentials.email },
+      basicAuth: true,
+    });
+    const userId = extractUserId(response);
+    if (userId) this.userId = userId;
+    return response;
+  }
+
+  async getUser(): Promise<OtterUserResponse> {
+    const response = await this.request<OtterUserResponse>("user");
+    const userId = extractUserId(response);
+    if (userId) this.userId = userId;
+    return response;
+  }
+
+  async listSpeeches(options: OtterListSpeechesOptions = {}): Promise<OtterSpeechSummary[]> {
+    const userId = await this.requireUserId();
+    const response = await this.request<Record<string, unknown>>("speeches", {
+      query: {
+        userid: userId,
+        folder: options.folder ?? 0,
+        page_size: options.pageSize ?? 45,
+        source: options.source ?? "owned",
+      },
+    });
+    return extractSpeeches(response);
+  }
+
+  async getSpeech(otid: string): Promise<OtterSpeechResponse> {
+    const userId = await this.requireUserId();
+    return this.request<OtterSpeechResponse>("speech", {
+      query: { userid: userId, otid },
+    });
+  }
+
+  async search(options: OtterSearchOptions): Promise<OtterSearchResponse> {
+    const query: Record<string, string | number> = { query: options.query, size: options.size ?? 50 };
+    if (options.otid) query.otid = options.otid;
+    return this.request<OtterSearchResponse>("advanced_search", { query });
+  }
+
+  private async requireUserId() {
+    if (!this.userId) {
+      const user = await this.getUser();
+      const userId = extractUserId(user);
+      if (!userId) {
+        throw new OtterApiError("Otter login succeeded but did not return a usable user id.", null, "user", user);
+      }
+      this.userId = userId;
+    }
+    return this.userId;
+  }
+
+  private async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt += 1) {
+      try {
+        const url = buildUrl(this.apiBaseUrl, path, options.query);
+        const headers: Record<string, string> = { Accept: "application/json" };
+        if (options.basicAuth) headers.Authorization = basicAuthHeader(this.credentials);
+
+        const cookieHeader = this.cookieHeader();
+        if (cookieHeader) headers.Cookie = cookieHeader;
+
+        const response = await this.fetchFn(url, {
+          method: "GET",
+          headers,
+          signal: this.timeoutMs > 0 ? AbortSignal.timeout(this.timeoutMs) : undefined,
+        });
+
+        this.storeCookies(response);
+
+        if (isRetryableStatus(response.status) && attempt < this.maxRetries) {
+          await sleep(this.retryDelayMs(response, attempt));
+          continue;
+        }
+
+        const body = await readResponseBody(response);
+        if (!response.ok) {
+          throw new OtterApiError(formatHttpErrorMessage(response.status, path, body), response.status, path, body);
+        }
+
+        return body as T;
+      } catch (err) {
+        if (err instanceof OtterApiError) throw err;
+        lastError = err;
+        if (attempt < this.maxRetries) {
+          await sleep(this.retryDelayMs(null, attempt));
+        }
+      }
+    }
+
+    throw new OtterApiError(`Otter network error at ${path}: ${errorMessage(lastError)}`, null, path, null);
+  }
+
+  private retryDelayMs(response: Response | null, attempt: number) {
+    const retryAfter = response?.headers.get("Retry-After");
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds)) return Math.min(Math.max(seconds * 1000, 0), this.retryMaxMs);
+
+      const retryAt = Date.parse(retryAfter);
+      if (Number.isFinite(retryAt)) return Math.min(Math.max(retryAt - Date.now(), 0), this.retryMaxMs);
+    }
+
+    return Math.min(this.retryBaseMs * 2 ** attempt, this.retryMaxMs);
+  }
+
+  private storeCookies(response: Response) {
+    for (const cookie of getSetCookieHeaders(response.headers)) {
+      const pair = cookie.split(";")[0]?.trim();
+      if (!pair) continue;
+      const separator = pair.indexOf("=");
+      if (separator <= 0) continue;
+      this.cookies.set(pair.slice(0, separator), pair.slice(separator + 1));
+    }
+  }
+
+  private cookieHeader() {
+    return [...this.cookies.entries()].map(([key, value]) => `${key}=${value}`).join("; ");
+  }
+}
+
+export function createOtterClient(options: OtterClientOptions) {
+  return new OtterClient(options);
+}
+
+export function createOtterConnector(options: OtterConnectorOptions = {}): Connector {
+  return {
+    type: "otter",
+    perUserAuth: true,
+    requiresOAuthClientSetup: false,
+
+    async validateCredentials(credentials) {
+      const client = createOtterClient({
+        credentials: getOtterCredentials(credentials),
+        fetchFn: options.fetchFn,
+        apiBaseUrl: options.apiBaseUrl,
+      });
+      await client.login();
+      await client.getUser();
+    },
+
+    async *sync({ credentials, scopeConfig, ownerEmail, logger, resolveNameToEmail }) {
+      const loginCredentials = getOtterCredentials(credentials);
+      const client = createOtterClient({
+        credentials: loginCredentials,
+        fetchFn: options.fetchFn,
+        apiBaseUrl: options.apiBaseUrl,
+      });
+      await client.login();
+
+      const source = parseSpeechSource(scopeConfig.source) ?? options.source ?? "all";
+      const pageSize = parsePageSize(scopeConfig.pageSize) ?? options.pageSize ?? DEFAULT_SYNC_PAGE_SIZE;
+      const speeches = await client.listSpeeches({ source, pageSize });
+      const accessEmail = ownerEmail?.trim() || loginCredentials.email;
+
+      for (const speech of speeches) {
+        const otid = getOtterSpeechId(speech);
+        if (!otid) continue;
+
+        try {
+          const speechResponse = await client.getSpeech(otid);
+          yield otterSpeechToSyncedItem(speechResponse, {
+            ownerEmail: accessEmail,
+            webBaseUrl: options.webBaseUrl,
+            resolveNameToEmail,
+          });
+        } catch (err) {
+          logger.warn({ error: summarizeOtterError(err), otid }, "Otter transcript fetch failed");
+        }
+      }
+    },
+
+    async getCursor() {
+      return new Date().toISOString();
+    },
+  };
+}
+
+export function buildOtterCredentialHint(credentials: ConnectorCredentials): string | null {
+  try {
+    return getOtterCredentials(credentials).email;
+  } catch {
+    return null;
+  }
+}
+
+export function extractOtterSpeech(response: OtterSpeechResponse): OtterSpeechSummary {
+  const responseRecord = asRecord(response);
+  const data = asRecord(responseRecord?.data);
+  const speech = asRecord(responseRecord?.speech) ?? asRecord(data?.speech) ?? responseRecord ?? {};
+  return speech as OtterSpeechSummary;
+}
+
+export function extractOtterTranscriptSegments(response: OtterSpeechResponse): OtterTranscriptSegment[] {
+  const responseRecord = asRecord(response);
+  const data = asRecord(responseRecord?.data);
+  const speech = extractOtterSpeech(response);
+  const candidates = [speech.transcripts, responseRecord?.transcripts, data?.transcripts];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate.filter(isRecord) as OtterTranscriptSegment[];
+  }
+  return [];
+}
+
+export function getOtterSpeechId(speech: OtterSpeechSummary): string | null {
+  return asStringId(speech.otid) ?? asStringId(speech.speech_otid) ?? asStringId(speech.speech_id);
+}
+
+export function getOtterSpeechTitle(speech: OtterSpeechSummary): string {
+  return asNonEmptyString(speech.title) ?? "Untitled Otter transcript";
+}
+
+export function formatOtterSpeechContent(response: OtterSpeechResponse): string {
+  const speech = extractOtterSpeech(response);
+  const segments = extractOtterTranscriptSegments(response);
+  const title = getOtterSpeechTitle(speech);
+  const lines = [`# ${title}`, ""];
+  const startedAt = unixTimestampToIso(speech.start_time ?? speech.created_at);
+  const duration = formatDurationSeconds(speech.duration);
+
+  if (startedAt) lines.push(`Date: ${startedAt}`);
+  if (duration) lines.push(`Duration: ${duration}`);
+  if (startedAt || duration) lines.push("");
+
+  const summary = formatSummary(speech.summary);
+  if (summary) lines.push("## Summary", summary, "");
+
+  if (segments.length > 0) {
+    const speakerNames = speakerNamesById(speech);
+    lines.push("## Transcript", "");
+    for (const segment of segments) {
+      const text = asNonEmptyString(segment.transcript);
+      if (!text) continue;
+      lines.push(`${resolveSegmentSpeaker(segment, speakerNames)}: ${text}`, "");
+    }
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+export function otterSpeechToSyncedItem(
+  response: OtterSpeechResponse,
+  options: { ownerEmail?: string | null; webBaseUrl?: string; resolveNameToEmail?: NameResolver } = {},
+): SyncedItem {
+  const speech = extractOtterSpeech(response);
+  const otid = getOtterSpeechId(speech);
+  if (!otid) {
+    throw new Error("Otter speech response did not include an otid");
+  }
+
+  const content = formatOtterSpeechContent(response);
+  const title = getOtterSpeechTitle(speech);
+  const createdAt = unixTimestampToIso(speech.created_at ?? speech.start_time);
+  const updatedAt = unixTimestampToIso(speech.transcript_updated_at) ?? createdAt;
+  const ownerEmail = normalizeEmail(options.ownerEmail);
+  const attendeeNames = extractSpeakerNames(speech, extractOtterTranscriptSegments(response));
+  const people = buildPeople(attendeeNames, ownerEmail, options.resolveNameToEmail);
+
+  return {
+    providerFileId: otid,
+    providerUrl: `${(options.webBaseUrl ?? DEFAULT_WEB_BASE_URL).replace(/\/+$/, "")}/u/${otid}`,
+    fileName: title,
+    fileType: "meeting_transcript",
+    contentCategory: "document",
+    content,
+    sourcePath: "Otter.ai",
+    contentHash: createHash("sha256").update(content).digest("hex"),
+    sourceCreatedAt: createdAt,
+    sourceUpdatedAt: updatedAt,
+    accessEmails: people.accessEmails.length > 0 ? people.accessEmails : null,
+    attendees: people.attendees.length > 0 ? people.attendees : undefined,
+  };
+}
+
+function extractSpeeches(response: Record<string, unknown>): OtterSpeechSummary[] {
+  const data = asRecord(response.data);
+  const candidates = [response.speeches, data?.speeches];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate.filter(isRecord) as OtterSpeechSummary[];
+  }
+  return [];
+}
+
+function buildUrl(baseUrl: string, path: string, query: RequestOptions["query"]) {
+  const url = new URL(path, baseUrl);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value === undefined || value === null) continue;
+    url.searchParams.set(key, String(value));
+  }
+  return url;
+}
+
+function basicAuthHeader(credentials: OtterLoginCredentials) {
+  return `Basic ${Buffer.from(`${credentials.email}:${credentials.password}`).toString("base64")}`;
+}
+
+function withTrailingSlash(value: string) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function isRetryableStatus(status: number) {
+  return status === 429 || status >= 500;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function summarizeBody(body: unknown) {
+  const record = asRecord(body);
+  if (record) {
+    const summary: Record<string, unknown> = {};
+    for (const key of ["status", "code", "message", "error"]) {
+      if (record[key] !== undefined) summary[key] = record[key];
+    }
+    if (Object.keys(summary).length > 0) return JSON.stringify(summary);
+    return `object with ${Object.keys(record).length} keys`;
+  }
+
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  if (!text) return "empty response body";
+  if (text.trim().startsWith("<")) return "upstream returned HTML error page";
+  return text.length > 300 ? `${text.slice(0, 300)}...` : text;
+}
+
+function formatHttpErrorMessage(status: number, path: string, body: unknown) {
+  if (status === 401 && path === "login") {
+    return "Otter rejected this email/password. If the account uses Google or SSO sign-in, create or reset an Otter password in Otter and try again.";
+  }
+  if (status === 401) {
+    return "Otter rejected the saved session. Update the Otter credentials and try again.";
+  }
+  if (status === 429) {
+    return "Otter rate limited the connector. Try again in a few minutes.";
+  }
+
+  const upstreamMessage = extractProviderMessage(body);
+  return upstreamMessage
+    ? `Otter request failed (${status}) at ${path}: ${upstreamMessage}`
+    : `Otter request failed (${status}) at ${path}`;
+}
+
+function extractProviderMessage(body: unknown) {
+  const record = asRecord(body);
+  return asNonEmptyString(record?.message) ?? asNonEmptyString(record?.error);
+}
+
+function errorMessage(err: unknown) {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function summarizeOtterError(err: unknown) {
+  if (err instanceof OtterApiError) {
+    return {
+      name: err.name,
+      message: err.message,
+      status: err.status,
+      path: err.path,
+      bodySummary: err.bodySummary,
+    };
+  }
+  if (err instanceof Error) return { name: err.name, message: err.message };
+  return { message: String(err) };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getSetCookieHeaders(headers: Headers) {
+  const maybeUndiciHeaders = headers as Headers & { getSetCookie?: () => string[] };
+  if (typeof maybeUndiciHeaders.getSetCookie === "function") return maybeUndiciHeaders.getSetCookie();
+
+  const header = headers.get("set-cookie");
+  if (!header) return [];
+  return header.split(/,(?=\s*[^;,]+=)/g).map((value) => value.trim());
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(asRecord(value));
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asStringId(value: unknown): string | null {
+  const stringValue = asNonEmptyString(value);
+  if (stringValue) return stringValue;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function extractUserId(response: OtterLoginResponse): string | null {
+  const record = asRecord(response);
+  const data = asRecord(record?.data);
+  const user = asRecord(record?.user) ?? asRecord(data?.user);
+  return (
+    asStringId(record?.userid) ??
+    asStringId(record?.user_id) ??
+    asStringId(record?.id) ??
+    asStringId(data?.userid) ??
+    asStringId(data?.user_id) ??
+    asStringId(data?.id) ??
+    asStringId(user?.userid) ??
+    asStringId(user?.user_id) ??
+    asStringId(user?.id)
+  );
+}
+
+function numberValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function unixTimestampToIso(value: unknown): string | null {
+  const timestamp = numberValue(value);
+  if (!timestamp || timestamp <= 0) return null;
+  const milliseconds = timestamp > 100_000_000_000 ? timestamp : timestamp * 1000;
+  return new Date(milliseconds).toISOString();
+}
+
+function formatDurationSeconds(value: unknown): string | null {
+  const seconds = numberValue(value);
+  if (!seconds || seconds <= 0) return null;
+  const rounded = Math.round(seconds);
+  const minutes = Math.floor(rounded / 60);
+  const remainingSeconds = rounded % 60;
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return `${hours}h ${remainingMinutes}m ${remainingSeconds}s`;
+  }
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function formatSummary(summary: unknown): string | null {
+  if (typeof summary === "string") return asNonEmptyString(summary);
+  if (Array.isArray(summary)) {
+    const lines = summary.map(asNonEmptyString).filter((value): value is string => Boolean(value));
+    return lines.length > 0 ? lines.map((line) => `- ${line}`).join("\n") : null;
+  }
+
+  const record = asRecord(summary);
+  if (!record) return null;
+
+  const parts: string[] = [];
+  for (const key of ["overview", "summary", "abstract_summary", "short_summary"]) {
+    const value = formatSummary(record[key]);
+    if (value) parts.push(value);
+  }
+  for (const key of ["action_items", "actionItems"]) {
+    const value = formatSummary(record[key]);
+    if (value) parts.push(`Action items:\n${value}`);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+function speakerNamesById(speech: OtterSpeechSummary) {
+  const result = new Map<string, string>();
+  for (const speaker of Array.isArray(speech.speakers) ? speech.speakers : []) {
+    const id = speaker.id ?? speaker.speaker_id;
+    const name = asNonEmptyString(speaker.speaker_name) ?? asNonEmptyString(speaker.name);
+    if (id !== undefined && id !== null && name) result.set(String(id), name);
+  }
+  return result;
+}
+
+function resolveSegmentSpeaker(segment: OtterTranscriptSegment, speakerNames: Map<string, string>) {
+  const named = asNonEmptyString(segment.speaker_name);
+  if (named) return named;
+
+  if (segment.speaker_id !== undefined && segment.speaker_id !== null) {
+    const speaker = speakerNames.get(String(segment.speaker_id));
+    if (speaker) return speaker;
+  }
+
+  return asNonEmptyString(segment.speaker_model_label) ?? "Unknown";
+}
+
+function extractSpeakerNames(speech: OtterSpeechSummary, segments: OtterTranscriptSegment[]) {
+  const names = new Set<string>();
+  for (const speaker of Array.isArray(speech.speakers) ? speech.speakers : []) {
+    const name = asNonEmptyString(speaker.speaker_name) ?? asNonEmptyString(speaker.name);
+    if (name) names.add(name);
+  }
+
+  const speakerNames = speakerNamesById(speech);
+  for (const segment of segments) {
+    const name = resolveSegmentSpeaker(segment, speakerNames);
+    if (name !== "Unknown") names.add(name);
+  }
+
+  return [...names];
+}
+
+function buildPeople(names: string[], ownerEmail: string | null, resolveNameToEmail: NameResolver | undefined) {
+  const attendees: Array<{ name?: string; email?: string }> = [];
+  const accessEmails = new Set<string>();
+
+  if (ownerEmail) accessEmails.add(ownerEmail);
+
+  for (const name of names) {
+    const resolvedEmail =
+      normalizeEmail(resolveNameToEmail?.(name)?.email) ?? normalizeEmail(name.includes("@") ? name : null);
+    if (resolvedEmail) {
+      attendees.push({ name, email: resolvedEmail });
+      accessEmails.add(resolvedEmail);
+    } else {
+      attendees.push({ name });
+    }
+  }
+
+  return { attendees, accessEmails: [...accessEmails] };
+}
+
+function normalizeEmail(email: string | null | undefined) {
+  const normalized = email?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function getOtterCredentials(credentials: ConnectorCredentials): OtterLoginCredentials {
+  if (credentials.type !== "api_key") {
+    throw new Error("Otter requires email/password credentials");
+  }
+
+  const record = credentials as ConnectorCredentials & { email?: unknown; password?: unknown };
+  const email = asNonEmptyString(record.email);
+  const password = asNonEmptyString(record.password);
+  if (!email || !password) {
+    throw new Error(
+      "Otter requires an Otter email and password. If this account uses Google or SSO sign-in, create or reset an Otter password in Otter and try again.",
+    );
+  }
+
+  return { email, password };
+}
+
+function parseSpeechSource(value: unknown): OtterSpeechSource | null {
+  if (value === "owned" || value === "shared" || value === "all") return value;
+  return null;
+}
+
+function parsePageSize(value: unknown): number | null {
+  const parsed = numberValue(value);
+  if (parsed === null || !Number.isInteger(parsed) || parsed < 1) return null;
+  return Math.min(parsed, MAX_SYNC_PAGE_SIZE);
+}

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -19,6 +19,7 @@ import { createGoogleCalendarConnector } from "./google-calendar";
 import { createGoogleDriveConnector } from "./google-drive";
 import { createLinearConnector } from "./linear";
 import { createNotionConnector } from "./notion";
+import { createOtterConnector } from "./otter";
 import { createOutlookConnector } from "./outlook";
 import { createTeamsConnector } from "./teams";
 import { createZohoCrmConnector } from "./zoho-crm";
@@ -33,6 +34,7 @@ export const connectorFactories: Record<ConnectorType, () => Connector> = {
   notion: createNotionConnector,
   linear: createLinearConnector,
   fireflies: createFirefliesConnector,
+  otter: createOtterConnector,
   zoho_crm: createZohoCrmConnector,
 };
 

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -566,7 +566,7 @@ export type KindRule = { sources?: string[]; fileTypes?: string[] };
  * sweeps in tasks under `kind: "doc"` — so we discriminate on file_type too.
  */
 export const KIND_TO_RULES: Record<string, KindRule[]> = {
-  meeting: [{ sources: ["fireflies"] }],
+  meeting: [{ sources: ["fireflies", "otter"] }],
   doc: [
     { sources: ["google_drive"], fileTypes: ["document", "presentation"] },
     { sources: ["notion"], fileTypes: ["page"] },

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -18,6 +18,7 @@ export type ConnectorType =
   | "notion"
   | "linear"
   | "fireflies"
+  | "otter"
   | "zoho_crm";
 
 export type AuthType = "oauth" | "api_key" | "service_account";

--- a/packages/web/src/components/connector-logos.tsx
+++ b/packages/web/src/components/connector-logos.tsx
@@ -159,6 +159,22 @@ export function ZohoLogo({ size = 16, className, style }: LogoProps) {
   );
 }
 
+export function OtterLogo({ size = 16, className, style }: LogoProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      width={size}
+      height={size}
+      className={className}
+      style={style}
+      aria-hidden="true"
+    >
+      <path d="M4 9.5a2 2 0 0 1 4 0v5a2 2 0 0 1-4 0v-5Zm6-3.5a2 2 0 0 1 4 0v12a2 2 0 0 1-4 0V6Zm6 3.5a2 2 0 0 1 4 0v5a2 2 0 0 1-4 0v-5Z" />
+    </svg>
+  );
+}
+
 export function ConnectorLogo({
   type,
   size = 16,
@@ -188,6 +204,8 @@ export function ConnectorLogo({
       return <NotionLogo {...props} />;
     case "linear":
       return <LinearLogo {...props} />;
+    case "otter":
+      return <OtterLogo {...props} />;
     case "zoho_crm":
       return <ZohoLogo {...props} />;
     default:

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1575,6 +1575,12 @@ export const api = {
         body: JSON.stringify({ api_key: apiKey }),
       });
     },
+    rotateCredentials(id: string, credentials: Record<string, unknown>) {
+      return request<{ ok: boolean }>(`/api/connectors/${id}/rotate-key`, {
+        method: "POST",
+        body: JSON.stringify({ credentials }),
+      });
+    },
     progress() {
       return request<{
         active: Array<{

--- a/packages/web/src/lib/integrations.ts
+++ b/packages/web/src/lib/integrations.ts
@@ -18,6 +18,7 @@ export type IntegrationType =
   | "notion"
   | "linear"
   | "fireflies"
+  | "otter"
   | "zoho_crm";
 
 export type AuthFieldType = "text" | "password" | "textarea" | "file";
@@ -422,6 +423,41 @@ export const INTEGRATIONS: IntegrationDefinition[] = [
       "Go to Fireflies Settings → Integrations → Fireflies API",
       "Generate an API key",
       "Paste the key below",
+    ],
+    perUserAuth: true,
+    requiresOAuthClientSetup: false,
+  },
+  {
+    type: "otter",
+    name: "Otter",
+    description: "Meeting transcripts from Otter",
+    category: "Meetings",
+    color: "#1264FF",
+    authType: "api_key",
+    authFields: [
+      {
+        key: "email",
+        label: "Otter email",
+        type: "text",
+        placeholder: "you@example.com",
+        helpText: "Use the email address on the Otter account that can access the transcripts.",
+      },
+      {
+        key: "password",
+        label: "Otter password",
+        type: "password",
+        placeholder: "Otter password",
+        helpText: "If this account uses Google or SSO sign-in, create or reset an Otter password in Otter first.",
+      },
+    ],
+    scopeLabel: "meetings",
+    scopeType: "none",
+    itemNoun: "transcripts",
+    credentialUrl: "https://help.otter.ai/hc/en-us/articles/360047845154-Change-or-reset-your-password",
+    connectSteps: [
+      "Enter the Otter email and password for the account that owns or can access the transcripts",
+      "If the account uses Google or SSO sign-in, create or reset an Otter password first",
+      "Sketch validates the Otter session and syncs recent owned and shared transcripts",
     ],
     perUserAuth: true,
     requiresOAuthClientSetup: false,

--- a/packages/web/src/routes/files/manage-connector-dialog.isolated.test.tsx
+++ b/packages/web/src/routes/files/manage-connector-dialog.isolated.test.tsx
@@ -12,6 +12,7 @@ import { ManageConnectorDialog } from "./manage-connector-dialog";
 const fireflies = getIntegration("fireflies") ?? null;
 const gmail = getIntegration("gmail") ?? null;
 const googleCalendar = getIntegration("google_calendar") ?? null;
+const otter = getIntegration("otter") ?? null;
 
 function connector(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
   return {
@@ -227,6 +228,38 @@ describe("ManageConnectorDialog connector capabilities", () => {
 
     await waitFor(() => {
       expect(patchedBody).toEqual({ scopeConfig: { calendarIds: ["team"] } });
+    });
+  });
+
+  it("updates Otter email/password credentials without disconnecting", async () => {
+    const user = userEvent.setup();
+    let rotateBody: unknown;
+    server.use(
+      http.post("/api/connectors/:id/rotate-key", async ({ request }) => {
+        rotateBody = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    renderWithProviders(
+      <ManageConnectorDialog
+        definition={otter}
+        connector={connector({ id: "otter-conn", connectorType: "otter", authType: "api_key" })}
+        open
+        onOpenChange={() => {}}
+        onDisconnected={() => {}}
+        onReconnect={() => {}}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /Update credentials/i }));
+    const dialog = await screen.findByRole("dialog");
+    await user.type(within(dialog).getByLabelText("Otter email"), "person@example.com");
+    await user.type(within(dialog).getByLabelText("Otter password"), "new-password");
+    await user.click(within(dialog).getByRole("button", { name: "Update credentials" }));
+
+    await waitFor(() => {
+      expect(rotateBody).toEqual({ credentials: { email: "person@example.com", password: "new-password" } });
     });
   });
 });

--- a/packages/web/src/routes/files/manage-connector-dialog.tsx
+++ b/packages/web/src/routes/files/manage-connector-dialog.tsx
@@ -113,11 +113,9 @@ export function ManageConnectorDialog({
     onError: (error: Error) => toast.error(error.message),
   });
 
-  // For api_key connectors, "Update credentials" opens a non-destructive rotate
-  // dialog (server validates the new key and replaces in place — no data loss
-  // if the user cancels). For OAuth connectors, fall back to the disconnect →
-  // reauth flow (destructive; can't be avoided without redoing the OAuth
-  // callback uniqueness contract).
+  // For local credential connectors, "Update credentials" validates replacement
+  // credentials before swapping them in place. OAuth connectors fall back to
+  // reconnect because their redirect callback owns the uniqueness contract.
   const updateCredentials = () => {
     if (!canUpdateCredentials) return;
     if (definition?.authType === "api_key") {
@@ -313,45 +311,46 @@ export function ManageConnectorDialog({
         </AlertDialogContent>
       </AlertDialog>
 
-      <RotateKeyDialog
+      <RotateCredentialsDialog
         open={showRotateKey}
         onOpenChange={setShowRotateKey}
         connectorId={connector.id}
-        connectorName={definition.name}
-        credentialUrl={definition.credentialUrl}
+        definition={definition}
       />
     </>
   );
 }
 
 /**
- * In-place rotate-key dialog. Calls POST /api/connectors/:id/rotate-key, which
- * validates the new key and swaps it on the existing row. Cancel is safe — the
- * existing key isn't touched until the new one validates.
+ * In-place credential dialog. Calls POST /api/connectors/:id/rotate-key, which
+ * validates the new credentials and swaps them on the existing row.
  */
-function RotateKeyDialog({
+function RotateCredentialsDialog({
   open,
   onOpenChange,
   connectorId,
-  connectorName,
-  credentialUrl,
+  definition,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   connectorId: string;
-  connectorName: string;
-  credentialUrl: string;
+  definition: IntegrationDefinition;
 }) {
   const queryClient = useQueryClient();
-  const [apiKey, setApiKey] = useState("");
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
+  const allFieldsFilled = definition.authFields.every((field) => (fieldValues[field.key] ?? "").trim().length > 0);
 
   const mutation = useMutation({
-    mutationFn: () => api.integrations.rotateKey(connectorId, apiKey.trim()),
+    mutationFn: () =>
+      api.integrations.rotateCredentials(
+        connectorId,
+        Object.fromEntries(definition.authFields.map((field) => [field.key, fieldValues[field.key]?.trim() ?? ""])),
+      ),
     onSuccess: () => {
       toast.success("Credentials updated.");
       queryClient.invalidateQueries({ queryKey: ["integrations"] });
-      setApiKey("");
+      setFieldValues({});
       setError(null);
       onOpenChange(false);
     },
@@ -360,7 +359,7 @@ function RotateKeyDialog({
 
   const handleClose = (next: boolean) => {
     if (!next) {
-      setApiKey("");
+      setFieldValues({});
       setError(null);
     }
     onOpenChange(next);
@@ -370,38 +369,48 @@ function RotateKeyDialog({
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Update {connectorName} credentials</DialogTitle>
+          <DialogTitle>Update {definition.name} credentials</DialogTitle>
           <DialogDescription>
-            Paste a new API key. The existing key stays in place until the new one validates — cancelling here keeps
-            your current connection intact. Get a key at{" "}
-            <a
-              href={credentialUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="text-primary underline-offset-2 hover:underline"
-            >
-              {credentialUrl}
-            </a>
-            .
+            Enter new credentials. The existing connection stays in place until the new credentials validate.
+            {definition.credentialUrl && (
+              <>
+                {" "}
+                Get credentials at{" "}
+                <a
+                  href={definition.credentialUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline-offset-2 hover:underline"
+                >
+                  {definition.credentialUrl}
+                </a>
+                .
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2">
-          <Label htmlFor="rotate-api-key">New API key</Label>
-          <Input
-            id="rotate-api-key"
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="Paste new API key"
-            autoComplete="off"
-          />
+          {definition.authFields.map((field) => (
+            <div key={field.key} className="space-y-1.5">
+              <Label htmlFor={`rotate-${field.key}`}>{field.label}</Label>
+              <Input
+                id={`rotate-${field.key}`}
+                type={field.type === "password" ? "password" : "text"}
+                value={fieldValues[field.key] ?? ""}
+                onChange={(e) => setFieldValues((prev) => ({ ...prev, [field.key]: e.target.value }))}
+                placeholder={field.placeholder}
+                autoComplete="off"
+              />
+              {field.helpText && <p className="text-[11px] text-muted-foreground">{field.helpText}</p>}
+            </div>
+          ))}
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>
         <DialogFooter>
           <Button variant="ghost" onClick={() => handleClose(false)} disabled={mutation.isPending}>
             Cancel
           </Button>
-          <Button onClick={() => mutation.mutate()} disabled={mutation.isPending || !apiKey.trim()}>
+          <Button onClick={() => mutation.mutate()} disabled={mutation.isPending || !allFieldsFilled}>
             {mutation.isPending ? "Updating…" : "Update credentials"}
           </Button>
         </DialogFooter>

--- a/scripts/otter-check.ts
+++ b/scripts/otter-check.ts
@@ -1,0 +1,171 @@
+import {
+  type OtterSpeechSource,
+  type OtterSpeechSummary,
+  createOtterClient,
+  extractOtterSpeech,
+  extractOtterTranscriptSegments,
+  getOtterSpeechId,
+  getOtterSpeechTitle,
+  otterSpeechToSyncedItem,
+} from "../packages/server/src/connectors/otter";
+
+type CheckArgs = {
+  email: string;
+  password: string;
+  source: OtterSpeechSource;
+  pageSize: number;
+  otid: string | null;
+  printContent: boolean;
+};
+
+function usage() {
+  return [
+    "Usage:",
+    "  OTTER_EMAIL=you@example.com OTTER_PASSWORD=... pnpm otter:check",
+    "  pnpm otter:check -- --email you@example.com --password ... --source all --page-size 10",
+    "",
+    "Options:",
+    "  --email <email>        Defaults to OTTER_EMAIL.",
+    "  --password <password>  Defaults to OTTER_PASSWORD.",
+    "  --source <source>      owned, shared, or all. Defaults to OTTER_SOURCE or owned.",
+    "  --page-size <n>        Number of recent speeches to request. Defaults to OTTER_PAGE_SIZE or 10.",
+    "  --otid <id>            Fetch this Otter transcript instead of the first listed speech.",
+    "  --print-content        Print mapped transcript content after the metadata summary.",
+  ].join("\n");
+}
+
+function readOption(args: string[], name: string) {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function parseSource(value: string | undefined): OtterSpeechSource {
+  if (value === "owned" || value === "shared" || value === "all") return value;
+  throw new Error("--source must be one of: owned, shared, all");
+}
+
+function parsePageSize(value: string | undefined) {
+  const parsed = Number(value ?? "10");
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 200) {
+    throw new Error("--page-size must be an integer between 1 and 200");
+  }
+  return parsed;
+}
+
+function parseArgs(argv: string[]): CheckArgs {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  const email = readOption(argv, "--email") ?? process.env.OTTER_EMAIL;
+  const password = readOption(argv, "--password") ?? process.env.OTTER_PASSWORD;
+  if (!email || !password) {
+    throw new Error(`Missing Otter credentials.\n\n${usage()}`);
+  }
+
+  return {
+    email,
+    password,
+    source: parseSource(readOption(argv, "--source") ?? process.env.OTTER_SOURCE ?? "owned"),
+    pageSize: parsePageSize(readOption(argv, "--page-size") ?? process.env.OTTER_PAGE_SIZE),
+    otid: readOption(argv, "--otid") ?? process.env.OTTER_OTID ?? null,
+    printContent: argv.includes("--print-content") || process.env.OTTER_CHECK_PRINT_CONTENT === "1",
+  };
+}
+
+function unixTimestampToIso(value: unknown) {
+  const numeric = typeof value === "number" ? value : typeof value === "string" ? Number(value) : null;
+  if (!numeric || !Number.isFinite(numeric)) return null;
+  return new Date((numeric > 100_000_000_000 ? numeric : numeric * 1000) as number).toISOString();
+}
+
+function speechPreview(speech: OtterSpeechSummary) {
+  return {
+    otid: getOtterSpeechId(speech),
+    title: getOtterSpeechTitle(speech),
+    createdAt: unixTimestampToIso(speech.created_at),
+    startTime: unixTimestampToIso(speech.start_time),
+    durationSeconds: speech.duration ?? null,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const client = createOtterClient({
+    credentials: { email: args.email, password: args.password },
+  });
+
+  await client.login();
+  const user = await client.getUser();
+  const speeches = await client.listSpeeches({ source: args.source, pageSize: args.pageSize });
+  const selectedOtid = args.otid ?? getOtterSpeechId(speeches[0] ?? {});
+
+  if (!selectedOtid) {
+    console.log(
+      JSON.stringify(
+        {
+          authenticated: true,
+          userId: client.getUserId(),
+          userEmailHint: maskEmail(user.email),
+          speechCount: speeches.length,
+          speechSamples: speeches.slice(0, 5).map(speechPreview),
+        },
+        null,
+        2,
+      ),
+    );
+    throw new Error("No speech otid found to fetch. Try --source all or --otid <id>.");
+  }
+
+  const speechResponse = await client.getSpeech(selectedOtid);
+  const speech = extractOtterSpeech(speechResponse);
+  const segments = extractOtterTranscriptSegments(speechResponse);
+  const item = otterSpeechToSyncedItem(speechResponse, { ownerEmail: args.email });
+
+  console.log(
+    JSON.stringify(
+      {
+        authenticated: true,
+        userId: client.getUserId(),
+        userEmailHint: maskEmail(user.email),
+        speechCount: speeches.length,
+        speechSamples: speeches.slice(0, 5).map(speechPreview),
+        selectedSpeech: {
+          ...speechPreview(speech),
+          transcriptSegments: segments.length,
+        },
+        syncedItem: {
+          providerFileId: item.providerFileId,
+          providerUrl: item.providerUrl,
+          fileName: item.fileName,
+          sourceCreatedAt: item.sourceCreatedAt,
+          sourceUpdatedAt: item.sourceUpdatedAt,
+          contentLength: item.content?.length ?? 0,
+          contentHash: item.contentHash,
+          attendeeCount: item.attendees?.length ?? 0,
+          accessEmailCount: item.accessEmails?.length ?? 0,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (args.printContent) {
+    console.log("\n--- mapped content ---\n");
+    console.log(item.content ?? "");
+  }
+}
+
+function maskEmail(value: unknown) {
+  if (typeof value !== "string" || !value.includes("@")) return null;
+  const [local, domain] = value.split("@");
+  if (!local || !domain) return null;
+  return `${local.slice(0, 2)}***@${domain}`;
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add an Otter Files connector that syncs meeting transcripts through Otter's informal web API using email/password authentication and cookie-backed requests.
- Index Otter speeches as meeting transcript documents with title, summary, transcript content, speaker/attendee metadata, content hashes, and per-user access emails.
- Wire Otter into the connector registry, Files connector UI, meeting search classification, source labels, and credential rotation flow.

## Linear Scope
- Implements `SKE-232: Otter Connector`.
- Supports users who joined Otter with Google/SSO by requiring them to create or reset an Otter password before connecting in Sketch.
- Keeps this PR stacked on `feat/ske-157-connector-credentials`, since the connector uses the credential-source and local credential handling added there.

## Implementation Details
- Added `packages/server/src/connectors/otter.ts` with an `OtterClient` for login, cookie capture, user-id resolution, speech listing, transcript fetches, retry handling, and provider error sanitization.
- Added fallback user-id resolution through `/user` when `/login` omits `userid`, matching the failure mode seen while testing a real account.
- Added Otter validation/sync coverage plus connector authz coverage for email/password credential rotation.
- Generalized the existing rotate-key path to accept multi-field local credentials so Otter can update email/password credentials without disconnecting.
- Added the Otter integration definition, logo, Files connector picker support, manage-connector credential form support, and `pnpm otter:check` for local endpoint verification.

## Verification
- `pnpm biome check` - passed
- `pnpm typecheck` - passed
- `pnpm test` - passed
- `pnpm build` - passed
- `pnpm --dir packages/server exec vitest run --project unit src/connectors/otter.test.ts` - passed

## Risk / Rollout
- Otter's endpoints are informal, so upstream response shape or auth behavior can change without notice.
- Google/SSO-only Otter accounts need an Otter password set before Sketch can connect.
- This PR should be reviewed and merged after `SKE-157` / PR #192, or rebased if that base branch changes.
