### PR TITLE
feat: add managed WhatsApp DM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,11 @@ LOG_LEVEL=info          # debug | info | warn | error
 # (`whatsapp.magic_link`, `whatsapp.introduction`, `whatsapp.proactive_update`).
 # See SELF_HOSTING.md for the admin API calls and parameter mapping format.
 # Managed tenants can use the platform-owned shared number for DMs while keeping
-# Baileys groups:
+# Baileys groups. The platform posts inbound DMs to:
+# POST /api/system/whatsapp/managed/events with Authorization: Bearer <SYSTEM_SECRET>
+# Outbound managed DMs call MANAGED_WHATSAPP_PLATFORM_URL for text and template
+# sends. Template sends resolve Sketch logical keys through the local WhatsApp
+# template mapping table before calling the platform.
 # WHATSAPP_DM_PROVIDER=managed
 # WHATSAPP_GROUP_PROVIDER=baileys
 # MANAGED_WHATSAPP_PLATFORM_URL=https://app.getsketch.ai

--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,12 @@ LOG_LEVEL=info          # debug | info | warn | error
 # For proactive Wati DMs, approve Wati templates and map them to Sketch logical keys
 # (`whatsapp.magic_link`, `whatsapp.introduction`, `whatsapp.proactive_update`).
 # See SELF_HOSTING.md for the admin API calls and parameter mapping format.
+# Managed tenants can use the platform-owned shared number for DMs while keeping
+# Baileys groups:
+# WHATSAPP_DM_PROVIDER=managed
+# WHATSAPP_GROUP_PROVIDER=baileys
+# MANAGED_WHATSAPP_PLATFORM_URL=https://app.getsketch.ai
+# MANAGED_WHATSAPP_TENANT_TOKEN=
 
 # Encryption (optional, recommended for shared Postgres deployments)
 # 64 hex chars = 32 bytes for AES-256-GCM

--- a/packages/server/src/api/managed-whatsapp-system.test.ts
+++ b/packages/server/src/api/managed-whatsapp-system.test.ts
@@ -3,10 +3,26 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSettingsRepository } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
-import { createTestDb } from "../test-utils";
+import { createTestDb, createTestLogger } from "../test-utils";
+import type { WhatsAppInboundMessage } from "../whatsapp/provider";
+import { createManagedWhatsAppProvider } from "../whatsapp/providers/managed";
 import { systemRoutes } from "./system";
 
 const SYSTEM_SECRET = "test-system-secret";
+
+function validPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    eventId: "event-1",
+    type: "message",
+    provider: "wati",
+    providerMessageId: "wamid.inbound",
+    providerConversationId: "conversation-1",
+    senderPhoneE164: "+15551234567",
+    senderName: "Alice",
+    text: "hello",
+    ...overrides,
+  };
+}
 
 describe("POST /api/system/whatsapp/managed/events", () => {
   let db: Kysely<DB>;
@@ -21,25 +37,55 @@ describe("POST /api/system/whatsapp/managed/events", () => {
 
   it("requires the system secret", async () => {
     const app = new Hono();
+    const handleInboundEvent = vi.fn();
     app.route(
       "/api/system",
       systemRoutes(createSettingsRepository(db), {
         systemSecret: SYSTEM_SECRET,
-        managedWhatsappInbound: { handleInboundEvent: vi.fn() },
+        managedWhatsappInbound: { handleInboundEvent },
       }),
     );
 
     const res = await app.request("/api/system/whatsapp/managed/events", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ providerMessageId: "wamid.inbound" }),
+      body: JSON.stringify(validPayload()),
     });
 
     expect(res.status).toBe(401);
+    expect(handleInboundEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects same-length wrong bearer values", async () => {
+    const app = new Hono();
+    const handleInboundEvent = vi.fn();
+    app.route(
+      "/api/system",
+      systemRoutes(createSettingsRepository(db), {
+        systemSecret: SYSTEM_SECRET,
+        managedWhatsappInbound: { handleInboundEvent },
+      }),
+    );
+
+    const wrongSecret = "wrong-system-token";
+    expect(wrongSecret).toHaveLength(SYSTEM_SECRET.length);
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${wrongSecret}` },
+      body: JSON.stringify(validPayload()),
+    });
+
+    expect(res.status).toBe(401);
+    expect(handleInboundEvent).not.toHaveBeenCalled();
   });
 
   it("hands normalized inbound events to the managed provider", async () => {
-    const handleInboundEvent = vi.fn(async () => undefined);
+    const handleInboundEvent = vi.fn(async () => ({
+      kind: "message" as const,
+      eventId: "event-1",
+      providerMessageId: "wamid.inbound",
+      senderPhoneE164: "+15551234567",
+    }));
     const app = new Hono();
     app.route(
       "/api/system",
@@ -49,14 +95,7 @@ describe("POST /api/system/whatsapp/managed/events", () => {
       }),
     );
 
-    const payload = {
-      provider: "wati",
-      providerMessageId: "wamid.inbound",
-      providerConversationId: "conversation-1",
-      senderPhoneE164: "+15551234567",
-      senderName: "Alice",
-      text: "hello",
-    };
+    const payload = validPayload();
     const res = await app.request("/api/system/whatsapp/managed/events", {
       method: "POST",
       headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
@@ -68,6 +107,59 @@ describe("POST /api/system/whatsapp/managed/events", () => {
     expect(handleInboundEvent).toHaveBeenCalledWith(payload);
   });
 
+  it("returns bad request when the managed provider rejects the event schema", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const app = new Hono();
+    app.route(
+      "/api/system",
+      systemRoutes(createSettingsRepository(db), {
+        systemSecret: SYSTEM_SECRET,
+        managedWhatsappInbound: provider,
+      }),
+    );
+
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
+      body: JSON.stringify(validPayload({ senderPhoneE164: "15551234567" })),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: { code: "BAD_REQUEST", message: "Invalid managed WhatsApp event" } });
+  });
+
+  it("accepts unknown managed event types without invoking agent handlers", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+    const app = new Hono();
+    app.route(
+      "/api/system",
+      systemRoutes(createSettingsRepository(db), {
+        systemSecret: SYSTEM_SECRET,
+        managedWhatsappInbound: provider,
+      }),
+    );
+
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
+      body: JSON.stringify({ eventId: "event-status-1", type: "status", text: "ignored" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("returns unavailable when the managed provider is not configured", async () => {
     const app = new Hono();
     app.route("/api/system", systemRoutes(createSettingsRepository(db), { systemSecret: SYSTEM_SECRET }));
@@ -75,7 +167,7 @@ describe("POST /api/system/whatsapp/managed/events", () => {
     const res = await app.request("/api/system/whatsapp/managed/events", {
       method: "POST",
       headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
-      body: JSON.stringify({ providerMessageId: "wamid.inbound" }),
+      body: JSON.stringify(validPayload()),
     });
 
     expect(res.status).toBe(503);

--- a/packages/server/src/api/managed-whatsapp-system.test.ts
+++ b/packages/server/src/api/managed-whatsapp-system.test.ts
@@ -1,0 +1,83 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSettingsRepository } from "../db/repositories/settings";
+import type { DB } from "../db/schema";
+import { createTestDb } from "../test-utils";
+import { systemRoutes } from "./system";
+
+const SYSTEM_SECRET = "test-system-secret";
+
+describe("POST /api/system/whatsapp/managed/events", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("requires the system secret", async () => {
+    const app = new Hono();
+    app.route(
+      "/api/system",
+      systemRoutes(createSettingsRepository(db), {
+        systemSecret: SYSTEM_SECRET,
+        managedWhatsappInbound: { handleInboundEvent: vi.fn() },
+      }),
+    );
+
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ providerMessageId: "wamid.inbound" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("hands normalized inbound events to the managed provider", async () => {
+    const handleInboundEvent = vi.fn(async () => undefined);
+    const app = new Hono();
+    app.route(
+      "/api/system",
+      systemRoutes(createSettingsRepository(db), {
+        systemSecret: SYSTEM_SECRET,
+        managedWhatsappInbound: { handleInboundEvent },
+      }),
+    );
+
+    const payload = {
+      provider: "wati",
+      providerMessageId: "wamid.inbound",
+      providerConversationId: "conversation-1",
+      senderPhoneE164: "+15551234567",
+      senderName: "Alice",
+      text: "hello",
+    };
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
+      body: JSON.stringify(payload),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(handleInboundEvent).toHaveBeenCalledWith(payload);
+  });
+
+  it("returns unavailable when the managed provider is not configured", async () => {
+    const app = new Hono();
+    app.route("/api/system", systemRoutes(createSettingsRepository(db), { systemSecret: SYSTEM_SECRET }));
+
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
+      body: JSON.stringify({ providerMessageId: "wamid.inbound" }),
+    });
+
+    expect(res.status).toBe(503);
+  });
+});

--- a/packages/server/src/api/managed-whatsapp-system.test.ts
+++ b/packages/server/src/api/managed-whatsapp-system.test.ts
@@ -107,6 +107,54 @@ describe("POST /api/system/whatsapp/managed/events", () => {
     expect(handleInboundEvent).toHaveBeenCalledWith(payload);
   });
 
+  it("accepts explicit null optional fields as omitted text message metadata", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+    const app = new Hono();
+    app.route(
+      "/api/system",
+      systemRoutes(createSettingsRepository(db), {
+        systemSecret: SYSTEM_SECRET,
+        managedWhatsappInbound: provider,
+      }),
+    );
+
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
+      body: JSON.stringify(
+        validPayload({
+          providerTimestamp: null,
+          senderName: null,
+          tenantUserId: null,
+          tenantUserEmail: null,
+          mediaType: null,
+          quotedMessage: null,
+        }),
+      ),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(handler).toHaveBeenCalledOnce();
+    const [message] = handler.mock.calls[0] as [WhatsAppInboundMessage];
+    expect(message).toEqual(
+      expect.objectContaining({
+        text: "hello",
+        providerTimestamp: null,
+        senderName: "+15551234567",
+        senderPhoneE164: "+15551234567",
+      }),
+    );
+    expect(message).not.toHaveProperty("mediaType");
+    expect(message).not.toHaveProperty("quotedMessage");
+  });
+
   it("returns bad request when the managed provider rejects the event schema", async () => {
     const provider = createManagedWhatsAppProvider({
       platformUrl: "https://app.getsketch.ai",

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { whatsappNumberSchema } from "@sketch/shared";
 /**
  * System API routes — internal management endpoints authenticated by bearer token.
@@ -12,6 +12,7 @@ import type { createMcpServerRepository } from "../db/repositories/mcp-servers";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
 import { upsertSlackIdentity } from "../slack/upsert-identity";
+import { InvalidManagedWhatsAppInboundEventError } from "../whatsapp/providers/managed";
 import type { ManagedWhatsAppProvider } from "../whatsapp/providers/managed";
 import { buildIntroductionTemplate } from "../whatsapp/templates";
 import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
@@ -145,6 +146,13 @@ function generateSketchApiKey(): string {
   return `sk_live_${randomBytes(32).toString("base64url")}`;
 }
 
+function isValidSystemAuthorization(auth: string | undefined, systemSecret: string): boolean {
+  if (!auth) return false;
+  const actualBytes = Buffer.from(auth);
+  const expectedBytes = Buffer.from(`Bearer ${systemSecret}`);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+}
+
 function buildOpeningIntroMessage(botName: string): string {
   return `I've added your team to ${botName}. Who should I introduce myself to first? Reply with names or @mentions.`;
 }
@@ -221,7 +229,7 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
 
   routes.use("/*", async (c, next) => {
     const auth = c.req.header("Authorization");
-    if (!auth || auth !== `Bearer ${deps.systemSecret}`) {
+    if (!isValidSystemAuthorization(auth, deps.systemSecret)) {
       return c.json({ error: { code: "UNAUTHORIZED", message: "Invalid system secret" } }, 401);
     }
     return next();
@@ -511,7 +519,14 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       return c.json({ error: { code: "BAD_REQUEST", message: "Invalid JSON body" } }, 400);
     }
 
-    await deps.managedWhatsappInbound.handleInboundEvent(body);
+    try {
+      await deps.managedWhatsappInbound.handleInboundEvent(body);
+    } catch (error) {
+      if (error instanceof InvalidManagedWhatsAppInboundEventError) {
+        return c.json({ error: { code: "BAD_REQUEST", message: "Invalid managed WhatsApp event" } }, 400);
+      }
+      throw error;
+    }
     return c.json({ ok: true });
   });
 

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -12,6 +12,7 @@ import type { createMcpServerRepository } from "../db/repositories/mcp-servers";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
 import { upsertSlackIdentity } from "../slack/upsert-identity";
+import type { ManagedWhatsAppProvider } from "../whatsapp/providers/managed";
 import { buildIntroductionTemplate } from "../whatsapp/templates";
 import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 import { upsertWhatsAppIdentity } from "../whatsapp/upsert-identity";
@@ -44,6 +45,7 @@ interface SystemDeps {
     message: string;
     template?: WhatsAppTemplateRequest;
   }) => Promise<{ channelId: string; messageRef: string }>;
+  managedWhatsappInbound?: Pick<ManagedWhatsAppProvider, "handleInboundEvent">;
   whatsappStatus?: () => { connected: boolean; phoneNumber: string | null; pairingInProgress: boolean };
   // biome-ignore lint/complexity/noBannedTypes: Function is needed here to accommodate Vitest mock types in tests
   startWhatsAppPairing?: Function;
@@ -497,6 +499,20 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
         409,
       );
     }
+  });
+
+  routes.post("/whatsapp/managed/events", async (c) => {
+    if (!deps.managedWhatsappInbound) {
+      return c.json({ error: { code: "UNAVAILABLE", message: "Managed WhatsApp provider is not configured" } }, 503);
+    }
+
+    const body = await c.req.json().catch(() => undefined);
+    if (body === undefined) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "Invalid JSON body" } }, 400);
+    }
+
+    await deps.managedWhatsappInbound.handleInboundEvent(body);
+    return c.json({ ok: true });
   });
 
   routes.get("/whatsapp", (c) => {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -59,6 +59,7 @@ import { wireWhatsAppHandlers } from "./whatsapp/adapter";
 import { WhatsAppBot } from "./whatsapp/bot";
 import { whatsappDeliveryTargetFromTarget } from "./whatsapp/provider";
 import { createBaileysWhatsAppProviders } from "./whatsapp/providers/baileys";
+import { WHATSAPP_MANAGED_PROVIDER_ID, createManagedWhatsAppProvider } from "./whatsapp/providers/managed";
 import { WHATSAPP_WATI_PROVIDER_ID, createWatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import { createWhatsAppRuntime } from "./whatsapp/runtime";
 import type { WhatsAppTemplateRequest } from "./whatsapp/templates";
@@ -251,12 +252,28 @@ export async function createServer(config: Config, options?: CreateServerOptions
           templateMappings: whatsappTemplateMappingsRepo,
         })
       : null;
+  const managedWhatsApp =
+    config.WHATSAPP_DM_PROVIDER === WHATSAPP_MANAGED_PROVIDER_ID
+      ? createManagedWhatsAppProvider({
+          platformUrl: config.MANAGED_WHATSAPP_PLATFORM_URL ?? "",
+          tenantToken: config.MANAGED_WHATSAPP_TENANT_TOKEN ?? "",
+          logger,
+        })
+      : null;
   const whatsappRuntime = createWhatsAppRuntime({
     dmProviderId: config.WHATSAPP_DM_PROVIDER,
     groupProviderId: config.WHATSAPP_GROUP_PROVIDER,
-    dmProviders: [baileysWhatsApp.dmProvider, ...(watiWhatsApp ? [watiWhatsApp.dmProvider] : [])],
+    dmProviders: [
+      baileysWhatsApp.dmProvider,
+      ...(watiWhatsApp ? [watiWhatsApp.dmProvider] : []),
+      ...(managedWhatsApp ? [managedWhatsApp.dmProvider] : []),
+    ],
     groupProviders: [baileysWhatsApp.groupProvider],
-    inboundProviders: [baileysWhatsApp.inboundProvider, ...(watiWhatsApp ? [watiWhatsApp.inboundProvider] : [])],
+    inboundProviders: [
+      baileysWhatsApp.inboundProvider,
+      ...(watiWhatsApp ? [watiWhatsApp.inboundProvider] : []),
+      ...(managedWhatsApp ? [managedWhatsApp.inboundProvider] : []),
+    ],
     logger,
   });
 
@@ -477,6 +494,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     whatsapp,
     whatsappRuntime,
     watiWebhook: watiWhatsApp ?? undefined,
+    managedWhatsapp: managedWhatsApp ?? undefined,
     getSlack: () => slack,
     scheduler,
     runAgent: trackedRunAgent,

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -258,6 +258,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
           platformUrl: config.MANAGED_WHATSAPP_PLATFORM_URL ?? "",
           tenantToken: config.MANAGED_WHATSAPP_TENANT_TOKEN ?? "",
           logger,
+          templateMappings: whatsappTemplateMappingsRepo,
         })
       : null;
   const whatsappRuntime = createWhatsAppRuntime({

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -72,6 +72,18 @@ describe("configSchema", () => {
       }
     });
 
+    it("treats blank managed WhatsApp settings as absent", () => {
+      const result = configSchema.safeParse({
+        MANAGED_WHATSAPP_PLATFORM_URL: "",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.MANAGED_WHATSAPP_PLATFORM_URL).toBeUndefined();
+        expect(result.data.MANAGED_WHATSAPP_TENANT_TOKEN).toBeUndefined();
+      }
+    });
+
     it("parses vision analysis environment settings", () => {
       const result = configSchema.safeParse({
         VISION_ENABLED: "true",
@@ -207,6 +219,11 @@ describe("configSchema", () => {
 
     it("rejects invalid Wati endpoint URLs", () => {
       const result = configSchema.safeParse({ WATI_API_ENDPOINT: "not-a-url" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid managed WhatsApp platform URLs", () => {
+      const result = configSchema.safeParse({ MANAGED_WHATSAPP_PLATFORM_URL: "not-a-url" });
       expect(result.success).toBe(false);
     });
   });

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -57,6 +57,21 @@ describe("configSchema", () => {
       }
     });
 
+    it("parses managed WhatsApp provider configuration", () => {
+      const result = configSchema.safeParse({
+        WHATSAPP_DM_PROVIDER: "managed",
+        WHATSAPP_GROUP_PROVIDER: "baileys",
+        MANAGED_WHATSAPP_PLATFORM_URL: "https://app.getsketch.ai",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.WHATSAPP_DM_PROVIDER).toBe("managed");
+        expect(result.data.MANAGED_WHATSAPP_PLATFORM_URL).toBe("https://app.getsketch.ai");
+        expect(result.data.MANAGED_WHATSAPP_TENANT_TOKEN).toBe("tenant-token");
+      }
+    });
+
     it("parses vision analysis environment settings", () => {
       const result = configSchema.safeParse({
         VISION_ENABLED: "true",
@@ -389,6 +404,39 @@ describe("validateConfig", () => {
         WATI_API_ENDPOINT: "https://tenant.wati.io",
         WATI_ACCESS_TOKEN: "access-token",
         WATI_WEBHOOK_TOKEN: "webhook-token",
+      });
+      validateConfig(config);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("managed WhatsApp validation", () => {
+    it("exits when managed WhatsApp is configured without a platform URL", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({
+        WHATSAPP_DM_PROVIDER: "managed",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      });
+      expect(() => validateConfig(config)).toThrow("exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("exits when managed WhatsApp is configured without a tenant token", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({
+        WHATSAPP_DM_PROVIDER: "managed",
+        MANAGED_WHATSAPP_PLATFORM_URL: "https://app.getsketch.ai",
+      });
+      expect(() => validateConfig(config)).toThrow("exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("accepts complete managed WhatsApp configuration", () => {
+      const exitSpy = mockProcessExit();
+      const config = makeConfig({
+        WHATSAPP_DM_PROVIDER: "managed",
+        MANAGED_WHATSAPP_PLATFORM_URL: "https://app.getsketch.ai",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
       });
       validateConfig(config);
       expect(exitSpy).not.toHaveBeenCalled();

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -64,6 +64,8 @@ export const configSchema = z.object({
   WATI_ACCESS_TOKEN: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   WATI_WEBHOOK_TOKEN: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   WATI_CHANNEL_PHONE_NUMBER: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
+  MANAGED_WHATSAPP_PLATFORM_URL: z.preprocess((v) => (v === "" ? undefined : v), z.string().url().optional()),
+  MANAGED_WHATSAPP_TENANT_TOKEN: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
 
   // Security
   ENCRYPTION_KEY: z.string().optional(),
@@ -178,6 +180,16 @@ export function validateConfig(config: Config): void {
     }
     if (!config.WATI_WEBHOOK_TOKEN) {
       console.error("WHATSAPP_DM_PROVIDER=wati requires WATI_WEBHOOK_TOKEN");
+      process.exit(1);
+    }
+  }
+  if (config.WHATSAPP_DM_PROVIDER === "managed") {
+    if (!config.MANAGED_WHATSAPP_PLATFORM_URL) {
+      console.error("WHATSAPP_DM_PROVIDER=managed requires MANAGED_WHATSAPP_PLATFORM_URL");
+      process.exit(1);
+    }
+    if (!config.MANAGED_WHATSAPP_TENANT_TOKEN) {
+      console.error("WHATSAPP_DM_PROVIDER=managed requires MANAGED_WHATSAPP_TENANT_TOKEN");
       process.exit(1);
     }
   }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -79,6 +79,7 @@ import type { TaskScheduler } from "./scheduler/service";
 import type { SlackBot } from "./slack/bot";
 import type { WhatsAppBot } from "./whatsapp/bot";
 import { phoneE164ToWhatsAppJid } from "./whatsapp/provider";
+import type { ManagedWhatsAppProvider } from "./whatsapp/providers/managed";
 import type { WatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import type { WhatsAppRuntime } from "./whatsapp/runtime";
 import { buildMagicLinkTemplate } from "./whatsapp/templates";
@@ -88,6 +89,7 @@ interface AppDeps {
   whatsapp?: WhatsAppBot;
   whatsappRuntime?: WhatsAppRuntime;
   watiWebhook?: WatiWhatsAppProvider;
+  managedWhatsapp?: ManagedWhatsAppProvider;
   getSlack?: () => SlackBot | null;
   logger?: Logger;
   onSlackTokensUpdated?: (tokens?: { botToken: string; appToken: string }) => Promise<void>;
@@ -511,6 +513,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
             }
           : undefined,
         sendDm: deps?.sendDm,
+        managedWhatsappInbound: deps?.managedWhatsapp,
         whatsappStatus: whatsapp
           ? () => ({
               connected: whatsapp.isConnected,

--- a/packages/server/src/whatsapp/providers/managed.test.ts
+++ b/packages/server/src/whatsapp/providers/managed.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "../../test-utils";
+import type { WhatsAppInboundMessage } from "../provider";
+import { createManagedWhatsAppProvider } from "./managed";
+
+describe("managed WhatsApp provider", () => {
+  it("sends outbound DM text through the platform API", async () => {
+    const requestFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            message: {
+              providerMessageId: "wamid.outbound",
+              providerConversationId: "conversation-1",
+              providerTimestamp: "2026-07-02T10:01:00.000Z",
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai/",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    const sent = await provider.dmProvider.sendText(
+      { kind: "dm", phoneE164: "+15551234567", providerConversationId: "conversation-1" },
+      "hello",
+      {
+        quotedMessage: {
+          kind: "dm",
+          providerId: "managed",
+          providerMessageId: "wamid.parent",
+          providerConversationId: "conversation-1",
+          canonicalConversationId: "dm:+15551234567",
+          providerTimestamp: null,
+          senderName: "Alice",
+          senderProviderId: "+15551234567",
+          senderPhoneE164: "+15551234567",
+          target: { kind: "dm", phoneE164: "+15551234567" },
+          text: "parent",
+        },
+      },
+    );
+
+    expect(sent).toMatchObject({
+      providerMessageId: "wamid.outbound",
+      providerConversationId: "conversation-1",
+      providerTimestamp: "2026-07-02T10:01:00.000Z",
+    });
+    const [url, init] = requestFetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://app.getsketch.ai/api/whatsapp/outbound/messages");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer tenant-token",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      to: "+15551234567",
+      text: "hello",
+      providerConversationId: "conversation-1",
+      quotedProviderMessageId: "wamid.parent",
+    });
+  });
+
+  it("emits normalized inbound platform events into the runtime shape", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+
+    await provider.handleInboundEvent({
+      provider: "wati",
+      providerMessageId: "wamid.inbound",
+      providerConversationId: "conversation-1",
+      providerTimestamp: "2026-07-02T10:00:00.000Z",
+      senderPhoneE164: "+15551234567",
+      senderName: "Alice",
+      text: "hello",
+      quotedMessage: { providerMessageId: "wamid.parent", text: "parent" },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      kind: "dm",
+      providerId: "managed",
+      providerMessageId: "wamid.inbound",
+      providerConversationId: "conversation-1",
+      canonicalConversationId: "dm:+15551234567",
+      providerTimestamp: "2026-07-02T10:00:00.000Z",
+      senderName: "Alice",
+      senderProviderId: "+15551234567",
+      senderPhoneE164: "+15551234567",
+      target: { kind: "dm", phoneE164: "+15551234567", providerConversationId: "conversation-1" },
+      text: "hello",
+      rawProviderPayload: expect.any(Object),
+      quotedMessage: { providerMessageId: "wamid.parent", participantJid: null, text: "parent" },
+    });
+  });
+
+  it("rejects group sends", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+
+    await expect(provider.dmProvider.sendText({ kind: "group", groupId: "group@g.us" }, "hello")).rejects.toThrow(
+      "cannot send group messages",
+    );
+  });
+});

--- a/packages/server/src/whatsapp/providers/managed.test.ts
+++ b/packages/server/src/whatsapp/providers/managed.test.ts
@@ -1,7 +1,26 @@
+import type { Logger } from "pino";
 import { describe, expect, it, vi } from "vitest";
-import { createTestLogger } from "../../test-utils";
+import { createWhatsAppTemplateMappingRepository } from "../../db/repositories/whatsapp-template-mappings";
+import { createTestDb, createTestLogger } from "../../test-utils";
 import type { WhatsAppInboundMessage } from "../provider";
-import { createManagedWhatsAppProvider } from "./managed";
+import { WHATSAPP_TEMPLATE_KEYS } from "../templates";
+import { InvalidManagedWhatsAppInboundEventError, createManagedWhatsAppProvider } from "./managed";
+
+function inboundPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    eventId: "event-1",
+    type: "message",
+    provider: "wati",
+    providerMessageId: "wamid.inbound",
+    providerConversationId: "conversation-1",
+    providerTimestamp: "2026-07-02T10:00:00.000Z",
+    senderPhoneE164: "+15551234567",
+    senderName: "Alice",
+    text: "hello",
+    quotedMessage: { providerMessageId: "wamid.parent", text: "parent" },
+    ...overrides,
+  };
+}
 
 describe("managed WhatsApp provider", () => {
   it("sends outbound DM text through the platform API", async () => {
@@ -57,12 +76,161 @@ describe("managed WhatsApp provider", () => {
       Authorization: "Bearer tenant-token",
       "Content-Type": "application/json",
     });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
     expect(JSON.parse(init.body as string)).toEqual({
       to: "+15551234567",
       text: "hello",
       providerConversationId: "conversation-1",
       quotedProviderMessageId: "wamid.parent",
     });
+  });
+
+  it("rejects invalid outbound phone numbers before calling the platform", async () => {
+    const requestFetch = vi.fn();
+    const logger = { warn: vi.fn() } as unknown as Logger;
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger,
+      fetch: requestFetch as unknown as typeof fetch,
+    });
+
+    await expect(provider.dmProvider.sendText({ kind: "dm", phoneE164: "15551234567" }, "hello")).rejects.toThrow(
+      "target phone number is invalid",
+    );
+
+    expect(requestFetch).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      { targetKind: "dm", decision: "rejected", reason: "invalid_e164" },
+      "Invalid managed WhatsApp target",
+    );
+  });
+
+  it("includes a bounded platform error response snippet in outbound failures", async () => {
+    const requestFetch = vi.fn(async () => new Response(`platform failed ${"x".repeat(800)}`, { status: 502 }));
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    await expect(provider.dmProvider.sendText({ kind: "dm", phoneE164: "+15551234567" }, "hello")).rejects.toThrow(
+      /^Managed WhatsApp request failed: HTTP 502: platform failed x+/u,
+    );
+
+    try {
+      await provider.dmProvider.sendText({ kind: "dm", phoneE164: "+15551234567" }, "hello");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message.length).toBeLessThan(580);
+    }
+  });
+
+  it("sends mapped logical templates through the platform template API", async () => {
+    const db = await createTestDb();
+    try {
+      const templateMappings = createWhatsAppTemplateMappingRepository(db);
+      await templateMappings.upsertMapping({
+        provider: "managed",
+        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        providerTemplateName: "sketch_magic_link",
+        language: "en_US",
+        status: "approved",
+        parameterMap: {
+          name: "recipientName",
+          bot: "botName",
+          link: "magicLinkUrl",
+          missing: "missingValue",
+        },
+      });
+      const requestFetch = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              message: {
+                providerMessageId: "wamid.template",
+                providerConversationId: "conversation-1",
+                providerTimestamp: "2026-07-02T10:02:00.000Z",
+              },
+            }),
+          ),
+      );
+      const provider = createManagedWhatsAppProvider({
+        platformUrl: "https://app.getsketch.ai",
+        tenantToken: "tenant-token",
+        logger: createTestLogger(),
+        templateMappings,
+        fetch: requestFetch as typeof fetch,
+      });
+
+      expect(provider.dmProvider.capabilities.templates).toBe(true);
+      expect(provider.dmProvider.capabilities.templateProvisioning).toBe("manual");
+      const sent = await provider.dmProvider.sendTemplate?.(
+        { kind: "dm", phoneE164: "+15551234567", providerConversationId: "conversation-1" },
+        {
+          key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+          params: {
+            recipientName: "Alice",
+            botName: "Sketch",
+            magicLinkUrl: "https://sketch.test/magic",
+            missingValue: null,
+          },
+        },
+      );
+
+      expect(sent).toMatchObject({
+        providerMessageId: "wamid.template",
+        providerConversationId: "conversation-1",
+        providerTimestamp: "2026-07-02T10:02:00.000Z",
+      });
+      const [url, init] = requestFetch.mock.calls[0] as unknown as [string, RequestInit];
+      expect(url).toBe("https://app.getsketch.ai/api/whatsapp/outbound/templates");
+      expect(init.headers).toMatchObject({
+        Authorization: "Bearer tenant-token",
+        "Content-Type": "application/json",
+      });
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      expect(JSON.parse(init.body as string)).toEqual({
+        to: "+15551234567",
+        templateName: "sketch_magic_link",
+        params: {
+          name: "Alice",
+          bot: "Sketch",
+          link: "https://sketch.test/magic",
+          missing: "",
+        },
+        providerConversationId: "conversation-1",
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("fails template sends clearly when no approved managed mapping exists", async () => {
+    const db = await createTestDb();
+    try {
+      const provider = createManagedWhatsAppProvider({
+        platformUrl: "https://app.getsketch.ai",
+        tenantToken: "tenant-token",
+        logger: createTestLogger(),
+        templateMappings: createWhatsAppTemplateMappingRepository(db),
+        fetch: vi.fn() as unknown as typeof fetch,
+      });
+
+      await expect(
+        provider.dmProvider.sendTemplate?.(
+          { kind: "dm", phoneE164: "+15551234567" },
+          {
+            key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+            params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+          },
+        ),
+      ).rejects.toThrow("No approved WhatsApp template mapping configured for whatsapp.magic_link");
+    } finally {
+      await db.destroy();
+    }
   });
 
   it("emits normalized inbound platform events into the runtime shape", async () => {
@@ -74,17 +242,14 @@ describe("managed WhatsApp provider", () => {
     const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
     provider.inboundProvider.onMessage(handler);
 
-    await provider.handleInboundEvent({
-      provider: "wati",
-      providerMessageId: "wamid.inbound",
-      providerConversationId: "conversation-1",
-      providerTimestamp: "2026-07-02T10:00:00.000Z",
-      senderPhoneE164: "+15551234567",
-      senderName: "Alice",
-      text: "hello",
-      quotedMessage: { providerMessageId: "wamid.parent", text: "parent" },
-    });
+    const result = await provider.handleInboundEvent(inboundPayload());
 
+    expect(result).toEqual({
+      kind: "message",
+      eventId: "event-1",
+      providerMessageId: "wamid.inbound",
+      senderPhoneE164: "+15551234567",
+    });
     expect(handler).toHaveBeenCalledWith({
       kind: "dm",
       providerId: "managed",
@@ -100,6 +265,67 @@ describe("managed WhatsApp provider", () => {
       rawProviderPayload: expect.any(Object),
       quotedMessage: { providerMessageId: "wamid.parent", participantJid: null, text: "parent" },
     });
+  });
+
+  it("ignores non-message event types with metadata-only logging", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn() } as unknown as Logger;
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger,
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+
+    await expect(
+      provider.handleInboundEvent({ eventId: "event-status-1", type: "status", text: "ignored" }),
+    ).resolves.toEqual({
+      kind: "ignored",
+      eventId: "event-status-1",
+      type: "status",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      { eventId: "event-status-1", type: "status", decision: "ignored" },
+      "Ignored managed WhatsApp inbound event",
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("rejects schema-invalid message events without invoking handlers", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+
+    await expect(provider.handleInboundEvent(inboundPayload({ senderPhoneE164: "15551234567" }))).rejects.toThrow(
+      InvalidManagedWhatsAppInboundEventError,
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("degrades media-only inbound messages to honest text placeholders", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+
+    await provider.handleInboundEvent(inboundPayload({ text: "", mediaType: "image" }));
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "[WhatsApp media message (image) - media content not available]",
+        mediaType: "image",
+      }),
+    );
   });
 
   it("rejects group sends", async () => {

--- a/packages/server/src/whatsapp/providers/managed.ts
+++ b/packages/server/src/whatsapp/providers/managed.ts
@@ -35,6 +35,16 @@ const OUTBOUND_TIMEOUT_MS = 30_000;
 const ERROR_BODY_SNIPPET_LIMIT = 500;
 
 const e164PhoneSchema = z.string().trim().regex(E164_PHONE_PATTERN);
+const optionalStringSchema = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined);
+const optionalTrimmedStringSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .nullish()
+  .transform((value) => value ?? undefined);
 
 const inboundEventEnvelopeSchema = z
   .object({
@@ -49,20 +59,20 @@ const inboundMessageEventSchema = z.object({
   provider: z.string().trim().min(1),
   providerMessageId: z.string().trim().min(1),
   providerConversationId: z.string().trim().min(1),
-  providerTimestamp: z.string().optional(),
+  providerTimestamp: optionalStringSchema,
   senderPhoneE164: e164PhoneSchema,
-  senderName: z.string().trim().min(1).optional(),
-  tenantUserId: z.string().trim().min(1).optional(),
-  tenantUserEmail: z.string().trim().min(1).optional(),
-  text: z.string().optional(),
-  mediaType: z.string().trim().min(1).optional(),
+  senderName: optionalTrimmedStringSchema,
+  tenantUserId: optionalTrimmedStringSchema,
+  tenantUserEmail: optionalTrimmedStringSchema,
+  text: optionalStringSchema,
+  mediaType: optionalTrimmedStringSchema,
   quotedMessage: z
     .object({
       providerMessageId: z.string().trim().min(1),
-      text: z.string().nullable().optional(),
+      text: optionalStringSchema,
     })
-    .nullable()
-    .optional(),
+    .nullish()
+    .transform((value) => value ?? undefined),
 });
 
 export interface ManagedWhatsAppConfig {

--- a/packages/server/src/whatsapp/providers/managed.ts
+++ b/packages/server/src/whatsapp/providers/managed.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { createWhatsAppTemplateMappingRepository } from "../../db/repositories/whatsapp-template-mappings";
 import type { Logger } from "../../logger";
 import {
   type WhatsAppCapabilities,
@@ -11,6 +12,7 @@ import {
   type WhatsAppTarget,
   canonicalDmConversationId,
 } from "../provider";
+import type { WhatsAppTemplateParamValue, WhatsAppTemplateRequest } from "../templates";
 
 export const WHATSAPP_MANAGED_PROVIDER_ID = "managed";
 
@@ -18,8 +20,8 @@ const MANAGED_CAPABILITIES: WhatsAppCapabilities = {
   text: true,
   media: false,
   quotedReply: true,
-  templates: false,
-  templateProvisioning: "none",
+  templates: true,
+  templateProvisioning: "manual",
   interactive: false,
   deliveryStatus: false,
   typing: false,
@@ -28,17 +30,32 @@ const MANAGED_CAPABILITIES: WhatsAppCapabilities = {
   groups: false,
 };
 
-const inboundEventSchema = z.object({
+const E164_PHONE_PATTERN = /^\+[1-9]\d{6,14}$/u;
+const OUTBOUND_TIMEOUT_MS = 30_000;
+const ERROR_BODY_SNIPPET_LIMIT = 500;
+
+const e164PhoneSchema = z.string().trim().regex(E164_PHONE_PATTERN);
+
+const inboundEventEnvelopeSchema = z
+  .object({
+    eventId: z.string().trim().min(1),
+    type: z.string().trim().min(1),
+  })
+  .passthrough();
+
+const inboundMessageEventSchema = z.object({
+  eventId: z.string().trim().min(1),
+  type: z.literal("message"),
   provider: z.string().trim().min(1),
   providerMessageId: z.string().trim().min(1),
   providerConversationId: z.string().trim().min(1),
-  providerTimestamp: z.string().nullable().optional(),
-  senderPhoneE164: z.string().trim().min(1),
+  providerTimestamp: z.string().optional(),
+  senderPhoneE164: e164PhoneSchema,
   senderName: z.string().trim().min(1).optional(),
   tenantUserId: z.string().trim().min(1).optional(),
-  tenantUserEmail: z.string().email().nullable().optional(),
-  text: z.string().default(""),
-  mediaType: z.string().trim().min(1).nullable().optional(),
+  tenantUserEmail: z.string().trim().min(1).optional(),
+  text: z.string().optional(),
+  mediaType: z.string().trim().min(1).optional(),
   quotedMessage: z
     .object({
       providerMessageId: z.string().trim().min(1),
@@ -52,13 +69,25 @@ export interface ManagedWhatsAppConfig {
   platformUrl: string;
   tenantToken: string;
   logger: Logger;
+  templateMappings?: ReturnType<typeof createWhatsAppTemplateMappingRepository>;
   fetch?: typeof fetch;
+}
+
+export type ManagedWhatsAppInboundHandleResult =
+  | { kind: "message"; eventId: string; providerMessageId: string; senderPhoneE164: string }
+  | { kind: "ignored"; eventId: string; type: string };
+
+export class InvalidManagedWhatsAppInboundEventError extends Error {
+  constructor(readonly issues: z.ZodIssue[]) {
+    super("Invalid managed WhatsApp inbound event");
+    this.name = "InvalidManagedWhatsAppInboundEventError";
+  }
 }
 
 export interface ManagedWhatsAppProvider {
   dmProvider: WhatsAppDmProvider;
   inboundProvider: WhatsAppInboundProvider;
-  handleInboundEvent(payload: unknown): Promise<void>;
+  handleInboundEvent(payload: unknown): Promise<ManagedWhatsAppInboundHandleResult>;
 }
 
 export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): ManagedWhatsAppProvider {
@@ -72,8 +101,9 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
     options?: WhatsAppSendOptions,
   ): Promise<WhatsAppSendResult | null> => {
     if (target.kind !== "dm") throw new Error("Managed WhatsApp cannot send group messages");
+    assertValidE164Target(target.phoneE164, config.logger);
 
-    const response = await requestFetch(`${platformUrl}/api/whatsapp/outbound/messages`, {
+    const body = await fetchManagedJson(requestFetch, `${platformUrl}/api/whatsapp/outbound/messages`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${config.tenantToken}`,
@@ -87,21 +117,41 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
       }),
     });
 
-    const body = await response.json().catch(() => null);
-    if (!response.ok) {
-      throw new Error(`Managed WhatsApp send failed: HTTP ${response.status}`);
+    return sendResultFromManagedBody(body, target);
+  };
+
+  const sendTemplate = async (
+    target: WhatsAppTarget,
+    template: WhatsAppTemplateRequest,
+  ): Promise<WhatsAppSendResult | null> => {
+    if (target.kind !== "dm") throw new Error("Managed WhatsApp cannot send group messages");
+    assertValidE164Target(target.phoneE164, config.logger);
+    if (!config.templateMappings) throw new Error("WhatsApp template mappings are not configured");
+
+    const mapping = await config.templateMappings.findApprovedMapping(
+      WHATSAPP_MANAGED_PROVIDER_ID,
+      template.key,
+      template.language,
+    );
+    if (!mapping) {
+      throw new Error(`No approved WhatsApp template mapping configured for ${template.key}`);
     }
 
-    const message = isRecord(body) && isRecord(body.message) ? body.message : {};
-    return {
-      providerMessageId: optionalString(message.providerMessageId),
-      providerConversationId:
-        optionalString(message.providerConversationId) ??
-        target.providerConversationId ??
-        canonicalDmConversationId(target.phoneE164),
-      providerTimestamp: optionalString(message.providerTimestamp),
-      rawProviderPayload: body,
-    };
+    const body = await fetchManagedJson(requestFetch, `${platformUrl}/api/whatsapp/outbound/templates`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.tenantToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        to: target.phoneE164,
+        templateName: mapping.provider_template_name,
+        params: providerTemplateParamRecord(mapping.parameterMap, template.params),
+        providerConversationId: target.providerConversationId,
+      }),
+    });
+
+    return sendResultFromManagedBody(body, target);
   };
 
   return {
@@ -113,6 +163,7 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
         return Boolean(platformUrl && config.tenantToken);
       },
       sendText,
+      sendTemplate,
     },
     inboundProvider: {
       id: WHATSAPP_MANAGED_PROVIDER_ID,
@@ -121,13 +172,31 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
       },
     },
     async handleInboundEvent(payload) {
-      const parsed = inboundEventSchema.safeParse(payload);
+      const envelope = inboundEventEnvelopeSchema.safeParse(payload);
+      if (!envelope.success) {
+        config.logger.warn({ issues: envelope.error.issues }, "Invalid managed WhatsApp inbound event");
+        throw new InvalidManagedWhatsAppInboundEventError(envelope.error.issues);
+      }
+
+      if (envelope.data.type !== "message") {
+        config.logger.info(
+          { eventId: envelope.data.eventId, type: envelope.data.type, decision: "ignored" },
+          "Ignored managed WhatsApp inbound event",
+        );
+        return { kind: "ignored", eventId: envelope.data.eventId, type: envelope.data.type };
+      }
+
+      const parsed = inboundMessageEventSchema.safeParse(payload);
       if (!parsed.success) {
-        config.logger.warn({ issues: parsed.error.issues }, "Invalid managed WhatsApp inbound event");
-        return;
+        config.logger.warn(
+          { eventId: envelope.data.eventId, issues: parsed.error.issues },
+          "Invalid managed WhatsApp inbound message event",
+        );
+        throw new InvalidManagedWhatsAppInboundEventError(parsed.error.issues);
       }
 
       const event = parsed.data;
+      const text = inboundMessageText(event.text, event.mediaType);
       const message: WhatsAppDmInboundMessage = {
         kind: "dm",
         providerId: WHATSAPP_MANAGED_PROVIDER_ID,
@@ -139,7 +208,7 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
         senderProviderId: event.senderPhoneE164,
         senderPhoneE164: event.senderPhoneE164,
         target: { kind: "dm", phoneE164: event.senderPhoneE164, providerConversationId: event.providerConversationId },
-        text: event.text,
+        text,
         rawProviderPayload: payload,
         ...(event.mediaType ? { mediaType: event.mediaType } : {}),
         ...(event.quotedMessage
@@ -156,8 +225,77 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
       for (const handler of handlers) {
         await handler(message);
       }
+
+      return {
+        kind: "message",
+        eventId: event.eventId,
+        providerMessageId: event.providerMessageId,
+        senderPhoneE164: event.senderPhoneE164,
+      };
     },
   };
+}
+
+function sendResultFromManagedBody(body: unknown, target: Extract<WhatsAppTarget, { kind: "dm" }>): WhatsAppSendResult {
+  const message = isRecord(body) && isRecord(body.message) ? body.message : {};
+  return {
+    providerMessageId: optionalString(message.providerMessageId),
+    providerConversationId:
+      optionalString(message.providerConversationId) ??
+      target.providerConversationId ??
+      canonicalDmConversationId(target.phoneE164),
+    providerTimestamp: optionalString(message.providerTimestamp),
+    rawProviderPayload: body,
+  };
+}
+
+async function fetchManagedJson(requestFetch: typeof fetch, url: string, init: RequestInit): Promise<unknown> {
+  const response = await requestFetch(url, { ...init, signal: AbortSignal.timeout(OUTBOUND_TIMEOUT_MS) });
+  const text = await response.text().catch(() => "");
+
+  if (!response.ok) {
+    const snippet = boundedResponseSnippet(text);
+    throw new Error(`Managed WhatsApp request failed: HTTP ${response.status}${snippet ? `: ${snippet}` : ""}`);
+  }
+
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function assertValidE164Target(phoneE164: string, logger: Logger): void {
+  if (E164_PHONE_PATTERN.test(phoneE164)) return;
+  logger.warn({ targetKind: "dm", decision: "rejected", reason: "invalid_e164" }, "Invalid managed WhatsApp target");
+  throw new Error("Managed WhatsApp target phone number is invalid");
+}
+
+function inboundMessageText(text: string | undefined, mediaType: string | undefined): string {
+  if (text?.trim()) return text;
+  if (mediaType) return `[WhatsApp media message (${mediaType}) - media content not available]`;
+  return text ?? "";
+}
+
+function providerTemplateParamRecord(
+  parameterMap: Record<string, string> | null,
+  params: Record<string, WhatsAppTemplateParamValue>,
+): Record<string, string> {
+  const entries = parameterMap ? Object.entries(parameterMap) : Object.keys(params).map((key) => [key, key]);
+  return Object.fromEntries(
+    entries.map(([providerName, logicalName]) => [providerName, stringifyTemplateParam(params[logicalName])]),
+  );
+}
+
+function stringifyTemplateParam(value: WhatsAppTemplateParamValue): string {
+  if (value == null) return "";
+  return String(value);
+}
+
+function boundedResponseSnippet(text: string): string {
+  const compact = text.replace(/\s+/gu, " ").trim();
+  return compact.length > ERROR_BODY_SNIPPET_LIMIT ? `${compact.slice(0, ERROR_BODY_SNIPPET_LIMIT)}...` : compact;
 }
 
 function optionalString(value: unknown): string | null {

--- a/packages/server/src/whatsapp/providers/managed.ts
+++ b/packages/server/src/whatsapp/providers/managed.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+import type { Logger } from "../../logger";
+import {
+  type WhatsAppCapabilities,
+  type WhatsAppDmInboundMessage,
+  type WhatsAppDmProvider,
+  type WhatsAppInboundProvider,
+  type WhatsAppMessageHandler,
+  type WhatsAppSendOptions,
+  type WhatsAppSendResult,
+  type WhatsAppTarget,
+  canonicalDmConversationId,
+} from "../provider";
+
+export const WHATSAPP_MANAGED_PROVIDER_ID = "managed";
+
+const MANAGED_CAPABILITIES: WhatsAppCapabilities = {
+  text: true,
+  media: false,
+  quotedReply: true,
+  templates: false,
+  templateProvisioning: "none",
+  interactive: false,
+  deliveryStatus: false,
+  typing: false,
+  reactions: false,
+  edit: false,
+  groups: false,
+};
+
+const inboundEventSchema = z.object({
+  provider: z.string().trim().min(1),
+  providerMessageId: z.string().trim().min(1),
+  providerConversationId: z.string().trim().min(1),
+  providerTimestamp: z.string().nullable().optional(),
+  senderPhoneE164: z.string().trim().min(1),
+  senderName: z.string().trim().min(1).optional(),
+  tenantUserId: z.string().trim().min(1).optional(),
+  tenantUserEmail: z.string().email().nullable().optional(),
+  text: z.string().default(""),
+  mediaType: z.string().trim().min(1).nullable().optional(),
+  quotedMessage: z
+    .object({
+      providerMessageId: z.string().trim().min(1),
+      text: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+export interface ManagedWhatsAppConfig {
+  platformUrl: string;
+  tenantToken: string;
+  logger: Logger;
+  fetch?: typeof fetch;
+}
+
+export interface ManagedWhatsAppProvider {
+  dmProvider: WhatsAppDmProvider;
+  inboundProvider: WhatsAppInboundProvider;
+  handleInboundEvent(payload: unknown): Promise<void>;
+}
+
+export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): ManagedWhatsAppProvider {
+  const platformUrl = config.platformUrl.replace(/\/+$/u, "");
+  const requestFetch = config.fetch ?? fetch;
+  const handlers = new Set<WhatsAppMessageHandler>();
+
+  const sendText = async (
+    target: WhatsAppTarget,
+    text: string,
+    options?: WhatsAppSendOptions,
+  ): Promise<WhatsAppSendResult | null> => {
+    if (target.kind !== "dm") throw new Error("Managed WhatsApp cannot send group messages");
+
+    const response = await requestFetch(`${platformUrl}/api/whatsapp/outbound/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.tenantToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        to: target.phoneE164,
+        text,
+        providerConversationId: target.providerConversationId,
+        quotedProviderMessageId: options?.quotedMessage?.providerMessageId,
+      }),
+    });
+
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(`Managed WhatsApp send failed: HTTP ${response.status}`);
+    }
+
+    const message = isRecord(body) && isRecord(body.message) ? body.message : {};
+    return {
+      providerMessageId: optionalString(message.providerMessageId),
+      providerConversationId:
+        optionalString(message.providerConversationId) ??
+        target.providerConversationId ??
+        canonicalDmConversationId(target.phoneE164),
+      providerTimestamp: optionalString(message.providerTimestamp),
+      rawProviderPayload: body,
+    };
+  };
+
+  return {
+    dmProvider: {
+      id: WHATSAPP_MANAGED_PROVIDER_ID,
+      role: "dm",
+      capabilities: MANAGED_CAPABILITIES,
+      get isConnected() {
+        return Boolean(platformUrl && config.tenantToken);
+      },
+      sendText,
+    },
+    inboundProvider: {
+      id: WHATSAPP_MANAGED_PROVIDER_ID,
+      onMessage(handler) {
+        handlers.add(handler);
+      },
+    },
+    async handleInboundEvent(payload) {
+      const parsed = inboundEventSchema.safeParse(payload);
+      if (!parsed.success) {
+        config.logger.warn({ issues: parsed.error.issues }, "Invalid managed WhatsApp inbound event");
+        return;
+      }
+
+      const event = parsed.data;
+      const message: WhatsAppDmInboundMessage = {
+        kind: "dm",
+        providerId: WHATSAPP_MANAGED_PROVIDER_ID,
+        providerMessageId: event.providerMessageId,
+        providerConversationId: event.providerConversationId,
+        canonicalConversationId: canonicalDmConversationId(event.senderPhoneE164),
+        providerTimestamp: event.providerTimestamp ?? null,
+        senderName: event.senderName ?? event.senderPhoneE164,
+        senderProviderId: event.senderPhoneE164,
+        senderPhoneE164: event.senderPhoneE164,
+        target: { kind: "dm", phoneE164: event.senderPhoneE164, providerConversationId: event.providerConversationId },
+        text: event.text,
+        rawProviderPayload: payload,
+        ...(event.mediaType ? { mediaType: event.mediaType } : {}),
+        ...(event.quotedMessage
+          ? {
+              quotedMessage: {
+                providerMessageId: event.quotedMessage.providerMessageId,
+                participantJid: null,
+                text: event.quotedMessage.text ?? "",
+              },
+            }
+          : {}),
+      };
+
+      for (const handler of handlers) {
+        await handler(message);
+      }
+    },
+  };
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
Tenant half of the managed WhatsApp shared-number architecture (SKE-256, epic SKE-243). Platform half: canvasxai/sketch-platform#49.

## What

Adds `WHATSAPP_DM_PROVIDER=managed` — a DM provider that plugs into the existing provider-neutral WhatsApp runtime and delegates delivery to the managed platform instead of talking to Wati/Meta directly. Groups remain Baileys. Self-hosted `wati`/`baileys` behavior is unchanged.

## Contracts

**Inbound:** `POST /api/system/whatsapp/managed/events` (system router, timing-safe `SYSTEM_SECRET` bearer). Normalized provider-neutral event with required `eventId` and `type: "message"`; unknown types are metadata-logged and ignored — they can never trigger agent runs. Invalid payloads return 400. Media-only messages surface an honest placeholder to the agent (no fabricated attachments).

**Outbound:** `POST {MANAGED_WHATSAPP_PLATFORM_URL}/api/whatsapp/outbound/messages` (session text) and `/api/whatsapp/outbound/templates` (proactive/out-of-window sends) with the tenant-scoped `MANAGED_WHATSAPP_TENANT_TOKEN`. Logical Sketch template keys resolve locally via the existing SKE-246 template mapping before relay, so scheduler/workflow/proactive paths keep native template support in managed mode.

Also: E.164 validation on sender/recipient phones, 30s outbound timeouts with error body context, timing-safe system-router auth.

## Config

`MANAGED_WHATSAPP_PLATFORM_URL` + `MANAGED_WHATSAPP_TENANT_TOKEN`, required only when the DM provider is `managed` (see `.env.example`).

## Issues

- https://linear.app/sketch-ai/issue/SKE-243
- https://linear.app/sketch-ai/issue/SKE-256
