### PR TITLE
SKE-267: Register managed team member invites

### DIFF
--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -757,6 +757,35 @@ describe("POST /api/system/users", () => {
     expect(body.userId).toBe(user?.id);
   });
 
+  it("creates a verified WhatsApp member user and returns userId", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+
+    const res = await app.request("/api/system/users", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${SYSTEM_SECRET}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: "contractor@gmail.com",
+        name: "Contractor",
+        whatsappNumber: "+14155550111",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    const user = await userRepo.findByWhatsappNumber("+14155550111");
+    expect(user?.id).toBe(body.userId);
+    expect(user?.email).toBe("contractor@gmail.com");
+    expect(user?.name).toBe("Contractor");
+    expect(user?.email_verified_at).toBeTruthy();
+  });
+
   it("returns and verifies the existing user when the email already exists", async () => {
     const settingsRepo = createSettingsRepository(db);
     const userRepo = createUserRepository(db);
@@ -911,7 +940,7 @@ describe("PUT /api/system/users", () => {
     expect(syncedAdmin?.password_hash).toBeNull();
   });
 
-  it("bulk upserts users by WhatsApp number and optional email", async () => {
+  it("bulk upserts users by WhatsApp number and email", async () => {
     const settingsRepo = createSettingsRepository(db);
     const userRepo = createUserRepository(db);
     const existing = await userRepo.create({
@@ -930,7 +959,7 @@ describe("PUT /api/system/users", () => {
       body: JSON.stringify({
         users: [
           { email: "alice@acme.com", name: "Alice WhatsApp", whatsappNumber: "+14155552671" },
-          { name: "Bob WhatsApp", whatsappNumber: "+919876543210" },
+          { email: "bob@acme.com", name: "Bob WhatsApp", whatsappNumber: "+919876543210" },
         ],
       }),
     });
@@ -943,6 +972,7 @@ describe("PUT /api/system/users", () => {
     expect(alice?.whatsapp_number).toBe("+14155552671");
 
     const bob = await userRepo.findByWhatsappNumber("+919876543210");
+    expect(bob?.email).toBe("bob@acme.com");
     expect(bob?.name).toBe("Bob WhatsApp");
     expect(bob?.auth_role).toBe("member");
   });
@@ -1109,6 +1139,19 @@ describe("PUT /api/system/users", () => {
     });
 
     expect(res.status).toBe(400);
+
+    const whatsappRes = await app.request("/api/system/users", {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${SYSTEM_SECRET}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        users: [{ name: "Alice", whatsappNumber: "+14155550003" }],
+      }),
+    });
+
+    expect(whatsappRes.status).toBe(400);
   });
 });
 

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -97,6 +97,7 @@ const llmSchema = z.discriminatedUnion("provider", [
 const systemUserSchema = z.object({
   email: z.string().email(),
   name: z.string().trim().min(1),
+  whatsappNumber: whatsappNumberSchema.optional(),
 });
 
 const systemBulkUsersSchema = z.object({
@@ -113,6 +114,9 @@ const systemBulkUsersSchema = z.object({
       })
       .refine((row) => !row.slackUserId || row.email, {
         message: "email is required for Slack users",
+      })
+      .refine((row) => !row.whatsappNumber || row.email, {
+        message: "email is required for WhatsApp users",
       }),
   ),
 });
@@ -419,6 +423,26 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     }
 
     const email = parsed.data.email.toLowerCase();
+    if (parsed.data.whatsappNumber) {
+      const result = await upsertWhatsAppIdentity(deps.userRepo, {
+        email,
+        name: parsed.data.name,
+        whatsappNumber: parsed.data.whatsappNumber,
+      });
+      if (result.status === "conflict") {
+        return c.json(
+          {
+            error: {
+              code: "CONFLICT",
+              message: "User is already linked to a different WhatsApp identity",
+            },
+          },
+          409,
+        );
+      }
+      return c.json({ ok: true, userId: result.user.id });
+    }
+
     const existing = await deps.userRepo.findByEmail(email);
     if (existing) {
       if (!existing.email_verified_at) {

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -148,6 +148,71 @@ describe("Users API — agent fields", () => {
     expect(body.error.message).toContain("Email and WhatsApp number");
   });
 
+  it("skips managed member registration when only managed login URL is configured", async () => {
+    const managedLoginOnlyApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedLoginOnlyApp, ADMIN_EMAIL);
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const res = await managedLoginOnlyApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Managed Login Only",
+        type: "human",
+        email: "managed.login.only@gmail.com",
+        whatsappNumber: "+14155550108",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.user.email).toBe("managed.login.only@gmail.com");
+    expect(body.user.whatsapp_number).toBe("+14155550108");
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
+  });
+
+  it("skips managed member registration on update when only managed login URL is configured", async () => {
+    const users = createUserRepository(db);
+    const existing = await users.create({
+      name: "Managed Login Existing",
+      type: "human",
+      email: "managed.login.existing@gmail.com",
+      whatsappNumber: "+14155550109",
+    });
+    const managedLoginOnlyApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedLoginOnlyApp, ADMIN_EMAIL);
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const res = await managedLoginOnlyApp.request(`/api/users/${existing.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Managed Login Updated",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.name).toBe("Managed Login Updated");
+    expect(body.user.email).toBe("managed.login.existing@gmail.com");
+    expect(body.user.whatsapp_number).toBe("+14155550109");
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
+  });
+
   it("registers managed human members with the platform before local create", async () => {
     const managedApp = createApp(
       db,

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -161,7 +161,7 @@ describe("Users API — agent fields", () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(
-        new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: true }), { status: 200 }),
+        new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
       );
 
     const res = await managedApp.request("/api/users", {
@@ -194,6 +194,44 @@ describe("Users API — agent fields", () => {
         }),
       }),
     );
+    fetchMock.mockRestore();
+  });
+
+  it("rejects managed human members when platform email invite delivery is incomplete", async () => {
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, emailSent: false, whatsappSent: true }), { status: 200 }),
+      );
+
+    const res = await managedApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Managed Person",
+        type: "human",
+        email: "managed.incomplete@test.com",
+        whatsappNumber: "+14155550107",
+      }),
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "MANAGED_MEMBER_REGISTRATION_FAILED",
+        message: "Managed member invite delivery failed",
+      },
+    });
+    await expect(createUserRepository(db).findByEmail("managed.incomplete@test.com")).resolves.toBeUndefined();
     fetchMock.mockRestore();
   });
 

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -7,7 +7,7 @@
  * additions from SKE-51.
  */
 import type { Kysely } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hashPassword } from "../auth/password";
 import { createChannelRepository } from "../db/repositories/channels";
 import { createSettingsRepository } from "../db/repositories/settings";
@@ -57,6 +57,7 @@ describe("Users API — agent fields", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await db.destroy();
   });
 
@@ -91,6 +92,7 @@ describe("Users API — agent fields", () => {
         name: "Real Person",
         type: "human",
         email: "person@test.com",
+        whatsappNumber: "+14155550101",
         allowedTools: ["Read"],
       }),
     });
@@ -129,6 +131,70 @@ describe("Users API — agent fields", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.user.whatsapp_number).toBe("+919876543210");
+  });
+
+  it("rejects human member creation without a WhatsApp number", async () => {
+    const res = await app.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({
+        name: "Email Only",
+        type: "human",
+        email: "email-only@test.com",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toContain("Email and WhatsApp number");
+  });
+
+  it("registers managed human members with the platform before local create", async () => {
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: true }), { status: 200 }),
+      );
+
+    const res = await managedApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Managed Person",
+        type: "human",
+        email: "managed.person@gmail.com",
+        whatsappNumber: "+14155550106",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://platform.test/api/tenant/members",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          Authorization: "Bearer tenant-token",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          tenantUserId: body.user.id,
+          email: "managed.person@gmail.com",
+          name: "Managed Person",
+          phoneNumber: "+14155550106",
+          sendInvite: true,
+        }),
+      }),
+    );
+    fetchMock.mockRestore();
   });
 
   it("rejects WhatsApp numbers without an international country code", async () => {
@@ -210,6 +276,7 @@ describe("Users API — agent fields", () => {
         name: "Real Person",
         type: "human",
         email: "rp@test.com",
+        whatsappNumber: "+14155550102",
       }),
     });
     expect(create.status).toBe(201);
@@ -311,6 +378,7 @@ describe("Users API — agent fields", () => {
           name: "Real Person",
           type: "human",
           email: "rp2@test.com",
+          whatsappNumber: "+14155550103",
           slackChannelIds: ["C-MARKETING"],
         }),
       });
@@ -472,6 +540,7 @@ describe("Users API — agent fields", () => {
           name: "Real Person",
           type: "human",
           email: "rp3@test.com",
+          whatsappNumber: "+14155550104",
           whatsappGroupJids: ["group-marketing@g.us"],
         }),
       });
@@ -562,6 +631,7 @@ describe("Users API — agent fields", () => {
           name: "Real Person",
           type: "human",
           email: "rp4@test.com",
+          whatsappNumber: "+14155550105",
           isWhatsappFallback: true,
         }),
       });

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 /**
  * Users API — CRUD for managing team members.
  * Primary use case: admin adds WhatsApp users so they can message the bot.
@@ -23,6 +24,7 @@ import type { createUserRepository } from "../db/repositories/users";
 import type { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
 import { createEmailTransport, sendVerificationEmail } from "../email";
+import { ManagedMemberRegistrationError, type ManagedMemberRegistrationInput } from "../managed-members";
 import type { SlackBot } from "../slack/bot";
 
 import { getSmtpConfig, resolveBaseUrl } from "./shared";
@@ -41,6 +43,7 @@ interface UserRoutesDeps {
   channels?: ChannelRepo;
   whatsappGroups?: WhatsAppGroupRepo;
   getSlack?: () => SlackBot | null;
+  registerManagedMember?: (input: ManagedMemberRegistrationInput) => Promise<unknown>;
 }
 
 const allowedToolsSchema = z.array(z.string().refine(isKnownAgentToolName, "Unknown tool name")).nullable().optional();
@@ -166,6 +169,52 @@ async function sendOrLogVerification(
   return { sent: false };
 }
 
+function humanContactError() {
+  return {
+    error: {
+      code: "VALIDATION_ERROR",
+      message: "Email and WhatsApp number are required for human members",
+    },
+  };
+}
+
+async function ensureContactAvailable(
+  users: UserRepo,
+  contact: { email: string; whatsappNumber: string },
+  excludeUserId?: string,
+): Promise<"ok" | "conflict"> {
+  const [byEmail, byWhatsapp] = await Promise.all([
+    users.findByEmail(contact.email),
+    users.findByWhatsappNumber(contact.whatsappNumber),
+  ]);
+  if (byEmail && byEmail.id !== excludeUserId) return "conflict";
+  if (byWhatsapp && byWhatsapp.id !== excludeUserId) return "conflict";
+  return "ok";
+}
+
+function managedRegistrationResponse(err: unknown) {
+  if (err instanceof ManagedMemberRegistrationError) {
+    return {
+      status: err.status,
+      body: {
+        error: {
+          code: err.code === "CONFLICT" ? "CONFLICT" : "MANAGED_MEMBER_REGISTRATION_FAILED",
+          message: err.message,
+        },
+      },
+    };
+  }
+  return {
+    status: 502,
+    body: {
+      error: {
+        code: "MANAGED_MEMBER_REGISTRATION_FAILED",
+        message: "Managed member registration failed",
+      },
+    },
+  };
+}
+
 export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
   const routes = new Hono();
 
@@ -229,6 +278,12 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     }
 
     const userType = parsed.data.type ?? "human";
+    const humanEmail = parsed.data.email?.trim().toLowerCase() ?? null;
+    const humanWhatsappNumber = parsed.data.whatsappNumber ?? null;
+
+    if (userType === "human" && (!humanEmail || !humanWhatsappNumber)) {
+      return c.json(humanContactError(), 400);
+    }
 
     if (userType === "human" && parsed.data.whatsappNumber) {
       const existing = await users.findByWhatsappNumber(parsed.data.whatsappNumber);
@@ -241,6 +296,16 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
             },
             promotionCandidate: { id: existing.id, type: existing.type, whatsapp_number: existing.whatsapp_number },
           },
+          409,
+        );
+      }
+    }
+
+    if (userType === "human" && humanEmail && humanWhatsappNumber) {
+      const available = await ensureContactAvailable(users, { email: humanEmail, whatsappNumber: humanWhatsappNumber });
+      if (available === "conflict") {
+        return c.json(
+          { error: { code: "CONFLICT", message: "This email or number is already linked to another member" } },
           409,
         );
       }
@@ -325,10 +390,27 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     }
 
     try {
+      const id = randomUUID();
+      if (userType === "human" && humanEmail && humanWhatsappNumber && deps.registerManagedMember) {
+        try {
+          await deps.registerManagedMember({
+            tenantUserId: id,
+            email: humanEmail,
+            name: parsed.data.name,
+            phoneNumber: humanWhatsappNumber,
+            sendInvite: true,
+          });
+        } catch (err) {
+          const response = managedRegistrationResponse(err);
+          return c.json(response.body, response.status as 400);
+        }
+      }
+
       const user = await users.create({
+        id,
         name: parsed.data.name,
-        email: parsed.data.email ?? undefined,
-        whatsappNumber: parsed.data.whatsappNumber ?? undefined,
+        email: humanEmail ?? undefined,
+        whatsappNumber: humanWhatsappNumber ?? undefined,
         description: parsed.data.description ?? undefined,
         type: userType,
         role: parsed.data.role ?? undefined,
@@ -502,8 +584,45 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     }
 
     try {
-      const emailValue = (parsed.data as { email?: string | null }).email;
+      const rawEmailValue = (parsed.data as { email?: string | null }).email;
+      const emailValue = rawEmailValue == null ? rawEmailValue : rawEmailValue.trim().toLowerCase();
       const emailChanged = emailValue !== undefined && emailValue !== (existing.email ?? null);
+      const nextEmail = emailValue === undefined ? existing.email : emailValue;
+      const nextWhatsappNumber =
+        parsed.data.whatsappNumber === undefined ? existing.whatsapp_number : parsed.data.whatsappNumber;
+
+      if (existing.type === "human") {
+        if (!nextEmail || !nextWhatsappNumber) {
+          return c.json(humanContactError(), 400);
+        }
+
+        const available = await ensureContactAvailable(
+          users,
+          { email: nextEmail, whatsappNumber: nextWhatsappNumber },
+          existing.id,
+        );
+        if (available === "conflict") {
+          return c.json(
+            { error: { code: "CONFLICT", message: "This email or number is already linked to another member" } },
+            409,
+          );
+        }
+
+        if (deps.registerManagedMember) {
+          try {
+            await deps.registerManagedMember({
+              tenantUserId: existing.id,
+              email: nextEmail,
+              name: parsed.data.name ?? existing.name,
+              phoneNumber: nextWhatsappNumber,
+              sendInvite: false,
+            });
+          } catch (err) {
+            const response = managedRegistrationResponse(err);
+            return c.json(response.body, response.status as 400);
+          }
+        }
+      }
 
       const user = await users.update(id, {
         name: parsed.data.name,
@@ -575,7 +694,7 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     const body = await c.req.json();
     const promoteSchema = z.object({
       name: z.string().min(1),
-      email: emailSchema.nullable().optional(),
+      email: emailSchema,
       role: z.string().max(100).nullable().optional(),
     });
     const parsed = promoteSchema.safeParse(body);
@@ -584,12 +703,44 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
       return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
     }
 
+    if (!existing.whatsapp_number) {
+      return c.json(humanContactError(), 400);
+    }
+
+    const email = parsed.data.email.trim().toLowerCase();
+    const available = await ensureContactAvailable(
+      users,
+      { email, whatsappNumber: existing.whatsapp_number },
+      existing.id,
+    );
+    if (available === "conflict") {
+      return c.json(
+        { error: { code: "CONFLICT", message: "This email or number is already linked to another member" } },
+        409,
+      );
+    }
+
+    if (deps.registerManagedMember) {
+      try {
+        await deps.registerManagedMember({
+          tenantUserId: existing.id,
+          email,
+          name: parsed.data.name,
+          phoneNumber: existing.whatsapp_number,
+          sendInvite: true,
+        });
+      } catch (err) {
+        const response = managedRegistrationResponse(err);
+        return c.json(response.body, response.status as 400);
+      }
+    }
+
     await deps.db
       .updateTable("users")
       .set({
         type: "human",
         name: parsed.data.name,
-        email: parsed.data.email ?? null,
+        email,
         role: parsed.data.role ?? null,
       })
       .where("id", "=", id)

--- a/packages/server/src/db/repositories/users.ts
+++ b/packages/server/src/db/repositories/users.ts
@@ -20,6 +20,7 @@ export interface UserRepository {
   searchByNamePrefix(query: string, limit?: number, excludeUserId?: string): Promise<UserRow[]>;
   searchByNameSubstring(query: string, limit?: number, excludeUserId?: string): Promise<UserRow[]>;
   create(data: {
+    id?: string;
     name: string;
     slackUserId?: string;
     whatsappNumber?: string;
@@ -213,6 +214,7 @@ export function createUserRepository(db: UserDb): UserRepository {
     },
 
     async create(data: {
+      id?: string;
       name: string;
       slackUserId?: string;
       whatsappNumber?: string;
@@ -226,7 +228,7 @@ export function createUserRepository(db: UserDb): UserRepository {
       reportsTo?: string;
       allowedTools?: string[] | null;
     }) {
-      const id = randomUUID();
+      const id = data.id ?? randomUUID();
       await db
         .insertInto("users")
         .values({

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1816,19 +1816,20 @@ describe("Users API", () => {
   });
 
   describe("POST /api/users", () => {
-    it("creates user with name and whatsappNumber", async () => {
+    it("creates user with name, email, and whatsappNumber", async () => {
       const app = createApp(db, config);
       const cookie = await setupAdmin(app);
 
       const res = await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Charlie", whatsappNumber: "+14155551234" }),
+        body: JSON.stringify({ name: "Charlie", email: "charlie@test.com", whatsappNumber: "+14155551234" }),
       });
       expect(res.status).toBe(201);
 
       const body = await res.json();
       expect(body.user.name).toBe("Charlie");
+      expect(body.user.email).toBe("charlie@test.com");
       expect(body.user.whatsapp_number).toBe("+14155551234");
       expect(body.user.id).toBeDefined();
     });
@@ -1870,13 +1871,13 @@ describe("Users API", () => {
       await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Eve", whatsappNumber: "+14155559999" }),
+        body: JSON.stringify({ name: "Eve", email: "eve@test.com", whatsappNumber: "+14155559999" }),
       });
 
       const res = await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Frank", whatsappNumber: "+14155559999" }),
+        body: JSON.stringify({ name: "Frank", email: "frank@test.com", whatsappNumber: "+14155559999" }),
       });
       expect(res.status).toBe(409);
 
@@ -1893,7 +1894,7 @@ describe("Users API", () => {
       const createRes = await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Grace", whatsappNumber: "+14155550001" }),
+        body: JSON.stringify({ name: "Grace", email: "grace@test.com", whatsappNumber: "+14155550001" }),
       });
       const { user: created } = await createRes.json();
 
@@ -1916,7 +1917,7 @@ describe("Users API", () => {
       const createRes = await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Hank", whatsappNumber: "+14155550002" }),
+        body: JSON.stringify({ name: "Hank", email: "hank@test.com", whatsappNumber: "+14155550002" }),
       });
       const { user: created } = await createRes.json();
 
@@ -1935,7 +1936,11 @@ describe("Users API", () => {
       const app = createApp(db, config);
       const cookie = await setupAdmin(app);
       const users = createUserRepository(db);
-      const target = await users.create({ name: "Target User", email: "target@test.com" });
+      const target = await users.create({
+        name: "Target User",
+        email: "target@test.com",
+        whatsappNumber: "+14155550004",
+      });
 
       const res = await app.request(`/api/users/${target.id}`, {
         method: "PATCH",
@@ -1956,6 +1961,7 @@ describe("Users API", () => {
       const target = await users.create({
         name: "Second Admin",
         email: "second-admin@test.com",
+        whatsappNumber: "+14155550005",
         authRole: "admin",
       });
 
@@ -1979,8 +1985,16 @@ describe("Users API", () => {
       if (!jwtSecret) throw new Error("JWT secret missing");
 
       const users = createUserRepository(db);
-      const caller = await users.create({ name: "Member Caller", email: "caller@test.com" });
-      const target = await users.create({ name: "Target User", email: "target-member@test.com" });
+      const caller = await users.create({
+        name: "Member Caller",
+        email: "caller@test.com",
+        whatsappNumber: "+14155550006",
+      });
+      const target = await users.create({
+        name: "Target User",
+        email: "target-member@test.com",
+        whatsappNumber: "+14155550007",
+      });
       const memberCookie = `sketch_session=${await signJwt(caller.id, "member", jwtSecret)}`;
 
       const res = await app.request(`/api/users/${target.id}`, {
@@ -2031,13 +2045,13 @@ describe("Users API", () => {
       await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Ivy", whatsappNumber: "+14155550010" }),
+        body: JSON.stringify({ name: "Ivy", email: "ivy@test.com", whatsappNumber: "+14155550010" }),
       });
 
       const createRes = await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Jack", whatsappNumber: "+14155550011" }),
+        body: JSON.stringify({ name: "Jack", email: "jack@test.com", whatsappNumber: "+14155550011" }),
       });
       const { user: jack } = await createRes.json();
 
@@ -2058,7 +2072,7 @@ describe("Users API", () => {
       const createRes = await app.request("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
-        body: JSON.stringify({ name: "Kim", whatsappNumber: "+14155550020" }),
+        body: JSON.stringify({ name: "Kim", email: "kim@test.com", whatsappNumber: "+14155550020" }),
       });
       const { user: created } = await createRes.json();
 
@@ -2084,8 +2098,17 @@ describe("Users API", () => {
       const users = createUserRepository(db);
       const admin = await users.findByEmail("admin@test.com");
       if (!admin) throw new Error("Admin user missing");
-      const manager = await users.create({ name: "Manager", email: "manager@test.com" });
-      const report = await users.create({ name: "Report", email: "report@test.com", reportsTo: manager.id });
+      const manager = await users.create({
+        name: "Manager",
+        email: "manager@test.com",
+        whatsappNumber: "+14155550012",
+      });
+      const report = await users.create({
+        name: "Report",
+        email: "report@test.com",
+        whatsappNumber: "+14155550013",
+        reportsTo: manager.id,
+      });
 
       await db
         .insertInto("user_provider_identities")
@@ -2173,7 +2196,11 @@ describe("RBAC", () => {
   /** Create a member user and return a member session cookie. */
   async function createMemberSession(jwtSecret: string) {
     const users = createUserRepository(db);
-    const user = await users.create({ name: "Member User" });
+    const user = await users.create({
+      name: "Member User",
+      email: "member-session@test.com",
+      whatsappNumber: "+14155550014",
+    });
     const token = await signJwt(user.id, "member", jwtSecret);
     return { memberId: user.id, memberCookie: `sketch_session=${token}` };
   }
@@ -2222,7 +2249,11 @@ describe("RBAC", () => {
 
       // Create another user
       const users = createUserRepository(db);
-      const other = await users.create({ name: "Other User" });
+      const other = await users.create({
+        name: "Other User",
+        email: "other-user@test.com",
+        whatsappNumber: "+14155550015",
+      });
 
       const res = await app.request(`/api/users/${other.id}`, {
         method: "PATCH",
@@ -2241,7 +2272,10 @@ describe("RBAC", () => {
       const { memberCookie } = await createMemberSession(jwtSecret);
 
       const users = createUserRepository(db);
-      const other = await users.create({ name: "Other" });
+      const other = await users.create({
+        name: "Other",
+        whatsappNumber: "+14155550016",
+      });
 
       const res = await app.request(`/api/users/${other.id}/verification`, {
         method: "POST",

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -71,6 +71,7 @@ import type { IntegrationProvider } from "./integrations/types";
 import { createLocalClaudeEventDispatcher } from "./local-devices/claude-event-dispatcher";
 import type { LocalClaudeSessionService } from "./local-devices/claude-sessions";
 import type { LocalDeviceGateway } from "./local-devices/gateway";
+import { registerManagedTenantMember } from "./managed-members";
 import { createManagedLoginUrl } from "./managed-url";
 import { mcpOAuthRoutes } from "./mcp/oauth/routes";
 import { mountPublicMcpServer } from "./mcp/server/transport";
@@ -334,7 +335,16 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   app.route("/api/skills", skillsRoutes(config));
   app.route(
     "/api/users",
-    userRoutes(users, { settings, db, logger, config, channels, whatsappGroups, getSlack: deps?.getSlack }),
+    userRoutes(users, {
+      settings,
+      db,
+      logger,
+      config,
+      channels,
+      whatsappGroups,
+      getSlack: deps?.getSlack,
+      registerManagedMember: (input) => registerManagedTenantMember(config, input),
+    }),
   );
   app.route(
     "/api/agent-environment-variables",

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -77,9 +77,15 @@ export async function registerManagedTenantMember(
   }
 
   const record = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
+  const emailSent = record.emailSent === true;
+  const whatsappSent = record.whatsappSent === true;
+  if (input.sendInvite !== false && !emailSent) {
+    throw new ManagedMemberRegistrationError(502, "INVITE_DELIVERY_FAILED", "Managed member invite delivery failed");
+  }
+
   return {
     registered: true,
-    emailSent: record.emailSent === true,
-    whatsappSent: record.whatsappSent === true,
+    emailSent,
+    whatsappSent,
   };
 }

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -1,0 +1,85 @@
+import type { Config } from "./config";
+
+export interface ManagedMemberRegistrationInput {
+  tenantUserId: string;
+  email: string;
+  name: string;
+  phoneNumber: string;
+  sendInvite?: boolean;
+}
+
+export interface ManagedMemberRegistrationResult {
+  registered: boolean;
+  emailSent?: boolean;
+  whatsappSent?: boolean;
+}
+
+export class ManagedMemberRegistrationError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ManagedMemberRegistrationError";
+  }
+}
+
+function managedPlatformUrl(config: Config): string | null {
+  return config.MANAGED_WHATSAPP_PLATFORM_URL ?? config.MANAGED_URL ?? null;
+}
+
+function shouldRegisterManagedMembers(config: Config): boolean {
+  return Boolean(config.MANAGED_URL || config.MANAGED_WHATSAPP_PLATFORM_URL || config.MANAGED_WHATSAPP_TENANT_TOKEN);
+}
+
+function errorFromBody(body: unknown): { code: string; message: string } {
+  if (typeof body === "object" && body !== null && "error" in body) {
+    const error = (body as { error?: unknown }).error;
+    if (typeof error === "object" && error !== null) {
+      const code = typeof (error as { code?: unknown }).code === "string" ? (error as { code: string }).code : "ERROR";
+      const message =
+        typeof (error as { message?: unknown }).message === "string"
+          ? (error as { message: string }).message
+          : "Managed member registration failed";
+      return { code, message };
+    }
+    if (typeof error === "string") return { code: "ERROR", message: error };
+  }
+  return { code: "ERROR", message: "Managed member registration failed" };
+}
+
+export async function registerManagedTenantMember(
+  config: Config,
+  input: ManagedMemberRegistrationInput,
+  requestFetch: typeof fetch = fetch,
+): Promise<ManagedMemberRegistrationResult> {
+  if (!shouldRegisterManagedMembers(config)) return { registered: false };
+
+  const platformUrl = managedPlatformUrl(config);
+  if (!platformUrl || !config.MANAGED_WHATSAPP_TENANT_TOKEN) {
+    throw new ManagedMemberRegistrationError(503, "UNCONFIGURED", "Managed member registration is not configured");
+  }
+
+  const response = await requestFetch(`${platformUrl.replace(/\/+$/u, "")}/api/tenant/members`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${config.MANAGED_WHATSAPP_TENANT_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = errorFromBody(body);
+    throw new ManagedMemberRegistrationError(response.status, error.code, error.message);
+  }
+
+  const record = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
+  return {
+    registered: true,
+    emailSent: record.emailSent === true,
+    whatsappSent: record.whatsappSent === true,
+  };
+}

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -30,7 +30,7 @@ function managedPlatformUrl(config: Config): string | null {
 }
 
 function shouldRegisterManagedMembers(config: Config): boolean {
-  return Boolean(config.MANAGED_URL || config.MANAGED_WHATSAPP_PLATFORM_URL || config.MANAGED_WHATSAPP_TENANT_TOKEN);
+  return Boolean(managedPlatformUrl(config) && config.MANAGED_WHATSAPP_TENANT_TOKEN);
 }
 
 function errorFromBody(body: unknown): { code: string; message: string } {

--- a/packages/web/src/components/team/add-member-dialog.tsx
+++ b/packages/web/src/components/team/add-member-dialog.tsx
@@ -17,7 +17,7 @@ import {
 } from "@sketch/shared";
 /**
  * AddMemberDialog — create a new human member or AI agent.
- * Human members require a name + email; agents require only a name.
+ * Human members require a name, email, and WhatsApp number; agents require only a name.
  * The toggle between Human/Agent changes which fields are shown and
  * which schema is used for validation.
  */
@@ -40,12 +40,10 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
 
-const optionalPhone = z.literal("").or(whatsappNumberSchema);
-
 const addMemberSchema = z.object({
   name: z.string().min(1),
   email: emailSchema,
-  whatsappNumber: optionalPhone,
+  whatsappNumber: whatsappNumberSchema,
 });
 
 const addAgentSchema = z.object({
@@ -161,7 +159,7 @@ export function AddMemberDialog({
           <DialogDescription>
             {memberType === "agent"
               ? "Add an AI agent to your team. Agents have no messaging channels."
-              : "Add a new team member. Name and email are required."}
+              : "Add a new team member. Name, email, and WhatsApp number are required."}
           </DialogDescription>
         </DialogHeader>
 

--- a/packages/web/src/components/team/edit-member-dialog.tsx
+++ b/packages/web/src/components/team/edit-member-dialog.tsx
@@ -54,13 +54,10 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
 
-const optionalEmail = z.literal("").or(emailSchema);
-const optionalPhone = z.literal("").or(whatsappNumberSchema);
-
 const editMemberSchema = z.object({
   name: z.string().min(1),
-  email: optionalEmail,
-  whatsappNumber: optionalPhone,
+  email: emailSchema,
+  whatsappNumber: whatsappNumberSchema,
 });
 
 export function EditMemberDialog({
@@ -205,9 +202,11 @@ export function EditMemberDialog({
 
   const canSubmit =
     isDirty &&
-    !phoneError &&
-    editMemberSchema.safeParse({ name: name.trim(), email: email.trim(), whatsappNumber: normalizedPhone ?? "" })
-      .success;
+    (isAgent
+      ? name.trim().length > 0
+      : !phoneError &&
+        editMemberSchema.safeParse({ name: name.trim(), email: email.trim(), whatsappNumber: normalizedPhone ?? "" })
+          .success);
 
   const otherUsers = users.filter((u) => u.id !== user?.id);
 

--- a/packages/web/src/routes/team.isolated.test.tsx
+++ b/packages/web/src/routes/team.isolated.test.tsx
@@ -92,7 +92,9 @@ describe("TeamPage", () => {
       await user.click(screen.getByRole("button", { name: /Add member/i }));
 
       await waitFor(() => {
-        expect(screen.getByText("Add a new team member. Name and email are required.")).toBeInTheDocument();
+        expect(
+          screen.getByText("Add a new team member. Name, email, and WhatsApp number are required."),
+        ).toBeInTheDocument();
       });
     });
 
@@ -294,11 +296,11 @@ describe("TeamPage", () => {
             user: {
               id: "u1",
               name: "Alice Smith",
-              email: null,
-              email_verified_at: null,
+              email: "alice@example.com",
+              email_verified_at: "2026-01-01T00:00:00Z",
               auth_role: body.authRole ?? "member",
               slack_user_id: "U001",
-              whatsapp_number: null,
+              whatsapp_number: "+14155550101",
               description: null,
               type: "human",
               role: null,

--- a/packages/web/src/test/msw.ts
+++ b/packages/web/src/test/msw.ts
@@ -141,11 +141,11 @@ export const handlers = [
         {
           id: "u1",
           name: "Alice Smith",
-          email: null,
-          email_verified_at: null,
+          email: "alice@example.com",
+          email_verified_at: "2026-01-01T00:00:00Z",
           auth_role: "member",
           slack_user_id: "U001",
-          whatsapp_number: null,
+          whatsapp_number: "+14155550101",
           description: null,
           type: "human",
           role: null,
@@ -159,11 +159,11 @@ export const handlers = [
         {
           id: "u2",
           name: "Bob Jones",
-          email: null,
-          email_verified_at: null,
+          email: "bob@example.com",
+          email_verified_at: "2026-01-02T00:00:00Z",
           auth_role: "admin",
           slack_user_id: null,
-          whatsapp_number: "+919876543210",
+          whatsapp_number: "+14155550102",
           description: null,
           type: "human",
           role: null,
@@ -180,9 +180,9 @@ export const handlers = [
 
   http.post("/api/users", async ({ request }) => {
     const body = (await request.json()) as { name?: string; email?: string; whatsappNumber?: string };
-    if (!body.name || (!body.email && !body.whatsappNumber)) {
+    if (!body.name || !body.email || !body.whatsappNumber) {
       return HttpResponse.json(
-        { error: { code: "VALIDATION_ERROR", message: "Name and either email or WhatsApp number required" } },
+        { error: { code: "VALIDATION_ERROR", message: "Name, email, and WhatsApp number required" } },
         { status: 400 },
       );
     }


### PR DESCRIPTION
## Summary
- Link this PR to `SKE-267` for email-first team-member authentication and invite registration.
- Require email and WhatsApp number for human team members in `/team` add/edit/promote flows.
- Register managed tenant members with the platform before local persistence so platform conflicts or invite delivery failures block local user creation.
- Accept email-only managed invite success from the platform: `emailSent: true` is sufficient, while `whatsappSent: false` is expected.
- Keep agent team management unchanged.

## Linear Scope
- Supports team members with personal email addresses, with Gmail currently allowed by design.
- Makes email the required and primary invite/auth field for team member creation.
- Keeps WhatsApp number collection for contact identity/mapping, not WhatsApp OTP or WhatsApp invite delivery.
- Mobile OTP remains out of scope.

## Implementation Details
- `packages/server/src/managed-members.ts` now treats platform invite registration as successful when email delivery succeeds.
- Managed member registration is skipped unless a platform URL and `MANAGED_WHATSAPP_TENANT_TOKEN` are both configured, so managed-login-only tenants can still create/update local human members.
- `packages/server/src/api/users.test.ts` covers accepting email-only invite success and rejecting incomplete platform email invite delivery.
- `packages/server/src/api/users.test.ts` also covers create/update behavior for `MANAGED_URL`-only deployments.
- Team UI tests continue covering mandatory email/WhatsApp collection and validation.

## Verification
- `pnpm lint` - passed.
- `pnpm typecheck` - passed.
- `pnpm exec vitest run --project unit src/api/users.test.ts -t "skips managed member registration"` - failed before the fix, then passed after the fix.
- `pnpm exec vitest run --project unit src/api/users.test.ts` - passed, 32 tests.
- `pnpm --filter @sketch/server test` - passed, 234 files / 2949 tests.
- `pnpm test` - passed after rerunning sequentially following `pnpm build`; server and web test packages passed.
- `pnpm build` - passed.
- Pre-push hook with bundled Node/PATH - passed and pushed the branch.
- GitHub CI `build (24)` - passed for the latest push.

## Risk / Rollout
- Mobile OTP remains unimplemented.
- Managed tenant registration now requires both a platform URL and `MANAGED_WHATSAPP_TENANT_TOKEN`; tenants with only managed login configured skip invite registration.
