### PR TITLE
SKE-257: Add configurable Summarizer agent

### DIFF
--- a/packages/server/src/agents/definitions/conversation-summary.test.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.test.ts
@@ -1,0 +1,198 @@
+import type { Kysely, Selectable } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentSourceConfig } from "../../db/repositories/agent-outputs";
+import type { DB, UsersTable } from "../../db/schema";
+import { createTestDb } from "../../test-utils";
+import {
+  CONVERSATION_SUMMARY_AGENT_KEY,
+  buildConversationSummaryRuntimeContext,
+  conversationSummaryDefinition,
+} from "./conversation-summary";
+
+const NOW = new Date("2026-07-01T18:00:00.000Z");
+
+async function seedUser(db: Kysely<DB>): Promise<Selectable<UsersTable>> {
+  await db.insertInto("users").values({ id: "user-1", name: "Summary User", email: "user@example.com" }).execute();
+  return db.selectFrom("users").selectAll().where("id", "=", "user-1").executeTakeFirstOrThrow();
+}
+
+async function seedConversation(db: Kysely<DB>): Promise<number> {
+  await db
+    .insertInto("conversations")
+    .values({
+      platform: "slack",
+      kind: "channel",
+      provider_conversation_id: "C_SUMMARY",
+      display_name: "summary-room",
+    })
+    .execute();
+  const row = await db
+    .selectFrom("conversations")
+    .select("id")
+    .where("provider_conversation_id", "=", "C_SUMMARY")
+    .executeTakeFirstOrThrow();
+  return row.id;
+}
+
+async function seedMessage(
+  db: Kysely<DB>,
+  conversationId: number,
+  params: { id: string; text: string; receivedAt: string; isBot?: boolean },
+): Promise<void> {
+  await db
+    .insertInto("conversation_messages")
+    .values({
+      conversation_id: conversationId,
+      provider_message_id: params.id,
+      sender_jid: "U_1",
+      sender_name: "Mina",
+      sender_user_id: "user-1",
+      is_bot: params.isBot ? 1 : 0,
+      addressed_to_sketch: 0,
+      text: params.text,
+      received_at: params.receivedAt,
+    })
+    .execute();
+}
+
+function source(): AgentSourceConfig {
+  return {
+    platform: "slack",
+    targetType: "channel",
+    targetId: "C_SUMMARY",
+    label: "#summary-room",
+  };
+}
+
+describe("conversationSummaryDefinition", () => {
+  it("is registered as a source-configurable summarizer", () => {
+    expect(conversationSummaryDefinition.key).toBe(CONVERSATION_SUMMARY_AGENT_KEY);
+    expect(conversationSummaryDefinition.sourceConfig).toMatchObject({
+      supportsSlackChannels: true,
+      supportsWhatsAppGroups: true,
+    });
+    expect(conversationSummaryDefinition.requiresKnowledgeRefs).toBe(false);
+  });
+});
+
+describe("buildConversationSummaryRuntimeContext", () => {
+  let db: Kysely<DB>;
+  let user: Selectable<UsersTable>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    user = await seedUser(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("uses a 24 hour first-run window and excludes bot messages", async () => {
+    const conversationId = await seedConversation(db);
+    await seedMessage(db, conversationId, {
+      id: "m-old",
+      text: "outside window",
+      receivedAt: "2026-06-30T17:00:00.000Z",
+    });
+    await seedMessage(db, conversationId, {
+      id: "m-new",
+      text: "Launch decision is ready",
+      receivedAt: "2026-07-01T10:00:00.000Z",
+    });
+    await seedMessage(db, conversationId, {
+      id: "m-bot",
+      text: "Previous summary",
+      receivedAt: "2026-07-01T11:00:00.000Z",
+      isBot: true,
+    });
+
+    const context = await buildConversationSummaryRuntimeContext({
+      db,
+      user,
+      outputDate: "2026-07-01",
+      timezone: "UTC",
+      now: NOW,
+      adminCanReadAllFiles: false,
+      contentUserEmails: ["user@example.com"],
+      agentConfig: {
+        enabledSections: {},
+        maxItemsPerSection: 5,
+        focus: null,
+        delivery: null,
+        sources: [source()],
+      },
+    });
+
+    expect(context.summaryWindow).toMatchObject({
+      mode: "first_run_last_24h",
+      start: "2026-06-30T18:00:00.000Z",
+      end: "2026-07-01T18:00:00.000Z",
+    });
+    expect(context.summarySources).toEqual([
+      expect.objectContaining({
+        label: "#summary-room",
+        conversationId,
+        messageCount: 1,
+        messages: [expect.objectContaining({ text: "Launch decision is ready" })],
+      }),
+    ]);
+  });
+
+  it("uses the last completed summary generation as the next window start", async () => {
+    const conversationId = await seedConversation(db);
+    await db
+      .insertInto("agent_outputs")
+      .values({
+        id: "summary-prev",
+        agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+        user_id: user.id,
+        output_date: "2026-07-01",
+        timezone: "UTC",
+        status: "completed",
+        trigger_type: "scheduled",
+        agent_version: "test",
+        generated_at: "2026-07-01T12:00:00.000Z",
+      })
+      .execute();
+    await seedMessage(db, conversationId, {
+      id: "m-before",
+      text: "already summarized",
+      receivedAt: "2026-07-01T11:00:00.000Z",
+    });
+    await seedMessage(db, conversationId, {
+      id: "m-after",
+      text: "new unblocker",
+      receivedAt: "2026-07-01T12:30:00.000Z",
+    });
+
+    const context = await buildConversationSummaryRuntimeContext({
+      db,
+      user,
+      outputDate: "2026-07-01",
+      timezone: "UTC",
+      now: NOW,
+      adminCanReadAllFiles: false,
+      contentUserEmails: ["user@example.com"],
+      agentConfig: {
+        enabledSections: {},
+        maxItemsPerSection: 5,
+        focus: null,
+        delivery: null,
+        sources: [source()],
+      },
+    });
+
+    expect(context.summaryWindow).toMatchObject({
+      mode: "since_last_successful_run",
+      start: "2026-07-01T12:00:00.000Z",
+      previousOutputId: "summary-prev",
+    });
+    expect(context.summarySources).toEqual([
+      expect.objectContaining({
+        messageCount: 1,
+        messages: [expect.objectContaining({ text: "new unblocker" })],
+      }),
+    ]);
+  });
+});

--- a/packages/server/src/agents/definitions/conversation-summary.test.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.test.ts
@@ -139,7 +139,7 @@ describe("buildConversationSummaryRuntimeContext", () => {
     ]);
   });
 
-  it("uses the last completed summary generation as the next window start", async () => {
+  it("uses the previous summary window end as the next window start", async () => {
     const conversationId = await seedConversation(db);
     await db
       .insertInto("agent_outputs")
@@ -152,7 +152,13 @@ describe("buildConversationSummaryRuntimeContext", () => {
         status: "completed",
         trigger_type: "scheduled",
         agent_version: "test",
-        generated_at: "2026-07-01T12:00:00.000Z",
+        generated_at: "2026-07-01T12:05:00.000Z",
+        raw_payload_json: JSON.stringify({
+          summaryWindow: {
+            start: "2026-07-01T11:00:00.000Z",
+            end: "2026-07-01T12:00:00.000Z",
+          },
+        }),
       })
       .execute();
     await seedMessage(db, conversationId, {
@@ -161,8 +167,13 @@ describe("buildConversationSummaryRuntimeContext", () => {
       receivedAt: "2026-07-01T11:00:00.000Z",
     });
     await seedMessage(db, conversationId, {
+      id: "m-during-completion",
+      text: "arrived while the prior summary was still writing",
+      receivedAt: "2026-07-01T12:03:00.000Z",
+    });
+    await seedMessage(db, conversationId, {
       id: "m-after",
-      text: "new unblocker",
+      text: "later unblocker",
       receivedAt: "2026-07-01T12:30:00.000Z",
     });
 
@@ -190,8 +201,11 @@ describe("buildConversationSummaryRuntimeContext", () => {
     });
     expect(context.summarySources).toEqual([
       expect.objectContaining({
-        messageCount: 1,
-        messages: [expect.objectContaining({ text: "new unblocker" })],
+        messageCount: 2,
+        messages: [
+          expect.objectContaining({ text: "arrived while the prior summary was still writing" }),
+          expect.objectContaining({ text: "later unblocker" }),
+        ],
       }),
     ]);
   });

--- a/packages/server/src/agents/definitions/conversation-summary.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.ts
@@ -1,0 +1,264 @@
+import type { Kysely } from "kysely";
+import type {
+  AgentOutputItemInput,
+  AgentSourceConfig,
+  AgentStructuredPayload,
+} from "../../db/repositories/agent-outputs";
+import { type StoredConversationMessage, createConversationRepository } from "../../db/repositories/conversations";
+import type { DB } from "../../db/schema";
+import type { AgentApiItem, AgentDefinition, AgentRuntimeContextParams, AgentStoredItem } from "../types";
+
+export const CONVERSATION_SUMMARY_AGENT_KEY = "conversation_summary";
+export const CONVERSATION_SUMMARY_AGENT_VERSION = "2026-07-conversation-summary-v1";
+export const CONVERSATION_SUMMARY_FIRST_RUN_LOOKBACK_HOURS = 24;
+export const CONVERSATION_SUMMARY_MAX_MESSAGES_PER_SOURCE = 300;
+export const CONVERSATION_SUMMARY_MAX_SOURCES = 12;
+
+const CONVERSATION_SUMMARY_ALLOWED_TOOLS = ["mcp__sketch__WriteAgentOutput"];
+
+const SECTION_LABELS = {
+  highlights: ["highlight"],
+  decisions: ["decision"],
+  action_items: ["action_item"],
+  open_questions: ["open_question"],
+} as const satisfies Record<string, readonly string[]>;
+
+type ConversationRow = {
+  id: number;
+  display_name: string | null;
+};
+
+type LatestOutputRow = {
+  id: string;
+  generated_at: string | null;
+  updated_at: string;
+};
+
+function sourceKind(source: AgentSourceConfig): "channel" | "group" {
+  return source.platform === "slack" ? "channel" : "group";
+}
+
+function sourceLabel(source: AgentSourceConfig, conversation: ConversationRow | undefined): string {
+  if (source.label) return source.label;
+  if (conversation?.display_name) return conversation.display_name;
+  if (source.platform === "slack") return source.targetId;
+  return source.targetId;
+}
+
+function fallbackWindowStart(now: Date): string {
+  return new Date(now.getTime() - CONVERSATION_SUMMARY_FIRST_RUN_LOOKBACK_HOURS * 60 * 60 * 1000).toISOString();
+}
+
+async function findLatestCompletedOutput(db: Kysely<DB>, userId: string): Promise<LatestOutputRow | undefined> {
+  return db
+    .selectFrom("agent_outputs")
+    .select(["id", "generated_at", "updated_at"])
+    .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+    .where("user_id", "=", userId)
+    .where("status", "=", "completed")
+    .orderBy("generated_at", "desc")
+    .orderBy("id", "desc")
+    .executeTakeFirst();
+}
+
+async function findConversation(db: Kysely<DB>, source: AgentSourceConfig): Promise<ConversationRow | undefined> {
+  return db
+    .selectFrom("conversations")
+    .select(["id", "display_name"])
+    .where("platform", "=", source.platform)
+    .where("kind", "=", sourceKind(source))
+    .where("provider_conversation_id", "=", source.targetId)
+    .executeTakeFirst();
+}
+
+function renderAttachment(attachment: StoredConversationMessage["attachments"][number]): Record<string, unknown> {
+  return {
+    name: attachment.originalName,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+    transcription: attachment.transcription ?? null,
+  };
+}
+
+function renderMessage(message: StoredConversationMessage): Record<string, unknown> {
+  return {
+    id: message.id,
+    senderName: message.senderName,
+    senderUserId: message.senderUserId,
+    text: message.text,
+    attachments: message.attachments.map(renderAttachment),
+    isThreadReply: message.isThreadReply,
+    providerThreadId: message.providerThreadId,
+    providerTimestamp: message.providerTimestamp,
+    receivedAt: message.receivedAt,
+  };
+}
+
+export async function buildConversationSummaryRuntimeContext(
+  params: AgentRuntimeContextParams,
+): Promise<Record<string, unknown>> {
+  const sources = params.agentConfig?.sources ?? [];
+  const previousOutput = await findLatestCompletedOutput(params.db, params.user.id);
+  const windowEnd = params.now.toISOString();
+  const windowStart = previousOutput?.generated_at ?? previousOutput?.updated_at ?? fallbackWindowStart(params.now);
+  const conversations = createConversationRepository(params.db);
+
+  const summarySources = await Promise.all(
+    sources.map(async (source) => {
+      const conversation = await findConversation(params.db, source);
+      const result = conversation
+        ? await conversations.listMessagesInWindow(conversation.id, {
+            afterReceivedAt: windowStart,
+            beforeReceivedAt: windowEnd,
+            limit: CONVERSATION_SUMMARY_MAX_MESSAGES_PER_SOURCE,
+            includeBotMessages: false,
+          })
+        : { messages: [], hasMore: false };
+
+      return {
+        platform: source.platform,
+        targetType: source.targetType,
+        targetId: source.targetId,
+        label: sourceLabel(source, conversation),
+        conversationId: conversation?.id ?? null,
+        messageCount: result.messages.length,
+        truncated: result.hasMore,
+        messages: result.messages.map(renderMessage),
+      };
+    }),
+  );
+
+  return {
+    summaryWindow: {
+      mode: previousOutput ? "since_last_successful_run" : "first_run_last_24h",
+      start: windowStart,
+      end: windowEnd,
+      previousOutputId: previousOutput?.id ?? null,
+      firstRunFallbackHours: CONVERSATION_SUMMARY_FIRST_RUN_LOOKBACK_HOURS,
+    },
+    summarySources,
+  };
+}
+
+const CONVERSATION_SUMMARY_INSTRUCTIONS = [
+  "You are Sketch's Summarizer.",
+  "",
+  "Generate a concise summary from the configured Slack channels and WhatsApp groups in the runtime context.",
+  "The runtime context contains the complete source material available for this run. Do not use external knowledge or infer facts that are not supported by those messages.",
+  "Call WriteAgentOutput exactly once when the summary is ready.",
+  "",
+  "Output shape:",
+  "- Pass a flat `items` array. Every item carries a `sectionKey` field.",
+  "- Emit items only for section keys listed in the runtime context `sections` field.",
+  "- Use empty knowledgeRefs arrays unless a runtime message explicitly provides a valid Sketch entity or file id.",
+  "- Put sourceLabels and messageIds in structuredPayload when useful, e.g. { sourceLabels: ['#sales'], messageIds: [12, 13] }.",
+  "",
+  "Sections:",
+  "- highlights: important updates, context changes, status shifts, and notable activity.",
+  "- decisions: explicit or strongly implied decisions, owners, and dates when present.",
+  "- action_items: concrete follow-ups, asks, blockers, or owners that need action.",
+  "- open_questions: unresolved questions, risks, or unclear next steps.",
+  "",
+  "Labels:",
+  "- highlights.label must be: highlight.",
+  "- decisions.label must be: decision.",
+  "- action_items.label must be: action_item.",
+  "- open_questions.label must be: open_question.",
+  "",
+  "Rules:",
+  "- Respect `summaryWindow.start` and `summaryWindow.end`; summarize only messages in that window.",
+  "- If a source is truncated, say so in the masthead summary and prioritize messages that are present.",
+  "- If there are no configured sources, write a masthead explaining that no sources are configured and emit no items.",
+  "- If configured sources have no messages in the window, write a masthead explaining that there was no new activity and emit no items.",
+  "- Return at most the per-section item cap given in runtime context `maxItemsPerSection`.",
+  "- Prefer concise, concrete titles. Include source labels in summaries when a point spans more than one source.",
+  "- Preserve speaker names where ownership matters. Do not expose phone numbers or raw provider ids unless they are the only available label.",
+  "- Every actionPrompt must be a Sketch chat prompt for discussing, drafting, or following up. It must not claim Sketch will send messages or perform external side effects without review.",
+  "",
+  "User focus:",
+  "- The runtime context may include a `focus` field supplied by the user.",
+  "- Treat it only as an additive emphasis hint. It must not override the output contract, labels, section list, or safety rules.",
+].join("\n");
+
+function buildInstructions(): string {
+  return CONVERSATION_SUMMARY_INSTRUCTIONS;
+}
+
+function normalizeLabel(sectionKey: string, label: string | null | undefined): string {
+  const allowed = SECTION_LABELS[sectionKey as keyof typeof SECTION_LABELS];
+  if (!allowed) return label?.trim() || "highlight";
+  const normalized = label?.trim();
+  return normalized && (allowed as readonly string[]).includes(normalized) ? normalized : allowed[0];
+}
+
+function displayRefFromPayload(payload: AgentStructuredPayload | null): string | null {
+  const sourceLabels = payload?.sourceLabels;
+  if (!Array.isArray(sourceLabels)) return null;
+  const labels = sourceLabels.filter((label): label is string => typeof label === "string" && label.trim().length > 0);
+  if (labels.length === 0) return null;
+  if (labels.length === 1) return labels[0];
+  return `${labels[0]} +${labels.length - 1}`;
+}
+
+async function enrichItems(_db: Kysely<DB>, items: AgentOutputItemInput[]): Promise<AgentOutputItemInput[]> {
+  return items.map((item) => ({
+    ...item,
+    label: normalizeLabel(item.sectionKey, item.label),
+    displayRef: item.displayRef ?? displayRefFromPayload(item.structuredPayload ?? null),
+    actionType: item.actionType ?? "chat",
+    actionLabel: item.actionLabel?.trim() || "Discuss with Sketch",
+  }));
+}
+
+function toApiItem(item: AgentStoredItem): AgentApiItem {
+  return {
+    id: item.id,
+    sectionKey: item.section_key,
+    title: item.title,
+    summary: item.summary,
+    priority: item.priority,
+    label: normalizeLabel(item.section_key, item.label),
+    displayRef: item.display_ref ?? displayRefFromPayload(item.structuredPayload),
+    actionType: item.action_type,
+    actionLabel: item.action_label ?? "Discuss with Sketch",
+    actionPrompt: item.action_prompt,
+    sourceUrl: item.source_url,
+    structuredPayload: item.structuredPayload,
+    knowledgeRefs: item.knowledgeRefs,
+    sortOrder: item.sort_order,
+  };
+}
+
+export const conversationSummaryDefinition: AgentDefinition = {
+  key: CONVERSATION_SUMMARY_AGENT_KEY,
+  version: CONVERSATION_SUMMARY_AGENT_VERSION,
+  title: "Summarizer",
+  tagline: "Summarizes selected Slack channels and WhatsApp groups.",
+  description:
+    "Reads configured shared conversations and produces focused summaries with highlights, decisions, action items, and open questions.",
+  category: "Briefings",
+  defaults: {
+    enabled: false,
+    scheduleHour: 18,
+    scheduleMinute: 0,
+    maxItemsPerSection: 5,
+  },
+  sections: [
+    { key: "highlights", title: "Highlights", enabledByDefault: true, labels: SECTION_LABELS.highlights },
+    { key: "decisions", title: "Decisions", enabledByDefault: true, labels: SECTION_LABELS.decisions },
+    { key: "action_items", title: "Action items", enabledByDefault: true, labels: SECTION_LABELS.action_items },
+    { key: "open_questions", title: "Open questions", enabledByDefault: true, labels: SECTION_LABELS.open_questions },
+  ],
+  sourceConfig: {
+    maxSources: CONVERSATION_SUMMARY_MAX_SOURCES,
+    supportsSlackChannels: true,
+    supportsWhatsAppGroups: true,
+  },
+  allowedTools: CONVERSATION_SUMMARY_ALLOWED_TOOLS,
+  itemsPerSectionRange: { min: 1, max: 12 },
+  requiresKnowledgeRefs: false,
+  buildInstructions,
+  buildRuntimeContext: buildConversationSummaryRuntimeContext,
+  enrichItems,
+  toApiItem,
+};

--- a/packages/server/src/agents/definitions/conversation-summary.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.ts
@@ -31,8 +31,13 @@ type ConversationRow = {
 type LatestOutputRow = {
   id: string;
   generated_at: string | null;
+  raw_payload_json: string | null;
   updated_at: string;
 };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
 
 function sourceKind(source: AgentSourceConfig): "channel" | "group" {
   return source.platform === "slack" ? "channel" : "group";
@@ -52,13 +57,37 @@ function fallbackWindowStart(now: Date): string {
 async function findLatestCompletedOutput(db: Kysely<DB>, userId: string): Promise<LatestOutputRow | undefined> {
   return db
     .selectFrom("agent_outputs")
-    .select(["id", "generated_at", "updated_at"])
+    .select(["id", "generated_at", "raw_payload_json", "updated_at"])
     .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
     .where("user_id", "=", userId)
     .where("status", "=", "completed")
     .orderBy("generated_at", "desc")
     .orderBy("id", "desc")
     .executeTakeFirst();
+}
+
+function summaryWindowEndFromRawPayload(rawPayloadJson: string | null): string | null {
+  if (!rawPayloadJson) return null;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawPayloadJson);
+  } catch {
+    return null;
+  }
+
+  const payloadRecord = asRecord(payload);
+  const summaryWindow = asRecord(payloadRecord?.summaryWindow);
+  const end = summaryWindow?.end;
+  return typeof end === "string" && end.trim().length > 0 ? end : null;
+}
+
+function previousOutputWatermark(previousOutput: LatestOutputRow | undefined, now: Date): string {
+  if (!previousOutput) return fallbackWindowStart(now);
+  return (
+    summaryWindowEndFromRawPayload(previousOutput.raw_payload_json) ??
+    previousOutput.generated_at ??
+    previousOutput.updated_at
+  );
 }
 
 async function findConversation(db: Kysely<DB>, source: AgentSourceConfig): Promise<ConversationRow | undefined> {
@@ -100,7 +129,7 @@ export async function buildConversationSummaryRuntimeContext(
   const sources = params.agentConfig?.sources ?? [];
   const previousOutput = await findLatestCompletedOutput(params.db, params.user.id);
   const windowEnd = params.now.toISOString();
-  const windowStart = previousOutput?.generated_at ?? previousOutput?.updated_at ?? fallbackWindowStart(params.now);
+  const windowStart = previousOutputWatermark(previousOutput, params.now);
   const conversations = createConversationRepository(params.db);
 
   const summarySources = await Promise.all(

--- a/packages/server/src/agents/output-delivery.test.ts
+++ b/packages/server/src/agents/output-delivery.test.ts
@@ -73,6 +73,7 @@ describe("createAgentOutputDeliveryService", () => {
         targetType: "channel",
         targetId: "C_DAILY",
         label: "#daily",
+        mentions: [{ platform: "slack", targetId: "UOWNER", label: "Owner" }],
       },
       output: {
         id: "output-delivery",
@@ -103,7 +104,8 @@ describe("createAgentOutputDeliveryService", () => {
       },
     });
 
-    expect(slack.postMessage).toHaveBeenCalledWith("C_DAILY", expect.stringContaining("*Daily Brief - Jun 26*"));
+    expect(slack.postMessage).toHaveBeenCalledWith("C_DAILY", expect.stringContaining("*Daily Brief | Jun 26*"));
+    expect(slack.postMessage).toHaveBeenCalledWith("C_DAILY", expect.stringContaining("Cc: <@UOWNER>"));
     const attempt = await db.selectFrom("agent_output_deliveries").selectAll().executeTakeFirstOrThrow();
     expect(attempt.status).toBe("sent");
     expect(attempt.message_refs_json).toBe(JSON.stringify(["123.456"]));
@@ -112,18 +114,14 @@ describe("createAgentOutputDeliveryService", () => {
     expect(captured[0].provider_message_id).toBe("123.456");
   });
 
-  it("sends WhatsApp delivery chunks and records every message ref", async () => {
-    let sentCount = 0;
+  it("sends compact WhatsApp delivery and records the message ref", async () => {
     const whatsapp = createMockWhatsApp({
       isConnected: true,
-      sendText: vi.fn(async () => {
-        sentCount += 1;
-        return {
-          providerMessageId: `wa-message-${sentCount}`,
-          providerConversationId: "120363000000001@g.us",
-          providerTimestamp: "2024-06-04T07:20:00.000Z",
-        };
-      }),
+      sendText: vi.fn(async () => ({
+        providerMessageId: "wa-message-1",
+        providerConversationId: "120363000000001@g.us",
+        providerTimestamp: "2024-06-04T07:20:00.000Z",
+      })),
     });
     const service = createAgentOutputDeliveryService({
       db,
@@ -150,28 +148,22 @@ describe("createAgentOutputDeliveryService", () => {
       },
     });
 
-    expect(whatsapp.sendText).toHaveBeenCalledTimes(4);
+    expect(whatsapp.sendText).toHaveBeenCalledTimes(1);
     for (const call of vi.mocked(whatsapp.sendText).mock.calls) {
       expect(call[0]).toEqual({ kind: "group", groupId: "120363000000001@g.us" });
       expect(call[1].length).toBeLessThanOrEqual(4000);
+      expect(call[1]).toContain("...");
     }
 
     const attempt = await db.selectFrom("agent_output_deliveries").selectAll().executeTakeFirstOrThrow();
     expect(attempt.status).toBe("sent");
-    expect(attempt.message_refs_json).toBe(
-      JSON.stringify(["wa-message-1", "wa-message-2", "wa-message-3", "wa-message-4"]),
-    );
+    expect(attempt.message_refs_json).toBe(JSON.stringify(["wa-message-1"]));
     const captured = await db
       .selectFrom("conversation_messages")
       .select(["text", "provider_message_id"])
       .orderBy("provider_message_id")
       .execute();
-    expect(captured.map((row) => row.provider_message_id)).toEqual([
-      "wa-message-1",
-      "wa-message-2",
-      "wa-message-3",
-      "wa-message-4",
-    ]);
+    expect(captured.map((row) => row.provider_message_id)).toEqual(["wa-message-1"]);
     expect(captured.every((row) => row.text.length <= 4000)).toBe(true);
   });
 

--- a/packages/server/src/agents/output-delivery.ts
+++ b/packages/server/src/agents/output-delivery.ts
@@ -109,6 +109,7 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
           sections: params.definition.sections,
           output: params.output,
           platform: params.delivery.platform,
+          mentions: params.delivery.mentions,
         });
         const messageRefs =
           params.delivery.platform === "slack"

--- a/packages/server/src/agents/output-renderer.test.ts
+++ b/packages/server/src/agents/output-renderer.test.ts
@@ -28,41 +28,101 @@ function item(overrides: Partial<AgentApiItem> = {}): AgentApiItem {
 }
 
 describe("renderAgentOutputForDelivery", () => {
-  it("renders Slack formatting with linked source titles", () => {
+  it("renders readable Slack formatting with linked source titles and mentions", () => {
+    const text = renderAgentOutputForDelivery({
+      title: "Daily Brief",
+      sections,
+      platform: "slack",
+      mentions: [{ platform: "slack", targetId: "U123", label: "Ada" }],
+      output: {
+        outputDate: "2026-06-26",
+        masthead: { title: "Daily Brief", summary: "Start with the launch follow-up." },
+        sections: { todos: [item()], customer_updates: [] },
+      },
+    });
+
+    expect(text).toContain("*Daily Brief | Jun 26*");
+    expect(text).toContain("Cc: <@U123>");
+    expect(text).toContain("Start with the launch follow-up.");
+    expect(text).toContain("*To-dos*");
+    expect(text).toContain(
+      "- *<https://linear.app/sketch-ai/issue/SKE-235/example|Follow up with Acme>* - Acme asked for the launch timeline.",
+    );
+    expect(text).toContain("_High priority / SKE-235_");
+  });
+
+  it("renders readable WhatsApp formatting with plain source URLs and text mentions", () => {
+    const text = renderAgentOutputForDelivery({
+      title: "Daily Brief",
+      sections,
+      platform: "whatsapp",
+      mentions: [{ platform: "whatsapp", targetId: "+15551234567", label: "Ada Lovelace" }],
+      output: {
+        outputDate: "2026-06-26",
+        masthead: { title: "Daily Brief", summary: "Start with the launch follow-up." },
+        sections: { todos: [item()], customer_updates: [] },
+      },
+    });
+
+    expect(text).toContain("Daily Brief | Jun 26");
+    expect(text).toContain("Cc: @AdaLovelace");
+    expect(text).toContain("To-dos");
+    expect(text).toContain("- Follow up with Acme - Acme asked for the launch timeline.");
+    expect(text).toContain("  High priority | SKE-235");
+    expect(text).toContain("  Source: https://linear.app/sketch-ai/issue/SKE-235/example");
+  });
+
+  it("clips busy sections for delivery while preserving the web output", () => {
     const text = renderAgentOutputForDelivery({
       title: "Daily Brief",
       sections,
       platform: "slack",
       output: {
         outputDate: "2026-06-26",
-        masthead: { title: "Daily Brief", summary: "Start with the launch follow-up." },
-        sections: { todos: [item()], customer_updates: [] },
+        masthead: { title: "Daily Brief", summary: "Long ".repeat(150) },
+        sections: {
+          todos: [item({ id: "1" }), item({ id: "2" }), item({ id: "3" }), item({ id: "4" }), item({ id: "5" })],
+          customer_updates: [],
+        },
       },
     });
 
-    expect(text).toContain("*Daily Brief - Jun 26*");
-    expect(text).toContain("Start with the launch follow-up.");
-    expect(text).toContain("*To-dos*");
-    expect(text).toContain(
-      "- High: <https://linear.app/sketch-ai/issue/SKE-235/example|Follow up with Acme> (SKE-235) - Acme asked for the launch timeline.",
-    );
+    expect(text).toContain("Long");
+    expect(text).toContain("...");
+    expect(text).toContain("_+1 more in Sketch_");
   });
 
-  it("renders WhatsApp formatting with plain source URLs", () => {
+  it("escapes Slack control characters outside configured mentions", () => {
     const text = renderAgentOutputForDelivery({
       title: "Daily Brief",
       sections,
-      platform: "whatsapp",
+      platform: "slack",
+      mentions: [
+        { platform: "slack", targetId: "UCONFIGURED", label: "Configured" },
+        { platform: "slack", targetId: "<!channel>", label: "Invalid" },
+      ],
       output: {
         outputDate: "2026-06-26",
-        masthead: { title: "Daily Brief", summary: "Start with the launch follow-up." },
-        sections: { todos: [item()], customer_updates: [] },
+        masthead: { title: "Daily Brief", summary: "Do not ping <@U_OTHER> or <#C_OTHER|ops>." },
+        sections: {
+          todos: [
+            item({
+              title: "Check <@U_OTHER>",
+              summary: "Avoid <@U_OTHER> and *format* injection.",
+              displayRef: "<#C_OTHER|ops>",
+              sourceUrl: null,
+            }),
+          ],
+          customer_updates: [],
+        },
       },
     });
 
-    expect(text).toContain("Daily Brief - Jun 26");
-    expect(text).toContain("To-dos");
-    expect(text).toContain("- High: Follow up with Acme (SKE-235) - Acme asked for the launch timeline.");
-    expect(text).toContain("  https://linear.app/sketch-ai/issue/SKE-235/example");
+    expect(text).toContain("Cc: <@UCONFIGURED>");
+    expect(text).not.toContain("<@<!channel>>");
+    expect(text).not.toContain("<@U_OTHER>");
+    expect(text).not.toContain("<#C_OTHER|ops>");
+    expect(text).toContain("(@UOTHER)");
+    expect(text).toContain("(#COTHER/ops)");
   });
 });

--- a/packages/server/src/agents/output-renderer.ts
+++ b/packages/server/src/agents/output-renderer.ts
@@ -1,4 +1,4 @@
-import type { AgentMasthead } from "../db/repositories/agent-outputs";
+import type { AgentDeliveryMention, AgentMasthead } from "../db/repositories/agent-outputs";
 import type { AgentApiItem, AgentSectionDef } from "./types";
 
 export type AgentDeliveryRenderPlatform = "slack" | "whatsapp";
@@ -10,6 +10,10 @@ export interface RenderableAgentOutput {
 }
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DELIVERY_MAX_ITEMS_PER_SECTION = 4;
+const MASTHEAD_SUMMARY_LIMIT = 420;
+const ITEM_TITLE_LIMIT = 96;
+const ITEM_SUMMARY_LIMIT = 260;
 
 function formatOutputDate(date: string): string {
   const [year, month, day] = date.split("-").map((part) => Number(part));
@@ -24,18 +28,61 @@ function priorityLabel(value: string): string {
   return value;
 }
 
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function clip(value: string, limit: number): string {
+  const compact = compactWhitespace(value);
+  if (compact.length <= limit) return compact;
+  return `${compact.slice(0, Math.max(0, limit - 3)).trimEnd()}...`;
+}
+
 function slackLink(label: string, url: string | null): string {
   if (!url) return label;
   const safeLabel = label.replaceAll("|", "/").replaceAll("<", "(").replaceAll(">", ")");
   return `<${url}|${safeLabel}>`;
 }
 
+function sanitizeSlackText(value: string): string {
+  return value
+    .replaceAll("*", "")
+    .replaceAll("_", "")
+    .replaceAll("`", "")
+    .replaceAll("|", "/")
+    .replaceAll("<", "(")
+    .replaceAll(">", ")");
+}
+
+function isSlackMentionTargetId(value: string): boolean {
+  return /^[UW][A-Z0-9]+$/.test(value);
+}
+
+function formatMention(mention: AgentDeliveryMention, platform: AgentDeliveryRenderPlatform): string | null {
+  if (mention.platform !== platform) return null;
+  if (platform === "slack") return isSlackMentionTargetId(mention.targetId) ? `<@${mention.targetId}>` : null;
+  const label = mention.label?.trim() || mention.targetId;
+  const withoutPhonePrefix = label.replace(/^dm:/, "");
+  const display = withoutPhonePrefix
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^\p{L}\p{N}._ -]/gu, "")
+    .replace(/\s+/g, "");
+  return display ? `@${display}` : null;
+}
+
 function formatItem(item: AgentApiItem, platform: AgentDeliveryRenderPlatform): string {
-  const ref = item.displayRef ? ` (${item.displayRef})` : "";
-  const title = platform === "slack" ? slackLink(item.title, item.sourceUrl) : item.title;
-  const line = `- ${priorityLabel(item.priority)}: ${title}${ref} - ${item.summary}`;
-  if (platform === "whatsapp" && item.sourceUrl) return `${line}\n  ${item.sourceUrl}`;
-  return line;
+  const titleText = clip(item.title, ITEM_TITLE_LIMIT);
+  const title = platform === "slack" ? slackLink(sanitizeSlackText(titleText), item.sourceUrl) : titleText;
+  const summaryText = clip(item.summary, ITEM_SUMMARY_LIMIT);
+  const summary = platform === "slack" ? sanitizeSlackText(summaryText) : summaryText;
+  const headline = platform === "slack" ? `- *${title}* - ${summary}` : `- ${title} - ${summary}`;
+  const metadata = [item.priority === "high" ? `${priorityLabel(item.priority)} priority` : null, item.displayRef]
+    .filter(Boolean)
+    .join(" | ");
+  const lines = [headline];
+  if (metadata) lines.push(platform === "slack" ? `  _${sanitizeSlackText(metadata)}_` : `  ${metadata}`);
+  if (platform === "whatsapp" && item.sourceUrl) lines.push(`  Source: ${item.sourceUrl}`);
+  return lines.join("\n");
 }
 
 export function renderAgentOutputForDelivery(params: {
@@ -43,20 +90,32 @@ export function renderAgentOutputForDelivery(params: {
   sections: readonly AgentSectionDef[];
   output: RenderableAgentOutput;
   platform: AgentDeliveryRenderPlatform;
+  mentions?: readonly AgentDeliveryMention[];
 }): string {
-  const header = `${params.title} - ${formatOutputDate(params.output.outputDate)}`;
+  const header = `${params.title} | ${formatOutputDate(params.output.outputDate)}`;
   const lines: string[] = [params.platform === "slack" ? `*${header}*` : header];
+  const mentions = (params.mentions ?? []).flatMap((mention) => {
+    const formatted = formatMention(mention, params.platform);
+    return formatted ? [formatted] : [];
+  });
+  if (mentions.length > 0) lines.push(`Cc: ${mentions.join(", ")}`);
+
   const summary = params.output.masthead?.summary?.trim();
   if (summary) {
-    lines.push("", summary);
+    const clipped = clip(summary, MASTHEAD_SUMMARY_LIMIT);
+    lines.push("", params.platform === "slack" ? sanitizeSlackText(clipped) : clipped);
   }
 
   for (const section of params.sections) {
     const items = params.output.sections[section.key] ?? [];
     if (items.length === 0) continue;
     lines.push("", params.platform === "slack" ? `*${section.title}*` : section.title);
-    for (const item of items) {
+    for (const item of items.slice(0, DELIVERY_MAX_ITEMS_PER_SECTION)) {
       lines.push(formatItem(item, params.platform));
+    }
+    const hidden = items.length - DELIVERY_MAX_ITEMS_PER_SECTION;
+    if (hidden > 0) {
+      lines.push(params.platform === "slack" ? `_+${hidden} more in Sketch_` : `+${hidden} more in Sketch`);
     }
   }
 

--- a/packages/server/src/agents/registry.ts
+++ b/packages/server/src/agents/registry.ts
@@ -1,3 +1,4 @@
+import { conversationSummaryDefinition } from "./definitions/conversation-summary";
 import { dailyBriefDefinition } from "./definitions/daily-brief";
 import type { AgentDefinition } from "./types";
 
@@ -5,7 +6,7 @@ import type { AgentDefinition } from "./types";
  * Curated catalog of prebuilt agents. The list is code-owned: shipping a new agent
  * means adding a definition here, never a user-authored row. v1 ships the Daily Brief.
  */
-export const AGENT_REGISTRY: readonly AgentDefinition[] = [dailyBriefDefinition];
+export const AGENT_REGISTRY: readonly AgentDefinition[] = [dailyBriefDefinition, conversationSummaryDefinition];
 
 const BY_KEY = new Map(AGENT_REGISTRY.map((def) => [def.key, def]));
 

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -37,6 +37,7 @@ describe("agentRoutes", () => {
       targetType: "dm" as const,
       targetId: "U_SELF",
       label: "Agent User <user@example.com>",
+      mentions: [{ platform: "slack" as const, targetId: "U_OWNER", label: "Owner" }],
     };
     const service = createService({
       resolveDeliveryConfigForUser: vi.fn(async () => resolved),
@@ -54,6 +55,7 @@ describe("agentRoutes", () => {
           targetType: "dm",
           targetId: "U_SELF",
           label: "Spoofed",
+          mentions: [{ platform: "slack", targetId: "U_OWNER", label: "Spoofed Owner" }],
         },
       }),
     });
@@ -64,6 +66,38 @@ describe("agentRoutes", () => {
       "user-1",
       expect.objectContaining({ delivery: resolved }),
     );
+    expect(service.resolveDeliveryConfigForUser).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({
+        mentions: [{ platform: "slack", targetId: "U_OWNER", label: "Spoofed Owner" }],
+      }),
+    );
+  });
+
+  it("rejects delivery mentions for the wrong platform", async () => {
+    const service = createService();
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request("/api/agents/daily-brief/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        delivery: {
+          enabled: true,
+          platform: "slack",
+          targetType: "channel",
+          targetId: "C_DAILY",
+          label: "#daily",
+          mentions: [{ platform: "whatsapp", targetId: "+15551234567", label: "Ada" }],
+        },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "delivery mention platform must match delivery.platform" },
+    });
+    expect(service.updateConfigForUser).not.toHaveBeenCalled();
   });
 
   it("rejects unauthorized delivery config before saving it", async () => {

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import { agentRoutes } from "./routes";
-import { AgentDeliveryTargetError, type AgentRunService } from "./service";
+import { AgentDeliveryTargetError, type AgentRunService, AgentSourceTargetError } from "./service";
 
 function createRoutesTestApp(service: AgentRunService) {
   const app = new Hono();
@@ -18,10 +18,13 @@ function createService(overrides: Record<string, unknown> = {}) {
   return {
     resolveUserId: vi.fn(async () => "user-1"),
     resolveDeliveryConfigForUser: vi.fn(async (_userId, delivery) => delivery),
+    listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
+    listOutputsForUser: vi.fn(async () => ({ outputs: [], nextCursor: null })),
     updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
     ...overrides,
   } as unknown as AgentRunService & {
     resolveDeliveryConfigForUser: ReturnType<typeof vi.fn>;
+    listOutputsForUser: ReturnType<typeof vi.fn>;
     updateConfigForUser: ReturnType<typeof vi.fn>;
   };
 }
@@ -90,5 +93,48 @@ describe("agentRoutes", () => {
     });
     expect(res.status).toBe(400);
     expect(service.updateConfigForUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthorized source config before saving it", async () => {
+    const service = createService({
+      updateConfigForUser: vi.fn(async () => {
+        throw new AgentSourceTargetError("Slack channel is not available for this user");
+      }),
+    });
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request("/api/agents/daily-brief/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [
+          {
+            platform: "slack",
+            targetType: "channel",
+            targetId: "C_PRIVATE",
+            label: "#private",
+          },
+        ],
+      }),
+    });
+
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "Slack channel is not available for this user" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("lists completed outputs for an agent", async () => {
+    const service = createService({
+      listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
+      listOutputsForUser: vi.fn(async () => ({ outputs: [{ id: "out-1" }], nextCursor: "out-1" })),
+    });
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request("/api/agents/daily-brief/outputs?limit=10&cursor=old");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ outputs: [{ id: "out-1" }], nextCursor: "out-1" });
+    expect(service.listOutputsForUser).toHaveBeenCalledWith("daily-brief", "user-1", { limit: 10, cursor: "old" });
   });
 });

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
-import type { AgentDeliveryConfig } from "../db/repositories/agent-outputs";
+import type { AgentDeliveryConfig, AgentSourceConfig } from "../db/repositories/agent-outputs";
 import type { DB } from "../db/schema";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
-import { AgentDeliveryTargetError, type AgentOutputApi, type AgentRunService } from "./service";
+import { AgentDeliveryTargetError, type AgentOutputApi, type AgentRunService, AgentSourceTargetError } from "./service";
 
 async function getCurrentUserId(c: { get: (key: "sub" | "email") => string | undefined }, service: AgentRunService) {
   const sub = c.get("sub");
@@ -125,6 +125,33 @@ function parseDeliveryConfig(value: unknown): AgentDeliveryConfig | null | undef
   return { enabled: true, platform, targetType, targetId, label };
 }
 
+function parseSourceConfigs(value: unknown): AgentSourceConfig[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new ConfigPatchError("sources must be an array");
+  return value.map((entry) => {
+    if (!entry || typeof entry !== "object") throw new ConfigPatchError("source must be an object");
+    const raw = entry as Record<string, unknown>;
+    const platform = raw.platform;
+    const targetType = raw.targetType;
+    const targetId = typeof raw.targetId === "string" ? raw.targetId.trim() : "";
+    if (platform !== "slack" && platform !== "whatsapp") {
+      throw new ConfigPatchError("source.platform must be slack or whatsapp");
+    }
+    if (targetType !== "channel" && targetType !== "group") {
+      throw new ConfigPatchError("source.targetType must be channel or group");
+    }
+    if (!targetId) throw new ConfigPatchError("source.targetId is required");
+    if (platform === "slack" && targetType !== "channel") {
+      throw new ConfigPatchError("Slack sources must be channels");
+    }
+    if (platform === "whatsapp" && targetType !== "group") {
+      throw new ConfigPatchError("WhatsApp sources must be groups");
+    }
+    const label = typeof raw.label === "string" && raw.label.trim() ? raw.label.trim() : null;
+    return { platform, targetType, targetId, label };
+  });
+}
+
 function parseConfigPatch(body: Record<string, unknown>) {
   const patch: {
     enabled?: boolean;
@@ -134,6 +161,7 @@ function parseConfigPatch(body: Record<string, unknown>) {
     sections?: Record<string, boolean>;
     focus?: string | null;
     delivery?: AgentDeliveryConfig | null;
+    sources?: AgentSourceConfig[];
   } = {};
   if (typeof body.enabled === "boolean") patch.enabled = body.enabled;
   if (typeof body.scheduleHour === "number" && Number.isInteger(body.scheduleHour)) {
@@ -157,6 +185,8 @@ function parseConfigPatch(body: Record<string, unknown>) {
   }
   const delivery = parseDeliveryConfig(body.delivery);
   if (delivery !== undefined) patch.delivery = delivery;
+  const sources = parseSourceConfigs(body.sources);
+  if (sources !== undefined) patch.sources = sources;
   return patch;
 }
 
@@ -191,20 +221,38 @@ export function agentRoutes(service: AgentRunService) {
     const agentKey = c.req.param("agentKey");
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
     let patch: ReturnType<typeof parseConfigPatch>;
+    let agent: Awaited<ReturnType<AgentRunService["updateConfigForUser"]>>;
     try {
       patch = parseConfigPatch(body);
       if (patch.delivery !== undefined) {
         patch.delivery = await service.resolveDeliveryConfigForUser(userId, patch.delivery);
       }
+      agent = await service.updateConfigForUser(agentKey, userId, patch);
     } catch (err) {
-      if (err instanceof ConfigPatchError || err instanceof AgentDeliveryTargetError) {
+      if (
+        err instanceof ConfigPatchError ||
+        err instanceof AgentDeliveryTargetError ||
+        err instanceof AgentSourceTargetError
+      ) {
         return c.json({ error: { code: "VALIDATION_ERROR", message: err.message } }, 400);
       }
       throw err;
     }
-    const agent = await service.updateConfigForUser(agentKey, userId, patch);
     if (!agent) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     return c.json({ agent });
+  });
+
+  routes.get("/:agentKey/outputs", async (c) => {
+    const userId = await getCurrentUserId(c, service);
+    if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
+    const agentKey = c.req.param("agentKey");
+    if (!service.listDefinitions().some((def) => def.key === agentKey)) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
+    }
+    const rawLimit = Number(c.req.query("limit") ?? "20");
+    const limit = Number.isInteger(rawLimit) ? rawLimit : 20;
+    const cursor = c.req.query("cursor") || null;
+    return c.json(await service.listOutputsForUser(agentKey, userId, { limit, cursor }));
   });
 
   routes.get("/:agentKey/outputs/:id", async (c) => {

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -1,6 +1,11 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
-import type { AgentDeliveryConfig, AgentSourceConfig } from "../db/repositories/agent-outputs";
+import type {
+  AgentDeliveryConfig,
+  AgentDeliveryMention,
+  AgentDeliveryPlatform,
+  AgentSourceConfig,
+} from "../db/repositories/agent-outputs";
 import type { DB } from "../db/schema";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import { AgentDeliveryTargetError, type AgentOutputApi, type AgentRunService, AgentSourceTargetError } from "./service";
@@ -98,6 +103,35 @@ export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>) {
 
 class ConfigPatchError extends Error {}
 
+function parseDeliveryMentions(value: unknown, deliveryPlatform: AgentDeliveryPlatform): AgentDeliveryMention[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new ConfigPatchError("delivery.mentions must be an array");
+  if (value.length > 20) throw new ConfigPatchError("delivery.mentions supports at most 20 people");
+  const mentions: AgentDeliveryMention[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") throw new ConfigPatchError("delivery mention must be an object");
+    const raw = entry as Record<string, unknown>;
+    const platform = raw.platform;
+    const targetId = typeof raw.targetId === "string" ? raw.targetId.trim() : "";
+    if (platform !== "slack" && platform !== "whatsapp") {
+      throw new ConfigPatchError("delivery mention platform must be slack or whatsapp");
+    }
+    if (platform !== deliveryPlatform) {
+      throw new ConfigPatchError("delivery mention platform must match delivery.platform");
+    }
+    if (!targetId) throw new ConfigPatchError("delivery mention targetId is required");
+    const key = `${platform}:${targetId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const label = typeof raw.label === "string" && raw.label.trim() ? raw.label.trim() : null;
+    mentions.push({ platform, targetId, label });
+  }
+
+  return mentions;
+}
+
 function parseDeliveryConfig(value: unknown): AgentDeliveryConfig | null | undefined {
   if (value === undefined) return undefined;
   if (value === null) return null;
@@ -122,7 +156,15 @@ function parseDeliveryConfig(value: unknown): AgentDeliveryConfig | null | undef
     throw new ConfigPatchError("WhatsApp delivery supports group targets");
   }
   const label = typeof raw.label === "string" && raw.label.trim() ? raw.label.trim() : null;
-  return { enabled: true, platform, targetType, targetId, label };
+  const mentions = parseDeliveryMentions(raw.mentions, platform);
+  return {
+    enabled: true,
+    platform,
+    targetType,
+    targetId,
+    label,
+    ...(mentions.length > 0 ? { mentions } : {}),
+  };
 }
 
 function parseSourceConfigs(value: unknown): AgentSourceConfig[] | undefined {

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -8,6 +8,7 @@ import type { DB } from "../db/schema";
 import type { QueueManager } from "../queue";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 import type { WhatsAppBot } from "../whatsapp/bot";
+import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
 import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION, dailyBriefDefinition } from "./definitions/daily-brief";
 import type { AgentOutputDeliveryPublisher } from "./output-delivery";
 import { AgentRunService, type AgentRunServiceDeps } from "./service";
@@ -122,6 +123,13 @@ function allowSlackDelivery(
       isUserInChannel,
     }),
   };
+}
+
+function runtimeContextFromUserMessage(userMessage: string): Record<string, unknown> {
+  const marker = "Runtime context:\n";
+  const markerIndex = userMessage.indexOf(marker);
+  if (markerIndex === -1) throw new Error("Runtime context marker missing");
+  return JSON.parse(userMessage.slice(markerIndex + marker.length)) as Record<string, unknown>;
 }
 
 async function seedIndexedFile(
@@ -938,6 +946,107 @@ describe("AgentRunService", () => {
       label: "Leadership",
       mentions: [{ platform: "whatsapp", targetId: "+15557654321", label: "Ada" }],
     });
+  });
+
+  it("drops saved conversation sources that fail run-time Slack membership revalidation", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    let currentUserInChannel = true;
+    const listChannels = vi.fn(async () => [
+      { id: "C_PRIVATE", name: "private-room", type: "private_channel", isMember: true },
+    ]);
+    const isUserInChannel = vi.fn(async () => currentUserInChannel);
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "No configured sources are currently available." },
+        rawPayload: {
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Summarizer", summary: "No configured sources are currently available." },
+          items: [],
+        },
+        items: [],
+      });
+      return {
+        messageSent: true,
+        sessionId: "agent-session",
+        costUsd: 0,
+        auxCostUsd: 0,
+        pendingUploads: [],
+        durationMs: 0,
+        durationApiMs: 0,
+        numTurns: 0,
+        stopReason: null,
+        errorSubtype: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        webSearchRequests: 0,
+        webFetchRequests: 0,
+        model: null,
+        isResumedSession: false,
+        totalAttachments: 0,
+        imageCount: 0,
+        nonImageCount: 0,
+        mimeTypes: [],
+        fileSizes: [],
+        promptMode: "text" as const,
+        toolCalls: [],
+        auxLlmCalls: [],
+        sdkCostUsd: 0,
+        rawUsage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+        trace: { progressEvents: [], finalText: "Done" },
+      };
+    });
+    const service = new AgentRunService({
+      db,
+      config: createTestConfig(),
+      logger: createTestLogger(),
+      users,
+      settings: createSettingsRepository(db),
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      queueManager: createPausedQueueManager(tasks),
+      getSlack: () => ({ listChannels, isUserInChannel }),
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      sources: [
+        {
+          platform: "slack",
+          targetType: "channel",
+          targetId: "C_PRIVATE",
+          label: "#private-room",
+        },
+      ],
+    });
+
+    currentUserInChannel = false;
+    const row = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    if (!row) throw new Error("Expected a generated output row");
+    await tasks[0]();
+
+    const runtimeContext = runtimeContextFromUserMessage(runAgent.mock.calls[0][0].userMessage);
+    const completed = await db
+      .selectFrom("agent_outputs")
+      .select("raw_payload_json")
+      .where("id", "=", row.id)
+      .executeTakeFirstOrThrow();
+    const rawPayload = JSON.parse(completed.raw_payload_json ?? "{}") as Record<string, unknown>;
+
+    expect(runtimeContext.sources).toEqual([]);
+    expect(runtimeContext.summarySources).toEqual([]);
+    expect(JSON.stringify(runtimeContext)).not.toContain("C_PRIVATE");
+    expect(rawPayload.summaryWindow).toMatchObject({ end: NOW.toISOString() });
+    expect(isUserInChannel).toHaveBeenCalledWith("C_PRIVATE", "U_AGENT");
   });
 
   it("rejects WhatsApp group delivery when the current user is not a participant", async () => {

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -759,6 +759,49 @@ describe("AgentRunService", () => {
     });
   });
 
+  it("resolves Slack delivery mentions to known channel members", async () => {
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    await users.create({ name: "Ada", email: "ada@example.com", slackUserId: "U_ADA" });
+    const isUserInChannel = vi.fn(async (_channelId: string, slackUserId: string) => slackUserId !== "U_MISSING");
+    const service = createService(db, [], {
+      getSlack: () => ({
+        listChannels: vi.fn(async () => [{ id: "C_DAILY", name: "daily", type: "private_channel", isMember: true }]),
+        isUserInChannel,
+      }),
+    });
+
+    await expect(
+      service.resolveDeliveryConfigForUser(user.id, {
+        enabled: true,
+        platform: "slack",
+        targetType: "channel",
+        targetId: "C_DAILY",
+        label: "#spoofed",
+        mentions: [{ platform: "slack", targetId: "U_ADA", label: "Spoofed Ada" }],
+      }),
+    ).resolves.toEqual({
+      enabled: true,
+      platform: "slack",
+      targetType: "channel",
+      targetId: "C_DAILY",
+      label: "#daily",
+      mentions: [{ platform: "slack", targetId: "U_ADA", label: "Ada <ada@example.com>" }],
+    });
+    expect(isUserInChannel).toHaveBeenCalledWith("C_DAILY", "U_ADA");
+
+    await expect(
+      service.resolveDeliveryConfigForUser(user.id, {
+        enabled: true,
+        platform: "slack",
+        targetType: "channel",
+        targetId: "C_DAILY",
+        label: "#daily",
+        mentions: [{ platform: "slack", targetId: "U_UNKNOWN", label: "Unknown" }],
+      }),
+    ).rejects.toThrow("Slack mention target is not available");
+  });
+
   it("resolves WhatsApp group delivery only when the current user is a participant", async () => {
     const users = createUserRepository(db);
     const user = await users.create({
@@ -852,6 +895,49 @@ describe("AgentRunService", () => {
       label: "Leadership",
     });
     expect(resolveJidToPhone).toHaveBeenCalledWith("86702773280883@lid");
+  });
+
+  it("resolves WhatsApp delivery mentions to known group participants", async () => {
+    const users = createUserRepository(db);
+    const user = await users.create({
+      name: "Agent User",
+      email: "user@example.com",
+      whatsappNumber: "+15551234567",
+    });
+    await users.create({ name: "Ada", email: "ada@example.com", whatsappNumber: "+15557654321" });
+    const groups = createWhatsAppGroupRepository(db);
+    await groups.upsert({
+      jid: "120363000000001@g.us",
+      name: "Leadership",
+      description: null,
+      updated_at: "2026-06-27T00:00:00.000Z",
+    });
+    const getGroupMetadata = vi.fn(
+      async () =>
+        ({
+          subject: "Leadership",
+          participants: [{ id: "15551234567@s.whatsapp.net" }, { id: "15557654321@s.whatsapp.net" }],
+        }) as Awaited<ReturnType<WhatsAppBot["getGroupMetadata"]>>,
+    );
+    const service = createService(db, [], { getWhatsApp: () => ({ getGroupMetadata }) });
+
+    await expect(
+      service.resolveDeliveryConfigForUser(user.id, {
+        enabled: true,
+        platform: "whatsapp",
+        targetType: "group",
+        targetId: "120363000000001@g.us",
+        label: "Spoofed",
+        mentions: [{ platform: "whatsapp", targetId: "+15557654321", label: "Spoofed Ada" }],
+      }),
+    ).resolves.toEqual({
+      enabled: true,
+      platform: "whatsapp",
+      targetType: "group",
+      targetId: "120363000000001@g.us",
+      label: "Leadership",
+      mentions: [{ platform: "whatsapp", targetId: "+15557654321", label: "Ada" }],
+    });
   });
 
   it("rejects WhatsApp group delivery when the current user is not a participant", async () => {

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -8,6 +8,7 @@ import { ensureWorkspace } from "../agent/workspace";
 import type { Config } from "../config";
 import {
   type AgentDeliveryConfig,
+  type AgentDeliveryMention,
   type AgentMasthead,
   type AgentOutputItemInput,
   type AgentOutputRow,
@@ -131,6 +132,16 @@ function normalizeWhatsappNumber(whatsappNumber: string): string {
   return whatsappNumber.replace(/^\+/, "");
 }
 
+function normalizeWhatsappMentionTarget(targetId: string): string {
+  if (targetId.startsWith("dm:+")) return targetId.slice("dm:".length);
+  if (targetId.startsWith("+")) return targetId;
+  if (targetId.endsWith("@s.whatsapp.net")) {
+    return `+${normalizeWhatsappNumber(targetId.replace("@s.whatsapp.net", ""))}`;
+  }
+  if (/^\d+$/.test(targetId)) return `+${targetId}`;
+  return targetId;
+}
+
 async function whatsappGroupHasParticipant(
   group: Awaited<ReturnType<WhatsAppBot["getGroupMetadata"]>>,
   whatsappNumber: string,
@@ -147,6 +158,10 @@ async function whatsappGroupHasParticipant(
   }
 
   return false;
+}
+
+function withMentions(mentions: AgentDeliveryMention[]): Pick<AgentDeliveryConfig, "mentions"> {
+  return mentions.length > 0 ? { mentions } : {};
 }
 
 function localDateInTimezone(now: Date, timezone: string): string {
@@ -380,10 +395,14 @@ export class AgentRunService {
         if (delivery.targetId !== user.slack_user_id) {
           throw new AgentDeliveryTargetError("Slack DM delivery must target the current user");
         }
-        return {
+        const normalized = {
           ...delivery,
           targetId: user.slack_user_id,
           label: user.email ? `${user.name} <${user.email}>` : user.name,
+        };
+        return {
+          ...normalized,
+          ...withMentions(await this.resolveDeliveryMentions(normalized)),
         };
       }
 
@@ -394,10 +413,14 @@ export class AgentRunService {
       if (!(await slack.isUserInChannel(delivery.targetId, user.slack_user_id))) {
         throw new AgentDeliveryTargetError("Slack channel is not available for this user");
       }
-      return {
+      const normalized = {
         ...delivery,
         targetId: channel.id,
         label: `#${channel.name}`,
+      };
+      return {
+        ...normalized,
+        ...withMentions(await this.resolveDeliveryMentions(normalized)),
       };
     }
 
@@ -424,11 +447,81 @@ export class AgentRunService {
       throw new AgentDeliveryTargetError("WhatsApp group is not available for this user");
     }
 
-    return {
+    const normalized = {
       ...delivery,
       targetId: group.jid,
       label: group.name,
     };
+    return {
+      ...normalized,
+      ...withMentions(await this.resolveDeliveryMentions(normalized, { whatsappGroup: groupMetadata })),
+    };
+  }
+
+  private async resolveDeliveryMentions(
+    delivery: AgentDeliveryConfig,
+    context: { whatsappGroup?: Awaited<ReturnType<WhatsAppBot["getGroupMetadata"]>> } = {},
+  ): Promise<AgentDeliveryMention[]> {
+    const mentions = delivery.mentions ?? [];
+    if (mentions.length === 0) return [];
+
+    const resolved: AgentDeliveryMention[] = [];
+    const seen = new Set<string>();
+
+    for (const mention of mentions) {
+      if (mention.platform !== delivery.platform) {
+        throw new AgentDeliveryTargetError("Delivery mention platform must match the delivery platform");
+      }
+
+      if (mention.platform === "slack") {
+        const user = await this.deps.users.findBySlackId(mention.targetId);
+        if (!user || user.type === "agent" || !user.slack_user_id) {
+          throw new AgentDeliveryTargetError("Slack mention target is not available");
+        }
+        if (delivery.targetType === "channel") {
+          const slack = this.deps.getSlack?.() ?? null;
+          if (!slack) throw new AgentDeliveryTargetError("Slack is not connected");
+          if (!(await slack.isUserInChannel(delivery.targetId, user.slack_user_id))) {
+            throw new AgentDeliveryTargetError("Slack mention target is not in the delivery channel");
+          }
+        }
+        const key = `${mention.platform}:${user.slack_user_id}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        resolved.push({
+          platform: "slack",
+          targetId: user.slack_user_id,
+          label: user.email ? `${user.name} <${user.email}>` : user.name,
+        });
+        continue;
+      }
+
+      const whatsappNumber = normalizeWhatsappMentionTarget(mention.targetId);
+      const user = await this.deps.users.findByWhatsappNumber(whatsappNumber);
+      if (!user || user.type === "agent" || !user.whatsapp_number) {
+        throw new AgentDeliveryTargetError("WhatsApp mention target is not available");
+      }
+      if (delivery.targetType === "group") {
+        const whatsapp = this.deps.getWhatsApp?.() ?? null;
+        if (!whatsapp) throw new AgentDeliveryTargetError("WhatsApp is not connected");
+        const group = context.whatsappGroup ?? (await whatsapp.getGroupMetadata(delivery.targetId));
+        if (
+          !(await whatsappGroupHasParticipant(
+            group,
+            user.whatsapp_number,
+            async (jid) => (await whatsapp.resolveJidToPhone?.(jid)) ?? null,
+          ))
+        ) {
+          throw new AgentDeliveryTargetError("WhatsApp mention target is not in the delivery group");
+        }
+      }
+      const key = `${mention.platform}:${user.whatsapp_number}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      resolved.push({ platform: "whatsapp", targetId: user.whatsapp_number, label: user.name });
+    }
+
+    return resolved;
   }
 
   async resolveSourceConfigsForUser(

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -12,6 +12,7 @@ import {
   type AgentOutputItemInput,
   type AgentOutputRow,
   type AgentOutputTriggerType,
+  type AgentSourceConfig,
   type AgentUserPrefs,
   createAgentOutputRepository,
 } from "../db/repositories/agent-outputs";
@@ -25,7 +26,7 @@ import type { SlackBot } from "../slack/bot";
 import type { WhatsAppBot } from "../whatsapp/bot";
 import type { AgentOutputDeliveryPublisher } from "./output-delivery";
 import { getAgentDefinition, listAgentDefinitions, requireAgentDefinition } from "./registry";
-import type { AgentApiItem, AgentDefinition } from "./types";
+import type { AgentApiItem, AgentDefinition, AgentSourceConfigDef } from "./types";
 
 const RUNNING_STALE_AFTER_MS = 30 * 60 * 1000;
 const SCHEDULED_FAILURE_SUPPRESS_AFTER_MS = 60 * 60 * 1000;
@@ -68,6 +69,7 @@ export interface ResolvedAgentConfig {
   enabledSections: Record<string, boolean>;
   focus: string | null;
   delivery: AgentDeliveryConfig | null;
+  sources: AgentSourceConfig[];
 }
 
 export interface AgentSectionView {
@@ -89,6 +91,8 @@ export interface AgentConfigView {
   itemsPerSectionRange: { min: number; max: number };
   focus: string | null;
   delivery: AgentDeliveryConfig | null;
+  sourceConfig: AgentSourceConfigDef | null;
+  sources: AgentSourceConfig[];
   sections: AgentSectionView[];
 }
 
@@ -117,6 +121,7 @@ export interface AgentSummaryView {
 }
 
 export class AgentDeliveryTargetError extends Error {}
+export class AgentSourceTargetError extends Error {}
 
 function whatsappNumberToJid(whatsappNumber: string): string {
   return `${normalizeWhatsappNumber(whatsappNumber)}@s.whatsapp.net`;
@@ -234,6 +239,7 @@ export class AgentRunService {
       enabledSections,
       focus: prefs.focus ?? null,
       delivery: prefs.delivery ?? null,
+      sources: prefs.sources ?? [],
     };
   }
 
@@ -277,6 +283,8 @@ export class AgentRunService {
       itemsPerSectionRange: def.itemsPerSectionRange,
       focus: config.focus,
       delivery: config.delivery,
+      sourceConfig: def.sourceConfig ?? null,
+      sources: config.sources,
       sections: def.sections.map((section) => ({
         key: section.key,
         title: section.title,
@@ -296,6 +304,7 @@ export class AgentRunService {
       sections?: Record<string, boolean>;
       focus?: string | null;
       delivery?: AgentDeliveryConfig | null;
+      sources?: AgentSourceConfig[];
     },
   ): Promise<AgentConfigView | null> {
     const def = getAgentDefinition(agentKey);
@@ -309,7 +318,12 @@ export class AgentRunService {
         : undefined;
 
     let prefs: AgentUserPrefs | undefined;
-    if (patch.sections !== undefined || patch.focus !== undefined || patch.delivery !== undefined) {
+    if (
+      patch.sections !== undefined ||
+      patch.focus !== undefined ||
+      patch.delivery !== undefined ||
+      patch.sources !== undefined
+    ) {
       const sections: Record<string, boolean> = { ...current.enabledSections };
       if (patch.sections) {
         for (const section of def.sections) {
@@ -318,7 +332,11 @@ export class AgentRunService {
       }
       const focus = patch.focus !== undefined ? (patch.focus?.trim() ? patch.focus.trim() : null) : current.focus;
       const delivery = patch.delivery !== undefined ? patch.delivery : current.delivery;
-      prefs = { sections, focus, delivery };
+      const sources =
+        patch.sources !== undefined
+          ? await this.resolveSourceConfigsForUser(def, userId, patch.sources)
+          : current.sources;
+      prefs = { sections, focus, delivery, sources };
     }
 
     await this.repo.upsertConfig(
@@ -413,6 +431,90 @@ export class AgentRunService {
     };
   }
 
+  async resolveSourceConfigsForUser(
+    agentKeyOrDef: string | AgentDefinition,
+    userId: string,
+    sources: AgentSourceConfig[],
+  ): Promise<AgentSourceConfig[]> {
+    const def = typeof agentKeyOrDef === "string" ? getAgentDefinition(agentKeyOrDef) : agentKeyOrDef;
+    if (!def?.sourceConfig) {
+      if (sources.length > 0) throw new AgentSourceTargetError("This agent does not support conversation sources");
+      return [];
+    }
+    if (sources.length > def.sourceConfig.maxSources) {
+      throw new AgentSourceTargetError(`Select at most ${def.sourceConfig.maxSources} sources`);
+    }
+
+    const resolved: AgentSourceConfig[] = [];
+    const seen = new Set<string>();
+    for (const source of sources) {
+      const normalized = await this.resolveSourceConfigForUser(userId, source, def.sourceConfig);
+      const key = `${normalized.platform}:${normalized.targetType}:${normalized.targetId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      resolved.push(normalized);
+    }
+    return resolved;
+  }
+
+  private async resolveSourceConfigForUser(
+    userId: string,
+    source: AgentSourceConfig,
+    config: AgentSourceConfigDef,
+  ): Promise<AgentSourceConfig> {
+    const user = await this.deps.users.findById(userId);
+    if (!user) throw new AgentSourceTargetError("User not found");
+
+    if (source.platform === "slack") {
+      if (!config.supportsSlackChannels || source.targetType !== "channel") {
+        throw new AgentSourceTargetError("Slack sources must be channels");
+      }
+      if (!user.slack_user_id) throw new AgentSourceTargetError("Slack sources are not available for this user");
+      const slack = this.deps.getSlack?.() ?? null;
+      if (!slack) throw new AgentSourceTargetError("Slack is not connected");
+      const channel = (await slack.listChannels()).find((candidate) => candidate.id === source.targetId);
+      if (!channel?.isMember) throw new AgentSourceTargetError("Slack channel is not available as a source");
+      if (!(await slack.isUserInChannel(source.targetId, user.slack_user_id))) {
+        throw new AgentSourceTargetError("Slack channel is not available for this user");
+      }
+      return {
+        platform: "slack",
+        targetType: "channel",
+        targetId: channel.id,
+        label: `#${channel.name}`,
+      };
+    }
+
+    if (!config.supportsWhatsAppGroups || source.targetType !== "group") {
+      throw new AgentSourceTargetError("WhatsApp sources must be groups");
+    }
+    const group = await this.deps.db
+      .selectFrom("whatsapp_groups")
+      .select(["jid", "name"])
+      .where("jid", "=", source.targetId)
+      .executeTakeFirst();
+    if (!group) throw new AgentSourceTargetError("WhatsApp group is not available as a source");
+    if (!user.whatsapp_number) throw new AgentSourceTargetError("WhatsApp sources are not available for this user");
+    const whatsapp = this.deps.getWhatsApp?.() ?? null;
+    if (!whatsapp) throw new AgentSourceTargetError("WhatsApp is not connected");
+    const groupMetadata = await whatsapp.getGroupMetadata(group.jid);
+    if (
+      !(await whatsappGroupHasParticipant(
+        groupMetadata,
+        user.whatsapp_number,
+        async (jid) => (await whatsapp.resolveJidToPhone?.(jid)) ?? null,
+      ))
+    ) {
+      throw new AgentSourceTargetError("WhatsApp group is not available for this user");
+    }
+    return {
+      platform: "whatsapp",
+      targetType: "group",
+      targetId: group.jid,
+      label: group.name,
+    };
+  }
+
   private toApiOutput(
     def: AgentDefinition,
     value: Awaited<ReturnType<ReturnType<typeof createAgentOutputRepository>["findLatestCompleted"]>>,
@@ -472,6 +574,22 @@ export class AgentRunService {
     return this.toApiOutput(def, await this.repo.getByIdForUser(def.key, id, userId));
   }
 
+  async listOutputsForUser(
+    agentKey: string,
+    userId: string,
+    options: { limit?: number; cursor?: string | null } = {},
+  ): Promise<{ outputs: AgentOutputApi[]; nextCursor: string | null }> {
+    const def = requireAgentDefinition(agentKey);
+    const result = await this.repo.listCompletedForUser(def.key, userId, options);
+    return {
+      outputs: result.outputs.flatMap((output) => {
+        const api = this.toApiOutput(def, output);
+        return api ? [api] : [];
+      }),
+      nextCursor: result.nextCursor,
+    };
+  }
+
   async requestGenerationForUser(params: RequestAgentGenerationParams): Promise<AgentOutputRow | null> {
     const def = requireAgentDefinition(params.agentKey);
     const user = await this.deps.users.findById(params.userId);
@@ -518,6 +636,7 @@ export class AgentRunService {
     now = new Date(),
   ): Promise<{ outputDate: string } | null> {
     const config = await this.resolveConfig(def, user.id);
+    if (def.sourceConfig && config.sources.length === 0) return null;
     if (!config.enabled) return null;
     const timezone = config.timezone || user.timezone || "UTC";
     const parts = new Intl.DateTimeFormat("en-US", {
@@ -618,6 +737,13 @@ export class AgentRunService {
               now,
               adminCanReadAllFiles,
               contentUserEmails,
+              agentConfig: {
+                enabledSections: config.enabledSections,
+                maxItemsPerSection: config.maxItemsPerSection,
+                focus: config.focus,
+                delivery: config.delivery,
+                sources: config.sources,
+              },
             })
           : Promise.resolve({}),
       ]);
@@ -631,6 +757,7 @@ export class AgentRunService {
         sections: enabledSections,
         maxItemsPerSection: config.maxItemsPerSection,
         focus: config.focus,
+        sources: config.sources,
         sameDayPreviousOutput: this.formatOutputForContext(sameDayPrevious.output),
         previousDayOutput: this.formatOutputForContext(previousDay.output),
         ...definitionContext,

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -164,6 +164,24 @@ function withMentions(mentions: AgentDeliveryMention[]): Pick<AgentDeliveryConfi
   return mentions.length > 0 ? { mentions } : {};
 }
 
+function isSummaryWindow(value: unknown): value is Record<string, unknown> {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).start === "string" &&
+    typeof (value as Record<string, unknown>).end === "string"
+  );
+}
+
+function rawPayloadWithRunMetadata(
+  rawPayload: WriteAgentOutputPayload,
+  runtimeContext: Record<string, unknown>,
+): WriteAgentOutputPayload | (WriteAgentOutputPayload & { summaryWindow: Record<string, unknown> }) {
+  const summaryWindow = runtimeContext.summaryWindow;
+  return isSummaryWindow(summaryWindow) ? { ...rawPayload, summaryWindow } : rawPayload;
+}
+
 function localDateInTimezone(now: Date, timezone: string): string {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
@@ -608,6 +626,33 @@ export class AgentRunService {
     };
   }
 
+  private async resolveSourcesForRun(
+    def: AgentDefinition,
+    userId: string,
+    sources: AgentSourceConfig[],
+  ): Promise<AgentSourceConfig[]> {
+    if (!def.sourceConfig) return [];
+
+    const resolved: AgentSourceConfig[] = [];
+    const seen = new Set<string>();
+    for (const source of sources) {
+      try {
+        const normalized = await this.resolveSourceConfigForUser(userId, source, def.sourceConfig);
+        const key = `${normalized.platform}:${normalized.targetType}:${normalized.targetId}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        resolved.push(normalized);
+      } catch (err) {
+        this.deps.logger.warn(
+          { err, agentKey: def.key, userId, platform: source.platform, targetType: source.targetType },
+          "Agent: dropping inaccessible source for generation",
+        );
+      }
+    }
+
+    return resolved;
+  }
+
   private toApiOutput(
     def: AgentDefinition,
     value: Awaited<ReturnType<ReturnType<typeof createAgentOutputRepository>["findLatestCompleted"]>>,
@@ -808,6 +853,7 @@ export class AgentRunService {
 
     let saved = false;
     const config = await this.resolveConfig(def, user.id);
+    const sources = await this.resolveSourcesForRun(def, user.id, config.sources);
     const enabledSections = def.sections.filter((s) => config.enabledSections[s.key]).map((s) => s.key);
 
     try {
@@ -835,7 +881,7 @@ export class AgentRunService {
                 maxItemsPerSection: config.maxItemsPerSection,
                 focus: config.focus,
                 delivery: config.delivery,
-                sources: config.sources,
+                sources,
               },
             })
           : Promise.resolve({}),
@@ -850,7 +896,7 @@ export class AgentRunService {
         sections: enabledSections,
         maxItemsPerSection: config.maxItemsPerSection,
         focus: config.focus,
-        sources: config.sources,
+        sources,
         sameDayPreviousOutput: this.formatOutputForContext(sameDayPrevious.output),
         previousDayOutput: this.formatOutputForContext(previousDay.output),
         ...definitionContext,
@@ -975,7 +1021,7 @@ export class AgentRunService {
         await this.repo.completeOutput({
           outputId: params.outputId,
           masthead: payload.masthead,
-          rawPayload: payload.rawPayload,
+          rawPayload: rawPayloadWithRunMetadata(payload.rawPayload, params.runtimeContext),
           items,
         });
         params.onSaved();

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -1,8 +1,10 @@
 import type { Kysely } from "kysely";
 import type { Selectable } from "kysely";
 import type {
+  AgentDeliveryConfig,
   AgentKnowledgeRefs,
   AgentOutputItemInput,
+  AgentSourceConfig,
   AgentStoredItemRow,
   AgentStructuredPayload,
 } from "../db/repositories/agent-outputs";
@@ -23,6 +25,12 @@ export interface AgentDefaults {
   scheduleHour: number;
   scheduleMinute: number;
   maxItemsPerSection: number;
+}
+
+export interface AgentSourceConfigDef {
+  maxSources: number;
+  supportsSlackChannels: boolean;
+  supportsWhatsAppGroups: boolean;
 }
 
 export interface AgentApiItem {
@@ -50,6 +58,13 @@ export interface AgentRuntimeContextParams {
   now: Date;
   adminCanReadAllFiles: boolean;
   contentUserEmails: string[] | undefined;
+  agentConfig?: {
+    enabledSections: Record<string, boolean>;
+    maxItemsPerSection: number;
+    focus: string | null;
+    delivery: AgentDeliveryConfig | null;
+    sources: AgentSourceConfig[];
+  };
 }
 
 /**
@@ -67,6 +82,7 @@ export interface AgentDefinition {
   category: string;
   defaults: AgentDefaults;
   sections: AgentSectionDef[];
+  sourceConfig?: AgentSourceConfigDef;
   allowedTools: string[];
   /** Allowed range for the per-section item cap; surfaced to the config editor. */
   itemsPerSectionRange: { min: number; max: number };

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -116,6 +116,7 @@ import * as m113 from "./migrations/113-indexed-file-all-day-flag";
 import * as m114 from "./migrations/114-agent-output-deliveries";
 import * as m115 from "./migrations/115-whatsapp-template-mappings-and-provider-events";
 import * as m116 from "./migrations/116-connector-credential-source";
+import * as m117 from "./migrations/117-conversation-message-window-index";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -236,6 +237,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "114-agent-output-deliveries": m114,
           "115-whatsapp-template-mappings-and-provider-events": m115,
           "116-connector-credential-source": m116,
+          "117-conversation-message-window-index": m117,
         };
       },
     },

--- a/packages/server/src/db/migrations/117-conversation-message-window-index.ts
+++ b/packages/server/src/db/migrations/117-conversation-message-window-index.ts
@@ -1,0 +1,13 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex("idx_conversation_messages_window")
+    .on("conversation_messages")
+    .columns(["conversation_id", "received_at", "id"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_conversation_messages_window").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 112;
+const EXPECTED_MIGRATION_COUNT = 113;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -145,6 +145,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[109]).toBe("114-agent-output-deliveries");
     expect(names[110]).toBe("115-whatsapp-template-mappings-and-provider-events");
     expect(names[111]).toBe("116-connector-credential-source");
+    expect(names[112]).toBe("117-conversation-message-window-index");
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 112;
+const EXPECTED_MIGRATION_COUNT = 113;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -168,6 +168,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[109]).toBe("114-agent-output-deliveries");
     expect(names[110]).toBe("115-whatsapp-template-mappings-and-provider-events");
     expect(names[111]).toBe("116-connector-credential-source");
+    expect(names[112]).toBe("117-conversation-message-window-index");
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {
@@ -562,12 +563,14 @@ describe("runMigrations — incremental upgrade", () => {
         '113-indexed-file-all-day-flag',
         '114-agent-output-deliveries',
         '115-whatsapp-template-mappings-and-provider-events',
-        '116-connector-credential-source'
+        '116-connector-credential-source',
+        '117-conversation-message-window-index'
       )
     `.execute(db);
     await sql`DROP TABLE agent_output_deliveries`.execute(db);
     await sql`DROP TABLE whatsapp_template_mappings`.execute(db);
     await sql`DROP TABLE whatsapp_provider_events`.execute(db);
+    await sql`DROP INDEX idx_conversation_messages_window`.execute(db);
 
     await expect(runMigrations(db, { quiet: true })).resolves.not.toThrow();
 
@@ -583,7 +586,8 @@ describe("runMigrations — incremental upgrade", () => {
         '113-indexed-file-all-day-flag',
         '114-agent-output-deliveries',
         '115-whatsapp-template-mappings-and-provider-events',
-        '116-connector-credential-source'
+        '116-connector-credential-source',
+        '117-conversation-message-window-index'
       )
       ORDER BY name ASC
     `.execute(db);
@@ -598,6 +602,7 @@ describe("runMigrations — incremental upgrade", () => {
       { name: "114-agent-output-deliveries" },
       { name: "115-whatsapp-template-mappings-and-provider-events" },
       { name: "116-connector-credential-source" },
+      { name: "117-conversation-message-window-index" },
     ]);
   });
 });

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -45,12 +45,19 @@ export type AgentDeliveryTargetType = "channel" | "dm" | "group";
 export type AgentSourcePlatform = "slack" | "whatsapp";
 export type AgentSourceTargetType = "channel" | "group";
 
+export interface AgentDeliveryMention {
+  platform: AgentDeliveryPlatform;
+  targetId: string;
+  label: string | null;
+}
+
 export interface AgentDeliveryConfig {
   enabled: true;
   platform: AgentDeliveryPlatform;
   targetType: AgentDeliveryTargetType;
   targetId: string;
   label: string | null;
+  mentions?: AgentDeliveryMention[];
 }
 
 export interface AgentSourceConfig {

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -42,11 +42,20 @@ export interface AgentOutputItemInput {
 
 export type AgentDeliveryPlatform = "slack" | "whatsapp";
 export type AgentDeliveryTargetType = "channel" | "dm" | "group";
+export type AgentSourcePlatform = "slack" | "whatsapp";
+export type AgentSourceTargetType = "channel" | "group";
 
 export interface AgentDeliveryConfig {
   enabled: true;
   platform: AgentDeliveryPlatform;
   targetType: AgentDeliveryTargetType;
+  targetId: string;
+  label: string | null;
+}
+
+export interface AgentSourceConfig {
+  platform: AgentSourcePlatform;
+  targetType: AgentSourceTargetType;
   targetId: string;
   label: string | null;
 }
@@ -60,6 +69,7 @@ export interface AgentUserPrefs {
   sections?: Record<string, boolean>;
   focus?: string | null;
   delivery?: AgentDeliveryConfig | null;
+  sources?: AgentSourceConfig[];
 }
 
 export interface AgentUserConfig {
@@ -131,6 +141,11 @@ export interface AgentOutputWithItems {
   output: AgentOutputRow;
   masthead: AgentMasthead | null;
   items: AgentStoredItemRow[];
+}
+
+export interface AgentOutputListResult {
+  outputs: AgentOutputWithItems[];
+  nextCursor: string | null;
 }
 
 function withRefs(item: AgentOutputItemRow): AgentStoredItemRow {
@@ -333,6 +348,71 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
         output,
         masthead: parseJson<AgentMasthead>(output.masthead_json),
         items: items.map(withRefs),
+      };
+    },
+
+    async listCompletedForUser(
+      agentKey: string,
+      userId: string,
+      options: { limit?: number; cursor?: string | null } = {},
+    ): Promise<AgentOutputListResult> {
+      const limit = Math.max(1, Math.min(options.limit ?? 20, 50));
+      let query = db
+        .selectFrom("agent_outputs")
+        .selectAll()
+        .where("agent_key", "=", agentKey)
+        .where("user_id", "=", userId)
+        .where("status", "=", "completed");
+
+      if (options.cursor) {
+        const cursorRow = await db
+          .selectFrom("agent_outputs")
+          .selectAll()
+          .where("agent_key", "=", agentKey)
+          .where("user_id", "=", userId)
+          .where("id", "=", options.cursor)
+          .executeTakeFirst();
+        if (cursorRow?.generated_at) {
+          query = query.where((eb) =>
+            eb.or([
+              eb("generated_at", "<", cursorRow.generated_at),
+              eb.and([eb("generated_at", "=", cursorRow.generated_at), eb("id", "<", cursorRow.id)]),
+            ]),
+          );
+        }
+      }
+
+      const rows = await query
+        .orderBy("generated_at", "desc")
+        .orderBy("id", "desc")
+        .limit(limit + 1)
+        .execute();
+      const visibleRows = rows.slice(0, limit);
+      const ids = visibleRows.map((row) => row.id);
+      const itemRows =
+        ids.length === 0
+          ? []
+          : await db
+              .selectFrom("agent_output_items")
+              .selectAll()
+              .where("agent_output_id", "in", ids)
+              .orderBy("agent_output_id", "asc")
+              .orderBy("section_key", "asc")
+              .orderBy("sort_order", "asc")
+              .execute();
+      const itemsByOutput = new Map<string, AgentStoredItemRow[]>();
+      for (const item of itemRows) {
+        const items = itemsByOutput.get(item.agent_output_id) ?? [];
+        items.push(withRefs(item));
+        itemsByOutput.set(item.agent_output_id, items);
+      }
+      return {
+        outputs: visibleRows.map((output) => ({
+          output,
+          masthead: parseJson<AgentMasthead>(output.masthead_json),
+          items: itemsByOutput.get(output.id) ?? [],
+        })),
+        nextCursor: rows.length > limit ? (visibleRows[visibleRows.length - 1]?.id ?? null) : null,
       };
     },
 

--- a/packages/server/src/db/repositories/conversations.ts
+++ b/packages/server/src/db/repositories/conversations.ts
@@ -58,6 +58,13 @@ export interface ListConversationMessagesOptions {
   providerThreadId?: string | null;
 }
 
+export interface ListConversationMessagesInWindowOptions {
+  afterReceivedAt: string;
+  beforeReceivedAt: string;
+  limit?: number;
+  includeBotMessages?: boolean;
+}
+
 export interface SearchConversationMessagesOptions {
   query: string;
   afterMessageId?: number;
@@ -447,6 +454,29 @@ export function createConversationRepository(db: Kysely<DB>) {
         messages,
         hasMore,
         nextCursor: hasMore ? visibleRows[visibleRows.length - 1]?.id : undefined,
+      };
+    },
+
+    async listMessagesInWindow(
+      conversationId: number,
+      options: ListConversationMessagesInWindowOptions,
+    ): Promise<{ messages: StoredConversationMessage[]; hasMore: boolean }> {
+      const limit = Math.max(1, Math.min(options.limit ?? 100, 500));
+      let query = db
+        .selectFrom("conversation_messages")
+        .selectAll()
+        .where("conversation_id", "=", conversationId)
+        .where("received_at", ">", options.afterReceivedAt)
+        .where("received_at", "<=", options.beforeReceivedAt);
+      if (!options.includeBotMessages) query = query.where("is_bot", "=", 0);
+      const rows = await query
+        .orderBy("received_at", "asc")
+        .orderBy("id", "asc")
+        .limit(limit + 1)
+        .execute();
+      return {
+        messages: rows.slice(0, limit).map(toStored),
+        hasMore: rows.length > limit,
       };
     },
 

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -1,11 +1,17 @@
 /**
- * The agent detail — read and tune one prebuilt agent. Two tabs: **Latest** (the
- * most recent output) and **Config** (the calm ledger — schedule · focus · volume,
- * each editable in a drawer, then per-section toggles). Behavior itself is
- * code-owned, so "What it does" is read-only. Design ported from the
- * `feat/demo-mask-pii` agent detail + background config.
+ * The agent detail lets users review generated output history and tune one
+ * code-owned prebuilt agent through schedule, sources, focus, volume, delivery,
+ * and per-section toggles.
  */
-import { type AgentConfig, type AgentDeliveryConfig, type AgentDetailResponse, type AgentOutput, api } from "@/lib/api";
+import {
+  type AgentConfig,
+  type AgentDeliveryConfig,
+  type AgentDetailResponse,
+  type AgentOutput,
+  type AgentOutputsResponse,
+  type AgentSourceConfig,
+  api,
+} from "@/lib/api";
 import {
   ArrowLeftIcon,
   CheckCircleIcon,
@@ -31,11 +37,15 @@ import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
-type Tab = "latest" | "config";
-type EditField = "schedule" | "focus" | "volume" | "delivery" | null;
+type Tab = "outputs" | "config";
+type EditField = "schedule" | "focus" | "volume" | "delivery" | "sources" | null;
 
 function detailKey(agentKey: string) {
   return ["agents", "detail", agentKey];
+}
+
+function outputsKey(agentKey: string) {
+  return ["agents", "outputs", agentKey];
 }
 
 function formatTime(hour: number, minute: number): string {
@@ -59,11 +69,18 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
     queryFn: () => api.agents.get(agentKey),
     refetchInterval: (query) => (query.state.data?.running ? 3000 : false),
   });
-  const [tab, setTab] = useState<Tab>("latest");
+  const outputsQuery = useQuery({
+    queryKey: outputsKey(agentKey),
+    queryFn: () => api.agents.outputs(agentKey, { limit: 50 }),
+    refetchInterval: () => (detailQuery.data?.running ? 3000 : false),
+  });
+  const [tab, setTab] = useState<Tab>("outputs");
   const [editing, setEditing] = useState<EditField>(null);
+  const [selectedOutputId, setSelectedOutputId] = useState<string | null>(null);
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: detailKey(agentKey) });
+    void queryClient.invalidateQueries({ queryKey: outputsKey(agentKey) });
     void queryClient.invalidateQueries({ queryKey: ["agents", "list"] });
   };
 
@@ -81,6 +98,11 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
     onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to start run"),
   });
 
+  const outputs = outputsQuery.data?.outputs ?? [];
+  useEffect(() => {
+    if (!selectedOutputId && outputs.length > 0) setSelectedOutputId(outputs[0].id);
+  }, [outputs, selectedOutputId]);
+
   const data = detailQuery.data;
   if (detailQuery.isLoading) {
     return <Shell>{null}</Shell>;
@@ -95,6 +117,7 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
 
   const { agent } = data;
   const running = data.running || runMutation.isPending;
+  const selectedOutput = outputs.find((output) => output.id === selectedOutputId) ?? outputs[0] ?? data.output;
 
   return (
     <Shell>
@@ -108,7 +131,7 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
             checked={agent.enabled}
             disabled={enabledMutation.isPending}
             onCheckedChange={(checked) => enabledMutation.mutate(checked)}
-            aria-label={`${agentKey} active`}
+            aria-label={`${agent.title} active`}
             className="data-[state=checked]:bg-emerald-500"
           />
           {agent.enabled ? "On" : "Off"}
@@ -116,8 +139,8 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
       </header>
 
       <div className="mt-6 flex items-center gap-1 border-b border-border/60">
-        <TabButton active={tab === "latest"} onClick={() => setTab("latest")}>
-          Latest
+        <TabButton active={tab === "outputs"} onClick={() => setTab("outputs")}>
+          Outputs
         </TabButton>
         <TabButton active={tab === "config"} onClick={() => setTab("config")}>
           Config
@@ -125,9 +148,14 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
       </div>
 
       <div className="pt-5">
-        {tab === "latest" ? (
-          <LatestTab
+        {tab === "outputs" ? (
+          <OutputsTab
             data={data}
+            outputsData={outputsQuery.data}
+            outputsLoading={outputsQuery.isLoading}
+            selectedOutput={selectedOutput}
+            selectedOutputId={selectedOutput?.id ?? null}
+            onSelectOutput={setSelectedOutputId}
             running={running}
             onRun={() => runMutation.mutate()}
             runPending={runMutation.isPending}
@@ -163,36 +191,72 @@ function Shell({ children }: { children: React.ReactNode }) {
   );
 }
 
-// --- Latest tab -------------------------------------------------------------
-
-function LatestTab({
+function OutputsTab({
   data,
+  outputsData,
+  outputsLoading,
+  selectedOutput,
+  selectedOutputId,
+  onSelectOutput,
   running,
   onRun,
   runPending,
 }: {
   data: AgentDetailResponse;
+  outputsData: AgentOutputsResponse | undefined;
+  outputsLoading: boolean;
+  selectedOutput: AgentOutput | null;
+  selectedOutputId: string | null;
+  onSelectOutput: (id: string) => void;
   running: boolean;
   onRun: () => void;
   runPending: boolean;
 }) {
-  const output = data.output;
+  const outputs = outputsData?.outputs ?? [];
   const sectionTitles = Object.fromEntries(data.agent.sections.map((section) => [section.key, section.title]));
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
         <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
-          {output ? `Generated ${formatDate(output.generatedAt ?? output.outputDate)}` : "No output yet"}
+          {selectedOutput
+            ? `Generated ${formatDate(selectedOutput.generatedAt ?? selectedOutput.outputDate)}`
+            : "No output yet"}
         </span>
         <RunButton running={running} pending={runPending} onRun={onRun} />
       </div>
 
-      {running && !output ? (
+      {running && !selectedOutput ? (
         <EmptyCard>Generating…</EmptyCard>
-      ) : !output ? (
+      ) : outputsLoading && outputs.length === 0 ? (
+        <EmptyCard>Loading…</EmptyCard>
+      ) : !selectedOutput ? (
         <EmptyCard>Nothing yet. Run it now or wait for its next scheduled run.</EmptyCard>
       ) : (
-        <OutputView output={output} sectionTitles={sectionTitles} />
+        <div className="grid gap-5 md:grid-cols-[220px_minmax(0,1fr)]">
+          <div className="flex flex-col gap-1">
+            {outputs.map((output) => (
+              <button
+                key={output.id}
+                type="button"
+                onClick={() => onSelectOutput(output.id)}
+                className={cn(
+                  "rounded-lg px-3 py-2 text-left transition-colors",
+                  selectedOutputId === output.id
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:bg-muted/50",
+                )}
+              >
+                <span className="block text-[12.5px] font-medium">
+                  {formatDate(output.generatedAt ?? output.outputDate)}
+                </span>
+                <span className="mt-0.5 block truncate font-mono text-[10px] uppercase tracking-[0.08em]">
+                  {output.outputDate}
+                </span>
+              </button>
+            ))}
+          </div>
+          <OutputView output={selectedOutput} sectionTitles={sectionTitles} />
+        </div>
       )}
     </div>
   );
@@ -264,8 +328,6 @@ function EmptyCard({ children }: { children: React.ReactNode }) {
   );
 }
 
-// --- Config tab -------------------------------------------------------------
-
 function ConfigTab({
   agentKey,
   agent,
@@ -293,6 +355,15 @@ function ConfigTab({
             {agent.focus ? agent.focus : <span className="text-muted-foreground">None — add what to emphasize.</span>}
           </p>
         </Row>
+        {agent.sourceConfig ? (
+          <Row label="Sources" onEdit={() => onEdit("sources")}>
+            <p className="line-clamp-2 text-[12.5px] leading-relaxed text-foreground/85">
+              {agent.sources.length > 0
+                ? agent.sources.map((source) => source.label ?? source.targetId).join(", ")
+                : "No sources selected"}
+            </p>
+          </Row>
+        ) : null}
         <Row label="Volume" onEdit={() => onEdit("volume")}>
           <p className="text-[12.5px] text-foreground/85">Up to {agent.maxItemsPerSection} items per section</p>
         </Row>
@@ -394,13 +465,12 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
   );
 }
 
-// --- Edit drawer ------------------------------------------------------------
-
 const EDIT_META: Record<Exclude<EditField, null>, { title: string; hint: string }> = {
   schedule: { title: "Runs on", hint: "When the agent runs each day, in your timezone." },
   focus: { title: "Focus", hint: "Plain-language emphasis. Added as a hint — it never overrides what the agent does." },
+  sources: { title: "Sources", hint: "Shared conversations this agent summarizes." },
   volume: { title: "Volume", hint: "How many items each section can hold." },
-  delivery: { title: "Deliver to", hint: "Where completed briefs are sent after generation finishes." },
+  delivery: { title: "Deliver to", hint: "Where completed outputs are sent after generation finishes." },
 };
 
 function EditDrawer({
@@ -420,6 +490,7 @@ function EditDrawer({
   const [hour, setHour] = useState(agent.scheduleHour);
   const [minute, setMinute] = useState(agent.scheduleMinute);
   const [focus, setFocus] = useState(agent.focus ?? "");
+  const [sources, setSources] = useState<AgentSourceConfig[]>(agent.sources);
   const [volume, setVolume] = useState(agent.maxItemsPerSection);
   const [delivery, setDelivery] = useState<AgentDeliveryConfig | null>(agent.delivery);
 
@@ -428,16 +499,26 @@ function EditDrawer({
       setHour(agent.scheduleHour);
       setMinute(agent.scheduleMinute);
       setFocus(agent.focus ?? "");
+      setSources(agent.sources);
       setVolume(agent.maxItemsPerSection);
       setDelivery(agent.delivery);
     }
-  }, [field, agent.scheduleHour, agent.scheduleMinute, agent.focus, agent.maxItemsPerSection, agent.delivery]);
+  }, [
+    field,
+    agent.scheduleHour,
+    agent.scheduleMinute,
+    agent.focus,
+    agent.sources,
+    agent.maxItemsPerSection,
+    agent.delivery,
+  ]);
 
   const saveMutation = useMutation({
     mutationFn: () => {
       if (field === "schedule")
         return api.agents.updateConfig(agentKey, { scheduleHour: hour, scheduleMinute: minute });
       if (field === "focus") return api.agents.updateConfig(agentKey, { focus: focus.trim() ? focus.trim() : null });
+      if (field === "sources") return api.agents.updateConfig(agentKey, { sources });
       if (field === "volume") return api.agents.updateConfig(agentKey, { maxItemsPerSection: volume });
       if (field === "delivery") return api.agents.updateConfig(agentKey, { delivery });
       return Promise.resolve({ agent });
@@ -489,8 +570,10 @@ function EditDrawer({
               value={volume}
               onChange={setVolume}
             />
+          ) : field === "sources" && agent.sourceConfig ? (
+            <SourceEditor agent={agent} value={sources} onChange={setSources} />
           ) : field === "delivery" ? (
-            <DeliveryEditor value={delivery} onChange={setDelivery} />
+            <DeliveryEditor value={delivery} sources={agent.sources} onChange={setDelivery} />
           ) : null}
         </div>
 
@@ -548,11 +631,166 @@ function NumberField({
   );
 }
 
-function DeliveryEditor({
+function sourceKey(source: AgentSourceConfig): string {
+  return `${source.platform}:${source.targetType}:${source.targetId}`;
+}
+
+function sourceToDelivery(source: AgentSourceConfig): AgentDeliveryConfig {
+  return {
+    enabled: true,
+    platform: source.platform,
+    targetType: source.targetType,
+    targetId: source.targetId,
+    label: source.label,
+  };
+}
+
+function SourceEditor({
+  agent,
   value,
   onChange,
 }: {
+  agent: AgentConfig;
+  value: AgentSourceConfig[];
+  onChange: (value: AgentSourceConfig[]) => void;
+}) {
+  const slackChannels = useQuery({ queryKey: ["slack-channels"], queryFn: () => api.channels.listSlack() });
+  const whatsappGroups = useQuery({ queryKey: ["whatsapp-groups"], queryFn: () => api.channels.listWhatsAppGroups() });
+  const selected = new Set(value.map(sourceKey));
+  const maxSources = agent.sourceConfig?.maxSources ?? 0;
+
+  const toggle = (source: AgentSourceConfig) => {
+    const key = sourceKey(source);
+    if (selected.has(key)) {
+      onChange(value.filter((item) => sourceKey(item) !== key));
+      return;
+    }
+    if (value.length >= maxSources) return;
+    onChange([...value, source]);
+  };
+
+  const slackOptions = (slackChannels.data?.channels ?? [])
+    .filter((channel) => channel.isMember)
+    .map(
+      (channel): AgentSourceConfig => ({
+        platform: "slack",
+        targetType: "channel",
+        targetId: channel.id,
+        label: `#${channel.name}`,
+      }),
+    );
+  const whatsappOptions = (whatsappGroups.data?.groups ?? []).map(
+    (group): AgentSourceConfig => ({
+      platform: "whatsapp",
+      targetType: "group",
+      targetId: group.jid,
+      label: group.name,
+    }),
+  );
+  const availableCount =
+    (agent.sourceConfig?.supportsSlackChannels ? slackOptions.length : 0) +
+    (agent.sourceConfig?.supportsWhatsAppGroups ? whatsappOptions.length : 0);
+  const sourcesLoading =
+    (agent.sourceConfig?.supportsSlackChannels && slackChannels.isLoading) ||
+    (agent.sourceConfig?.supportsWhatsAppGroups && whatsappGroups.isLoading);
+  const countSummary = [
+    `${value.length} selected`,
+    sourcesLoading ? null : `${availableCount} available`,
+    maxSources > 0 ? `limit ${maxSources}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div className="space-y-5">
+      {agent.sourceConfig?.supportsSlackChannels ? (
+        <SourceGroup
+          title="Slack channels"
+          loading={slackChannels.isLoading}
+          empty="No Slack channels available."
+          selected={selected}
+          options={slackOptions}
+          onToggle={toggle}
+        />
+      ) : null}
+      {agent.sourceConfig?.supportsWhatsAppGroups ? (
+        <SourceGroup
+          title="WhatsApp groups"
+          loading={whatsappGroups.isLoading}
+          empty="No WhatsApp groups available."
+          selected={selected}
+          options={whatsappOptions}
+          onToggle={toggle}
+        />
+      ) : null}
+      <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">{countSummary}</p>
+    </div>
+  );
+}
+
+function SourceGroup({
+  title,
+  loading,
+  empty,
+  selected,
+  options,
+  onToggle,
+}: {
+  title: string;
+  loading: boolean;
+  empty: string;
+  selected: Set<string>;
+  options: AgentSourceConfig[];
+  onToggle: (source: AgentSourceConfig) => void;
+}) {
+  return (
+    <div>
+      <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">{title}</span>
+      <div className="mt-2 max-h-56 overflow-y-auto rounded-lg border-[0.5px] border-border p-1">
+        {loading ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading...</p>
+        ) : options.length === 0 ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">{empty}</p>
+        ) : (
+          <div className="flex flex-col">
+            {options.map((source) => {
+              const active = selected.has(sourceKey(source));
+              return (
+                <button
+                  key={sourceKey(source)}
+                  type="button"
+                  onClick={() => onToggle(source)}
+                  className={cn(
+                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+                    active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+                  )}
+                >
+                  <span className="shrink-0">
+                    {source.platform === "slack" ? (
+                      <HashIcon size={14} aria-hidden />
+                    ) : (
+                      <UsersThreeIcon size={14} aria-hidden />
+                    )}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{source.label ?? source.targetId}</span>
+                  {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DeliveryEditor({
+  value,
+  sources,
+  onChange,
+}: {
   value: AgentDeliveryConfig | null;
+  sources: AgentSourceConfig[];
   onChange: (value: AgentDeliveryConfig | null) => void;
 }) {
   const slackChannels = useQuery({ queryKey: ["slack-channels"], queryFn: () => api.channels.listSlack() });
@@ -598,21 +836,37 @@ function DeliveryEditor({
     (user) => user.id === session.data?.userId && user.type !== "agent" && user.slack_user_id,
   );
   const groupOptions = whatsappGroups.data?.groups ?? [];
+  const canPostToSource = sources.length === 1;
 
   return (
     <div className="space-y-5">
       <div className="flex items-center justify-between gap-3 rounded-lg border-[0.5px] border-border px-3 py-2.5">
-        <span className="text-[13px] font-medium text-foreground">Send completed briefs</span>
+        <span className="text-[13px] font-medium text-foreground">Send completed outputs</span>
         <Switch
           checked={enabled}
           onCheckedChange={setEnabled}
-          aria-label="Send completed briefs"
+          aria-label="Send completed outputs"
           className="data-[state=checked]:bg-emerald-500"
         />
       </div>
 
       {enabled ? (
         <>
+          {canPostToSource ? (
+            <button
+              type="button"
+              onClick={() => onChange(sourceToDelivery(sources[0]))}
+              className="flex w-full items-center justify-between gap-3 rounded-lg border-[0.5px] border-border px-3 py-2.5 text-left text-[12.5px] text-foreground transition-colors hover:bg-muted/50"
+            >
+              <span>Post back to {sources[0].label ?? sources[0].targetId}</span>
+              {value?.platform === sources[0].platform &&
+              value.targetType === sources[0].targetType &&
+              value.targetId === sources[0].targetId ? (
+                <CheckCircleIcon size={13} weight="fill" aria-hidden />
+              ) : null}
+            </button>
+          ) : null}
+
           <SegmentedControl
             label="Platform"
             options={[
@@ -682,7 +936,7 @@ function DeliveryEditor({
         </>
       ) : (
         <p className="text-[12px] leading-relaxed text-muted-foreground">
-          The brief will remain available on Home and will not be posted to a channel.
+          The output will remain available here and will not be posted to a channel.
         </p>
       )}
     </div>
@@ -760,8 +1014,6 @@ function TargetList({
     </div>
   );
 }
-
-// --- helpers ----------------------------------------------------------------
 
 function formatDate(value: string): string {
   const parsed = new Date(value.length === 10 ? `${value}T00:00:00` : value);

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -6,6 +6,7 @@
 import {
   type AgentConfig,
   type AgentDeliveryConfig,
+  type AgentDeliveryMention,
   type AgentDetailResponse,
   type AgentOutput,
   type AgentOutputsResponse,
@@ -56,10 +57,11 @@ function formatTime(hour: number, minute: number): string {
 
 function deliverySummary(delivery: AgentDeliveryConfig | null): string {
   if (!delivery) return "Web only";
+  const tagged = delivery.mentions?.length ? ` · ${delivery.mentions.length} tagged` : "";
   if (delivery.platform === "slack" && delivery.targetType === "channel")
-    return `Slack ${delivery.label ?? delivery.targetId}`;
-  if (delivery.platform === "slack") return `Slack DM ${delivery.label ?? delivery.targetId}`;
-  return `WhatsApp ${delivery.label ?? delivery.targetId}`;
+    return `Slack ${delivery.label ?? delivery.targetId}${tagged}`;
+  if (delivery.platform === "slack") return `Slack DM ${delivery.label ?? delivery.targetId}${tagged}`;
+  return `WhatsApp ${delivery.label ?? delivery.targetId}${tagged}`;
 }
 
 export function AgentDetail({ agentKey }: { agentKey: string }) {
@@ -635,6 +637,10 @@ function sourceKey(source: AgentSourceConfig): string {
   return `${source.platform}:${source.targetType}:${source.targetId}`;
 }
 
+function mentionKey(mention: AgentDeliveryMention): string {
+  return `${mention.platform}:${mention.targetId}`;
+}
+
 function sourceToDelivery(source: AgentSourceConfig): AgentDeliveryConfig {
   return {
     enabled: true,
@@ -801,6 +807,7 @@ function DeliveryEditor({
   const platform = value?.platform ?? "slack";
   const targetType = value?.targetType ?? (platform === "slack" ? "channel" : "group");
   const enabled = value !== null;
+  const mentions = value?.mentions ?? [];
 
   const setEnabled = (next: boolean) => {
     if (!next) {
@@ -818,25 +825,53 @@ function DeliveryEditor({
       targetType: next === "slack" ? "channel" : "group",
       targetId: "",
       label: null,
+      mentions: [],
     });
   };
 
   const setTargetType = (next: "channel" | "dm" | "group") => {
     if (!enabled) return;
-    onChange({ enabled: true, platform, targetType: next, targetId: "", label: null });
+    onChange({ enabled: true, platform, targetType: next, targetId: "", label: null, mentions: [] });
   };
 
   const selectTarget = (targetId: string, label: string) => {
     if (!enabled) return;
-    onChange({ enabled: true, platform, targetType, targetId, label });
+    onChange({ enabled: true, platform, targetType, targetId, label, mentions: [] });
+  };
+
+  const toggleMention = (mention: AgentDeliveryMention) => {
+    if (!value?.targetId) return;
+    const key = mentionKey(mention);
+    const selected = mentions.some((item) => mentionKey(item) === key);
+    const next = selected ? mentions.filter((item) => mentionKey(item) !== key) : [...mentions, mention];
+    onChange({ ...value, mentions: next });
   };
 
   const channelOptions = (slackChannels.data?.channels ?? []).filter((channel) => channel.isMember);
   const dmOptions = (users.data?.users ?? []).filter(
     (user) => user.id === session.data?.userId && user.type !== "agent" && user.slack_user_id,
   );
+  const slackMentionOptions = (users.data?.users ?? [])
+    .filter((user) => user.type !== "agent" && user.slack_user_id)
+    .map(
+      (user): AgentDeliveryMention => ({
+        platform: "slack",
+        targetId: user.slack_user_id ?? "",
+        label: user.email ? `${user.name} <${user.email}>` : user.name,
+      }),
+    );
+  const whatsappMentionOptions = (users.data?.users ?? [])
+    .filter((user) => user.type !== "agent" && user.whatsapp_number)
+    .map(
+      (user): AgentDeliveryMention => ({
+        platform: "whatsapp",
+        targetId: user.whatsapp_number ?? "",
+        label: user.name,
+      }),
+    );
   const groupOptions = whatsappGroups.data?.groups ?? [];
   const canPostToSource = sources.length === 1;
+  const mentionOptions = platform === "slack" ? slackMentionOptions : whatsappMentionOptions;
 
   return (
     <div className="space-y-5">
@@ -933,6 +968,25 @@ function DeliveryEditor({
               )}
             </div>
           </div>
+
+          <div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
+              Notify people
+            </span>
+            <div className="mt-2 max-h-48 overflow-y-auto rounded-lg border-[0.5px] border-border p-1">
+              {!value?.targetId ? (
+                <p className="px-2 py-2 text-[12px] text-muted-foreground">Choose a destination first.</p>
+              ) : (
+                <MentionList
+                  loading={users.isLoading}
+                  empty={platform === "slack" ? "No Slack people available." : "No WhatsApp people available."}
+                  selected={new Set(mentions.map(mentionKey))}
+                  options={mentionOptions}
+                  onToggle={toggleMention}
+                />
+              )}
+            </div>
+          </div>
         </>
       ) : (
         <p className="text-[12px] leading-relaxed text-muted-foreground">
@@ -1011,6 +1065,47 @@ function TargetList({
           {selectedId === option.id ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
         </button>
       ))}
+    </div>
+  );
+}
+
+function MentionList({
+  loading,
+  empty,
+  selected,
+  options,
+  onToggle,
+}: {
+  loading: boolean;
+  empty: string;
+  selected: Set<string>;
+  options: AgentDeliveryMention[];
+  onToggle: (mention: AgentDeliveryMention) => void;
+}) {
+  if (loading) return <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading...</p>;
+  if (options.length === 0) return <p className="px-2 py-2 text-[12px] text-muted-foreground">{empty}</p>;
+  return (
+    <div className="flex flex-col">
+      {options.map((option) => {
+        const active = selected.has(mentionKey(option));
+        return (
+          <button
+            key={mentionKey(option)}
+            type="button"
+            onClick={() => onToggle(option)}
+            className={cn(
+              "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+              active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+            )}
+          >
+            <span className="shrink-0">
+              <UserIcon size={14} aria-hidden />
+            </span>
+            <span className="min-w-0 flex-1 truncate">{option.label ?? option.targetId}</span>
+            {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1051,6 +1051,19 @@ export interface AgentDeliveryConfig {
   label: string | null;
 }
 
+export interface AgentSourceConfig {
+  platform: "slack" | "whatsapp";
+  targetType: "channel" | "group";
+  targetId: string;
+  label: string | null;
+}
+
+export interface AgentSourceConfigMeta {
+  maxSources: number;
+  supportsSlackChannels: boolean;
+  supportsWhatsAppGroups: boolean;
+}
+
 export interface AgentConfig {
   agentKey: string;
   title: string;
@@ -1064,6 +1077,8 @@ export interface AgentConfig {
   itemsPerSectionRange: { min: number; max: number };
   focus: string | null;
   delivery: AgentDeliveryConfig | null;
+  sourceConfig: AgentSourceConfigMeta | null;
+  sources: AgentSourceConfig[];
   sections: AgentSectionConfig[];
 }
 
@@ -1080,6 +1095,7 @@ export interface AgentOutputItem {
   actionLabel: string | null;
   actionPrompt: string | null;
   sourceUrl: string | null;
+  structuredPayload: Record<string, unknown> | null;
   knowledgeRefs: DailyBriefKnowledgeRefs;
   sortOrder: number;
 }
@@ -1116,6 +1132,12 @@ export interface AgentConfigPatch {
   sections?: Record<string, boolean>;
   focus?: string | null;
   delivery?: AgentDeliveryConfig | null;
+  sources?: AgentSourceConfig[];
+}
+
+export interface AgentOutputsResponse {
+  outputs: AgentOutput[];
+  nextCursor: string | null;
 }
 
 export type WebChatMessagePart =
@@ -1233,6 +1255,13 @@ export const api = {
         `/api/agents/${agentKey}/runs`,
         { method: "POST", body: JSON.stringify({}) },
       );
+    },
+    outputs(agentKey: string, opts?: { limit?: number; cursor?: string | null }) {
+      const params = new URLSearchParams();
+      if (opts?.limit) params.set("limit", String(opts.limit));
+      if (opts?.cursor) params.set("cursor", opts.cursor);
+      const qs = params.toString();
+      return request<AgentOutputsResponse>(`/api/agents/${agentKey}/outputs${qs ? `?${qs}` : ""}`);
     },
   },
   webChat: {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1049,6 +1049,13 @@ export interface AgentDeliveryConfig {
   targetType: "channel" | "dm" | "group";
   targetId: string;
   label: string | null;
+  mentions?: AgentDeliveryMention[];
+}
+
+export interface AgentDeliveryMention {
+  platform: "slack" | "whatsapp";
+  targetId: string;
+  label: string | null;
 }
 
 export interface AgentSourceConfig {

--- a/packages/web/src/routes/agents/index.tsx
+++ b/packages/web/src/routes/agents/index.tsx
@@ -1,7 +1,6 @@
 /**
  * Agents — the prebuilt agent catalog (experimental). `/agents` lists the catalog
- * (roster); `/agents/$agentKey` reads and tunes one agent. The Daily Brief is v1's
- * only agent; `/home` stays its flagship surface.
+ * (roster); `/agents/$agentKey` reads output history and tunes one agent.
  */
 import { AgentDetail } from "@/components/agents/agent-detail";
 import { AgentRoster } from "@/components/agents/agent-roster";


### PR DESCRIPTION
## Summary
- Adds a configurable `Summarizer` agent that can summarize selected Slack channels and WhatsApp groups.
- Adds reusable agent output history so Daily Brief and Summarizer can show past generated outputs in the agent detail/config flow.
- Adds source selection, source-aware delivery, and clearer selected/available/limit UX for conversation-based agents.

## Linear Scope
- Implements SKE-257: Add configurable Summarizer agent.
- Covers backend agent runtime/config plumbing, API output history, frontend configuration UX, and DB indexing needed for conversation summary windows.

## Implementation Details
- Added `conversation_summary` as the stable agent key while surfacing the user-facing title as `Summarizer`.
- The Summarizer runtime builds context from configured Slack/WhatsApp conversations, summarizes messages since the last successful completed run, and falls back to the previous 24 hours on first run.
- Added source config validation to agent config updates, including max source limits, Slack membership checks, WhatsApp group validation, and deduplication.
- Added `GET /api/agents/:agentKey/outputs` for paginated output history and wired the web client/detail page to render a newest-first history with selected output detail.
- Extended agent user prefs with `sources` and kept delivery support generic, including the option to post back to the single selected source.
- Added migration `115-conversation-message-window-index` to index conversation message windows by conversation, received time, and bot flag.
- Updated migration tests and date-sensitive Teams tests to keep the full test suite deterministic.

## Verification
- `pnpm biome check` - passed.
- `pnpm typecheck` - passed.
- `pnpm test` - passed.
- `pnpm build` - passed. Build completed with existing tsdown `define` warnings and the existing Vite chunk-size warning.
- In-app browser verification - passed: Summary route now shows `Summarizer`, the toggle accessibility label is `Summarizer active`, and source picker copy separates selected count, available count, and source limit.

## Risk / Rollout
- Includes a new DB migration that adds an index only; no destructive schema changes.
- Existing stored configs and routes keep using `conversation_summary`, so the user-facing rename does not break saved data.
- Summarizer first-run output is intentionally bounded to 24 hours to avoid unexpectedly large initial summaries.
