### PR TITLE
fix: send Wati template recipients with phone_number

### DIFF
--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -635,7 +635,7 @@ describe("Wati outbound provider", () => {
         template_name: "sketch_magic_link",
         recipients: [
           {
-            whatsappNumber: "15551234567",
+            phone_number: "15551234567",
             customParams: [
               { name: "name", value: "Alice" },
               { name: "bot", value: "Sketch" },

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -161,7 +161,7 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
       broadcast_name: buildBroadcastName(template.key),
       recipients: [
         {
-          whatsappNumber: phone,
+          phone_number: phone,
           customParams,
         },
       ],


### PR DESCRIPTION
## What changed

- Updated Wati v3 template sends to identify recipients with `phone_number` instead of `whatsappNumber`.
- Updated the focused Wati provider test assertion to match the v3 request shape.

## Why

Goosebumps workflow template delivery was failing after the workflow step completed because Wati rejected the template-send request with HTTP 400. The live failure matched Wati's current v3 template-send contract, where each recipient must provide `phone_number` or `target`.

## Validation

- `pnpm --filter @sketch/server exec vitest run src/whatsapp/providers/wati.test.ts --project unit`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Pre-push hook reran lint, typecheck, test, and build successfully.
