### PR TITLE
feat: harden WhatsApp delivery, capture, and template mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,9 @@ LOG_LEVEL=info          # debug | info | warn | error
 # Sent Message is READ v2, and Session message FAILED. Avoid the legacy non-v2
 # delivery/read events unless a Wati tenant cannot emit v2.
 # Authorization: Bearer <token> and x-wati-webhook-token are also accepted when a caller can send headers.
+# For proactive Wati DMs, approve Wati templates and map them to Sketch logical keys
+# (`whatsapp.magic_link`, `whatsapp.introduction`, `whatsapp.proactive_update`).
+# See SELF_HOSTING.md for the admin API calls and parameter mapping format.
 
 # Encryption (optional, recommended for shared Postgres deployments)
 # 64 hex chars = 32 bytes for AES-256-GCM

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -148,6 +148,35 @@ Self-hosted installs can route one-to-one WhatsApp DMs through Wati while keepin
 
 Wati allows multiple events on one webhook row, and live testing rejected a second row with the same callback URL. Prefer the v2 status events to avoid duplicate callbacks from the legacy delivery/read event family. Query-token auth is supported because Wati webhook setup may not allow custom Authorization headers; `Authorization: Bearer <token>` and `x-wati-webhook-token` are also accepted when headers are available.
 
+##### Wati template mappings
+
+Wati and other official WhatsApp providers require approved message templates for proactive DMs, such as magic links, onboarding introductions, scheduled updates, workflow output, and direct teammate messages. Reactive replies inside an active WhatsApp conversation still use normal session text messages.
+
+Sketch stores provider-specific mappings from logical product keys to Wati template names. Configure these after Wati is connected:
+
+1. Create and approve templates in Wati for the logical keys you use: `whatsapp.magic_link`, `whatsapp.introduction`, and `whatsapp.proactive_update`.
+2. Call `GET /api/channels/whatsapp/templates/provider` as an admin to list templates visible through Wati.
+3. Upsert each mapping with `PUT /api/channels/whatsapp/templates/mappings`.
+
+Example:
+
+```json
+{
+  "provider": "wati",
+  "logicalKey": "whatsapp.magic_link",
+  "providerTemplateName": "sketch_magic_link",
+  "language": "en_US",
+  "status": "approved",
+  "parameterMap": {
+    "name": "recipientName",
+    "bot": "botName",
+    "link": "magicLinkUrl"
+  }
+}
+```
+
+`parameterMap` maps Wati template parameter names to Sketch's logical parameter names. Proactive WhatsApp DMs fail clearly when an approved mapping is missing; Sketch will not send arbitrary agent text as an unstructured template payload.
+
 ## Troubleshooting
 
 **Port already in use** — Change `PORT` in `.env`.

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -37,6 +37,7 @@ import type { TranscriptionSettings } from "../transcription/service";
 import { resolveTranscriptionConfig } from "../transcription/service";
 import type { VisionConfig } from "../vision/service";
 import { resolveVisionConfig } from "../vision/service";
+import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 import { AuxCostCollector, type AuxLlmCall, sumAuxCost } from "./aux-cost";
 import { createCanUseTool } from "./permissions";
 import { type ResponseSurface, buildSystemContext } from "./prompt";
@@ -200,7 +201,12 @@ export interface RunAgentParams {
   currentUserId?: string | null;
   localDeviceInvoker?: Pick<LocalDeviceGateway, "invoke">;
   localClaudeSessionService?: LocalClaudeSessionService;
-  sendDm?: (params: { userId: string; platform: string; message: string }) => Promise<{
+  sendDm?: (params: {
+    userId: string;
+    platform: string;
+    message: string;
+    template?: WhatsAppTemplateRequest;
+  }) => Promise<{
     channelId: string;
     messageRef: string;
   }>;

--- a/packages/server/src/agent/sketch-tools.test.ts
+++ b/packages/server/src/agent/sketch-tools.test.ts
@@ -590,11 +590,14 @@ describe("handleSendMessageToUser", () => {
       },
     );
 
-    expect(sendDm).toHaveBeenCalledWith({
-      userId: "user-bob",
-      platform: "whatsapp",
-      message: "Need your latest update.",
-    });
+    expect(sendDm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-bob",
+        platform: "whatsapp",
+        message: "Need your latest update.",
+        template: expect.objectContaining({ key: "whatsapp.proactive_update" }),
+      }),
+    );
     expect(createInboxMessage).toHaveBeenCalledWith({
       senderUserId: "user-alice",
       recipientUserId: "user-bob",

--- a/packages/server/src/agent/tools/messaging.ts
+++ b/packages/server/src/agent/tools/messaging.ts
@@ -1,5 +1,6 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod/v4";
+import { buildProactiveUpdateTemplate } from "../../whatsapp/templates";
 import type { SelectableUser, SketchMcpDeps, ToolResult } from "./types";
 
 function detectPlatform(recipient: SelectableUser): "slack" | "whatsapp" | null {
@@ -56,6 +57,14 @@ async function deliverMessageToUser(
     userId: params.recipientUserId,
     platform,
     message: params.message,
+    ...(platform === "whatsapp"
+      ? {
+          template: buildProactiveUpdateTemplate({
+            recipientName: recipient.name,
+            messageSummary: params.message,
+          }),
+        }
+      : {}),
   });
 
   let inboxMessageId: string | undefined;

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -15,6 +15,7 @@ import type { TaskContext } from "../../scheduler/types";
 import type { SlackBot } from "../../slack/bot";
 import type { TranscriptionSettings } from "../../transcription/service";
 import type { VisionConfig } from "../../vision/service";
+import type { WhatsAppTemplateRequest } from "../../whatsapp/templates";
 import type { AuxCostCollector } from "../aux-cost";
 import type { AgentOutputWriter } from "./agent-output";
 
@@ -110,7 +111,12 @@ export interface SketchMcpDeps {
   workspaceKey?: string;
   originThreadTs?: string;
   activeQueueKey?: string;
-  sendDm?: (params: { userId: string; platform: string; message: string }) => Promise<{
+  sendDm?: (params: {
+    userId: string;
+    platform: string;
+    message: string;
+    template?: WhatsAppTemplateRequest;
+  }) => Promise<{
     channelId: string;
     messageRef: string;
   }>;

--- a/packages/server/src/agents/output-delivery.test.ts
+++ b/packages/server/src/agents/output-delivery.test.ts
@@ -13,6 +13,7 @@ function createMockWhatsApp(overrides: Partial<WhatsAppRuntime> = {}): WhatsAppR
     isConnected: false,
     onMessage: vi.fn(),
     sendText: vi.fn(),
+    sendTemplate: vi.fn(),
     sendFile: vi.fn(),
     startComposing: vi.fn(),
     stopComposing: vi.fn(),
@@ -172,6 +173,58 @@ describe("createAgentOutputDeliveryService", () => {
       "wa-message-4",
     ]);
     expect(captured.every((row) => row.text.length <= 4000)).toBe(true);
+  });
+
+  it("sends WhatsApp DM deliveries through logical templates", async () => {
+    const whatsapp = createMockWhatsApp({
+      isConnected: true,
+      sendTemplate: vi.fn(async () => ({
+        providerMessageId: "wa-template-1",
+        providerConversationId: "dm:+15551234567",
+        providerTimestamp: "2024-06-04T07:20:00.000Z",
+      })),
+    });
+    const service = createAgentOutputDeliveryService({
+      db,
+      logger: createTestLogger(),
+      getSlack: () => null,
+      whatsapp,
+      settingsRepo: createSettingsRepository(db),
+    });
+
+    await service.deliver({
+      definition: dailyBriefDefinition,
+      delivery: {
+        enabled: true,
+        platform: "whatsapp",
+        targetType: "dm",
+        targetId: "dm:+15551234567",
+        label: "Alice",
+      },
+      output: {
+        id: "output-delivery",
+        outputDate: "2026-06-26",
+        masthead: { title: "Daily Brief", summary: "Start here." },
+        sections: {},
+      },
+    });
+
+    expect(whatsapp.sendText).not.toHaveBeenCalled();
+    expect(whatsapp.sendTemplate).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+15551234567" },
+      expect.objectContaining({
+        key: "whatsapp.proactive_update",
+        params: expect.objectContaining({
+          recipientName: "Alice",
+          messageSummary: expect.stringContaining("Daily Brief"),
+        }),
+      }),
+    );
+    const captured = await db
+      .selectFrom("conversation_messages")
+      .select(["provider_message_id", "text"])
+      .executeTakeFirstOrThrow();
+    expect(captured.provider_message_id).toBe("wa-template-1");
   });
 
   it("records a failed attempt when the target platform is unavailable", async () => {

--- a/packages/server/src/agents/output-delivery.ts
+++ b/packages/server/src/agents/output-delivery.ts
@@ -9,8 +9,9 @@ import type { Logger } from "../logger";
 import { createWorkflowDeliveryCapture } from "../scheduler/delivery-capture";
 import type { SlackBot } from "../slack/bot";
 import { WHATSAPP_TEXT_LIMIT } from "../whatsapp/chunking";
-import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
+import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
+import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import { isSlackDmChannelId, isSlackUserId } from "../workflows/delivery";
 import { type RenderableAgentOutput, renderAgentOutputForDelivery } from "./output-renderer";
 import type { AgentDefinition } from "./types";
@@ -67,13 +68,24 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
   async function sendWhatsApp(delivery: AgentDeliveryConfig, text: string): Promise<string[]> {
     if (!deps.whatsapp.isConnected) throw new Error("WhatsApp is not connected.");
     const refs: string[] = [];
+    const target = whatsappTargetFromDeliveryTarget(delivery.targetId);
     for (const chunk of chunkText(text, WHATSAPP_TEXT_LIMIT)) {
-      const sent = await deps.whatsapp.sendText(whatsappTargetFromDeliveryTarget(delivery.targetId), chunk);
+      const sent =
+        target.kind === "dm"
+          ? await deps.whatsapp.sendTemplate(
+              target,
+              buildProactiveUpdateTemplate({
+                recipientName: delivery.label,
+                botName: (await deps.settingsRepo.get())?.bot_name,
+                messageSummary: chunk,
+              }),
+            )
+          : await deps.whatsapp.sendText(target, chunk);
       const messageRef = sent?.providerMessageId;
       if (!messageRef) continue;
       refs.push(messageRef);
       await capture.captureWhatsApp({
-        deliveryTarget: delivery.targetId,
+        deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : delivery.targetId,
         messageRef,
         providerTimestamp: sent.providerTimestamp,
         text: chunk,

--- a/packages/server/src/api/agent-runs.ts
+++ b/packages/server/src/api/agent-runs.ts
@@ -27,6 +27,8 @@ import type { WhatsAppBot } from "../whatsapp/bot";
 import { createWhatsAppMessageHandler } from "../whatsapp/message-handler";
 import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
+import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
+import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 
 type UserRepo = ReturnType<typeof createUserRepository>;
 type ChannelRepo = ReturnType<typeof createChannelRepository>;
@@ -79,7 +81,12 @@ interface AgentRunRouteDeps {
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: QueueManager;
-  sendDm?: (params: { userId: string; platform: string; message: string }) => Promise<{
+  sendDm?: (params: {
+    userId: string;
+    platform: string;
+    message: string;
+    template?: WhatsAppTemplateRequest;
+  }) => Promise<{
     channelId: string;
     messageRef: string;
   }>;
@@ -222,10 +229,19 @@ export function agentRunRoutes(deps: AgentRunRouteDeps) {
             platform: parsed.data.target.platform,
           };
           if (parsed.data.deliveryMode === "target" && deps.sendDm) {
+            const template =
+              parsed.data.target.platform === "whatsapp"
+                ? buildProactiveUpdateTemplate({
+                    recipientName: target.name,
+                    botName: settingsRow?.bot_name,
+                    messageSummary: parsed.data.message,
+                  })
+                : undefined;
             delivery.request = await deps.sendDm({
               userId: target.id,
               platform: parsed.data.target.platform,
               message: parsed.data.message,
+              ...(template ? { template } : {}),
             });
           }
           const deliveryTarget =
@@ -265,10 +281,19 @@ export function agentRunRoutes(deps: AgentRunRouteDeps) {
             toolConfig,
           );
           if (parsed.data.deliveryMode === "target" && finalText && deps.sendDm) {
+            const template =
+              parsed.data.target.platform === "whatsapp"
+                ? buildProactiveUpdateTemplate({
+                    recipientName: target.name,
+                    botName: settingsRow?.bot_name,
+                    messageSummary: finalText,
+                  })
+                : undefined;
             delivery.response = await deps.sendDm({
               userId: target.id,
               platform: parsed.data.target.platform,
               message: finalText,
+              ...(template ? { template } : {}),
             });
           }
 

--- a/packages/server/src/api/auth.ts
+++ b/packages/server/src/api/auth.ts
@@ -24,7 +24,7 @@ import type { DB } from "../db/schema";
 import { resolveBaseUrl } from "./shared";
 
 export type MagicLinkSender = (opts: {
-  user: Pick<VerifiedUser, "email" | "slack_user_id" | "whatsapp_number">;
+  user: Pick<VerifiedUser, "id" | "name" | "email" | "slack_user_id" | "whatsapp_number">;
   magicLinkUrl: string;
   botName: string;
 }) => Promise<string[]>;

--- a/packages/server/src/api/channels-authz.test.ts
+++ b/packages/server/src/api/channels-authz.test.ts
@@ -3,11 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hashPassword } from "../auth/password";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
+import { createWhatsAppTemplateMappingRepository } from "../db/repositories/whatsapp-template-mappings";
 import type { DB } from "../db/schema";
 import { createApp } from "../http";
 import type { SlackBot } from "../slack/bot";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 import type { WhatsAppBot } from "../whatsapp/bot";
+import type { WatiWhatsAppProvider } from "../whatsapp/providers/wati";
 
 const ADMIN_EMAIL = "admin@test.com";
 const MEMBER_EMAIL = "member@test.com";
@@ -48,7 +50,10 @@ async function login(app: ReturnType<typeof createApp>, email: string): Promise<
   return res.headers.get("set-cookie") ?? "";
 }
 
-function makeApp(db: Kysely<DB>, options: { whatsappConnected?: boolean } = {}) {
+function makeApp(
+  db: Kysely<DB>,
+  options: { whatsappConnected?: boolean; watiProvider?: Pick<WatiWhatsAppProvider, "listTemplates"> } = {},
+) {
   let whatsappConnected = options.whatsappConnected ?? true;
   const slack = {
     listChannels: vi.fn().mockResolvedValue([]),
@@ -73,6 +78,7 @@ function makeApp(db: Kysely<DB>, options: { whatsappConnected?: boolean } = {}) 
     logger,
     getSlack: () => slack,
     whatsapp,
+    watiWebhook: options.watiProvider as WatiWhatsAppProvider | undefined,
     onSlackDisconnect,
     onSmtpUpdated,
   });
@@ -137,6 +143,20 @@ describe("Channels API authorization", () => {
       app.request("/api/channels/email", { method: "DELETE", headers: { Cookie: memberCookie } }),
       app.request("/api/channels/whatsapp/pair", { headers: { Cookie: memberCookie } }),
       app.request("/api/channels/whatsapp", { method: "DELETE", headers: { Cookie: memberCookie } }),
+      app.request("/api/channels/whatsapp/templates/provider", { headers: { Cookie: memberCookie } }),
+      app.request("/api/channels/whatsapp/templates/mappings", { headers: { Cookie: memberCookie } }),
+      app.request("/api/channels/whatsapp/templates/mappings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Cookie: memberCookie },
+        body: JSON.stringify({
+          logicalKey: "whatsapp.magic_link",
+          providerTemplateName: "sketch_magic_link",
+        }),
+      }),
+      app.request("/api/channels/whatsapp/templates/sync", {
+        method: "POST",
+        headers: { Cookie: memberCookie },
+      }),
       app.request("/api/setup/slack", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: memberCookie },
@@ -254,5 +274,67 @@ describe("Channels API authorization", () => {
     const settingsAfterSlack = await createSettingsRepository(db).get();
     expect(settingsAfterSlack?.slack_bot_token).toBe("xoxb-admin");
     expect(settingsAfterSlack?.slack_app_token).toBe("xapp-admin");
+  });
+
+  it("allows admins to configure and sync WhatsApp template mappings", async () => {
+    const listTemplates = vi.fn().mockResolvedValue([
+      {
+        providerTemplateName: "sketch_magic_link",
+        language: "en_US",
+        status: "APPROVED",
+        category: "UTILITY",
+      },
+    ]);
+    const { app } = makeApp(db, { watiProvider: { listTemplates } });
+
+    const upsertRes = await app.request("/api/channels/whatsapp/templates/mappings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Cookie: adminCookie },
+      body: JSON.stringify({
+        logicalKey: "whatsapp.magic_link",
+        providerTemplateName: "sketch_magic_link",
+        status: "pending",
+        parameterMap: { name: "recipientName", link: "magicLinkUrl" },
+      }),
+    });
+    expect(upsertRes.status).toBe(200);
+    await expect(upsertRes.json()).resolves.toMatchObject({
+      mapping: {
+        provider: "wati",
+        logical_key: "whatsapp.magic_link",
+        provider_template_name: "sketch_magic_link",
+        status: "pending",
+      },
+    });
+
+    const syncRes = await app.request("/api/channels/whatsapp/templates/sync", {
+      method: "POST",
+      headers: { Cookie: adminCookie },
+    });
+    expect(syncRes.status).toBe(200);
+    await expect(syncRes.json()).resolves.toMatchObject({ provider: "wati", updatedMappings: 1 });
+    expect(listTemplates).toHaveBeenCalledOnce();
+
+    const mappingsRes = await app.request("/api/channels/whatsapp/templates/mappings?provider=wati", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(mappingsRes.status).toBe(200);
+    await expect(mappingsRes.json()).resolves.toMatchObject({
+      mappings: [
+        {
+          provider: "wati",
+          logical_key: "whatsapp.magic_link",
+          provider_template_name: "sketch_magic_link",
+          status: "approved",
+          category: "UTILITY",
+        },
+      ],
+    });
+
+    const mapping = await createWhatsAppTemplateMappingRepository(db).findApprovedMapping(
+      "wati",
+      "whatsapp.magic_link",
+    );
+    expect(mapping?.parameterMap).toEqual({ name: "recipientName", link: "magicLinkUrl" });
   });
 });

--- a/packages/server/src/api/channels.ts
+++ b/packages/server/src/api/channels.ts
@@ -2,16 +2,21 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
+import type { createWhatsAppTemplateMappingRepository } from "../db/repositories/whatsapp-template-mappings";
 import { createEmailTransport, verifyEmailTransport } from "../email";
 import type { SlackBot } from "../slack/bot";
 import type { WhatsAppBot } from "../whatsapp/bot";
+import type { WatiWhatsAppProvider } from "../whatsapp/providers/wati";
 import { denyIfNotAdmin } from "./auth-helpers";
 
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 type WhatsAppGroupsRepo = ReturnType<typeof createWhatsAppGroupRepository>;
+type WhatsAppTemplateMappingsRepo = ReturnType<typeof createWhatsAppTemplateMappingRepository>;
 
 interface ChannelDeps {
   whatsapp?: WhatsAppBot;
+  watiProvider?: Pick<WatiWhatsAppProvider, "listTemplates">;
+  whatsappTemplateMappings?: WhatsAppTemplateMappingsRepo;
   getSlack?: () => SlackBot | null;
   whatsappGroups?: WhatsAppGroupsRepo;
   onSlackDisconnect?: () => Promise<void>;
@@ -25,6 +30,16 @@ const smtpConfigSchema = z.object({
   user: z.string().min(1),
   password: z.string().min(1),
   from: z.string().email(),
+});
+
+const templateMappingSchema = z.object({
+  provider: z.string().trim().min(1).default("wati"),
+  logicalKey: z.string().trim().min(1),
+  providerTemplateName: z.string().trim().min(1),
+  language: z.string().trim().min(1).default("en_US"),
+  status: z.string().trim().min(1).default("approved"),
+  category: z.string().trim().min(1).nullable().optional(),
+  parameterMap: z.record(z.string(), z.string()).nullable().optional(),
 });
 
 export function channelRoutes(deps: ChannelDeps) {
@@ -80,6 +95,57 @@ export function channelRoutes(deps: ChannelDeps) {
     }
 
     return c.json({ groups: await deps.whatsappGroups.list() });
+  });
+
+  routes.get("/whatsapp/templates/provider", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
+    if (!deps.watiProvider) {
+      return c.json({ error: { code: "NOT_CONFIGURED", message: "Wati is not configured" } }, 404);
+    }
+
+    return c.json({ provider: "wati", templates: await deps.watiProvider.listTemplates() });
+  });
+
+  routes.get("/whatsapp/templates/mappings", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
+    const provider = c.req.query("provider")?.trim() || undefined;
+    return c.json({ mappings: (await deps.whatsappTemplateMappings?.listMappings(provider)) ?? [] });
+  });
+
+  routes.put("/whatsapp/templates/mappings", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
+    if (!deps.whatsappTemplateMappings) {
+      return c.json({ error: { code: "NOT_CONFIGURED", message: "Template mappings are not configured" } }, 404);
+    }
+
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = templateMappingSchema.safeParse(body);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid template mapping";
+      return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+
+    const mapping = await deps.whatsappTemplateMappings.upsertMapping(parsed.data);
+    return c.json({ mapping });
+  });
+
+  routes.post("/whatsapp/templates/sync", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
+    if (!deps.watiProvider || !deps.whatsappTemplateMappings) {
+      return c.json({ error: { code: "NOT_CONFIGURED", message: "Wati templates are not configured" } }, 404);
+    }
+
+    const templates = await deps.watiProvider.listTemplates();
+    const updatedMappings = await deps.whatsappTemplateMappings.syncProviderTemplates("wati", templates);
+    return c.json({ provider: "wati", templates, updatedMappings });
   });
 
   routes.delete("/slack", async (c) => {

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -48,7 +48,12 @@ function createTestSystemApp(
       slackUserId: string;
       message: string;
     }) => Promise<{ channelId: string; messageRef: string }>;
-    sendDm?: (params: { userId: string; platform: "slack" | "whatsapp"; message: string }) => Promise<{
+    sendDm?: (params: {
+      userId: string;
+      platform: "slack" | "whatsapp";
+      message: string;
+      template?: unknown;
+    }) => Promise<{
       channelId: string;
       messageRef: string;
     }>;
@@ -1802,18 +1807,24 @@ describe("POST /api/system/onboarding-introductions", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ ok: true, status: "sent", sent: 2, failed: 0 });
-    expect(sendDm).toHaveBeenCalledWith({
-      userId: admin.id,
-      platform: "whatsapp",
-      message:
-        "Hi, I'm Sketch, your AI coworker in Acme. You can message me here when you need help with your workspace.",
-    });
-    expect(sendDm).toHaveBeenCalledWith({
-      userId: teammate.id,
-      platform: "whatsapp",
-      message:
-        "Hi, I'm Sketch, your AI coworker in Acme. You can message me here when you need help with your workspace.",
-    });
+    expect(sendDm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: admin.id,
+        platform: "whatsapp",
+        message:
+          "Hi, I'm Sketch, your AI coworker in Acme. You can message me here when you need help with your workspace.",
+        template: expect.objectContaining({ key: "whatsapp.introduction" }),
+      }),
+    );
+    expect(sendDm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: teammate.id,
+        platform: "whatsapp",
+        message:
+          "Hi, I'm Sketch, your AI coworker in Acme. You can message me here when you need help with your workspace.",
+        template: expect.objectContaining({ key: "whatsapp.introduction" }),
+      }),
+    );
     const workflow = await inboxMessagesRepo.findUnresolvedByRecipientAndKind(admin.id, "managed_onboarding_intro");
     expect(workflow).toBeUndefined();
   });
@@ -1906,12 +1917,15 @@ describe("POST /api/system/onboarding-introductions", () => {
       ],
     });
     expect(sendDm).toHaveBeenCalledTimes(1);
-    expect(sendDm).toHaveBeenCalledWith({
-      userId: admin.id,
-      platform: "whatsapp",
-      message:
-        "Hi, I'm Sketch, your AI coworker in your workspace. You can message me here when you need help with your workspace.",
-    });
+    expect(sendDm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: admin.id,
+        platform: "whatsapp",
+        message:
+          "Hi, I'm Sketch, your AI coworker in your workspace. You can message me here when you need help with your workspace.",
+        template: expect.objectContaining({ key: "whatsapp.introduction" }),
+      }),
+    );
   });
 
   it("requires admin WhatsApp number before WhatsApp introductions", async () => {

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -12,6 +12,8 @@ import type { createMcpServerRepository } from "../db/repositories/mcp-servers";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
 import { upsertSlackIdentity } from "../slack/upsert-identity";
+import { buildIntroductionTemplate } from "../whatsapp/templates";
+import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 import { upsertWhatsAppIdentity } from "../whatsapp/upsert-identity";
 
 type InboxMessagesRepo = ReturnType<typeof createInboxMessagesRepository>;
@@ -40,6 +42,7 @@ interface SystemDeps {
     userId: string;
     platform: "slack" | "whatsapp";
     message: string;
+    template?: WhatsAppTemplateRequest;
   }) => Promise<{ channelId: string; messageRef: string }>;
   whatsappStatus?: () => { connected: boolean; phoneNumber: string | null; pairingInProgress: boolean };
   // biome-ignore lint/complexity/noBannedTypes: Function is needed here to accommodate Vitest mock types in tests
@@ -626,7 +629,7 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       }
 
       const requestedNumbers = parsed.data.whatsappNumbers ?? [];
-      const targetUsers = new Map<string, { id: string; whatsapp_number: string | null }>();
+      const targetUsers = new Map<string, { id: string; name: string; whatsapp_number: string | null }>();
       const missingNumbers: string[] = [];
       targetUsers.set(admin.id, admin);
       for (const whatsappNumber of requestedNumbers) {
@@ -663,7 +666,17 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       }
       for (const user of targetUsers.values()) {
         try {
-          const delivery = await deps.sendDm({ userId: user.id, platform: "whatsapp", message });
+          const delivery = await deps.sendDm({
+            userId: user.id,
+            platform: "whatsapp",
+            message,
+            template: buildIntroductionTemplate({
+              recipientName: user.name,
+              botName: settingsRow?.bot_name ?? "Sketch",
+              orgName: parsed.data.orgName ?? settingsRow?.org_name,
+              fallbackText: message,
+            }),
+          });
           deliveries.push({
             userId: user.id,
             ok: true,

--- a/packages/server/src/api/wati-webhook.test.ts
+++ b/packages/server/src/api/wati-webhook.test.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
+import { QueueManager } from "../queue";
 import { createTestLogger } from "../test-utils";
-import { extractWebhookToken, isValidWebhookToken, watiWebhookRoutes } from "./wati-webhook";
+import { WATI_WEBHOOK_QUEUE_KEY, extractWebhookToken, isValidWebhookToken, watiWebhookRoutes } from "./wati-webhook";
 
 function createTestApp(
   handleWebhook = vi.fn(async () => [
@@ -9,6 +10,13 @@ function createTestApp(
   ]),
 ) {
   const app = new Hono();
+  const queueManager = new QueueManager();
+  const queue = {
+    enqueue: vi.fn((work: () => Promise<void>) => {
+      void work();
+    }),
+  };
+  const getQueue = vi.spyOn(queueManager, "getQueue").mockReturnValue(queue as never);
   app.route(
     "/whatsapp/wati",
     watiWebhookRoutes(
@@ -16,15 +24,16 @@ function createTestApp(
         webhookToken: "secret-token",
         handleWebhook,
       },
+      queueManager,
       createTestLogger(),
     ),
   );
-  return { app, handleWebhook };
+  return { app, handleWebhook, queue, getQueue };
 }
 
 describe("watiWebhookRoutes", () => {
   it("accepts query-token authenticated webhook payloads for Wati setups without custom headers", async () => {
-    const { app, handleWebhook } = createTestApp();
+    const { app, handleWebhook, queue, getQueue } = createTestApp();
 
     const res = await app.request("/whatsapp/wati/events?token=secret-token", {
       method: "POST",
@@ -34,6 +43,8 @@ describe("watiWebhookRoutes", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
+    expect(getQueue).toHaveBeenCalledWith(WATI_WEBHOOK_QUEUE_KEY);
+    expect(queue.enqueue).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(handleWebhook).toHaveBeenCalledWith({ eventType: "message" }));
   });
 
@@ -75,7 +86,7 @@ describe("watiWebhookRoutes", () => {
   });
 
   it("rejects missing or incorrect webhook tokens before processing the body", async () => {
-    const { app, handleWebhook } = createTestApp();
+    const { app, handleWebhook, queue } = createTestApp();
 
     const res = await app.request("/whatsapp/wati/events", {
       method: "POST",
@@ -87,11 +98,12 @@ describe("watiWebhookRoutes", () => {
     });
 
     expect(res.status).toBe(401);
+    expect(queue.enqueue).not.toHaveBeenCalled();
     expect(handleWebhook).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid JSON after authentication", async () => {
-    const { app, handleWebhook } = createTestApp();
+    const { app, handleWebhook, queue } = createTestApp();
 
     const res = await app.request("/whatsapp/wati/events", {
       method: "POST",
@@ -103,6 +115,7 @@ describe("watiWebhookRoutes", () => {
     });
 
     expect(res.status).toBe(400);
+    expect(queue.enqueue).not.toHaveBeenCalled();
     expect(handleWebhook).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/api/wati-webhook.ts
+++ b/packages/server/src/api/wati-webhook.ts
@@ -1,10 +1,14 @@
 import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import type { Logger } from "../logger";
+import type { QueueManager } from "../queue";
 import type { WatiWhatsAppProvider } from "../whatsapp/providers/wati";
+
+export const WATI_WEBHOOK_QUEUE_KEY = "whatsapp:wati:webhooks";
 
 export function watiWebhookRoutes(
   provider: Pick<WatiWhatsAppProvider, "handleWebhook" | "webhookToken">,
+  queueManager: QueueManager,
   logger: Logger,
 ) {
   const routes = new Hono();
@@ -23,12 +27,21 @@ export function watiWebhookRoutes(
       return c.json({ error: { code: "INVALID_JSON", message: "Invalid JSON body" } }, 400);
     }
 
-    setImmediate(() => {
-      void Promise.resolve()
-        .then(() => provider.handleWebhook(payload))
-        .catch((err) => {
-          logger.error({ err }, "Wati webhook processing failed");
-        });
+    queueManager.getQueue(WATI_WEBHOOK_QUEUE_KEY).enqueue(async () => {
+      try {
+        const results = await provider.handleWebhook(payload);
+        logger.debug(
+          {
+            messages: results.filter((result) => result.kind === "message").length,
+            deliveryStatuses: results.filter((result) => result.kind === "delivery_status").length,
+            ignored: results.filter((result) => result.kind === "ignored").length,
+            unrecognized: results.filter((result) => result.kind === "unrecognized").length,
+          },
+          "Wati webhook processed",
+        );
+      } catch (err) {
+        logger.error({ err }, "Wati webhook processing failed");
+      }
     });
 
     return c.json({ ok: true }, 200);

--- a/packages/server/src/api/web-chat.ts
+++ b/packages/server/src/api/web-chat.ts
@@ -47,6 +47,7 @@ import type { QueueManager } from "../queue";
 import type { TaskScheduler } from "../scheduler/service";
 import type { ScheduledTask } from "../scheduler/types";
 import { transcribeAudioFile } from "../transcription/service";
+import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 
 type UserRepo = ReturnType<typeof createUserRepository>;
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
@@ -70,7 +71,12 @@ interface WebChatRouteDeps {
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: QueueManager;
   getSlack?: () => SlackDmResolver | null;
-  sendDm?: (params: { userId: string; platform: string; message: string }) => Promise<{
+  sendDm?: (params: {
+    userId: string;
+    platform: string;
+    message: string;
+    template?: WhatsAppTemplateRequest;
+  }) => Promise<{
     channelId: string;
     messageRef: string;
   }>;

--- a/packages/server/src/api/workflows.ts
+++ b/packages/server/src/api/workflows.ts
@@ -7,16 +7,20 @@ import type { Config } from "../config";
 import type { AgentEnvironmentRuntimeContext } from "../db/repositories/agent-environment-variables";
 import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createConversationRepository } from "../db/repositories/conversations";
 import type { createInboxMessagesRepository } from "../db/repositories/inbox-messages";
 import { type ScheduledTaskRow, createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import { createSettingsRepository } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import type { IntegrationProvider } from "../integrations/types";
 import type { Logger } from "../logger";
+import { createWorkflowDeliveryCapture } from "../scheduler/delivery-capture";
 import type { SlackBot } from "../slack/bot";
 import type { WhatsAppBot } from "../whatsapp/bot";
-import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
+import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
+import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import { isSlackDmChannelId, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
 import { executeAutomation } from "../workflows/runtime";
 
@@ -206,11 +210,31 @@ function createDelivery(task: ScheduledTaskRow, deps: WorkflowRouteDeps) {
     throw new WorkflowApiError("NOT_CONNECTED", "WhatsApp is not connected");
   }
   const delivery: Record<string, unknown> = { mode: "target", platform: "whatsapp", target: resolved.targetId };
+  const capture = deps.whatsappRuntime
+    ? createWorkflowDeliveryCapture({
+        conversations: createConversationRepository(deps.db),
+        settingsRepo: createSettingsRepository(deps.db),
+        logger: deps.logger,
+      })
+    : null;
   return {
     delivery,
     sendMessage: async (text: string) => {
       if (deps.whatsappRuntime) {
-        await deps.whatsappRuntime.sendText(whatsappTargetFromDeliveryTarget(resolved.targetId), text);
+        const target = whatsappTargetFromDeliveryTarget(resolved.targetId);
+        const sent =
+          target.kind === "dm"
+            ? await deps.whatsappRuntime.sendTemplate(target, buildProactiveUpdateTemplate({ messageSummary: text }))
+            : await deps.whatsappRuntime.sendText(target, text);
+        if (sent?.providerMessageId) {
+          delivery.messageRef = sent.providerMessageId;
+          await capture?.captureWhatsApp({
+            deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : resolved.targetId,
+            messageRef: sent.providerMessageId,
+            providerTimestamp: sent.providerTimestamp,
+            text,
+          });
+        }
       } else {
         await deps.whatsapp?.sendText(resolved.targetId, text);
       }

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -33,6 +33,8 @@ import { createMcpServerRepository } from "./db/repositories/mcp-servers";
 import { createSettingsRepository } from "./db/repositories/settings";
 import { createUserRepository } from "./db/repositories/users";
 import { createWhatsAppGroupRepository } from "./db/repositories/whatsapp-groups";
+import { createWhatsAppProviderEventRepository } from "./db/repositories/whatsapp-provider-events";
+import { createWhatsAppTemplateMappingRepository } from "./db/repositories/whatsapp-template-mappings";
 import type { DB } from "./db/schema";
 import { configureMaterializeDefaults } from "./entities/materialize";
 import { createApp } from "./http";
@@ -54,10 +56,11 @@ import { initTelemetry } from "./telemetry/setup";
 import { resolveVisionConfigFromAppConfig } from "./vision/service";
 import { wireWhatsAppHandlers } from "./whatsapp/adapter";
 import { WhatsAppBot } from "./whatsapp/bot";
-import { phoneE164ToWhatsAppJid } from "./whatsapp/provider";
+import { whatsappDeliveryTargetFromTarget } from "./whatsapp/provider";
 import { createBaileysWhatsAppProviders } from "./whatsapp/providers/baileys";
 import { WHATSAPP_WATI_PROVIDER_ID, createWatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import { createWhatsAppRuntime } from "./whatsapp/runtime";
+import type { WhatsAppTemplateRequest } from "./whatsapp/templates";
 
 export interface ServerHandle {
   config: Config;
@@ -126,6 +129,8 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const mcpServersRepo = createMcpServerRepository(db);
   const whatsappGroupsRepo = createWhatsAppGroupRepository(db);
   const conversationsRepo = createConversationRepository(db);
+  const whatsappProviderEventsRepo = createWhatsAppProviderEventRepository(db);
+  const whatsappTemplateMappingsRepo = createWhatsAppTemplateMappingRepository(db);
   const automationRunsRepo = createAutomationRunsRepository(db);
   const stepContentRepo = createAutomationStepContentRepository(db);
   const staleCount = await automationRunsRepo.markRunningAsFailed("Interrupted by server restart");
@@ -240,6 +245,8 @@ export async function createServer(config: Config, options?: CreateServerOptions
           webhookToken: config.WATI_WEBHOOK_TOKEN ?? "",
           channelPhoneNumber: config.WATI_CHANNEL_PHONE_NUMBER,
           logger,
+          providerEvents: whatsappProviderEventsRepo,
+          templateMappings: whatsappTemplateMappingsRepo,
         })
       : null;
   const whatsappRuntime = createWhatsAppRuntime({
@@ -255,10 +262,12 @@ export async function createServer(config: Config, options?: CreateServerOptions
     userId,
     platform,
     message,
+    template,
   }: {
     userId: string;
     platform: string;
     message: string;
+    template?: WhatsAppTemplateRequest;
   }) => {
     const recipient = await users.findById(userId);
 
@@ -280,12 +289,35 @@ export async function createServer(config: Config, options?: CreateServerOptions
 
     if (platform === "whatsapp") {
       if (!recipient?.whatsapp_number) throw new Error("No WhatsApp number for recipient");
-      const channelId = phoneE164ToWhatsAppJid(recipient.whatsapp_number);
-      const sent = await whatsappRuntime.sendText(
-        { kind: "dm", phoneE164: recipient.whatsapp_number, providerConversationId: channelId },
-        message,
-      );
-      return { channelId: sent?.providerConversationId ?? channelId, messageRef: sent?.providerMessageId ?? "" };
+      if (config.WHATSAPP_DM_PROVIDER === WHATSAPP_WATI_PROVIDER_ID && !template) {
+        throw new Error("Wati WhatsApp DMs require an approved template for proactive delivery");
+      }
+
+      const target = { kind: "dm" as const, phoneE164: recipient.whatsapp_number };
+      const channelId = whatsappDeliveryTargetFromTarget(target);
+      const sent = template
+        ? await whatsappRuntime.sendTemplate(target, { ...template, fallbackText: template.fallbackText ?? message })
+        : await whatsappRuntime.sendText(target, message);
+
+      if (sent?.providerMessageId) {
+        const settingsRow = await settingsRepo.get();
+        const conversation = await conversationsRepo.getOrCreate(
+          { platform: "whatsapp", kind: "dm", providerConversationId: channelId },
+          recipient.name,
+        );
+        await conversationsRepo.insertMessage({
+          conversationId: conversation.id,
+          providerMessageId: sent.providerMessageId,
+          senderJid: "bot",
+          senderName: settingsRow?.bot_name ?? "Sketch",
+          isBot: true,
+          addressedToSketch: false,
+          text: message,
+          providerTimestamp: sent.providerTimestamp,
+        });
+      }
+
+      return { channelId, messageRef: sent?.providerMessageId ?? "" };
     }
 
     throw new Error(`Unsupported platform: ${platform}`);

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -114,6 +114,7 @@ import * as m111 from "./migrations/111-settings-embedding-provider";
 import * as m112 from "./migrations/112-agent-output-structured-payload";
 import * as m113 from "./migrations/113-indexed-file-all-day-flag";
 import * as m114 from "./migrations/114-agent-output-deliveries";
+import * as m115 from "./migrations/115-whatsapp-template-mappings-and-provider-events";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -232,6 +233,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "112-agent-output-structured-payload": m112,
           "113-indexed-file-all-day-flag": m113,
           "114-agent-output-deliveries": m114,
+          "115-whatsapp-template-mappings-and-provider-events": m115,
         };
       },
     },

--- a/packages/server/src/db/migrations/115-whatsapp-template-mappings-and-provider-events.ts
+++ b/packages/server/src/db/migrations/115-whatsapp-template-mappings-and-provider-events.ts
@@ -1,0 +1,73 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("whatsapp_provider_events")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("provider", "text", (col) => col.notNull())
+    .addColumn("dedupe_key", "text", (col) => col.notNull())
+    .addColumn("provider_message_id", "text")
+    .addColumn("provider_conversation_id", "text")
+    .addColumn("event_family", "text", (col) => col.notNull())
+    .addColumn("event_type", "text")
+    .addColumn("status", "text")
+    .addColumn("failure_code", "text")
+    .addColumn("failure_detail", "text")
+    .addColumn("provider_timestamp", "text")
+    .addColumn("raw_payload_json", "text")
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createIndex("whatsapp_provider_events_dedupe_uidx")
+    .on("whatsapp_provider_events")
+    .columns(["provider", "dedupe_key"])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex("whatsapp_provider_events_message_idx")
+    .on("whatsapp_provider_events")
+    .columns(["provider", "provider_message_id"])
+    .execute();
+
+  await db.schema
+    .createIndex("whatsapp_provider_events_family_idx")
+    .on("whatsapp_provider_events")
+    .columns(["provider", "event_family", "created_at"])
+    .execute();
+
+  await db.schema
+    .createTable("whatsapp_template_mappings")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("provider", "text", (col) => col.notNull())
+    .addColumn("logical_key", "text", (col) => col.notNull())
+    .addColumn("provider_template_name", "text", (col) => col.notNull())
+    .addColumn("language", "text", (col) => col.notNull().defaultTo("en_US"))
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("approved"))
+    .addColumn("category", "text")
+    .addColumn("parameter_map_json", "text")
+    .addColumn("last_synced_at", "text")
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createIndex("whatsapp_template_mappings_logical_uidx")
+    .on("whatsapp_template_mappings")
+    .columns(["provider", "logical_key", "language"])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex("whatsapp_template_mappings_provider_template_idx")
+    .on("whatsapp_template_mappings")
+    .columns(["provider", "provider_template_name", "language"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("whatsapp_template_mappings").execute();
+  await db.schema.dropTable("whatsapp_provider_events").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 110;
+const EXPECTED_MIGRATION_COUNT = 111;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -143,6 +143,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[107]).toBe("112-agent-output-structured-payload");
     expect(names[108]).toBe("113-indexed-file-all-day-flag");
     expect(names[109]).toBe("114-agent-output-deliveries");
+    expect(names[110]).toBe("115-whatsapp-template-mappings-and-provider-events");
   });
 
   it("running migrations twice is idempotent", async () => {
@@ -458,6 +459,16 @@ describe("runMigrations on Postgres — full sequence", () => {
         WHERE table_schema = 'public' AND table_name = ${sql.lit(table)}
       `.execute(db);
       expect(result.rows).toHaveLength(0);
+    }
+  });
+
+  it("creates WhatsApp provider event and template mapping tables", async () => {
+    for (const table of ["whatsapp_provider_events", "whatsapp_template_mappings"]) {
+      const result = await sql<{ table_name: string }>`
+        SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = ${sql.lit(table)}
+      `.execute(db);
+      expect(result.rows).toHaveLength(1);
     }
   });
 

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 110;
+const EXPECTED_MIGRATION_COUNT = 111;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -166,6 +166,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[107]).toBe("112-agent-output-structured-payload");
     expect(names[108]).toBe("113-indexed-file-all-day-flag");
     expect(names[109]).toBe("114-agent-output-deliveries");
+    expect(names[110]).toBe("115-whatsapp-template-mappings-and-provider-events");
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {
@@ -474,6 +475,17 @@ describe("runMigrations — full sequence", () => {
       SELECT name FROM sqlite_master WHERE type='table' AND name='agent_output_deliveries'
     `.execute(db);
     expect(result.rows).toHaveLength(1);
+  });
+
+  it("creates WhatsApp provider event and template mapping tables", async () => {
+    await runMigrations(db, { quiet: true });
+
+    for (const table of ["whatsapp_provider_events", "whatsapp_template_mappings"]) {
+      const result = await sql<{ name: string }>`
+        SELECT name FROM sqlite_master WHERE type='table' AND name=${sql.lit(table)}
+      `.execute(db);
+      expect(result.rows).toHaveLength(1);
+    }
   });
 
   it("running migrations twice is idempotent (only applies each migration once)", async () => {

--- a/packages/server/src/db/repositories/conversations.integration.test.ts
+++ b/packages/server/src/db/repositories/conversations.integration.test.ts
@@ -413,6 +413,84 @@ function runRepositorySuite(label: string, getDb: () => Promise<Kysely<DB>>, opt
       expect(updated.last_seen_message_id).toBe(message.row.id);
     });
 
+    it("merges legacy conversation rows into an existing canonical provider id", async () => {
+      const repo = createConversationRepository(db);
+      const legacy = await repo.getOrCreate({
+        platform: "whatsapp",
+        kind: "dm",
+        providerConversationId: "wati-conversation-1",
+      });
+      const canonicalRef = {
+        platform: "whatsapp",
+        kind: "dm",
+        providerConversationId: "dm:+1234567890",
+      };
+      const canonical = await repo.getOrCreate(canonicalRef);
+      const legacyMessage = await repo.insertMessage({
+        conversationId: legacy.id,
+        providerMessageId: "legacy-1",
+        senderJid: "1234567890",
+        senderName: "Alice",
+        text: "old context",
+      });
+      await repo.insertMessage({
+        conversationId: legacy.id,
+        providerMessageId: "duplicate",
+        senderJid: "1234567890",
+        senderName: "Alice",
+        text: "legacy duplicate",
+      });
+      const canonicalMessage = await repo.insertMessage({
+        conversationId: canonical.id,
+        providerMessageId: "canonical-1",
+        senderJid: "1234567890",
+        senderName: "Alice",
+        text: "new context",
+      });
+      await repo.insertMessage({
+        conversationId: canonical.id,
+        providerMessageId: "duplicate",
+        senderJid: "1234567890",
+        senderName: "Alice",
+        text: "canonical duplicate",
+      });
+      await repo.updateWatermark(legacy.id, legacyMessage.row.id);
+      await repo.updateWatermark(canonical.id, canonicalMessage.row.id);
+      await repo.updateCursor({
+        conversationId: legacy.id,
+        scopeType: "whatsapp_dm",
+        scopeKey: "default",
+        messageId: legacyMessage.row.id,
+      });
+      await repo.updateCursor({
+        conversationId: canonical.id,
+        scopeType: "whatsapp_dm",
+        scopeKey: "default",
+        messageId: canonicalMessage.row.id,
+      });
+
+      const claimed = await repo.claimProviderConversationId(legacy.id, canonicalRef, "Alice");
+
+      expect(claimed.id).toBe(canonical.id);
+      expect(claimed.provider_conversation_id).toBe("dm:+1234567890");
+      expect(claimed.last_seen_message_id).toBe(legacyMessage.row.id);
+      const legacyRow = await db.selectFrom("conversations").selectAll().where("id", "=", legacy.id).executeTakeFirst();
+      expect(legacyRow).toBeUndefined();
+      const messages = await repo.listMessages(canonical.id, { includeBotMessages: true });
+      expect(messages.messages.map((message) => message.providerMessageId).sort()).toEqual([
+        "canonical-1",
+        "duplicate",
+        "legacy-1",
+      ]);
+      expect(messages.messages.every((message) => message.conversationId === canonical.id)).toBe(true);
+      const cursor = await repo.getCursor({
+        conversationId: canonical.id,
+        scopeType: "whatsapp_dm",
+        scopeKey: "default",
+      });
+      expect(cursor?.last_seen_message_id).toBe(legacyMessage.row.id);
+    });
+
     it("filters backlog by Slack thread id and stores thread metadata", async () => {
       const repo = createConversationRepository(db);
       const conversation = await repo.getOrCreate({

--- a/packages/server/src/db/repositories/conversations.ts
+++ b/packages/server/src/db/repositories/conversations.ts
@@ -193,6 +193,46 @@ export function createConversationRepository(db: Kysely<DB>) {
         .executeTakeFirst();
     },
 
+    async claimProviderConversationId(
+      id: number,
+      ref: ConversationRef,
+      displayName?: string | null,
+    ): Promise<ConversationRow> {
+      const now = new Date().toISOString();
+      const existing = await db
+        .selectFrom("conversations")
+        .selectAll()
+        .where("platform", "=", ref.platform)
+        .where("kind", "=", ref.kind)
+        .where("provider_conversation_id", "=", ref.providerConversationId)
+        .executeTakeFirst();
+      if (existing) return existing;
+
+      try {
+        await db
+          .updateTable("conversations")
+          .set({
+            provider_conversation_id: ref.providerConversationId,
+            ...(displayName !== undefined ? { display_name: displayName } : {}),
+            updated_at: now,
+          })
+          .where("id", "=", id)
+          .execute();
+      } catch {
+        const row = await db
+          .selectFrom("conversations")
+          .selectAll()
+          .where("platform", "=", ref.platform)
+          .where("kind", "=", ref.kind)
+          .where("provider_conversation_id", "=", ref.providerConversationId)
+          .executeTakeFirst();
+        if (row) return row;
+        throw new Error("Failed to claim conversation provider id");
+      }
+
+      return db.selectFrom("conversations").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
+    },
+
     async findMessageByProviderMessageId(
       conversationId: number,
       providerMessageId: string,

--- a/packages/server/src/db/repositories/conversations.ts
+++ b/packages/server/src/db/repositories/conversations.ts
@@ -130,7 +130,143 @@ function rankedToStored(row: RankedConversationMessageRow): SearchConversationMe
   return { ...toStored(row), rank: Number(row.rank) };
 }
 
+function mergeSeenMessageId(left: number | null, right: number | null): number | null {
+  if (left === null || right === null) return null;
+  return Math.min(left, right);
+}
+
 export function createConversationRepository(db: Kysely<DB>) {
+  async function mergeConversationRows(
+    sourceId: number,
+    target: ConversationRow,
+    displayName?: string | null,
+  ): Promise<ConversationRow> {
+    const now = new Date().toISOString();
+    const source = await db.selectFrom("conversations").selectAll().where("id", "=", sourceId).executeTakeFirst();
+    if (!source) return target;
+    if (source.id === target.id) {
+      if (displayName !== undefined && displayName !== target.display_name) {
+        await db
+          .updateTable("conversations")
+          .set({ display_name: displayName, updated_at: now })
+          .where("id", "=", target.id)
+          .execute();
+        return db.selectFrom("conversations").selectAll().where("id", "=", target.id).executeTakeFirstOrThrow();
+      }
+      return target;
+    }
+
+    const sourceMessages = await db
+      .selectFrom("conversation_messages")
+      .select(["id", "provider_message_id", "sender_jid", "is_bot"])
+      .where("conversation_id", "=", source.id)
+      .orderBy("id", "asc")
+      .execute();
+
+    for (const message of sourceMessages) {
+      const duplicate = await db
+        .selectFrom("conversation_messages")
+        .select("id")
+        .where("conversation_id", "=", target.id)
+        .where("provider_message_id", "=", message.provider_message_id)
+        .where("sender_jid", "=", message.sender_jid)
+        .where("is_bot", "=", message.is_bot)
+        .executeTakeFirst();
+
+      if (duplicate) {
+        await db.deleteFrom("conversation_messages").where("id", "=", message.id).execute();
+        continue;
+      }
+
+      try {
+        await db
+          .updateTable("conversation_messages")
+          .set({ conversation_id: target.id })
+          .where("id", "=", message.id)
+          .execute();
+      } catch {
+        const conflicting = await db
+          .selectFrom("conversation_messages")
+          .select("id")
+          .where("conversation_id", "=", target.id)
+          .where("provider_message_id", "=", message.provider_message_id)
+          .where("sender_jid", "=", message.sender_jid)
+          .where("is_bot", "=", message.is_bot)
+          .executeTakeFirst();
+        if (!conflicting) throw new Error("Failed to move legacy conversation message");
+        await db.deleteFrom("conversation_messages").where("id", "=", message.id).execute();
+      }
+    }
+
+    const sourceCursors = await db
+      .selectFrom("conversation_cursors")
+      .selectAll()
+      .where("conversation_id", "=", source.id)
+      .execute();
+
+    for (const cursor of sourceCursors) {
+      const existingCursor = await db
+        .selectFrom("conversation_cursors")
+        .selectAll()
+        .where("conversation_id", "=", target.id)
+        .where("scope_type", "=", cursor.scope_type)
+        .where("scope_key", "=", cursor.scope_key)
+        .executeTakeFirst();
+
+      if (existingCursor) {
+        await db
+          .updateTable("conversation_cursors")
+          .set({
+            last_seen_message_id: mergeSeenMessageId(existingCursor.last_seen_message_id, cursor.last_seen_message_id),
+            updated_at: now,
+          })
+          .where("id", "=", existingCursor.id)
+          .execute();
+        await db.deleteFrom("conversation_cursors").where("id", "=", cursor.id).execute();
+        continue;
+      }
+
+      try {
+        await db
+          .updateTable("conversation_cursors")
+          .set({ conversation_id: target.id, updated_at: now })
+          .where("id", "=", cursor.id)
+          .execute();
+      } catch {
+        const conflicting = await db
+          .selectFrom("conversation_cursors")
+          .selectAll()
+          .where("conversation_id", "=", target.id)
+          .where("scope_type", "=", cursor.scope_type)
+          .where("scope_key", "=", cursor.scope_key)
+          .executeTakeFirst();
+        if (!conflicting) throw new Error("Failed to move legacy conversation cursor");
+        await db
+          .updateTable("conversation_cursors")
+          .set({
+            last_seen_message_id: mergeSeenMessageId(conflicting.last_seen_message_id, cursor.last_seen_message_id),
+            updated_at: now,
+          })
+          .where("id", "=", conflicting.id)
+          .execute();
+        await db.deleteFrom("conversation_cursors").where("id", "=", cursor.id).execute();
+      }
+    }
+
+    await db
+      .updateTable("conversations")
+      .set({
+        ...(displayName !== undefined ? { display_name: displayName } : {}),
+        last_seen_message_id: mergeSeenMessageId(target.last_seen_message_id, source.last_seen_message_id),
+        updated_at: now,
+      })
+      .where("id", "=", target.id)
+      .execute();
+    await db.deleteFrom("conversations").where("id", "=", source.id).execute();
+
+    return db.selectFrom("conversations").selectAll().where("id", "=", target.id).executeTakeFirstOrThrow();
+  }
+
   return {
     async getOrCreate(ref: ConversationRef, displayName?: string | null): Promise<ConversationRow> {
       const existing = await db
@@ -206,7 +342,7 @@ export function createConversationRepository(db: Kysely<DB>) {
         .where("kind", "=", ref.kind)
         .where("provider_conversation_id", "=", ref.providerConversationId)
         .executeTakeFirst();
-      if (existing) return existing;
+      if (existing) return mergeConversationRows(id, existing, displayName);
 
       try {
         await db
@@ -226,7 +362,7 @@ export function createConversationRepository(db: Kysely<DB>) {
           .where("kind", "=", ref.kind)
           .where("provider_conversation_id", "=", ref.providerConversationId)
           .executeTakeFirst();
-        if (row) return row;
+        if (row) return mergeConversationRows(id, row, displayName);
         throw new Error("Failed to claim conversation provider id");
       }
 

--- a/packages/server/src/db/repositories/whatsapp-provider-events.ts
+++ b/packages/server/src/db/repositories/whatsapp-provider-events.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from "node:crypto";
+import type { Insertable, Kysely, Selectable } from "kysely";
+import type { DB, WhatsAppProviderEventsTable } from "../schema";
+
+export type WhatsAppProviderEventRow = Selectable<WhatsAppProviderEventsTable>;
+
+export interface WhatsAppProviderEventInput {
+  provider: string;
+  providerMessageId?: string | null;
+  providerConversationId?: string | null;
+  eventType?: string | null;
+  status?: string | null;
+  failureCode?: string | null;
+  failureDetail?: string | null;
+  providerTimestamp?: string | null;
+  rawProviderPayload?: unknown;
+}
+
+export function normalizeWhatsAppProviderEventFamily(input: {
+  eventType?: string | null;
+  status?: string | null;
+}): string {
+  const status =
+    input.status
+      ?.trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gu, "_") ?? "";
+  const eventType =
+    input.eventType
+      ?.trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gu, "_") ?? "";
+  const combined = `${eventType}:${status}`;
+
+  if (combined.includes("failed") || combined.includes("fail")) return "failed";
+  if (combined.includes("read")) return "read";
+  if (combined.includes("delivered")) return "delivered";
+  if (combined.includes("replied")) return "replied";
+  if (combined.includes("sent")) return "sent";
+  return status || eventType || "unknown";
+}
+
+export function createWhatsAppProviderEventRepository(db: Kysely<DB>) {
+  async function findByDedupeKey(provider: string, dedupeKey: string): Promise<WhatsAppProviderEventRow | undefined> {
+    return db
+      .selectFrom("whatsapp_provider_events")
+      .selectAll()
+      .where("provider", "=", provider)
+      .where("dedupe_key", "=", dedupeKey)
+      .executeTakeFirst();
+  }
+
+  return {
+    async upsertDeliveryStatus(
+      input: WhatsAppProviderEventInput,
+    ): Promise<{ row: WhatsAppProviderEventRow; inserted: boolean }> {
+      const eventFamily = normalizeWhatsAppProviderEventFamily(input);
+      const providerMessageId = input.providerMessageId ?? null;
+      const fallbackId = input.providerConversationId ?? input.providerTimestamp ?? input.eventType ?? "unknown";
+      const dedupeKey = `${providerMessageId ?? fallbackId}:${eventFamily}`;
+      const rawPayloadJson =
+        input.rawProviderPayload === undefined ? null : JSON.stringify(input.rawProviderPayload).slice(0, 100_000);
+      const now = new Date().toISOString();
+
+      const existing = await findByDedupeKey(input.provider, dedupeKey);
+      if (existing) {
+        await db
+          .updateTable("whatsapp_provider_events")
+          .set({
+            provider_message_id: providerMessageId,
+            provider_conversation_id: input.providerConversationId ?? null,
+            event_type: input.eventType ?? null,
+            status: input.status ?? null,
+            failure_code: input.failureCode ?? null,
+            failure_detail: input.failureDetail ?? null,
+            provider_timestamp: input.providerTimestamp ?? null,
+            raw_payload_json: rawPayloadJson,
+            updated_at: now,
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        return {
+          row: await db
+            .selectFrom("whatsapp_provider_events")
+            .selectAll()
+            .where("id", "=", existing.id)
+            .executeTakeFirstOrThrow(),
+          inserted: false,
+        };
+      }
+
+      const values: Insertable<WhatsAppProviderEventsTable> = {
+        id: randomUUID(),
+        provider: input.provider,
+        dedupe_key: dedupeKey,
+        provider_message_id: providerMessageId,
+        provider_conversation_id: input.providerConversationId ?? null,
+        event_family: eventFamily,
+        event_type: input.eventType ?? null,
+        status: input.status ?? null,
+        failure_code: input.failureCode ?? null,
+        failure_detail: input.failureDetail ?? null,
+        provider_timestamp: input.providerTimestamp ?? null,
+        raw_payload_json: rawPayloadJson,
+      };
+
+      try {
+        await db.insertInto("whatsapp_provider_events").values(values).execute();
+        return {
+          row: await db
+            .selectFrom("whatsapp_provider_events")
+            .selectAll()
+            .where("id", "=", values.id)
+            .executeTakeFirstOrThrow(),
+          inserted: true,
+        };
+      } catch {
+        const row = await findByDedupeKey(input.provider, dedupeKey);
+        if (row) return { row, inserted: false };
+        throw new Error("Failed to record WhatsApp provider event");
+      }
+    },
+
+    async listRecent(provider?: string, limit = 50): Promise<WhatsAppProviderEventRow[]> {
+      let query = db.selectFrom("whatsapp_provider_events").selectAll();
+      if (provider) query = query.where("provider", "=", provider);
+      return query
+        .orderBy("created_at", "desc")
+        .limit(Math.max(1, Math.min(limit, 200)))
+        .execute();
+    },
+  };
+}

--- a/packages/server/src/db/repositories/whatsapp-template-mappings.ts
+++ b/packages/server/src/db/repositories/whatsapp-template-mappings.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+import type { Insertable, Kysely, Selectable } from "kysely";
+import type { DB, WhatsAppTemplateMappingsTable } from "../schema";
+
+export const DEFAULT_WHATSAPP_TEMPLATE_LANGUAGE = "en_US";
+
+export type WhatsAppTemplateMappingRow = Selectable<WhatsAppTemplateMappingsTable>;
+
+export interface WhatsAppTemplateMappingInput {
+  provider: string;
+  logicalKey: string;
+  providerTemplateName: string;
+  language?: string | null;
+  status?: string | null;
+  category?: string | null;
+  parameterMap?: Record<string, string> | null;
+}
+
+export interface ProviderTemplateSummary {
+  providerTemplateName: string;
+  language: string;
+  status: string | null;
+  category: string | null;
+  rawProviderPayload?: unknown;
+}
+
+function normalizeLanguage(value: string | null | undefined): string {
+  return value?.trim() || DEFAULT_WHATSAPP_TEMPLATE_LANGUAGE;
+}
+
+function normalizeStatus(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() || "approved";
+}
+
+function parseParameterMap(value: string | null): Record<string, string> | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const entries = Object.entries(parsed).filter(
+      (entry): entry is [string, string] => typeof entry[0] === "string" && typeof entry[1] === "string",
+    );
+    return Object.fromEntries(entries);
+  } catch {
+    return null;
+  }
+}
+
+function toMapping(row: WhatsAppTemplateMappingRow) {
+  return {
+    ...row,
+    parameterMap: parseParameterMap(row.parameter_map_json),
+  };
+}
+
+export function createWhatsAppTemplateMappingRepository(db: Kysely<DB>) {
+  async function findByLogicalKey(provider: string, logicalKey: string, language: string) {
+    return db
+      .selectFrom("whatsapp_template_mappings")
+      .selectAll()
+      .where("provider", "=", provider)
+      .where("logical_key", "=", logicalKey)
+      .where("language", "=", language)
+      .executeTakeFirst();
+  }
+
+  return {
+    async upsertMapping(input: WhatsAppTemplateMappingInput): Promise<WhatsAppTemplateMappingRow> {
+      const language = normalizeLanguage(input.language);
+      const now = new Date().toISOString();
+      const parameterMapJson = input.parameterMap ? JSON.stringify(input.parameterMap) : null;
+      const existing = await findByLogicalKey(input.provider, input.logicalKey, language);
+
+      if (existing) {
+        await db
+          .updateTable("whatsapp_template_mappings")
+          .set({
+            provider_template_name: input.providerTemplateName,
+            status: normalizeStatus(input.status),
+            category: input.category ?? null,
+            parameter_map_json: parameterMapJson,
+            updated_at: now,
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        return db
+          .selectFrom("whatsapp_template_mappings")
+          .selectAll()
+          .where("id", "=", existing.id)
+          .executeTakeFirstOrThrow();
+      }
+
+      const values: Insertable<WhatsAppTemplateMappingsTable> = {
+        id: randomUUID(),
+        provider: input.provider,
+        logical_key: input.logicalKey,
+        provider_template_name: input.providerTemplateName,
+        language,
+        status: normalizeStatus(input.status),
+        category: input.category ?? null,
+        parameter_map_json: parameterMapJson,
+        last_synced_at: null,
+      };
+
+      try {
+        await db.insertInto("whatsapp_template_mappings").values(values).execute();
+      } catch {
+        const row = await findByLogicalKey(input.provider, input.logicalKey, language);
+        if (row) return row;
+        throw new Error("Failed to upsert WhatsApp template mapping");
+      }
+
+      return db
+        .selectFrom("whatsapp_template_mappings")
+        .selectAll()
+        .where("id", "=", values.id)
+        .executeTakeFirstOrThrow();
+    },
+
+    async findApprovedMapping(
+      provider: string,
+      logicalKey: string,
+      language?: string | null,
+    ): Promise<(WhatsAppTemplateMappingRow & { parameterMap: Record<string, string> | null }) | null> {
+      const requestedLanguage = language ? normalizeLanguage(language) : null;
+      let query = db
+        .selectFrom("whatsapp_template_mappings")
+        .selectAll()
+        .where("provider", "=", provider)
+        .where("logical_key", "=", logicalKey)
+        .where("status", "=", "approved");
+      if (requestedLanguage) query = query.where("language", "=", requestedLanguage);
+
+      const exact = await query.orderBy("updated_at", "desc").executeTakeFirst();
+      if (exact) return toMapping(exact);
+      if (requestedLanguage) return null;
+
+      const fallback = await db
+        .selectFrom("whatsapp_template_mappings")
+        .selectAll()
+        .where("provider", "=", provider)
+        .where("logical_key", "=", logicalKey)
+        .where("language", "=", DEFAULT_WHATSAPP_TEMPLATE_LANGUAGE)
+        .where("status", "=", "approved")
+        .orderBy("updated_at", "desc")
+        .executeTakeFirst();
+      return fallback ? toMapping(fallback) : null;
+    },
+
+    async listMappings(provider?: string): Promise<WhatsAppTemplateMappingRow[]> {
+      let query = db.selectFrom("whatsapp_template_mappings").selectAll();
+      if (provider) query = query.where("provider", "=", provider);
+      return query.orderBy("provider", "asc").orderBy("logical_key", "asc").orderBy("language", "asc").execute();
+    },
+
+    async syncProviderTemplates(provider: string, templates: ProviderTemplateSummary[]): Promise<number> {
+      let updated = 0;
+      const now = new Date().toISOString();
+
+      for (const template of templates) {
+        const rows = await db
+          .selectFrom("whatsapp_template_mappings")
+          .select(["id"])
+          .where("provider", "=", provider)
+          .where("provider_template_name", "=", template.providerTemplateName)
+          .where("language", "=", normalizeLanguage(template.language))
+          .execute();
+
+        for (const row of rows) {
+          await db
+            .updateTable("whatsapp_template_mappings")
+            .set({
+              status: normalizeStatus(template.status),
+              category: template.category ?? null,
+              last_synced_at: now,
+              updated_at: now,
+            })
+            .where("id", "=", row.id)
+            .execute();
+          updated += 1;
+        }
+      }
+
+      return updated;
+    },
+  };
+}

--- a/packages/server/src/db/repositories/whatsapp-template-mappings.ts
+++ b/packages/server/src/db/repositories/whatsapp-template-mappings.ts
@@ -122,29 +122,17 @@ export function createWhatsAppTemplateMappingRepository(db: Kysely<DB>) {
       logicalKey: string,
       language?: string | null,
     ): Promise<(WhatsAppTemplateMappingRow & { parameterMap: Record<string, string> | null }) | null> {
-      const requestedLanguage = language ? normalizeLanguage(language) : null;
-      let query = db
+      const requestedLanguage = normalizeLanguage(language);
+      const exact = await db
         .selectFrom("whatsapp_template_mappings")
         .selectAll()
         .where("provider", "=", provider)
         .where("logical_key", "=", logicalKey)
-        .where("status", "=", "approved");
-      if (requestedLanguage) query = query.where("language", "=", requestedLanguage);
-
-      const exact = await query.orderBy("updated_at", "desc").executeTakeFirst();
-      if (exact) return toMapping(exact);
-      if (requestedLanguage) return null;
-
-      const fallback = await db
-        .selectFrom("whatsapp_template_mappings")
-        .selectAll()
-        .where("provider", "=", provider)
-        .where("logical_key", "=", logicalKey)
-        .where("language", "=", DEFAULT_WHATSAPP_TEMPLATE_LANGUAGE)
+        .where("language", "=", requestedLanguage)
         .where("status", "=", "approved")
         .orderBy("updated_at", "desc")
         .executeTakeFirst();
-      return fallback ? toMapping(fallback) : null;
+      return exact ? toMapping(exact) : null;
     },
 
     async listMappings(provider?: string): Promise<WhatsAppTemplateMappingRow[]> {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -574,6 +574,37 @@ export interface AgentOutputDeliveriesTable {
   updated_at: Generated<string>;
 }
 
+export interface WhatsAppProviderEventsTable {
+  id: string;
+  provider: string;
+  dedupe_key: string;
+  provider_message_id: string | null;
+  provider_conversation_id: string | null;
+  event_family: string;
+  event_type: string | null;
+  status: string | null;
+  failure_code: string | null;
+  failure_detail: string | null;
+  provider_timestamp: string | null;
+  raw_payload_json: string | null;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
+export interface WhatsAppTemplateMappingsTable {
+  id: string;
+  provider: string;
+  logical_key: string;
+  provider_template_name: string;
+  language: Generated<string>;
+  status: Generated<string>;
+  category: string | null;
+  parameter_map_json: string | null;
+  last_synced_at: string | null;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
 export interface AgentUserConfigsTable {
   agent_key: string;
   user_id: string;
@@ -926,6 +957,8 @@ export interface DB {
   agent_outputs: AgentOutputsTable;
   agent_output_items: AgentOutputItemsTable;
   agent_output_deliveries: AgentOutputDeliveriesTable;
+  whatsapp_provider_events: WhatsAppProviderEventsTable;
+  whatsapp_template_mappings: WhatsAppTemplateMappingsTable;
   agent_user_configs: AgentUserConfigsTable;
   inbox_messages: InboxMessagesTable;
   entities: EntitiesTable;

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -55,6 +55,7 @@ import { createInboxMessagesRepository } from "./db/repositories/inbox-messages"
 import { createMcpServerRepository } from "./db/repositories/mcp-servers";
 import { createProviderIdentityRepository } from "./db/repositories/provider-identities";
 import { createSettingsRepository } from "./db/repositories/settings";
+import { createWhatsAppTemplateMappingRepository } from "./db/repositories/whatsapp-template-mappings";
 
 import type { McpServerConfig, RunAgentParams, RunAgentResult } from "./agent/runner";
 import { agentRoutes, dailyBriefRoutes } from "./agents/routes";
@@ -80,6 +81,8 @@ import type { WhatsAppBot } from "./whatsapp/bot";
 import { phoneE164ToWhatsAppJid } from "./whatsapp/provider";
 import type { WatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import type { WhatsAppRuntime } from "./whatsapp/runtime";
+import { buildMagicLinkTemplate } from "./whatsapp/templates";
+import type { WhatsAppTemplateRequest } from "./whatsapp/templates";
 
 interface AppDeps {
   whatsapp?: WhatsAppBot;
@@ -100,7 +103,12 @@ interface AppDeps {
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: QueueManager;
-  sendDm?: (params: { userId: string; platform: string; message: string }) => Promise<{
+  sendDm?: (params: {
+    userId: string;
+    platform: string;
+    message: string;
+    template?: WhatsAppTemplateRequest;
+  }) => Promise<{
     channelId: string;
     messageRef: string;
   }>;
@@ -117,6 +125,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   const channels = createChannelRepository(db);
   const whatsappGroups = createWhatsAppGroupRepository(db);
   const conversations = createConversationRepository(db);
+  const whatsappTemplateMappings = createWhatsAppTemplateMappingRepository(db);
   const inboxMessages = createInboxMessagesRepository(db);
   const connectors = createConnectorRepository(db, config.ENCRYPTION_KEY);
   const entityRepo = createEntityRepository(db);
@@ -196,8 +205,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     });
   }
 
-  if (deps?.watiWebhook) {
-    app.route("/whatsapp/wati", watiWebhookRoutes(deps.watiWebhook, logger));
+  if (deps?.watiWebhook && deps.queueManager) {
+    app.route("/whatsapp/wati", watiWebhookRoutes(deps.watiWebhook, deps.queueManager, logger));
   }
 
   app.use(
@@ -258,13 +267,35 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       }
     }
 
-    if (deps?.whatsappRuntime && user.whatsapp_number) {
+    if (deps?.sendDm && user.whatsapp_number) {
       try {
-        const channelId = phoneE164ToWhatsAppJid(user.whatsapp_number);
         const text = `Here's your sign-in link for ${botName}:\n${magicLinkUrl}\n\nThis link expires in 15 minutes and can only be used once.`;
-        await deps.whatsappRuntime.sendText(
-          { kind: "dm", phoneE164: user.whatsapp_number, providerConversationId: channelId },
-          text,
+        await deps.sendDm({
+          userId: user.id,
+          platform: "whatsapp",
+          message: text,
+          template: buildMagicLinkTemplate({
+            recipientName: user.name,
+            botName,
+            magicLinkUrl,
+            fallbackText: text,
+          }),
+        });
+        channels.push("whatsapp");
+      } catch (err) {
+        logger.warn({ err }, "Failed to send magic link via WhatsApp");
+      }
+    } else if (deps?.whatsappRuntime && user.whatsapp_number) {
+      try {
+        const text = `Here's your sign-in link for ${botName}:\n${magicLinkUrl}\n\nThis link expires in 15 minutes and can only be used once.`;
+        await deps.whatsappRuntime.sendTemplate(
+          { kind: "dm", phoneE164: user.whatsapp_number },
+          buildMagicLinkTemplate({
+            recipientName: user.name,
+            botName,
+            magicLinkUrl,
+            fallbackText: text,
+          }),
         );
         channels.push("whatsapp");
       } catch (err) {
@@ -395,6 +426,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     "/api/channels",
     channelRoutes({
       whatsapp: deps?.whatsapp,
+      watiProvider: deps?.watiWebhook,
+      whatsappTemplateMappings,
       getSlack: deps?.getSlack,
       whatsappGroups,
       onSlackDisconnect: deps?.onSlackDisconnect,

--- a/packages/server/src/scheduler/delivery-capture.ts
+++ b/packages/server/src/scheduler/delivery-capture.ts
@@ -1,6 +1,7 @@
 import type { createConversationRepository } from "../db/repositories/conversations";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { Logger } from "../logger";
+import { canonicalDmConversationId, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 
 export interface WorkflowDeliveryCaptureDeps {
   conversations: ReturnType<typeof createConversationRepository>;
@@ -36,6 +37,16 @@ export function providerTimestampFromWhatsApp(message: { messageTimestamp?: unkn
 }
 
 export function createWorkflowDeliveryCapture(deps: WorkflowDeliveryCaptureDeps) {
+  function whatsappConversationRef(deliveryTarget: string) {
+    if (deliveryTarget.endsWith("@g.us")) {
+      return { platform: "whatsapp", kind: "group", providerConversationId: deliveryTarget };
+    }
+
+    const target = whatsappTargetFromDeliveryTarget(deliveryTarget);
+    const providerConversationId = target.kind === "dm" ? canonicalDmConversationId(target.phoneE164) : target.groupId;
+    return { platform: "whatsapp", kind: "dm", providerConversationId };
+  }
+
   async function getBotName(): Promise<string> {
     try {
       const settings = await deps.settingsRepo.get();
@@ -73,11 +84,7 @@ export function createWorkflowDeliveryCapture(deps: WorkflowDeliveryCaptureDeps)
 
     async captureWhatsApp(params: WhatsAppDeliveryCaptureParams): Promise<void> {
       try {
-        const conversation = await deps.conversations.getOrCreate({
-          platform: "whatsapp",
-          kind: params.deliveryTarget.endsWith("@g.us") ? "group" : "dm",
-          providerConversationId: params.deliveryTarget,
-        });
+        const conversation = await deps.conversations.getOrCreate(whatsappConversationRef(params.deliveryTarget));
         await deps.conversations.insertMessage({
           conversationId: conversation.id,
           providerMessageId: params.messageRef,

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -86,6 +86,11 @@ function buildMockWhatsApp(connected = true) {
       providerConversationId: "5511999999999@s.whatsapp.net",
       providerTimestamp: "2024-06-04T10:00:00.000Z",
     }),
+    sendTemplate: vi.fn().mockResolvedValue({
+      providerMessageId: "wa-template-1",
+      providerConversationId: "dm:+5511999999999",
+      providerTimestamp: "2024-06-04T10:00:00.000Z",
+    }),
     get isConnected() {
       return connected;
     },
@@ -845,7 +850,7 @@ describe("executeTask() delivery routing", () => {
     );
   });
 
-  it("WhatsApp: sendMessage calls sendText", async () => {
+  it("WhatsApp DM: sendMessage calls sendTemplate", async () => {
     const deps = buildDeps(db);
     const scheduler = new TaskScheduler(deps as never);
 
@@ -861,13 +866,17 @@ describe("executeTask() delivery routing", () => {
 
     await lastExecuteAutomationParams?.sendMessage?.("WhatsApp message");
 
-    expect((deps._whatsapp as ReturnType<typeof buildMockWhatsApp>).sendText).toHaveBeenCalledWith(
+    expect((deps._whatsapp as ReturnType<typeof buildMockWhatsApp>).sendText).not.toHaveBeenCalled();
+    expect((deps._whatsapp as ReturnType<typeof buildMockWhatsApp>).sendTemplate).toHaveBeenCalledWith(
       {
         kind: "dm",
         phoneE164: "+5511999999999",
         providerConversationId: "5511999999999@s.whatsapp.net",
       },
-      "WhatsApp message",
+      expect.objectContaining({
+        key: "whatsapp.proactive_update",
+        params: expect.objectContaining({ messageSummary: "WhatsApp message" }),
+      }),
     );
 
     const captured = await db
@@ -886,8 +895,8 @@ describe("executeTask() delivery routing", () => {
     expect(captured).toMatchObject({
       platform: "whatsapp",
       kind: "dm",
-      provider_conversation_id: "5511999999999@s.whatsapp.net",
-      provider_message_id: "wa-message-1",
+      provider_conversation_id: "dm:+5511999999999",
+      provider_message_id: "wa-template-1",
       sender_jid: "bot",
       is_bot: 1,
       text: "WhatsApp message",

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -33,8 +33,9 @@ import type { Logger } from "../logger";
 import type { QueueManager } from "../queue";
 import type { SlackBot } from "../slack/bot";
 import type { RecordWorkflowStep } from "../telemetry/agent-run-telemetry";
-import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
+import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
+import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import { isSlackDmChannelId, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
 import { type AutomationExecutionResult, executeAutomation } from "../workflows/runtime";
 import { testAutomationStep } from "../workflows/runtime";
@@ -303,11 +304,21 @@ export class TaskScheduler {
     }
 
     return async (text) => {
-      const sent = await whatsapp.sendText(whatsappTargetFromDeliveryTarget(delivery.targetId), text);
+      const target = whatsappTargetFromDeliveryTarget(delivery.targetId);
+      const sent =
+        target.kind === "dm"
+          ? await whatsapp.sendTemplate(
+              target,
+              buildProactiveUpdateTemplate({
+                botName: (await this.deps.settingsRepo.get())?.bot_name,
+                messageSummary: text,
+              }),
+            )
+          : await whatsapp.sendText(target, text);
       const messageRef = sent?.providerMessageId;
       if (!messageRef) return;
       await this.deliveryCapture.captureWhatsApp({
-        deliveryTarget: delivery.targetId,
+        deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : delivery.targetId,
         messageRef,
         providerTimestamp: sent.providerTimestamp,
         text,

--- a/packages/server/src/whatsapp/adapter.isolated.test.ts
+++ b/packages/server/src/whatsapp/adapter.isolated.test.ts
@@ -564,6 +564,81 @@ describe("whatsapp/adapter", () => {
       expect(deps.runAgent).toHaveBeenCalledOnce();
     });
 
+    it("claims all matching legacy Wati DM conversations before capturing", async () => {
+      const legacyWatiConversation = {
+        id: 42,
+        platform: "whatsapp",
+        kind: "dm",
+        provider_conversation_id: "wati-conversation-1",
+        display_name: "Alice",
+        last_seen_message_id: null,
+        created_at: "2025-01-01",
+        updated_at: "2025-01-01",
+      };
+      const legacyJidConversation = {
+        ...legacyWatiConversation,
+        id: 43,
+        provider_conversation_id: "1234567890@s.whatsapp.net",
+      };
+      const canonicalConversation = {
+        ...legacyWatiConversation,
+        id: 99,
+        provider_conversation_id: "dm:+1234567890",
+      };
+      const deps = makeDeps();
+      const claimedLegacyIds = new Set<number>();
+      vi.mocked(deps.repos.conversations.find).mockImplementation(async (ref) => {
+        if (ref.providerConversationId === "wati-conversation-1" && !claimedLegacyIds.has(42)) {
+          return legacyWatiConversation;
+        }
+        if (ref.providerConversationId === "1234567890@s.whatsapp.net" && !claimedLegacyIds.has(43)) {
+          return legacyJidConversation;
+        }
+        return undefined;
+      });
+      vi.mocked(deps.repos.conversations.claimProviderConversationId).mockImplementation(async (id) => {
+        claimedLegacyIds.add(id);
+        return canonicalConversation;
+      });
+      vi.mocked(deps.repos.conversations.getOrCreate).mockResolvedValue(canonicalConversation);
+      const { mock, getHandler } = createMockWhatsApp();
+      wireWhatsAppHandlers(mock as never, deps);
+      const handler = getHandler();
+
+      await handler({
+        kind: "dm" as const,
+        providerId: "wati",
+        providerMessageId: "wamid.legacy-all",
+        providerConversationId: "wati-conversation-1",
+        canonicalConversationId: "dm:+1234567890",
+        providerTimestamp: "2026-07-01T00:00:00.000Z",
+        senderName: "Alice",
+        senderProviderId: "1234567890@s.whatsapp.net",
+        senderPhoneE164: "+1234567890",
+        target: { kind: "dm" as const, phoneE164: "+1234567890" },
+        text: "hello",
+      });
+      await flush();
+
+      expect(deps.repos.conversations.claimProviderConversationId).toHaveBeenCalledTimes(2);
+      expect(deps.repos.conversations.claimProviderConversationId).toHaveBeenNthCalledWith(
+        1,
+        42,
+        { platform: "whatsapp", kind: "dm", providerConversationId: "dm:+1234567890" },
+        "Alice",
+      );
+      expect(deps.repos.conversations.claimProviderConversationId).toHaveBeenNthCalledWith(
+        2,
+        43,
+        { platform: "whatsapp", kind: "dm", providerConversationId: "dm:+1234567890" },
+        "Alice",
+      );
+      expect(deps.repos.conversations.insertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: 99, providerMessageId: "wamid.legacy-all" }),
+      );
+      expect(deps.runAgent).toHaveBeenCalledOnce();
+    });
+
     it("starts and stops composing indicator", async () => {
       const deps = makeDeps();
       const { mock, getHandler } = createMockWhatsApp();

--- a/packages/server/src/whatsapp/adapter.isolated.test.ts
+++ b/packages/server/src/whatsapp/adapter.isolated.test.ts
@@ -271,7 +271,8 @@ function makeDeps(overrides: Partial<WhatsAppAdapterDeps> = {}): WhatsAppAdapter
         updateWatermark: vi.fn().mockResolvedValue(conversationRow),
         advanceWatermarkToCurrentMax: vi.fn().mockResolvedValue(conversationRow),
         getMaxMessageId: vi.fn().mockResolvedValue(null),
-        find: vi.fn().mockResolvedValue(conversationRow),
+        find: vi.fn().mockResolvedValue(undefined),
+        claimProviderConversationId: vi.fn().mockResolvedValue(conversationRow),
       } as unknown as WhatsAppAdapterDeps["repos"]["conversations"],
     },
     queue: new QueueManager(),
@@ -504,6 +505,62 @@ describe("whatsapp/adapter", () => {
       await flush();
 
       expect(persistedUserMessageCount).toBe(1);
+      expect(deps.runAgent).toHaveBeenCalledOnce();
+    });
+
+    it("claims legacy Wati DM conversations before capturing canonical inbound messages", async () => {
+      const legacyConversation = {
+        id: 42,
+        platform: "whatsapp",
+        kind: "dm",
+        provider_conversation_id: "wati-conversation-1",
+        display_name: "Alice",
+        last_seen_message_id: null,
+        created_at: "2025-01-01",
+        updated_at: "2025-01-01",
+      };
+      const canonicalConversation = {
+        ...legacyConversation,
+        provider_conversation_id: "dm:+1234567890",
+      };
+      const deps = makeDeps();
+      let legacyClaimed = false;
+      vi.mocked(deps.repos.conversations.find).mockImplementation(async (ref) => {
+        if (!legacyClaimed && ref.providerConversationId === "wati-conversation-1") return legacyConversation;
+        return undefined;
+      });
+      vi.mocked(deps.repos.conversations.claimProviderConversationId).mockImplementation(async () => {
+        legacyClaimed = true;
+        return canonicalConversation;
+      });
+      vi.mocked(deps.repos.conversations.getOrCreate).mockResolvedValue(canonicalConversation);
+      const { mock, getHandler } = createMockWhatsApp();
+      wireWhatsAppHandlers(mock as never, deps);
+      const handler = getHandler();
+
+      await handler({
+        kind: "dm" as const,
+        providerId: "wati",
+        providerMessageId: "wamid.legacy",
+        providerConversationId: "wati-conversation-1",
+        canonicalConversationId: "dm:+1234567890",
+        providerTimestamp: "2026-07-01T00:00:00.000Z",
+        senderName: "Alice",
+        senderProviderId: "1234567890",
+        senderPhoneE164: "+1234567890",
+        target: { kind: "dm" as const, phoneE164: "+1234567890" },
+        text: "hello",
+      });
+      await flush();
+
+      expect(deps.repos.conversations.claimProviderConversationId).toHaveBeenCalledWith(
+        42,
+        { platform: "whatsapp", kind: "dm", providerConversationId: "dm:+1234567890" },
+        "Alice",
+      );
+      expect(deps.repos.conversations.insertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: 42, providerMessageId: "wamid.legacy" }),
+      );
       expect(deps.runAgent).toHaveBeenCalledOnce();
     });
 

--- a/packages/server/src/whatsapp/adapter.isolated.test.ts
+++ b/packages/server/src/whatsapp/adapter.isolated.test.ts
@@ -103,6 +103,11 @@ function createMockWhatsApp(connected = true) {
         );
         return [attachment];
       }),
+      sendTemplate: vi.fn(async (target: WhatsAppTarget) => ({
+        providerMessageId: "sent-template-1",
+        providerConversationId: targetId(target),
+        providerTimestamp: null,
+      })),
       getGroupMetadata: vi.fn().mockResolvedValue({ subject: "Test Group", desc: "A test group" }),
       getGroupName: vi.fn().mockResolvedValue("Test Group"),
       resolveJidToPhone: vi.fn().mockResolvedValue(null),
@@ -449,6 +454,57 @@ describe("whatsapp/adapter", () => {
       expect(agentCall.userMessage).toContain("hello");
       expect(agentCall.platform).toBe("whatsapp");
       expect(agentCall.userName).toBe("Alice");
+    });
+
+    it("does not persist or run duplicate Wati DM retries", async () => {
+      const deps = makeDeps();
+      const insertMessage = vi.mocked(deps.repos.conversations.insertMessage);
+      const originalInsert = insertMessage.getMockImplementation();
+      if (!originalInsert) throw new Error("expected insertMessage mock");
+      const persistedUserMessages = new Map<string, unknown>();
+      let persistedUserMessageCount = 0;
+      insertMessage.mockImplementation(async (data) => {
+        const dedupeKey = [
+          data.conversationId,
+          data.providerMessageId,
+          data.senderJid ?? "",
+          data.isBot ? "bot" : "user",
+        ].join(":");
+        if (!data.isBot && persistedUserMessages.has(dedupeKey)) {
+          return { row: persistedUserMessages.get(dedupeKey) as never, inserted: false };
+        }
+
+        const result = await originalInsert(data);
+        if (!data.isBot) {
+          persistedUserMessages.set(dedupeKey, result.row);
+          persistedUserMessageCount += 1;
+        }
+        return result;
+      });
+
+      const { mock, getHandler } = createMockWhatsApp();
+      wireWhatsAppHandlers(mock as never, deps);
+      const handler = getHandler();
+      const message = {
+        kind: "dm" as const,
+        providerId: "wati",
+        providerMessageId: "wamid.retry",
+        providerConversationId: "wati-conversation-1",
+        canonicalConversationId: "dm:+1234567890",
+        providerTimestamp: "2026-07-01T00:00:00.000Z",
+        senderName: "Alice",
+        senderProviderId: "1234567890",
+        senderPhoneE164: "+1234567890",
+        target: { kind: "dm" as const, phoneE164: "+1234567890" },
+        text: "hello",
+      };
+
+      await handler(message);
+      await handler(message);
+      await flush();
+
+      expect(persistedUserMessageCount).toBe(1);
+      expect(deps.runAgent).toHaveBeenCalledOnce();
     });
 
     it("starts and stops composing indicator", async () => {

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -45,6 +45,7 @@ import {
   whatsappDeliveryTargetFromTarget,
 } from "./provider";
 import type { WhatsAppRuntime } from "./runtime";
+import type { WhatsAppTemplateRequest } from "./templates";
 import { phoneToTimezone } from "./timezone";
 
 type UserRepository = ReturnType<typeof createUserRepository>;
@@ -85,7 +86,12 @@ export interface WhatsAppAdapterDeps {
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   inboxMessagesRepo?: InboxMessagesRepository;
-  sendDm: (params: { userId: string; platform: string; message: string }) => Promise<{
+  sendDm: (params: {
+    userId: string;
+    platform: string;
+    message: string;
+    template?: WhatsAppTemplateRequest;
+  }) => Promise<{
     channelId: string;
     messageRef: string;
   }>;
@@ -136,7 +142,7 @@ function conversationRefForMessage(message: WhatsAppInboundMessage): {
   providerConversationId: string;
 } {
   if (message.kind === "dm") {
-    return { platform: "whatsapp", kind: "dm", providerConversationId: message.providerConversationId };
+    return { platform: "whatsapp", kind: "dm", providerConversationId: message.canonicalConversationId };
   }
   return { platform: "whatsapp", kind: "group", providerConversationId: message.target.groupId };
 }

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -42,6 +42,7 @@ import {
   type WhatsAppInboundMessage,
   type WhatsAppSendResult,
   type WhatsAppTarget,
+  phoneE164ToWhatsAppJid,
   whatsappDeliveryTargetFromTarget,
 } from "./provider";
 import type { WhatsAppRuntime } from "./runtime";
@@ -151,6 +152,21 @@ function senderJidForMessage(message: WhatsAppInboundMessage): string {
   return message.senderProviderId ?? message.providerConversationId;
 }
 
+function legacyDmConversationIds(message: WhatsAppInboundMessage): string[] {
+  if (message.kind !== "dm") return [];
+  const phoneDigits = message.senderPhoneE164.replace(/\D/gu, "");
+  return [
+    message.providerConversationId,
+    message.senderProviderId,
+    phoneE164ToWhatsAppJid(message.senderPhoneE164),
+    phoneDigits,
+    `wati:${message.senderPhoneE164}`,
+  ].filter(
+    (value, index, values): value is string =>
+      Boolean(value) && value !== message.canonicalConversationId && values.indexOf(value) === index,
+  );
+}
+
 export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAdapterDeps): void {
   const {
     db,
@@ -169,6 +185,23 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
   } = deps;
   const toolConfig = { BASE_URL: config.BASE_URL, PORT: config.PORT };
   const maxFileBytes = config.MAX_FILE_SIZE_MB * 1024 * 1024;
+
+  const getOrCreateConversationForMessage = async (message: WhatsAppInboundMessage, displayName?: string | null) => {
+    const ref = conversationRefForMessage(message);
+    if (message.kind === "dm") {
+      for (const legacyId of legacyDmConversationIds(message)) {
+        const legacyConversation = await repos.conversations.find({
+          platform: ref.platform,
+          kind: ref.kind,
+          providerConversationId: legacyId,
+        });
+        if (legacyConversation) {
+          return repos.conversations.claimProviderConversationId(legacyConversation.id, ref, displayName);
+        }
+      }
+    }
+    return repos.conversations.getOrCreate(ref, displayName);
+  };
 
   const updateReaction = async (message: WhatsAppInboundMessage, emoji: string | null) => {
     if (!whatsapp.isConnected) return;
@@ -224,8 +257,8 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
     senderUserId?: string | null;
     addressedToSketch: boolean;
   }) => {
-    const conversation = await repos.conversations.getOrCreate(
-      conversationRefForMessage(params.message),
+    const conversation = await getOrCreateConversationForMessage(
+      params.message,
       params.message.kind === "group" ? params.message.target.groupId : params.senderName,
     );
 
@@ -360,7 +393,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
             ? await repos.users.findById(settingsRowEarly.whatsapp_fallback_agent_id)
             : null;
         const dmWorkspaceKeyEarly = fallbackAgentEarly ? `agent-${fallbackAgentEarly.id}/${user.id}` : user.id;
-        const dmConversation = await repos.conversations.getOrCreate(conversationRefForMessage(message), user.name);
+        const dmConversation = await getOrCreateConversationForMessage(message, user.name);
         if (command === "new_session") {
           await deleteSessionId(db, dmWorkspaceKeyEarly);
           await repos.conversations.advanceWatermarkToCurrentMax(dmConversation.id);
@@ -612,7 +645,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
       const groupWorkspaceKey = boundAgent
         ? `agent-${boundAgent.id}/whatsappgroup-${groupJid}`
         : `wa-group-${groupJid}`;
-      const groupConversation = await repos.conversations.getOrCreate(conversationRefForMessage(message));
+      const groupConversation = await getOrCreateConversationForMessage(message);
       if (command === "new_session") {
         await deleteSessionId(db, groupWorkspaceKey);
         await repos.conversations.advanceWatermarkToCurrentMax(groupConversation.id);
@@ -628,7 +661,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
       const groupMeta = await whatsapp.getGroupMetadata(groupJid);
       const groupName = groupMeta?.subject ?? "Unknown Group";
       const groupDescription = groupMeta?.desc ?? undefined;
-      await repos.conversations.getOrCreate(conversationRefForMessage(message), groupName);
+      await getOrCreateConversationForMessage(message, groupName);
 
       if (isWhatsAppProgressControlMessage(message.text, command)) {
         return;

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -189,6 +189,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
   const getOrCreateConversationForMessage = async (message: WhatsAppInboundMessage, displayName?: string | null) => {
     const ref = conversationRefForMessage(message);
     if (message.kind === "dm") {
+      let canonicalConversation: Awaited<ReturnType<ConversationRepository["getOrCreate"]>> | undefined;
       for (const legacyId of legacyDmConversationIds(message)) {
         const legacyConversation = await repos.conversations.find({
           platform: ref.platform,
@@ -196,9 +197,14 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
           providerConversationId: legacyId,
         });
         if (legacyConversation) {
-          return repos.conversations.claimProviderConversationId(legacyConversation.id, ref, displayName);
+          canonicalConversation = await repos.conversations.claimProviderConversationId(
+            legacyConversation.id,
+            ref,
+            displayName,
+          );
         }
       }
+      if (canonicalConversation) return canonicalConversation;
     }
     return repos.conversations.getOrCreate(ref, displayName);
   };

--- a/packages/server/src/whatsapp/provider.ts
+++ b/packages/server/src/whatsapp/provider.ts
@@ -1,4 +1,5 @@
 import type { Attachment } from "../files";
+import type { WhatsAppTemplateRequest } from "./templates";
 
 export const WHATSAPP_BAILEYS_PROVIDER_ID = "baileys";
 export const WHATSAPP_NONE_PROVIDER_ID = "none";
@@ -88,6 +89,7 @@ interface WhatsAppProviderBase {
   capabilities: WhatsAppCapabilities;
   isConnected: boolean;
   sendText: (target: WhatsAppTarget, text: string, options?: WhatsAppSendOptions) => Promise<WhatsAppSendResult | null>;
+  sendTemplate?: (target: WhatsAppTarget, template: WhatsAppTemplateRequest) => Promise<WhatsAppSendResult | null>;
   sendFile?: (target: WhatsAppTarget, filePath: string, mimeType: string, fileName: string) => Promise<void>;
   startComposing?: (target: WhatsAppTarget) => void;
   stopComposing?: (target: WhatsAppTarget) => void;

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -486,6 +486,39 @@ describe("Wati outbound provider", () => {
     }
   });
 
+  it("ignores status callbacks from other configured Wati channels", async () => {
+    const db = await createTestDb();
+    try {
+      const providerEvents = createWhatsAppProviderEventRepository(db);
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        channelPhoneNumber: "+17435002445",
+        logger: createTestLogger(),
+        providerEvents,
+        fetch: vi.fn() as unknown as typeof fetch,
+      });
+      const handler = vi.fn();
+      provider.inboundProvider.onMessage(handler);
+
+      const results = await provider.handleWebhook({
+        eventType: "sentMessageREAD_v2",
+        statusString: "Read",
+        localMessageId: "local-1",
+        whatsappMessageId: "wamid.status",
+        timestamp: "1764238453",
+        channelPhoneNumber: "+15551234567",
+      });
+
+      expect(results).toEqual([{ kind: "ignored", reason: "channel_mismatch" }]);
+      expect(handler).not.toHaveBeenCalled();
+      await expect(db.selectFrom("whatsapp_provider_events").selectAll().execute()).resolves.toEqual([]);
+    } finally {
+      await db.destroy();
+    }
+  });
+
   it("fails template sends clearly when no approved logical mapping exists", async () => {
     const db = await createTestDb();
     try {

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -122,9 +122,9 @@ describe("Wati webhook parsing", () => {
       parseWatiWebhookEvent(documentedMessagePayload({ channelPhoneNumber: null }), {
         channelPhoneNumber: "+15551234567",
       }),
-    ).toEqual({
-      kind: "ignored",
-      reason: "channel_mismatch",
+    ).toMatchObject({
+      kind: "message",
+      message: { providerMessageId: "wamid.inbound" },
     });
   });
 
@@ -472,6 +472,45 @@ describe("Wati outbound provider", () => {
 
       await provider.handleWebhook([payload, payload]);
 
+      expect(handler).not.toHaveBeenCalled();
+      const rows = await db.selectFrom("whatsapp_provider_events").selectAll().execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        provider: "wati",
+        provider_message_id: "local-1",
+        event_family: "read",
+        status: "Read",
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("records status callbacks that omit channel when a Wati channel is configured", async () => {
+    const db = await createTestDb();
+    try {
+      const providerEvents = createWhatsAppProviderEventRepository(db);
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        channelPhoneNumber: "+17435002445",
+        logger: createTestLogger(),
+        providerEvents,
+        fetch: vi.fn() as unknown as typeof fetch,
+      });
+      const handler = vi.fn();
+      provider.inboundProvider.onMessage(handler);
+
+      const results = await provider.handleWebhook({
+        eventType: "sentMessageREAD_v2",
+        statusString: "Read",
+        localMessageId: "local-1",
+        whatsappMessageId: "wamid.status",
+        timestamp: "1764238453",
+      });
+
+      expect(results).toEqual([expect.objectContaining({ kind: "delivery_status" })]);
       expect(handler).not.toHaveBeenCalled();
       const rows = await db.selectFrom("whatsapp_provider_events").selectAll().execute();
       expect(rows).toHaveLength(1);

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -579,4 +579,92 @@ describe("Wati outbound provider", () => {
       await db.destroy();
     }
   });
+
+  it("includes the configured Wati channel in template sends", async () => {
+    const db = await createTestDb();
+    try {
+      const templateMappings = createWhatsAppTemplateMappingRepository(db);
+      await templateMappings.upsertMapping({
+        provider: "wati",
+        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        providerTemplateName: "sketch_magic_link",
+        language: "en_US",
+        status: "approved",
+      });
+      const requestFetch = vi.fn(async () => {
+        return new Response(JSON.stringify({ receivers: [{ localMessageId: "local-template-1" }] }));
+      });
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        channelPhoneNumber: "+17435002445",
+        logger: createTestLogger(),
+        templateMappings,
+        fetch: requestFetch as typeof fetch,
+      });
+
+      await provider.dmProvider.sendTemplate?.(
+        { kind: "dm", phoneE164: "+15551234567" },
+        {
+          key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+          params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+        },
+      );
+
+      const [, init] = firstFetchCall(requestFetch);
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        channelNumber: "17435002445",
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("defaults template mapping lookup to the default language", async () => {
+    const db = await createTestDb();
+    try {
+      const templateMappings = createWhatsAppTemplateMappingRepository(db);
+      await templateMappings.upsertMapping({
+        provider: "wati",
+        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        providerTemplateName: "sketch_magic_link_en",
+        language: "en_US",
+        status: "approved",
+      });
+      await templateMappings.upsertMapping({
+        provider: "wati",
+        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        providerTemplateName: "sketch_magic_link_hi",
+        language: "hi_IN",
+        status: "approved",
+      });
+      const requestFetch = vi.fn(async () => {
+        return new Response(JSON.stringify({ receivers: [{ localMessageId: "local-template-1" }] }));
+      });
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        logger: createTestLogger(),
+        templateMappings,
+        fetch: requestFetch as typeof fetch,
+      });
+
+      await provider.dmProvider.sendTemplate?.(
+        { kind: "dm", phoneE164: "+15551234567" },
+        {
+          key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+          params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+        },
+      );
+
+      const [, init] = firstFetchCall(requestFetch);
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        template_name: "sketch_magic_link_en",
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
 });

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -605,7 +605,7 @@ describe("Wati outbound provider", () => {
         return new Response(
           JSON.stringify({
             result: true,
-            receivers: [{ localMessageId: "local-template-1", whatsappNumber: "15551234567" }],
+            recipients: [{ localMessageId: "local-template-1", whatsappNumber: "15551234567" }],
           }),
         );
       });
@@ -628,11 +628,12 @@ describe("Wati outbound provider", () => {
       );
 
       const [url, init] = firstFetchCall(requestFetch);
-      expect(url.toString()).toBe("https://tenant.wati.io/api/v1/sendTemplateMessages");
+      expect(url.toString()).toBe("https://tenant.wati.io/api/ext/v3/messageTemplates/send");
       expect(init.headers).toEqual({ Authorization: "Bearer wati-token", "Content-Type": "application/json" });
       expect(JSON.parse(init.body as string)).toMatchObject({
+        channel: null,
         template_name: "sketch_magic_link",
-        receivers: [
+        recipients: [
           {
             whatsappNumber: "15551234567",
             customParams: [
@@ -664,7 +665,7 @@ describe("Wati outbound provider", () => {
         status: "approved",
       });
       const requestFetch = vi.fn(async () => {
-        return new Response(JSON.stringify({ receivers: [{ localMessageId: "local-template-1" }] }));
+        return new Response(JSON.stringify({ recipients: [{ localMessageId: "local-template-1" }] }));
       });
       const provider = createWatiWhatsAppProvider({
         apiEndpoint: "https://tenant.wati.io",
@@ -686,7 +687,7 @@ describe("Wati outbound provider", () => {
 
       const [, init] = firstFetchCall(requestFetch);
       expect(JSON.parse(init.body as string)).toMatchObject({
-        channelNumber: "17435002445",
+        channel: "17435002445",
       });
     } finally {
       await db.destroy();
@@ -712,7 +713,7 @@ describe("Wati outbound provider", () => {
         status: "approved",
       });
       const requestFetch = vi.fn(async () => {
-        return new Response(JSON.stringify({ receivers: [{ localMessageId: "local-template-1" }] }));
+        return new Response(JSON.stringify({ recipients: [{ localMessageId: "local-template-1" }] }));
       });
       const provider = createWatiWhatsAppProvider({
         apiEndpoint: "https://tenant.wati.io",

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -2,8 +2,12 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWhatsAppProviderEventRepository } from "../../db/repositories/whatsapp-provider-events";
+import { createWhatsAppTemplateMappingRepository } from "../../db/repositories/whatsapp-template-mappings";
 import { createTestLogger } from "../../test-utils";
+import { createTestDb } from "../../test-utils";
 import { type WhatsAppInboundMessage, whatsappDeliveryTargetFromTarget } from "../provider";
+import { WHATSAPP_TEMPLATE_KEYS } from "../templates";
 import {
   createWatiWhatsAppProvider,
   normalizeWatiPhoneNumber,
@@ -144,6 +148,18 @@ describe("Wati webhook parsing", () => {
         failureCode: null,
         failureDetail: null,
         providerTimestamp: "2025-11-27T10:14:13.000Z",
+      },
+    });
+  });
+
+  it("treats documented messageReceived events as inbound user messages", () => {
+    const parsed = parseWatiWebhookEvent(documentedMessagePayload({ eventType: "messageReceived" }));
+
+    expect(parsed).toMatchObject({
+      kind: "message",
+      message: {
+        providerMessageId: "wamid.inbound",
+        senderPhoneE164: "+8618719149214",
       },
     });
   });
@@ -429,5 +445,138 @@ describe("Wati outbound provider", () => {
       { kind: "message", providerMessageId: "wamid.one", senderPhoneE164: "+8618719149214" },
       expect.objectContaining({ kind: "delivery_status" }),
     ]);
+  });
+
+  it("records duplicate Wati status callbacks once without invoking inbound handlers", async () => {
+    const db = await createTestDb();
+    try {
+      const providerEvents = createWhatsAppProviderEventRepository(db);
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        logger: createTestLogger(),
+        providerEvents,
+        fetch: vi.fn() as unknown as typeof fetch,
+      });
+      const handler = vi.fn();
+      provider.inboundProvider.onMessage(handler);
+
+      const payload = {
+        eventType: "sentMessageREAD_v2",
+        statusString: "Read",
+        localMessageId: "local-1",
+        whatsappMessageId: "wamid.status",
+        timestamp: "1764238453",
+      };
+
+      await provider.handleWebhook([payload, payload]);
+
+      expect(handler).not.toHaveBeenCalled();
+      const rows = await db.selectFrom("whatsapp_provider_events").selectAll().execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        provider: "wati",
+        provider_message_id: "local-1",
+        event_family: "read",
+        status: "Read",
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("fails template sends clearly when no approved logical mapping exists", async () => {
+    const db = await createTestDb();
+    try {
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        logger: createTestLogger(),
+        templateMappings: createWhatsAppTemplateMappingRepository(db),
+        fetch: vi.fn() as unknown as typeof fetch,
+      });
+
+      await expect(
+        provider.dmProvider.sendTemplate?.(
+          { kind: "dm", phoneE164: "+15551234567" },
+          {
+            key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+            params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+            fallbackText: "magic link",
+          },
+        ),
+      ).rejects.toThrow("No approved WhatsApp template mapping configured for whatsapp.magic_link");
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("sends logical template mappings through the Wati template endpoint", async () => {
+    const db = await createTestDb();
+    try {
+      const templateMappings = createWhatsAppTemplateMappingRepository(db);
+      await templateMappings.upsertMapping({
+        provider: "wati",
+        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        providerTemplateName: "sketch_magic_link",
+        language: "en_US",
+        status: "approved",
+        parameterMap: {
+          name: "recipientName",
+          bot: "botName",
+          link: "magicLinkUrl",
+        },
+      });
+      const requestFetch = vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            result: true,
+            receivers: [{ localMessageId: "local-template-1", whatsappNumber: "15551234567" }],
+          }),
+        );
+      });
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        logger: createTestLogger(),
+        templateMappings,
+        fetch: requestFetch as typeof fetch,
+      });
+
+      const sent = await provider.dmProvider.sendTemplate?.(
+        { kind: "dm", phoneE164: "+15551234567" },
+        {
+          key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+          params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+          fallbackText: "magic link",
+        },
+      );
+
+      const [url, init] = firstFetchCall(requestFetch);
+      expect(url.toString()).toBe("https://tenant.wati.io/api/v1/sendTemplateMessages");
+      expect(init.headers).toEqual({ Authorization: "Bearer wati-token", "Content-Type": "application/json" });
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        template_name: "sketch_magic_link",
+        receivers: [
+          {
+            whatsappNumber: "15551234567",
+            customParams: [
+              { name: "name", value: "Alice" },
+              { name: "bot", value: "Sketch" },
+              { name: "link", value: "https://sketch.test/magic" },
+            ],
+          },
+        ],
+      });
+      expect(sent).toMatchObject({
+        providerMessageId: "local-template-1",
+        providerConversationId: "dm:+15551234567",
+      });
+    } finally {
+      await db.destroy();
+    }
   });
 });

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -694,6 +694,97 @@ describe("Wati outbound provider", () => {
     }
   });
 
+  it("surfaces Wati template recipient failures returned with HTTP 200", async () => {
+    const db = await createTestDb();
+    try {
+      const templateMappings = createWhatsAppTemplateMappingRepository(db);
+      await templateMappings.upsertMapping({
+        provider: "wati",
+        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        providerTemplateName: "sketch_magic_link",
+        language: "en_US",
+        status: "approved",
+      });
+      const requestFetch = vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            result: true,
+            error: null,
+            recipients: [
+              {
+                isValidWhatsAppNumber: false,
+                errors: ["invalid recipient"],
+              },
+            ],
+          }),
+        );
+      });
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        logger: createTestLogger(),
+        templateMappings,
+        fetch: requestFetch as typeof fetch,
+      });
+
+      await expect(
+        provider.dmProvider.sendTemplate?.(
+          { kind: "dm", phoneE164: "+15551234567" },
+          {
+            key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+            params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+          },
+        ),
+      ).rejects.toThrow("Wati template send failed: invalid WhatsApp recipient");
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("does not mark Wati template sends successful without a provider message id", async () => {
+    const db = await createTestDb();
+    try {
+      const templateMappings = createWhatsAppTemplateMappingRepository(db);
+      await templateMappings.upsertMapping({
+        provider: "wati",
+        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        providerTemplateName: "sketch_magic_link",
+        language: "en_US",
+        status: "approved",
+      });
+      const requestFetch = vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            result: true,
+            error: null,
+            recipients: [{ isValidWhatsAppNumber: true, errors: [] }],
+          }),
+        );
+      });
+      const provider = createWatiWhatsAppProvider({
+        apiEndpoint: "https://tenant.wati.io",
+        accessToken: "wati-token",
+        webhookToken: "webhook-token",
+        logger: createTestLogger(),
+        templateMappings,
+        fetch: requestFetch as typeof fetch,
+      });
+
+      await expect(
+        provider.dmProvider.sendTemplate?.(
+          { kind: "dm", phoneE164: "+15551234567" },
+          {
+            key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+            params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+          },
+        ),
+      ).rejects.toThrow("Wati template send failed: missing provider message id");
+    } finally {
+      await db.destroy();
+    }
+  });
+
   it("defaults template mapping lookup to the default language", async () => {
     const db = await createTestDb();
     try {

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -1,5 +1,10 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
+import type { createWhatsAppProviderEventRepository } from "../../db/repositories/whatsapp-provider-events";
+import type {
+  ProviderTemplateSummary,
+  createWhatsAppTemplateMappingRepository,
+} from "../../db/repositories/whatsapp-template-mappings";
 import type { Attachment } from "../../files";
 import { mimeToExtension } from "../../files";
 import type { Logger } from "../../logger";
@@ -14,6 +19,7 @@ import {
   type WhatsAppTarget,
   canonicalDmConversationId,
 } from "../provider";
+import type { WhatsAppTemplateParamValue, WhatsAppTemplateRequest } from "../templates";
 
 export const WHATSAPP_WATI_PROVIDER_ID = "wati";
 
@@ -33,6 +39,7 @@ const WATI_CAPABILITIES: WhatsAppCapabilities = {
 
 const MEDIA_MESSAGE_TYPES = new Set(["image", "document", "voice", "audio", "video", "sticker", "media_placeholder"]);
 const UNSUPPORTED_INBOUND_MESSAGE_TYPES = new Set(["reaction"]);
+const INBOUND_EVENT_TYPES = new Set(["message", "messagereceived", "message_received"]);
 
 export interface WatiWhatsAppConfig {
   apiEndpoint: string;
@@ -40,6 +47,8 @@ export interface WatiWhatsAppConfig {
   webhookToken: string;
   channelPhoneNumber?: string | null;
   logger: Logger;
+  providerEvents?: ReturnType<typeof createWhatsAppProviderEventRepository>;
+  templateMappings?: ReturnType<typeof createWhatsAppTemplateMappingRepository>;
   fetch?: typeof fetch;
 }
 
@@ -48,6 +57,7 @@ export interface WatiWhatsAppProvider {
   inboundProvider: WhatsAppInboundProvider;
   webhookToken: string;
   handleWebhook(payload: unknown): Promise<WatiWebhookHandleResult[]>;
+  listTemplates(): Promise<ProviderTemplateSummary[]>;
 }
 
 export type WatiWebhookHandleResult =
@@ -126,6 +136,65 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
       headers: authorizationHeaders(config.accessToken),
       body: form,
     });
+  };
+
+  const sendTemplate = async (
+    target: WhatsAppTarget,
+    template: WhatsAppTemplateRequest,
+  ): Promise<WhatsAppSendResult | null> => {
+    if (!config.templateMappings) throw new Error("WhatsApp template mappings are not configured");
+    const mapping = await config.templateMappings.findApprovedMapping(
+      WHATSAPP_WATI_PROVIDER_ID,
+      template.key,
+      template.language,
+    );
+    if (!mapping) {
+      throw new Error(`No approved WhatsApp template mapping configured for ${template.key}`);
+    }
+
+    const phone = targetPhoneDigits(target);
+    const url = new URL(`${endpoint}/api/v1/sendTemplateMessages`);
+    const customParams = providerTemplateParameters(mapping.parameterMap, template.params);
+    const body = {
+      template_name: mapping.provider_template_name,
+      broadcast_name: buildBroadcastName(template.key),
+      receivers: [
+        {
+          whatsappNumber: phone,
+          customParams,
+        },
+      ],
+    };
+
+    const responseBody = await fetchJson(requestFetch, url, {
+      method: "POST",
+      headers: { ...authorizationHeaders(config.accessToken), "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    return sendResultFromWatiTemplateBody(responseBody, target);
+  };
+
+  const listTemplates = async (): Promise<ProviderTemplateSummary[]> => {
+    const templates: ProviderTemplateSummary[] = [];
+    const pageSize = 100;
+
+    for (let pageNumber = 1; pageNumber <= 20; pageNumber += 1) {
+      const url = new URL(`${v3Endpoint}/api/ext/v3/messageTemplates`);
+      url.searchParams.set("page_number", String(pageNumber));
+      url.searchParams.set("page_size", String(pageSize));
+      if (channelPhoneDigits) url.searchParams.set("channel", channelPhoneDigits);
+
+      const body = await fetchJson(requestFetch, url, {
+        method: "GET",
+        headers: authorizationHeaders(config.accessToken),
+      });
+      const pageTemplates = parseWatiTemplateList(body);
+      templates.push(...pageTemplates);
+      if (pageTemplates.length < pageSize) break;
+    }
+
+    return templates;
   };
 
   const downloadMedia = async (
@@ -219,6 +288,7 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
         return Boolean(endpoint && config.accessToken);
       },
       sendText,
+      sendTemplate,
       sendFile,
       downloadMedia: (message, workspaceDir, params) =>
         message.kind === "dm" ? downloadMedia(message, workspaceDir, params) : Promise.resolve([]),
@@ -230,6 +300,7 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
       },
     },
     webhookToken: config.webhookToken,
+    listTemplates,
     async handleWebhook(payload) {
       const events = Array.isArray(payload) ? payload : [payload];
       const results: WatiWebhookHandleResult[] = [];
@@ -249,12 +320,26 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
         }
 
         if (parsed.kind === "delivery_status") {
+          const recorded = config.providerEvents
+            ? await config.providerEvents.upsertDeliveryStatus({
+                provider: parsed.event.providerId,
+                providerMessageId: parsed.event.providerMessageId,
+                providerConversationId: parsed.event.providerConversationId,
+                eventType: parsed.event.eventType,
+                status: parsed.event.status,
+                failureCode: parsed.event.failureCode,
+                failureDetail: parsed.event.failureDetail,
+                providerTimestamp: parsed.event.providerTimestamp,
+                rawProviderPayload: parsed.event.rawProviderPayload,
+              })
+            : null;
           config.logger.debug(
             {
               providerMessageId: parsed.event.providerMessageId,
               providerConversationId: parsed.event.providerConversationId,
               eventType: parsed.event.eventType,
               status: parsed.event.status,
+              inserted: recorded?.inserted ?? null,
             },
             "Parsed Wati delivery/status webhook event",
           );
@@ -290,13 +375,14 @@ export function parseWatiWebhookEvent(
   const eventType = optionalString(payload.eventType);
   const messageType = optionalString(payload.type);
   const owner = optionalBoolean(payload.owner);
+  const normalizedEventType = normalizeEventType(eventType);
 
   if (owner === true) {
     const delivery = parseWatiDeliveryStatusEvent(payload);
     return delivery ?? { kind: "ignored", reason: "owner_event" };
   }
 
-  if (eventType && eventType !== "message") {
+  if (eventType && !INBOUND_EVENT_TYPES.has(normalizedEventType)) {
     const delivery = parseWatiDeliveryStatusEvent(payload);
     return (
       delivery ?? {
@@ -373,6 +459,8 @@ export function parseWatiDeliveryStatusEvent(
     optionalString(payload.status_string) ??
     optionalString(payload.event);
   const providerMessageId =
+    optionalString(payload.localMessageId) ??
+    optionalString(payload.local_message_id) ??
     optionalString(payload.whatsappMessageId) ??
     optionalString(payload.messageId) ??
     optionalString(payload.message_id) ??
@@ -397,6 +485,26 @@ export function parseWatiDeliveryStatusEvent(
       rawProviderPayload: payload,
     },
   };
+}
+
+function providerTemplateParameters(
+  parameterMap: Record<string, string> | null,
+  params: Record<string, WhatsAppTemplateParamValue>,
+): Array<{ name: string; value: string }> {
+  const entries = parameterMap ? Object.entries(parameterMap) : Object.keys(params).map((key) => [key, key]);
+  return entries.map(([providerName, logicalName]) => ({
+    name: providerName,
+    value: stringifyTemplateParam(params[logicalName]),
+  }));
+}
+
+function stringifyTemplateParam(value: WhatsAppTemplateParamValue): string {
+  if (value == null) return "";
+  return String(value);
+}
+
+function buildBroadcastName(key: string): string {
+  return `sketch_${key.replace(/[^a-zA-Z0-9]+/gu, "_").slice(0, 48)}_${Date.now()}`;
 }
 
 export function normalizeWatiPhoneNumber(value: unknown): string | null {
@@ -462,6 +570,86 @@ function sendResultFromWatiBody(body: unknown, target: WhatsAppTarget): WhatsApp
   };
 }
 
+function sendResultFromWatiTemplateBody(body: unknown, target: WhatsAppTarget): WhatsAppSendResult | null {
+  const record = isRecord(body) ? body : {};
+  const receivers = Array.isArray(record.receivers) ? record.receivers : [];
+  const firstReceiver = isRecord(receivers[0]) ? receivers[0] : {};
+  const fallbackConversationId =
+    target.kind === "dm"
+      ? (target.providerConversationId ?? canonicalDmConversationId(target.phoneE164))
+      : target.groupId;
+
+  return {
+    providerMessageId:
+      optionalString(firstReceiver.localMessageId) ??
+      optionalString(firstReceiver.local_message_id) ??
+      optionalString(firstReceiver.whatsappMessageId) ??
+      optionalString(firstReceiver.id) ??
+      optionalString(record.localMessageId) ??
+      optionalString(record.whatsappMessageId),
+    providerConversationId:
+      optionalString(firstReceiver.conversationId) ??
+      optionalString(firstReceiver.conversation_id) ??
+      optionalString(record.conversationId) ??
+      optionalString(record.conversation_id) ??
+      fallbackConversationId,
+    providerTimestamp:
+      parseWatiTimestamp(firstReceiver.time) ??
+      parseWatiTimestamp(firstReceiver.timestamp) ??
+      parseWatiTimestamp(record.created),
+    rawProviderPayload: body,
+  };
+}
+
+function parseWatiTemplateList(body: unknown): ProviderTemplateSummary[] {
+  const candidates = templateArrayCandidates(body);
+  const templates: ProviderTemplateSummary[] = [];
+
+  for (const item of candidates) {
+    if (!isRecord(item)) continue;
+    const providerTemplateName =
+      optionalString(item.elementName) ??
+      optionalString(item.templateName) ??
+      optionalString(item.template_name) ??
+      optionalString(item.name);
+    if (!providerTemplateName) continue;
+    templates.push({
+      providerTemplateName,
+      language: templateLanguage(item),
+      status: optionalString(item.status),
+      category: optionalString(item.category),
+      rawProviderPayload: item,
+    });
+  }
+
+  return templates;
+}
+
+function templateArrayCandidates(body: unknown): unknown[] {
+  if (Array.isArray(body)) return body;
+  if (!isRecord(body)) return [];
+  for (const key of ["messageTemplates", "templates", "data", "items", "result", "results", "rows"]) {
+    const value = body[key];
+    if (Array.isArray(value)) return value;
+  }
+  return [];
+}
+
+function templateLanguage(item: Record<string, unknown>): string {
+  const language = item.language;
+  if (typeof language === "string" && language.trim()) return language.trim();
+  if (isRecord(language)) {
+    return (
+      optionalString(language.code) ??
+      optionalString(language.value) ??
+      optionalString(language.name) ??
+      optionalString(language.text) ??
+      "en_US"
+    );
+  }
+  return optionalString(item.languageCode) ?? optionalString(item.language_code) ?? "en_US";
+}
+
 function fileMessageIdsForDownload(message: WhatsAppDmInboundMessage): string[] {
   const raw = isRecord(message.rawProviderPayload) ? message.rawProviderPayload : null;
   return uniqueStrings([optionalString(raw?.id), optionalString(raw?.whatsappMessageId), message.providerMessageId]);
@@ -514,6 +702,15 @@ function parseWatiTimestamp(value: unknown): string | null {
   const millis = Date.parse(input);
   if (!Number.isFinite(millis)) return null;
   return new Date(millis).toISOString();
+}
+
+function normalizeEventType(value: string | null): string {
+  return (
+    value
+      ?.trim()
+      .replace(/[^a-zA-Z0-9]+/gu, "_")
+      .toLowerCase() ?? ""
+  );
 }
 
 function textFromInteractiveReply(payload: Record<string, unknown>): string | null {

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -158,6 +158,7 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
     const body = {
       template_name: mapping.provider_template_name,
       broadcast_name: buildBroadcastName(template.key),
+      ...(channelPhoneDigits ? { channelNumber: channelPhoneDigits } : {}),
       receivers: [
         {
           whatsappNumber: phone,

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -380,7 +380,7 @@ export function parseWatiWebhookEvent(
   const configuredChannel = phoneDigits(options.channelPhoneNumber ?? null);
   const eventChannel = phoneDigits(optionalString(payload.channelPhoneNumber));
 
-  if (configuredChannel && eventChannel !== configuredChannel) {
+  if (configuredChannel && eventChannel && eventChannel !== configuredChannel) {
     return { kind: "ignored", reason: "channel_mismatch" };
   }
 

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -153,13 +153,13 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
     }
 
     const phone = targetPhoneDigits(target);
-    const url = new URL(`${endpoint}/api/v1/sendTemplateMessages`);
+    const url = new URL(`${v3Endpoint}/api/ext/v3/messageTemplates/send`);
     const customParams = providerTemplateParameters(mapping.parameterMap, template.params);
     const body = {
+      channel: channelPhoneDigits ?? null,
       template_name: mapping.provider_template_name,
       broadcast_name: buildBroadcastName(template.key),
-      ...(channelPhoneDigits ? { channelNumber: channelPhoneDigits } : {}),
-      receivers: [
+      recipients: [
         {
           whatsappNumber: phone,
           customParams,
@@ -573,8 +573,12 @@ function sendResultFromWatiBody(body: unknown, target: WhatsAppTarget): WhatsApp
 
 function sendResultFromWatiTemplateBody(body: unknown, target: WhatsAppTarget): WhatsAppSendResult | null {
   const record = isRecord(body) ? body : {};
-  const receivers = Array.isArray(record.receivers) ? record.receivers : [];
-  const firstReceiver = isRecord(receivers[0]) ? receivers[0] : {};
+  const deliveryRows = Array.isArray(record.recipients)
+    ? record.recipients
+    : Array.isArray(record.receivers)
+      ? record.receivers
+      : [];
+  const firstReceiver = isRecord(deliveryRows[0]) ? deliveryRows[0] : {};
   const fallbackConversationId =
     target.kind === "dm"
       ? (target.providerConversationId ?? canonicalDmConversationId(target.phoneE164))

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -377,6 +377,12 @@ export function parseWatiWebhookEvent(
   const messageType = optionalString(payload.type);
   const owner = optionalBoolean(payload.owner);
   const normalizedEventType = normalizeEventType(eventType);
+  const configuredChannel = phoneDigits(options.channelPhoneNumber ?? null);
+  const eventChannel = phoneDigits(optionalString(payload.channelPhoneNumber));
+
+  if (configuredChannel && eventChannel !== configuredChannel) {
+    return { kind: "ignored", reason: "channel_mismatch" };
+  }
 
   if (owner === true) {
     const delivery = parseWatiDeliveryStatusEvent(payload);
@@ -397,12 +403,6 @@ export function parseWatiWebhookEvent(
 
   if (messageType && UNSUPPORTED_INBOUND_MESSAGE_TYPES.has(messageType)) {
     return { kind: "ignored", reason: "unsupported_message_type" };
-  }
-
-  const configuredChannel = phoneDigits(options.channelPhoneNumber ?? null);
-  const eventChannel = phoneDigits(optionalString(payload.channelPhoneNumber));
-  if (configuredChannel && eventChannel !== configuredChannel) {
-    return { kind: "ignored", reason: "channel_mismatch" };
   }
 
   const senderPhoneE164 = normalizeWatiPhoneNumber(payload.waId);

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -579,19 +579,25 @@ function sendResultFromWatiTemplateBody(body: unknown, target: WhatsAppTarget): 
       ? record.receivers
       : [];
   const firstReceiver = isRecord(deliveryRows[0]) ? deliveryRows[0] : {};
+  const failureReason = watiTemplateSendFailure(record, firstReceiver);
+  if (failureReason) throw new Error(failureReason);
   const fallbackConversationId =
     target.kind === "dm"
       ? (target.providerConversationId ?? canonicalDmConversationId(target.phoneE164))
       : target.groupId;
+  const providerMessageId =
+    optionalString(firstReceiver.localMessageId) ??
+    optionalString(firstReceiver.local_message_id) ??
+    optionalString(firstReceiver.whatsappMessageId) ??
+    optionalString(firstReceiver.id) ??
+    optionalString(record.localMessageId) ??
+    optionalString(record.whatsappMessageId);
+  if (!providerMessageId) {
+    throw new Error("Wati template send failed: missing provider message id");
+  }
 
   return {
-    providerMessageId:
-      optionalString(firstReceiver.localMessageId) ??
-      optionalString(firstReceiver.local_message_id) ??
-      optionalString(firstReceiver.whatsappMessageId) ??
-      optionalString(firstReceiver.id) ??
-      optionalString(record.localMessageId) ??
-      optionalString(record.whatsappMessageId),
+    providerMessageId,
     providerConversationId:
       optionalString(firstReceiver.conversationId) ??
       optionalString(firstReceiver.conversation_id) ??
@@ -604,6 +610,36 @@ function sendResultFromWatiTemplateBody(body: unknown, target: WhatsAppTarget): 
       parseWatiTimestamp(record.created),
     rawProviderPayload: body,
   };
+}
+
+function watiTemplateSendFailure(
+  record: Record<string, unknown>,
+  firstReceiver: Record<string, unknown>,
+): string | null {
+  if (isExplicitFalse(record.result) || hasProviderErrors(record.error)) {
+    return "Wati template send failed: provider rejected request";
+  }
+  if (
+    optionalBoolean(firstReceiver.isValidWhatsAppNumber) === false ||
+    optionalBoolean(firstReceiver.is_valid_whatsapp_number) === false
+  ) {
+    return "Wati template send failed: invalid WhatsApp recipient";
+  }
+  if (hasProviderErrors(firstReceiver.errors) || hasProviderErrors(firstReceiver.error)) {
+    return "Wati template send failed: recipient rejected";
+  }
+  return null;
+}
+
+function isExplicitFalse(value: unknown): boolean {
+  return value === false || (typeof value === "string" && value.trim().toLowerCase() === "false");
+}
+
+function hasProviderErrors(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "string") return value.trim().length > 0;
+  return true;
 }
 
 function parseWatiTemplateList(body: unknown): ProviderTemplateSummary[] {

--- a/packages/server/src/whatsapp/runtime.test.ts
+++ b/packages/server/src/whatsapp/runtime.test.ts
@@ -41,6 +41,11 @@ function createDmProvider(id: string): WhatsAppDmProvider {
       providerConversationId: providerConversationId(target),
       providerTimestamp: null,
     })),
+    sendTemplate: vi.fn(async (target) => ({
+      providerMessageId: `${id}-template-sent`,
+      providerConversationId: providerConversationId(target),
+      providerTimestamp: null,
+    })),
   };
 }
 
@@ -164,5 +169,45 @@ describe("createWhatsAppRuntime", () => {
     expect(handler).toHaveBeenNthCalledWith(1, expect.objectContaining({ kind: "group", providerId: "baileys" }));
     expect(handler).toHaveBeenNthCalledWith(2, expect.objectContaining({ kind: "dm", providerId: "wati" }));
     expect(handler).not.toHaveBeenCalledWith(expect.objectContaining({ kind: "dm", providerId: "baileys" }));
+  });
+
+  it("uses provider templates for configured DM providers without affecting Baileys groups", async () => {
+    const dmProvider = createDmProvider("wati");
+    const groupProvider = createGroupProvider("baileys");
+    const runtime = createWhatsAppRuntime({
+      dmProviderId: "wati",
+      groupProviderId: "baileys",
+      dmProviders: [dmProvider],
+      groupProviders: [groupProvider],
+      inboundProviders: [],
+      logger: createTestLogger(),
+    });
+
+    await runtime.sendTemplate({ kind: "dm", phoneE164: "+111" }, { key: "whatsapp.magic_link", params: {} });
+    await runtime.sendText({ kind: "group", groupId: "group@g.us" }, "group");
+
+    expect(dmProvider.sendTemplate).toHaveBeenCalledOnce();
+    expect(groupProvider.sendText).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to text templates for providers without official template support", async () => {
+    const dmProvider = createDmProvider("baileys");
+    dmProvider.sendTemplate = undefined;
+    dmProvider.capabilities.templates = false;
+    const runtime = createWhatsAppRuntime({
+      dmProviderId: "baileys",
+      groupProviderId: "none",
+      dmProviders: [dmProvider],
+      groupProviders: [],
+      inboundProviders: [],
+      logger: createTestLogger(),
+    });
+
+    await runtime.sendTemplate(
+      { kind: "dm", phoneE164: "+111" },
+      { key: "whatsapp.magic_link", params: {}, fallbackText: "fallback" },
+    );
+
+    expect(dmProvider.sendText).toHaveBeenCalledWith({ kind: "dm", phoneE164: "+111" }, "fallback");
   });
 });

--- a/packages/server/src/whatsapp/runtime.ts
+++ b/packages/server/src/whatsapp/runtime.ts
@@ -13,11 +13,13 @@ import {
   type WhatsAppSendResult,
   type WhatsAppTarget,
 } from "./provider";
+import type { WhatsAppTemplateRequest } from "./templates";
 
 export interface WhatsAppRuntime {
   isConnected: boolean;
   onMessage(handler: WhatsAppMessageHandler): void;
   sendText(target: WhatsAppTarget, text: string, options?: WhatsAppSendOptions): Promise<WhatsAppSendResult | null>;
+  sendTemplate(target: WhatsAppTarget, template: WhatsAppTemplateRequest): Promise<WhatsAppSendResult | null>;
   sendFile(target: WhatsAppTarget, filePath: string, mimeType: string, fileName: string): Promise<void>;
   startComposing(target: WhatsAppTarget): void;
   stopComposing(target: WhatsAppTarget): void;
@@ -92,6 +94,18 @@ export function createWhatsAppRuntime(config: WhatsAppRuntimeConfig): WhatsAppRu
 
     async sendText(target, text, options) {
       return resolveProviderForTarget(target).sendText(target, text, options);
+    },
+
+    async sendTemplate(target, template) {
+      const provider = resolveProviderForTarget(target);
+      if (provider.sendTemplate) return provider.sendTemplate(target, template);
+      if (provider.capabilities.templates) {
+        throw new Error(`WhatsApp provider ${provider.id} cannot send templates from this runtime`);
+      }
+      if (!template.fallbackText) {
+        throw new Error(`WhatsApp provider ${provider.id} does not support templates`);
+      }
+      return provider.sendText(target, template.fallbackText);
     },
 
     async sendFile(target, filePath, mimeType, fileName) {

--- a/packages/server/src/whatsapp/templates.ts
+++ b/packages/server/src/whatsapp/templates.ts
@@ -1,0 +1,73 @@
+export const WHATSAPP_TEMPLATE_KEYS = {
+  proactiveUpdate: "whatsapp.proactive_update",
+  magicLink: "whatsapp.magic_link",
+  introduction: "whatsapp.introduction",
+} as const;
+
+export type WhatsAppTemplateKey = (typeof WHATSAPP_TEMPLATE_KEYS)[keyof typeof WHATSAPP_TEMPLATE_KEYS] | string;
+
+export type WhatsAppTemplateParamValue = string | number | boolean | null | undefined;
+
+export interface WhatsAppTemplateRequest {
+  key: WhatsAppTemplateKey;
+  params: Record<string, WhatsAppTemplateParamValue>;
+  fallbackText?: string;
+  language?: string;
+}
+
+export function buildProactiveUpdateTemplate(params: {
+  recipientName?: string | null;
+  botName?: string | null;
+  messageSummary: string;
+  fallbackText?: string;
+  language?: string;
+}): WhatsAppTemplateRequest {
+  return {
+    key: WHATSAPP_TEMPLATE_KEYS.proactiveUpdate,
+    params: {
+      recipientName: params.recipientName ?? "there",
+      botName: params.botName ?? "Sketch",
+      messageSummary: params.messageSummary,
+    },
+    fallbackText: params.fallbackText ?? params.messageSummary,
+    language: params.language,
+  };
+}
+
+export function buildMagicLinkTemplate(params: {
+  recipientName?: string | null;
+  botName?: string | null;
+  magicLinkUrl: string;
+  fallbackText: string;
+  language?: string;
+}): WhatsAppTemplateRequest {
+  return {
+    key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+    params: {
+      recipientName: params.recipientName ?? "there",
+      botName: params.botName ?? "Sketch",
+      magicLinkUrl: params.magicLinkUrl,
+    },
+    fallbackText: params.fallbackText,
+    language: params.language,
+  };
+}
+
+export function buildIntroductionTemplate(params: {
+  recipientName?: string | null;
+  botName?: string | null;
+  orgName?: string | null;
+  fallbackText: string;
+  language?: string;
+}): WhatsAppTemplateRequest {
+  return {
+    key: WHATSAPP_TEMPLATE_KEYS.introduction,
+    params: {
+      recipientName: params.recipientName ?? "there",
+      botName: params.botName ?? "Sketch",
+      orgName: params.orgName?.trim() || "your workspace",
+    },
+    fallbackText: params.fallbackText,
+    language: params.language,
+  };
+}


### PR DESCRIPTION
## Summary

- Route Wati webhooks through a named `QueueManager` queue while keeping the HTTP acknowledgement immediate.
- Classify Wati inbound, ignored, unrecognized, and delivery/status callbacks; persist status events with provider-level dedupe.
- Add provider-specific WhatsApp template mappings, admin mapping/list/sync routes, and Wati template send/list support behind logical Sketch keys.
- Route proactive WhatsApp DM paths through the runtime/template abstraction while preserving reactive text replies and Baileys group handling.
- Normalize Wati DM conversation capture to phone-based conversation ids and document self-hosted Wati template setup.

## Validation

- `pnpm biome check . --diagnostic-level=error`
- `pnpm typecheck`
- `pnpm --dir packages/server exec vitest run src/api/wati-webhook.test.ts src/whatsapp/providers/wati.test.ts src/whatsapp/runtime.test.ts src/whatsapp/adapter.isolated.test.ts src/api/channels-authz.test.ts src/agent/sketch-tools.test.ts src/api/system.test.ts src/agents/output-delivery.test.ts src/scheduler/service.isolated.test.ts src/api/agent-runs.isolated.test.ts src/api/workflows.isolated.test.ts`
- `pnpm test`
- `pnpm build`

Pre-push also ran Biome, typecheck, full tests, and build before pushing the branch.