### PR TITLE
fix: send Wati template params as custom_params

### DIFF
--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -605,7 +605,7 @@ describe("Wati outbound provider", () => {
         return new Response(
           JSON.stringify({
             result: true,
-            recipients: [{ localMessageId: "local-template-1", whatsappNumber: "15551234567" }],
+            recipients: [{ local_message_id: "local-template-1", phone_number: "15551234567" }],
           }),
         );
       });
@@ -636,7 +636,7 @@ describe("Wati outbound provider", () => {
         recipients: [
           {
             phone_number: "15551234567",
-            customParams: [
+            custom_params: [
               { name: "name", value: "Alice" },
               { name: "bot", value: "Sketch" },
               { name: "link", value: "https://sketch.test/magic" },

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -162,7 +162,7 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
       recipients: [
         {
           phone_number: phone,
-          customParams,
+          custom_params: customParams,
         },
       ],
     };


### PR DESCRIPTION
## Summary
- Send Wati v3 template recipient params with the live custom_params field.
- Keep phone_number recipient shape and update provider tests for live Wati response casing.

## Verification
- pnpm --filter @sketch/server test -- src/whatsapp/providers/wati.test.ts (runs full server suite: 2906 passed)
- pnpm exec biome check .
- pnpm typecheck
- pnpm build
- pre-push hook: lint, typecheck, full tests, build
