### PR TITLE
fix: acknowledge Wati webhooks before agent processing

### DIFF
--- a/packages/server/src/api/wati-webhook.test.ts
+++ b/packages/server/src/api/wati-webhook.test.ts
@@ -33,8 +33,8 @@ describe("watiWebhookRoutes", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, acceptedMessages: 1 });
-    expect(handleWebhook).toHaveBeenCalledWith({ eventType: "message" });
+    expect(await res.json()).toEqual({ ok: true });
+    await vi.waitFor(() => expect(handleWebhook).toHaveBeenCalledWith({ eventType: "message" }));
   });
 
   it("accepts bearer-token authenticated webhook payloads when headers are available", async () => {
@@ -50,7 +50,28 @@ describe("watiWebhookRoutes", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(handleWebhook).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(handleWebhook).toHaveBeenCalledOnce());
+  });
+
+  it("acknowledges valid webhook payloads before provider processing finishes", async () => {
+    const handleWebhook = vi.fn(() => new Promise<never>(() => undefined));
+    const { app } = createTestApp(handleWebhook);
+
+    const request = app.request("/whatsapp/wati/events?token=secret-token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ eventType: "message" }),
+    });
+
+    const res = await Promise.race([
+      request,
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 50)),
+    ]);
+
+    expect(res).not.toBe("timeout");
+    expect((res as Response).status).toBe(200);
+    expect(await (res as Response).json()).toEqual({ ok: true });
+    await vi.waitFor(() => expect(handleWebhook).toHaveBeenCalledOnce());
   });
 
   it("rejects missing or incorrect webhook tokens before processing the body", async () => {

--- a/packages/server/src/api/wati-webhook.ts
+++ b/packages/server/src/api/wati-webhook.ts
@@ -23,9 +23,15 @@ export function watiWebhookRoutes(
       return c.json({ error: { code: "INVALID_JSON", message: "Invalid JSON body" } }, 400);
     }
 
-    const results = await provider.handleWebhook(payload);
-    const acceptedMessages = results.filter((result) => result.kind === "message").length;
-    return c.json({ ok: true, acceptedMessages }, 200);
+    setImmediate(() => {
+      void Promise.resolve()
+        .then(() => provider.handleWebhook(payload))
+        .catch((err) => {
+          logger.error({ err }, "Wati webhook processing failed");
+        });
+    });
+
+    return c.json({ ok: true }, 200);
   });
 
   return routes;


### PR DESCRIPTION
## Summary

- Acknowledge authenticated Wati webhooks immediately after JSON parsing.
- Continue provider/runtime processing asynchronously so Wati does not wait on the agent run or fallback send path.
- Update route coverage to assert fast acknowledgement while preserving auth and invalid JSON rejection behavior.

## Why

Live Wati testing showed inbound `Message Received` callbacks could be marked as errored by Wati even when Sketch later sent the final reply. The route was awaiting the full provider message pipeline before returning 200.

## Validation

- `pnpm exec biome check packages/server/src/api/wati-webhook.ts packages/server/src/api/wati-webhook.test.ts`
- `pnpm --filter @sketch/server test -- src/api/wati-webhook.test.ts` (repo config ran full server suite: 224 files, 2,831 tests)
- `pnpm typecheck`
- `pnpm build`
- Pre-push hook: `biome check .`, `pnpm -r typecheck`, `pnpm -r --workspace-concurrency=1 test`, `pnpm build`