### PR TITLE
feat: session-first WhatsApp delivery with nudge template fallback

### DIFF
--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -206,9 +206,14 @@ export interface RunAgentParams {
     platform: string;
     message: string;
     template?: WhatsAppTemplateRequest;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
   }) => Promise<{
     channelId: string;
     messageRef: string;
+    inboxMessageId?: string;
   }>;
   channelContext?: {
     channelName: string;

--- a/packages/server/src/agent/sketch-tools.test.ts
+++ b/packages/server/src/agent/sketch-tools.test.ts
@@ -44,6 +44,7 @@ function makeInboxMessagesRepoMock() {
   return {
     create: vi.fn(),
     listPendingForRecipient: vi.fn(),
+    hasPendingForRecipientByKind: vi.fn().mockResolvedValue(false),
     markConsumed: vi.fn(),
     findById: vi.fn(),
     findUnresolvedByRecipientAndKind: vi.fn(),
@@ -595,7 +596,9 @@ describe("handleSendMessageToUser", () => {
         userId: "user-bob",
         platform: "whatsapp",
         message: "Need your latest update.",
-        template: expect.objectContaining({ key: "whatsapp.proactive_update" }),
+        senderUserId: "user-alice",
+        storeInInbox: true,
+        inboxKind: "note",
       }),
     );
     expect(createInboxMessage).toHaveBeenCalledWith({
@@ -636,6 +639,28 @@ describe("handleSendMessageToUser", () => {
     expect(result.content[0].text).toBe("Error: user not found.");
   });
 
+  it("uses the parked WhatsApp inbox row when sendDm returns one", async () => {
+    const bob = makeUser({ id: "user-bob", name: "Bob", slack_user_id: null, whatsapp_number: "+1234567890" });
+    const sendDm = vi.fn().mockResolvedValue({
+      channelId: "dm:+1234567890",
+      messageRef: "wa-nudge-1",
+      inboxMessageId: "inbox-parked",
+    });
+    const createInboxMessage = vi.fn().mockResolvedValue({ id: "inbox-1" });
+
+    const result = await handleSendMessageToUser(
+      { recipientUserId: "user-bob", message: "Need your latest update." },
+      {
+        inboxMessagesRepo: { ...makeInboxMessagesRepoMock(), create: createInboxMessage },
+        userRepo: makeUserRepoMock({ findById: async (id: string) => (id === "user-bob" ? bob : undefined) }),
+        sendDm,
+        currentUserId: "user-alice",
+      },
+    );
+
+    expect(createInboxMessage).not.toHaveBeenCalled();
+    expect(JSON.parse(result.content[0].text)).toMatchObject({ inboxMessageId: "inbox-parked", status: "sent" });
+  });
   it("rejects recipients with no connected channel", async () => {
     const charlie = makeUser({ id: "user-charlie", name: "Charlie", slack_user_id: null, whatsapp_number: null });
     const result = await handleSendMessageToUser(

--- a/packages/server/src/agent/sketch-tools.test.ts
+++ b/packages/server/src/agent/sketch-tools.test.ts
@@ -45,6 +45,7 @@ function makeInboxMessagesRepoMock() {
     create: vi.fn(),
     listPendingForRecipient: vi.fn(),
     hasPendingForRecipientByKind: vi.fn().mockResolvedValue(false),
+    listPendingForRecipientByKind: vi.fn().mockResolvedValue([{ id: "inbox-1" }]),
     markConsumed: vi.fn(),
     findById: vi.fn(),
     findUnresolvedByRecipientAndKind: vi.fn(),

--- a/packages/server/src/agent/tools/messaging.ts
+++ b/packages/server/src/agent/tools/messaging.ts
@@ -1,6 +1,5 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod/v4";
-import { buildProactiveUpdateTemplate } from "../../whatsapp/templates";
 import type { SelectableUser, SketchMcpDeps, ToolResult } from "./types";
 
 function detectPlatform(recipient: SelectableUser): "slack" | "whatsapp" | null {
@@ -53,22 +52,22 @@ async function deliverMessageToUser(
     return { status: "failed", error: `${recipient.name} has no connected channel (Slack or WhatsApp).`, recipient };
   }
 
-  const { channelId, messageRef } = await deps.sendDm({
+  const delivery = await deps.sendDm({
     userId: params.recipientUserId,
     platform,
     message: params.message,
     ...(platform === "whatsapp"
       ? {
-          template: buildProactiveUpdateTemplate({
-            recipientName: recipient.name,
-            messageSummary: params.message,
-          }),
+          senderUserId: deps.currentUserId,
+          storeInInbox: params.storeInInbox !== false,
+          inboxKind: "note",
         }
       : {}),
   });
+  const { channelId, messageRef } = delivery;
 
-  let inboxMessageId: string | undefined;
-  if (params.storeInInbox !== false) {
+  let inboxMessageId: string | undefined = delivery.inboxMessageId;
+  if (params.storeInInbox !== false && !inboxMessageId) {
     if (!deps.inboxMessagesRepo) {
       return { status: "failed", error: "Inbox storage is not available in this context.", recipient };
     }

--- a/packages/server/src/agent/tools/messaging.ts
+++ b/packages/server/src/agent/tools/messaging.ts
@@ -240,7 +240,9 @@ export function createMessagingTools(deps: SketchMcpDeps) {
         storeInInbox: z
           .boolean()
           .optional()
-          .describe("Whether to store the sent message in each recipient's inbox. Defaults to true."),
+          .describe(
+            "Whether to store the sent message in each recipient's inbox. Defaults to true. WhatsApp out-of-window content is always parked in the inbox regardless of this setting so it is not lost.",
+          ),
       },
       async (params) => handleSendMessageToUsers(params, deps),
     ),

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -116,9 +116,14 @@ export interface SketchMcpDeps {
     platform: string;
     message: string;
     template?: WhatsAppTemplateRequest;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
   }) => Promise<{
     channelId: string;
     messageRef: string;
+    inboxMessageId?: string;
   }>;
   enqueueMessage?: (params: { requesterUserId: string; message: string }) => Promise<void>;
   loadTranscriptionSettings?: () => Promise<TranscriptionSettings | null>;

--- a/packages/server/src/agents/output-delivery.test.ts
+++ b/packages/server/src/agents/output-delivery.test.ts
@@ -1,9 +1,11 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createConversationRepository } from "../db/repositories/conversations";
 import { createSettingsRepository } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 import type { SlackBot } from "../slack/bot";
 import { createTestDb, createTestLogger } from "../test-utils";
+import { WHATSAPP_TEXT_LIMIT } from "../whatsapp/chunking";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 import { dailyBriefDefinition } from "./definitions/daily-brief";
 import { createAgentOutputDeliveryService } from "./output-delivery";
@@ -229,6 +231,100 @@ describe("createAgentOutputDeliveryService", () => {
     const attempt = await db.selectFrom("agent_output_deliveries").selectAll().executeTakeFirstOrThrow();
     expect(attempt.status).toBe("sent");
     expect(attempt.message_refs_json).toBe(JSON.stringify(["wa-nudge-1"]));
+  });
+
+  it("chunks in-window WhatsApp DM deliveries and captures each chunk", async () => {
+    const conversations = createConversationRepository(db);
+    const conversation = await conversations.getOrCreate(
+      { platform: "whatsapp", kind: "dm", providerConversationId: "dm:+15551234567" },
+      "Alice",
+    );
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "wa-inbound-1",
+      senderJid: "+15551234567",
+      senderName: "Alice",
+      senderUserId: "user-delivery",
+      isBot: false,
+      addressedToSketch: true,
+      text: "latest inbound",
+      providerTimestamp: new Date(Date.now() - 1_000).toISOString(),
+      receivedAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const sendText = vi.fn(async (_target: unknown, _text: string) => ({
+      providerMessageId: `wa-dm-${sendText.mock.calls.length}`,
+      providerConversationId: "dm:+15551234567",
+      providerTimestamp: new Date().toISOString(),
+    }));
+    const whatsapp = createMockWhatsApp({
+      isConnected: true,
+      sendText,
+    });
+    const service = createAgentOutputDeliveryService({
+      db,
+      logger: createTestLogger(),
+      getSlack: () => null,
+      whatsapp,
+      settingsRepo: createSettingsRepository(db),
+    });
+    const makeItem = (sectionKey: string, index: number) => ({
+      id: `${sectionKey}-${index}`,
+      sectionKey,
+      title: `Important ${sectionKey} ${index} ${"T".repeat(140)}`,
+      summary: `Detailed update ${sectionKey} ${index} ${"S".repeat(360)}`,
+      priority: "high" as const,
+      label: "todo",
+      displayRef: `REF-${sectionKey}-${index}`,
+      actionType: "generic",
+      actionLabel: "Plan with Sketch",
+      actionPrompt: "Plan it.",
+      sourceUrl: null,
+      knowledgeRefs: { entityIds: [`entity-${sectionKey}-${index}`], fileIds: [] },
+      structuredPayload: null,
+      sortOrder: index,
+    });
+    const sections = Object.fromEntries(
+      dailyBriefDefinition.sections.map((section) => [
+        section.key,
+        Array.from({ length: 4 }, (_, index) => makeItem(section.key, index)),
+      ]),
+    );
+
+    await service.deliver({
+      definition: dailyBriefDefinition,
+      delivery: {
+        enabled: true,
+        platform: "whatsapp",
+        targetType: "dm",
+        targetId: "dm:+15551234567",
+        label: "Alice",
+      },
+      output: {
+        id: "output-delivery",
+        userId: "user-delivery",
+        agentKey: dailyBriefDefinition.key,
+        outputDate: "2026-06-26",
+        masthead: { title: "Daily Brief", summary: "Executive summary ".repeat(40) },
+        sections,
+      },
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(2);
+    for (const call of sendText.mock.calls) {
+      expect(call[0]).toEqual({ kind: "dm", phoneE164: "+15551234567" });
+      expect(call[1].length).toBeLessThanOrEqual(WHATSAPP_TEXT_LIMIT);
+    }
+    const attempt = await db.selectFrom("agent_output_deliveries").selectAll().executeTakeFirstOrThrow();
+    expect(attempt.status).toBe("sent");
+    expect(attempt.message_refs_json).toBe(JSON.stringify(["wa-dm-1", "wa-dm-2"]));
+    const captured = await db
+      .selectFrom("conversation_messages")
+      .select(["text", "provider_message_id", "is_bot"])
+      .where("is_bot", "=", 1)
+      .orderBy("provider_message_id")
+      .execute();
+    expect(captured.map((row) => row.provider_message_id)).toEqual(["wa-dm-1", "wa-dm-2"]);
+    expect(captured.every((row) => row.text.length <= WHATSAPP_TEXT_LIMIT)).toBe(true);
   });
 
   it("records a failed attempt when the target platform is unavailable", async () => {

--- a/packages/server/src/agents/output-delivery.test.ts
+++ b/packages/server/src/agents/output-delivery.test.ts
@@ -327,6 +327,109 @@ describe("createAgentOutputDeliveryService", () => {
     expect(captured.every((row) => row.text.length <= WHATSAPP_TEXT_LIMIT)).toBe(true);
   });
 
+  it("captures successful WhatsApp DM chunks before propagating a later chunk failure", async () => {
+    const conversations = createConversationRepository(db);
+    const conversation = await conversations.getOrCreate(
+      { platform: "whatsapp", kind: "dm", providerConversationId: "dm:+15551234567" },
+      "Alice",
+    );
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "wa-inbound-1",
+      senderJid: "+15551234567",
+      senderName: "Alice",
+      senderUserId: "user-delivery",
+      isBot: false,
+      addressedToSketch: true,
+      text: "latest inbound",
+      providerTimestamp: new Date(Date.now() - 1_000).toISOString(),
+      receivedAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const cause = new Error("second chunk failed");
+    const sendText = vi.fn(async (_target: unknown, _text: string) => {
+      if (sendText.mock.calls.length === 2) throw cause;
+      return {
+        providerMessageId: `wa-dm-${sendText.mock.calls.length}`,
+        providerConversationId: "dm:+15551234567",
+        providerTimestamp: new Date().toISOString(),
+      };
+    });
+    const whatsapp = createMockWhatsApp({
+      isConnected: true,
+      sendText,
+    });
+    const service = createAgentOutputDeliveryService({
+      db,
+      logger: createTestLogger(),
+      getSlack: () => null,
+      whatsapp,
+      settingsRepo: createSettingsRepository(db),
+    });
+    const deliverySections = Array.from({ length: 7 }, (_, index) => ({
+      key: `section_${index}`,
+      title: `Section ${index}`,
+      enabledByDefault: true,
+      labels: ["todo"],
+    }));
+    const definition = { ...dailyBriefDefinition, sections: deliverySections };
+    const makeItem = (sectionKey: string, index: number) => ({
+      id: `${sectionKey}-${index}`,
+      sectionKey,
+      title: `Important ${sectionKey} ${index} ${"T".repeat(140)}`,
+      summary: `Detailed update ${sectionKey} ${index} ${"S".repeat(360)}`,
+      priority: "high" as const,
+      label: "todo",
+      displayRef: `REF-${sectionKey}-${index}`,
+      actionType: "generic",
+      actionLabel: "Plan with Sketch",
+      actionPrompt: "Plan it.",
+      sourceUrl: null,
+      knowledgeRefs: { entityIds: [`entity-${sectionKey}-${index}`], fileIds: [] },
+      structuredPayload: null,
+      sortOrder: index,
+    });
+    const sections = Object.fromEntries(
+      deliverySections.map((section) => [
+        section.key,
+        Array.from({ length: 4 }, (_, index) => makeItem(section.key, index)),
+      ]),
+    );
+
+    await expect(
+      service.deliver({
+        definition,
+        delivery: {
+          enabled: true,
+          platform: "whatsapp",
+          targetType: "dm",
+          targetId: "dm:+15551234567",
+          label: "Alice",
+        },
+        output: {
+          id: "output-delivery",
+          userId: "user-delivery",
+          agentKey: dailyBriefDefinition.key,
+          outputDate: "2026-06-26",
+          masthead: { title: "Daily Brief", summary: "Executive summary ".repeat(40) },
+          sections,
+        },
+      }),
+    ).rejects.toBe(cause);
+
+    expect(sendText).toHaveBeenCalledTimes(2);
+    const captured = await db
+      .selectFrom("conversation_messages")
+      .select(["text", "provider_message_id", "is_bot"])
+      .where("is_bot", "=", 1)
+      .execute();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].provider_message_id).toBe("wa-dm-1");
+    expect(captured[0].text.length).toBeLessThanOrEqual(WHATSAPP_TEXT_LIMIT);
+    const attempt = await db.selectFrom("agent_output_deliveries").selectAll().executeTakeFirstOrThrow();
+    expect(attempt.status).toBe("failed");
+    expect(attempt.error_message).toBe("second chunk failed");
+  });
+
   it("records a failed attempt when the target platform is unavailable", async () => {
     const whatsapp = createMockWhatsApp();
     const service = createAgentOutputDeliveryService({

--- a/packages/server/src/agents/output-delivery.test.ts
+++ b/packages/server/src/agents/output-delivery.test.ts
@@ -12,6 +12,7 @@ function createMockWhatsApp(overrides: Partial<WhatsAppRuntime> = {}): WhatsAppR
   return {
     isConnected: false,
     onMessage: vi.fn(),
+    getCapabilities: vi.fn(() => ({ templates: true })),
     sendText: vi.fn(),
     sendTemplate: vi.fn(),
     sendFile: vi.fn(),
@@ -77,6 +78,8 @@ describe("createAgentOutputDeliveryService", () => {
       },
       output: {
         id: "output-delivery",
+        userId: "user-delivery",
+        agentKey: dailyBriefDefinition.key,
         outputDate: "2026-06-26",
         masthead: { title: "Daily Brief", summary: "Start here." },
         sections: {
@@ -142,6 +145,8 @@ describe("createAgentOutputDeliveryService", () => {
       },
       output: {
         id: "output-delivery",
+        userId: "user-delivery",
+        agentKey: dailyBriefDefinition.key,
         outputDate: "2026-06-26",
         masthead: { title: "Daily Brief", summary: "x".repeat(8500) },
         sections: {},
@@ -167,11 +172,11 @@ describe("createAgentOutputDeliveryService", () => {
     expect(captured.every((row) => row.text.length <= 4000)).toBe(true);
   });
 
-  it("sends WhatsApp DM deliveries through logical templates", async () => {
+  it("parks WhatsApp DM deliveries and sends a task nudge when no session window is open", async () => {
     const whatsapp = createMockWhatsApp({
       isConnected: true,
       sendTemplate: vi.fn(async () => ({
-        providerMessageId: "wa-template-1",
+        providerMessageId: "wa-nudge-1",
         providerConversationId: "dm:+15551234567",
         providerTimestamp: "2024-06-04T07:20:00.000Z",
       })),
@@ -195,6 +200,8 @@ describe("createAgentOutputDeliveryService", () => {
       },
       output: {
         id: "output-delivery",
+        userId: "user-delivery",
+        agentKey: dailyBriefDefinition.key,
         outputDate: "2026-06-26",
         masthead: { title: "Daily Brief", summary: "Start here." },
         sections: {},
@@ -205,18 +212,23 @@ describe("createAgentOutputDeliveryService", () => {
     expect(whatsapp.sendTemplate).toHaveBeenCalledWith(
       { kind: "dm", phoneE164: "+15551234567" },
       expect.objectContaining({
-        key: "whatsapp.proactive_update",
-        params: expect.objectContaining({
-          recipientName: "Alice",
-          messageSummary: expect.stringContaining("Daily Brief"),
-        }),
+        key: "whatsapp.task_nudge",
+        params: { recipientName: "Alice" },
       }),
     );
-    const captured = await db
-      .selectFrom("conversation_messages")
-      .select(["provider_message_id", "text"])
-      .executeTakeFirstOrThrow();
-    expect(captured.provider_message_id).toBe("wa-template-1");
+    const inbox = await db.selectFrom("inbox_messages").selectAll().executeTakeFirstOrThrow();
+    expect(inbox).toMatchObject({
+      recipient_user_id: "user-delivery",
+      sender_user_id: "user-delivery",
+      kind: "workflow_output",
+      platform: "whatsapp",
+    });
+    expect(inbox.message).toContain("Daily Brief");
+    const captured = await db.selectFrom("conversation_messages").selectAll().execute();
+    expect(captured).toHaveLength(0);
+    const attempt = await db.selectFrom("agent_output_deliveries").selectAll().executeTakeFirstOrThrow();
+    expect(attempt.status).toBe("sent");
+    expect(attempt.message_refs_json).toBe(JSON.stringify(["wa-nudge-1"]));
   });
 
   it("records a failed attempt when the target platform is unavailable", async () => {
@@ -241,6 +253,8 @@ describe("createAgentOutputDeliveryService", () => {
         },
         output: {
           id: "output-delivery",
+          userId: "user-delivery",
+          agentKey: dailyBriefDefinition.key,
           outputDate: "2026-06-26",
           masthead: null,
           sections: {},

--- a/packages/server/src/agents/output-delivery.ts
+++ b/packages/server/src/agents/output-delivery.ts
@@ -10,8 +10,16 @@ import type { Logger } from "../logger";
 import { createWorkflowDeliveryCapture } from "../scheduler/delivery-capture";
 import type { SlackBot } from "../slack/bot";
 import { WHATSAPP_TEXT_LIMIT } from "../whatsapp/chunking";
-import { deliverProactiveDm } from "../whatsapp/proactive-delivery";
-import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
+import {
+  type ProactiveDeliveryTextSend,
+  ProactiveDeliveryTextSendError,
+  deliverProactiveDm,
+} from "../whatsapp/proactive-delivery";
+import {
+  type WhatsAppTarget,
+  whatsappDeliveryTargetFromTarget,
+  whatsappTargetFromDeliveryTarget,
+} from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 import { isSlackDmChannelId, isSlackUserId } from "../workflows/delivery";
 import { type RenderableAgentOutput, renderAgentOutputForDelivery } from "./output-renderer";
@@ -77,36 +85,32 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
     const target = whatsappTargetFromDeliveryTarget(delivery.targetId);
 
     if (target.kind === "dm") {
-      const result = await deliverProactiveDm({
-        target,
-        recipientUserId: output.userId,
-        senderUserId: output.userId,
-        text,
-        whatsapp: deps.whatsapp,
-        conversations,
-        inboxMessages,
-        logger: deps.logger,
-        recipientName: delivery.label,
-        recipientPhoneE164: target.phoneE164,
-        inboxMetadata: { source: "agent_output", outputId: output.id, agentKey: output.agentKey },
-      });
-      if (result.mode === "text") {
-        const refs: string[] = [];
-        for (const textSend of result.textSends) {
-          const messageRef = textSend.sent?.providerMessageId;
-          if (!messageRef) continue;
-          refs.push(messageRef);
-          await capture.captureWhatsApp({
-            deliveryTarget: whatsappDeliveryTargetFromTarget(target),
-            messageRef,
-            providerTimestamp: textSend.sent?.providerTimestamp ?? null,
-            text: textSend.text,
-          });
+      try {
+        const result = await deliverProactiveDm({
+          target,
+          recipientUserId: output.userId,
+          senderUserId: output.userId,
+          text,
+          whatsapp: deps.whatsapp,
+          conversations,
+          inboxMessages,
+          logger: deps.logger,
+          recipientName: delivery.label,
+          recipientPhoneE164: target.phoneE164,
+          inboxMetadata: { source: "agent_output", outputId: output.id, agentKey: output.agentKey },
+        });
+        if (result.mode === "text") {
+          return captureWhatsAppDmTextSends(target, result.textSends);
         }
-        return refs;
+        const messageRef = result.sent?.providerMessageId;
+        return [messageRef ?? result.inboxMessageId].filter((ref): ref is string => Boolean(ref));
+      } catch (err) {
+        if (err instanceof ProactiveDeliveryTextSendError) {
+          await captureWhatsAppDmTextSends(target, err.textSends);
+          throw err.cause ?? err;
+        }
+        throw err;
       }
-      const messageRef = result.sent?.providerMessageId;
-      return [messageRef ?? result.inboxMessageId].filter((ref): ref is string => Boolean(ref));
     }
 
     const refs: string[] = [];
@@ -120,6 +124,25 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
         messageRef,
         providerTimestamp: sent.providerTimestamp,
         text: chunk,
+      });
+    }
+    return refs;
+  }
+
+  async function captureWhatsAppDmTextSends(
+    target: WhatsAppTarget & { kind: "dm" },
+    textSends: ProactiveDeliveryTextSend[],
+  ): Promise<string[]> {
+    const refs: string[] = [];
+    for (const textSend of textSends) {
+      const messageRef = textSend.sent?.providerMessageId;
+      if (!messageRef) continue;
+      refs.push(messageRef);
+      await capture.captureWhatsApp({
+        deliveryTarget: whatsappDeliveryTargetFromTarget(target),
+        messageRef,
+        providerTimestamp: textSend.sent?.providerTimestamp ?? null,
+        text: textSend.text,
       });
     }
     return refs;

--- a/packages/server/src/agents/output-delivery.ts
+++ b/packages/server/src/agents/output-delivery.ts
@@ -90,15 +90,22 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
         recipientPhoneE164: target.phoneE164,
         inboxMetadata: { source: "agent_output", outputId: output.id, agentKey: output.agentKey },
       });
-      const messageRef = result.sent?.providerMessageId;
-      if (result.mode === "text" && messageRef) {
-        await capture.captureWhatsApp({
-          deliveryTarget: whatsappDeliveryTargetFromTarget(target),
-          messageRef,
-          providerTimestamp: result.sent?.providerTimestamp ?? null,
-          text,
-        });
+      if (result.mode === "text") {
+        const refs: string[] = [];
+        for (const textSend of result.textSends) {
+          const messageRef = textSend.sent?.providerMessageId;
+          if (!messageRef) continue;
+          refs.push(messageRef);
+          await capture.captureWhatsApp({
+            deliveryTarget: whatsappDeliveryTargetFromTarget(target),
+            messageRef,
+            providerTimestamp: textSend.sent?.providerTimestamp ?? null,
+            text: textSend.text,
+          });
+        }
+        return refs;
       }
+      const messageRef = result.sent?.providerMessageId;
       return [messageRef ?? result.inboxMessageId].filter((ref): ref is string => Boolean(ref));
     }
 

--- a/packages/server/src/agents/output-delivery.ts
+++ b/packages/server/src/agents/output-delivery.ts
@@ -2,6 +2,7 @@ import type { Kysely } from "kysely";
 import { createAgentOutputDeliveryRepository } from "../db/repositories/agent-output-deliveries";
 import type { AgentDeliveryConfig } from "../db/repositories/agent-outputs";
 import { createConversationRepository } from "../db/repositories/conversations";
+import { createInboxMessagesRepository } from "../db/repositories/inbox-messages";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 import { chunkText } from "../formatting/chunking";
@@ -9,9 +10,9 @@ import type { Logger } from "../logger";
 import { createWorkflowDeliveryCapture } from "../scheduler/delivery-capture";
 import type { SlackBot } from "../slack/bot";
 import { WHATSAPP_TEXT_LIMIT } from "../whatsapp/chunking";
+import { deliverProactiveDm } from "../whatsapp/proactive-delivery";
 import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
-import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import { isSlackDmChannelId, isSlackUserId } from "../workflows/delivery";
 import { type RenderableAgentOutput, renderAgentOutputForDelivery } from "./output-renderer";
 import type { AgentDefinition } from "./types";
@@ -20,7 +21,7 @@ const SLACK_TEXT_LIMIT = 39_000;
 
 export interface AgentOutputDeliveryRequest {
   definition: AgentDefinition;
-  output: RenderableAgentOutput & { id: string };
+  output: RenderableAgentOutput & { id: string; userId: string; agentKey: string };
   delivery: AgentDeliveryConfig;
 }
 
@@ -38,8 +39,10 @@ export interface AgentOutputDeliveryDeps {
 
 export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps): AgentOutputDeliveryPublisher {
   const repo = createAgentOutputDeliveryRepository(deps.db);
+  const conversations = createConversationRepository(deps.db);
+  const inboxMessages = createInboxMessagesRepository(deps.db);
   const capture = createWorkflowDeliveryCapture({
-    conversations: createConversationRepository(deps.db),
+    conversations,
     settingsRepo: deps.settingsRepo,
     logger: deps.logger,
   });
@@ -65,27 +68,48 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
     return refs;
   }
 
-  async function sendWhatsApp(delivery: AgentDeliveryConfig, text: string): Promise<string[]> {
+  async function sendWhatsApp(
+    delivery: AgentDeliveryConfig,
+    output: RenderableAgentOutput & { id: string; userId: string; agentKey: string },
+    text: string,
+  ): Promise<string[]> {
     if (!deps.whatsapp.isConnected) throw new Error("WhatsApp is not connected.");
-    const refs: string[] = [];
     const target = whatsappTargetFromDeliveryTarget(delivery.targetId);
+
+    if (target.kind === "dm") {
+      const result = await deliverProactiveDm({
+        target,
+        recipientUserId: output.userId,
+        senderUserId: output.userId,
+        text,
+        whatsapp: deps.whatsapp,
+        conversations,
+        inboxMessages,
+        logger: deps.logger,
+        recipientName: delivery.label,
+        recipientPhoneE164: target.phoneE164,
+        inboxMetadata: { source: "agent_output", outputId: output.id, agentKey: output.agentKey },
+      });
+      const messageRef = result.sent?.providerMessageId;
+      if (result.mode === "text" && messageRef) {
+        await capture.captureWhatsApp({
+          deliveryTarget: whatsappDeliveryTargetFromTarget(target),
+          messageRef,
+          providerTimestamp: result.sent?.providerTimestamp ?? null,
+          text,
+        });
+      }
+      return [messageRef ?? result.inboxMessageId].filter((ref): ref is string => Boolean(ref));
+    }
+
+    const refs: string[] = [];
     for (const chunk of chunkText(text, WHATSAPP_TEXT_LIMIT)) {
-      const sent =
-        target.kind === "dm"
-          ? await deps.whatsapp.sendTemplate(
-              target,
-              buildProactiveUpdateTemplate({
-                recipientName: delivery.label,
-                botName: (await deps.settingsRepo.get())?.bot_name,
-                messageSummary: chunk,
-              }),
-            )
-          : await deps.whatsapp.sendText(target, chunk);
+      const sent = await deps.whatsapp.sendText(target, chunk);
       const messageRef = sent?.providerMessageId;
       if (!messageRef) continue;
       refs.push(messageRef);
       await capture.captureWhatsApp({
-        deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : delivery.targetId,
+        deliveryTarget: delivery.targetId,
         messageRef,
         providerTimestamp: sent.providerTimestamp,
         text: chunk,
@@ -114,7 +138,7 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
         const messageRefs =
           params.delivery.platform === "slack"
             ? await sendSlack(params.delivery, text)
-            : await sendWhatsApp(params.delivery, text);
+            : await sendWhatsApp(params.delivery, params.output, text);
         await repo.markSent(attempt.id, messageRefs);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/packages/server/src/api/agent-runs.ts
+++ b/packages/server/src/api/agent-runs.ts
@@ -27,7 +27,6 @@ import type { WhatsAppBot } from "../whatsapp/bot";
 import { createWhatsAppMessageHandler } from "../whatsapp/message-handler";
 import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
-import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 
 type UserRepo = ReturnType<typeof createUserRepository>;
@@ -86,9 +85,14 @@ interface AgentRunRouteDeps {
     platform: string;
     message: string;
     template?: WhatsAppTemplateRequest;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
   }) => Promise<{
     channelId: string;
     messageRef: string;
+    inboxMessageId?: string;
   }>;
 }
 
@@ -229,19 +233,13 @@ export function agentRunRoutes(deps: AgentRunRouteDeps) {
             platform: parsed.data.target.platform,
           };
           if (parsed.data.deliveryMode === "target" && deps.sendDm) {
-            const template =
-              parsed.data.target.platform === "whatsapp"
-                ? buildProactiveUpdateTemplate({
-                    recipientName: target.name,
-                    botName: settingsRow?.bot_name,
-                    messageSummary: parsed.data.message,
-                  })
-                : undefined;
             delivery.request = await deps.sendDm({
               userId: target.id,
               platform: parsed.data.target.platform,
               message: parsed.data.message,
-              ...(template ? { template } : {}),
+              ...(parsed.data.target.platform === "whatsapp"
+                ? { senderUserId: requester.id, storeInInbox: true, inboxKind: "note" }
+                : {}),
             });
           }
           const deliveryTarget =
@@ -281,19 +279,13 @@ export function agentRunRoutes(deps: AgentRunRouteDeps) {
             toolConfig,
           );
           if (parsed.data.deliveryMode === "target" && finalText && deps.sendDm) {
-            const template =
-              parsed.data.target.platform === "whatsapp"
-                ? buildProactiveUpdateTemplate({
-                    recipientName: target.name,
-                    botName: settingsRow?.bot_name,
-                    messageSummary: finalText,
-                  })
-                : undefined;
             delivery.response = await deps.sendDm({
               userId: target.id,
               platform: parsed.data.target.platform,
               message: finalText,
-              ...(template ? { template } : {}),
+              ...(parsed.data.target.platform === "whatsapp"
+                ? { senderUserId: requester.id, storeInInbox: true, inboxKind: "workflow_output" }
+                : {}),
             });
           }
 

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -53,9 +53,14 @@ function createTestSystemApp(
       platform: "slack" | "whatsapp";
       message: string;
       template?: unknown;
+      senderUserId?: string;
+      storeInInbox?: boolean;
+      inboxKind?: string;
+      inboxMetadata?: Record<string, unknown> | null;
     }) => Promise<{
       channelId: string;
       messageRef: string;
+      inboxMessageId?: string;
     }>;
     whatsappStatus?: () => { connected: boolean; phoneNumber: string | null; pairingInProgress: boolean };
     startWhatsAppPairing?: ReturnType<typeof vi.fn>;

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -45,7 +45,11 @@ interface SystemDeps {
     platform: "slack" | "whatsapp";
     message: string;
     template?: WhatsAppTemplateRequest;
-  }) => Promise<{ channelId: string; messageRef: string }>;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
+  }) => Promise<{ channelId: string; messageRef: string; inboxMessageId?: string }>;
   managedWhatsappInbound?: Pick<ManagedWhatsAppProvider, "handleInboundEvent">;
   whatsappStatus?: () => { connected: boolean; phoneNumber: string | null; pairingInProgress: boolean };
   // biome-ignore lint/complexity/noBannedTypes: Function is needed here to accommodate Vitest mock types in tests

--- a/packages/server/src/api/web-chat.ts
+++ b/packages/server/src/api/web-chat.ts
@@ -76,9 +76,14 @@ interface WebChatRouteDeps {
     platform: string;
     message: string;
     template?: WhatsAppTemplateRequest;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
   }) => Promise<{
     channelId: string;
     messageRef: string;
+    inboxMessageId?: string;
   }>;
 }
 

--- a/packages/server/src/api/workflows.isolated.test.ts
+++ b/packages/server/src/api/workflows.isolated.test.ts
@@ -5,6 +5,7 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hashPassword } from "../auth/password";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createConversationRepository } from "../db/repositories/conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
@@ -12,6 +13,7 @@ import type { DB } from "../db/schema";
 import { createApp } from "../http";
 import type { SlackBot } from "../slack/bot";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import { WHATSAPP_TEXT_LIMIT } from "../whatsapp/chunking";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 
 const API_KEY = "sk_live_test_key";
@@ -553,6 +555,80 @@ describe("workflow invoke API", () => {
       messageRef: "wa-nudge-1",
     });
   });
+
+  it("chunks in-window WhatsApp DM target output and reports one last-chunk ref", async () => {
+    const { requester } = await seedTenant(db);
+    const task = await createWorkflow(db, { createdBy: requester.id, deliveryTarget: "dm:+15551234567" });
+    await db
+      .updateTable("scheduled_tasks")
+      .set({ platform: "whatsapp", context_type: "dm" })
+      .where("id", "=", task.id)
+      .execute();
+    const conversations = createConversationRepository(db);
+    const conversation = await conversations.getOrCreate(
+      { platform: "whatsapp", kind: "dm", providerConversationId: "dm:+15551234567" },
+      "Requester",
+    );
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "wa-inbound-1",
+      senderJid: "+15551234567",
+      senderName: "Requester",
+      senderUserId: requester.id,
+      isBot: false,
+      addressedToSketch: true,
+      text: "latest inbound",
+      providerTimestamp: new Date(Date.now() - 1_000).toISOString(),
+      receivedAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const longOutput = `${"a".repeat(WHATSAPP_TEXT_LIMIT)} ${"b".repeat(24)}`;
+    mockLightResult(longOutput);
+    const sendText = vi.fn(async (_target: unknown, _text: string) => ({
+      providerMessageId: `wa-session-${sendText.mock.calls.length}`,
+      providerConversationId: "dm:+15551234567",
+      providerTimestamp: "2026-07-03T10:00:00.000Z",
+    }));
+    const whatsappRuntime = {
+      isConnected: true,
+      getCapabilities: vi.fn(() => ({ templates: true })),
+      sendText,
+      sendTemplate: vi.fn(),
+    } as unknown as WhatsAppRuntime;
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      whatsappRuntime,
+    });
+
+    const res = await app.request(`/api/workflows/${task.id}/runs`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${API_KEY}` },
+      body: JSON.stringify({ requesterUserId: requester.id, deliveryMode: "target" }),
+    });
+
+    expect(res.status).toBe(200);
+    const completed = sseData(await readSse(res), "completed");
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(sendText).toHaveBeenNthCalledWith(
+      1,
+      { kind: "dm", phoneE164: "+15551234567" },
+      "a".repeat(WHATSAPP_TEXT_LIMIT),
+    );
+    expect(sendText).toHaveBeenNthCalledWith(2, { kind: "dm", phoneE164: "+15551234567" }, "b".repeat(24));
+    expect(completed.delivery).toMatchObject({
+      mode: "target",
+      platform: "whatsapp",
+      target: "dm:+15551234567",
+      messageRef: "wa-session-2",
+    });
+    const captured = await db
+      .selectFrom("conversation_messages")
+      .select(["provider_message_id", "is_bot", "text"])
+      .where("is_bot", "=", 1)
+      .execute();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({ provider_message_id: "wa-session-2", is_bot: 1, text: longOutput });
+  });
+
   it("delivers final output to a Slack user DM target", async () => {
     const { requester } = await seedTenant(db);
     const task = await createWorkflow(db, {

--- a/packages/server/src/api/workflows.isolated.test.ts
+++ b/packages/server/src/api/workflows.isolated.test.ts
@@ -12,6 +12,7 @@ import type { DB } from "../db/schema";
 import { createApp } from "../http";
 import type { SlackBot } from "../slack/bot";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import type { WhatsAppRuntime } from "../whatsapp/runtime";
 
 const API_KEY = "sk_live_test_key";
 
@@ -501,6 +502,57 @@ describe("workflow invoke API", () => {
     });
   });
 
+  it("parks WhatsApp DM target output and sends a task nudge", async () => {
+    const { requester } = await seedTenant(db);
+    const task = await createWorkflow(db, { createdBy: requester.id, deliveryTarget: "dm:+15551234567" });
+    await db
+      .updateTable("scheduled_tasks")
+      .set({ platform: "whatsapp", context_type: "dm" })
+      .where("id", "=", task.id)
+      .execute();
+    const whatsappRuntime = {
+      isConnected: true,
+      getCapabilities: vi.fn(() => ({ templates: true })),
+      sendText: vi.fn(),
+      sendTemplate: vi.fn().mockResolvedValue({
+        providerMessageId: "wa-nudge-1",
+        providerConversationId: "dm:+15551234567",
+        providerTimestamp: "2026-07-03T10:00:00.000Z",
+      }),
+    } as unknown as WhatsAppRuntime;
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      whatsappRuntime,
+    });
+
+    const res = await app.request(`/api/workflows/${task.id}/runs`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${API_KEY}` },
+      body: JSON.stringify({ requesterUserId: requester.id, deliveryMode: "target" }),
+    });
+
+    expect(res.status).toBe(200);
+    const completed = sseData(await readSse(res), "completed");
+    expect(whatsappRuntime.sendText).not.toHaveBeenCalled();
+    expect(whatsappRuntime.sendTemplate).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+15551234567" },
+      expect.objectContaining({ key: "whatsapp.task_nudge" }),
+    );
+    const inbox = await db.selectFrom("inbox_messages").selectAll().executeTakeFirstOrThrow();
+    expect(inbox).toMatchObject({
+      recipient_user_id: requester.id,
+      sender_user_id: requester.id,
+      kind: "workflow_output",
+      platform: "whatsapp",
+    });
+    expect(inbox.message).toBe("workflow result");
+    expect(completed.delivery).toMatchObject({
+      mode: "target",
+      platform: "whatsapp",
+      target: "dm:+15551234567",
+      messageRef: "wa-nudge-1",
+    });
+  });
   it("delivers final output to a Slack user DM target", async () => {
     const { requester } = await seedTenant(db);
     const task = await createWorkflow(db, {

--- a/packages/server/src/api/workflows.ts
+++ b/packages/server/src/api/workflows.ts
@@ -18,9 +18,9 @@ import type { Logger } from "../logger";
 import { createWorkflowDeliveryCapture } from "../scheduler/delivery-capture";
 import type { SlackBot } from "../slack/bot";
 import type { WhatsAppBot } from "../whatsapp/bot";
+import { deliverProactiveDm } from "../whatsapp/proactive-delivery";
 import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
-import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import { isSlackDmChannelId, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
 import { executeAutomation } from "../workflows/runtime";
 
@@ -210,9 +210,10 @@ function createDelivery(task: ScheduledTaskRow, deps: WorkflowRouteDeps) {
     throw new WorkflowApiError("NOT_CONNECTED", "WhatsApp is not connected");
   }
   const delivery: Record<string, unknown> = { mode: "target", platform: "whatsapp", target: resolved.targetId };
+  const conversations = createConversationRepository(deps.db);
   const capture = deps.whatsappRuntime
     ? createWorkflowDeliveryCapture({
-        conversations: createConversationRepository(deps.db),
+        conversations,
         settingsRepo: createSettingsRepository(deps.db),
         logger: deps.logger,
       })
@@ -222,16 +223,17 @@ function createDelivery(task: ScheduledTaskRow, deps: WorkflowRouteDeps) {
     sendMessage: async (text: string) => {
       if (deps.whatsappRuntime) {
         const target = whatsappTargetFromDeliveryTarget(resolved.targetId);
-        const sent =
+        const result =
           target.kind === "dm"
-            ? await deps.whatsappRuntime.sendTemplate(target, buildProactiveUpdateTemplate({ messageSummary: text }))
-            : await deps.whatsappRuntime.sendText(target, text);
-        if (sent?.providerMessageId) {
-          delivery.messageRef = sent.providerMessageId;
+            ? await deliverWorkflowWhatsAppDm(task, target, text, deps, conversations)
+            : { mode: "text" as const, sent: await deps.whatsappRuntime.sendText(target, text) };
+        const messageRef = result.sent?.providerMessageId;
+        if (messageRef) delivery.messageRef = messageRef;
+        if (messageRef && result.mode === "text") {
           await capture?.captureWhatsApp({
             deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : resolved.targetId,
-            messageRef: sent.providerMessageId,
-            providerTimestamp: sent.providerTimestamp,
+            messageRef,
+            providerTimestamp: result.sent?.providerTimestamp ?? null,
             text,
           });
         }
@@ -242,6 +244,34 @@ function createDelivery(task: ScheduledTaskRow, deps: WorkflowRouteDeps) {
   };
 }
 
+async function deliverWorkflowWhatsAppDm(
+  task: ScheduledTaskRow,
+  target: ReturnType<typeof whatsappTargetFromDeliveryTarget>,
+  text: string,
+  deps: WorkflowRouteDeps,
+  conversations: ReturnType<typeof createConversationRepository>,
+) {
+  if (target.kind !== "dm") throw new Error("Expected WhatsApp DM target");
+  if (!task.created_by)
+    throw new WorkflowApiError("INVALID_STATE", "Workflow creator is required for WhatsApp DM delivery");
+  if (!deps.inboxMessagesRepo)
+    throw new WorkflowApiError("INVALID_STATE", "Inbox storage is required for WhatsApp DM delivery");
+  if (!deps.whatsappRuntime) throw new WorkflowApiError("NOT_CONNECTED", "WhatsApp is not connected");
+  const recipient = await deps.users.findById(task.created_by);
+  return deliverProactiveDm({
+    target,
+    recipientUserId: task.created_by,
+    senderUserId: task.created_by,
+    text,
+    whatsapp: deps.whatsappRuntime,
+    conversations,
+    inboxMessages: deps.inboxMessagesRepo,
+    logger: deps.logger,
+    recipientName: recipient?.name,
+    recipientPhoneE164: recipient?.whatsapp_number ?? target.phoneE164,
+    inboxMetadata: { source: "workflow", taskId: task.id },
+  });
+}
 function finalOutputSummary(value: unknown): string | null {
   if (value == null) return null;
   return typeof value === "string" ? value.slice(0, 200) : JSON.stringify(value).slice(0, 200);

--- a/packages/server/src/bootstrap.integration.test.ts
+++ b/packages/server/src/bootstrap.integration.test.ts
@@ -1,7 +1,25 @@
-import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { createServer } from "./bootstrap";
+import { createUserRepository } from "./db/repositories/users";
 import { createTestConfig } from "./test-utils";
+import { WHATSAPP_TEMPLATE_KEYS } from "./whatsapp/templates";
+
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+
+const mockServeState = vi.hoisted(() => ({
+  fetch: null as FetchHandler | null,
+}));
+
+vi.mock("@hono/node-server", () => ({
+  serve: vi.fn((opts: { fetch: FetchHandler; port: number }) => {
+    mockServeState.fetch = opts.fetch;
+    return {
+      address: () => ({ address: "127.0.0.1", family: "IPv4", port: opts.port }),
+      close: vi.fn(),
+      on: vi.fn(),
+    };
+  }),
+}));
 
 // Avoid env-var side effects from LLM config
 vi.mock("./agent/llm-env", () => ({
@@ -41,6 +59,7 @@ describe("bootstrap", () => {
       await handle.shutdown();
       handle = null;
     }
+    mockServeState.fetch = null;
     vi.clearAllMocks();
   });
 
@@ -50,6 +69,11 @@ describe("bootstrap", () => {
     const config = createTestConfig({ PORT: 0, LOG_LEVEL: "error", ...configOverrides });
     handle = await createServer(config, { connect: false });
     return handle;
+  }
+
+  async function request(path: string, init?: RequestInit) {
+    if (!mockServeState.fetch) throw new Error("Server fetch handler was not captured");
+    return mockServeState.fetch(new Request(`http://localhost${path}`, init));
   }
 
   it("starts and returns expected handle shape", { timeout: 15_000 }, async () => {
@@ -80,15 +104,56 @@ describe("bootstrap", () => {
   });
 
   it("health endpoint responds 200", async () => {
-    const h = await boot();
-    const { port } = h.server.address() as AddressInfo;
+    await boot();
 
-    const res = await fetch(`http://localhost:${port}/api/health`);
+    const res = await request("/api/health");
     expect(res.status).toBe(200);
 
     const body = await res.json();
     expect(body.status).toBe("ok");
     expect(body.db).toBe("ok");
+  });
+
+  it("sends explicit WhatsApp magic-link templates without proactive parking", async () => {
+    const h = await boot({ BASE_URL: "https://sketch.test" });
+    const users = createUserRepository(h.db);
+    await users.create({
+      name: "Alice",
+      email: "alice@example.com",
+      emailVerified: true,
+      whatsappNumber: "+15551234567",
+    });
+    const sendTemplate = vi.spyOn(h.whatsappRuntime, "sendTemplate").mockResolvedValue({
+      providerMessageId: "wa-template-1",
+      providerConversationId: "dm:+15551234567",
+      providerTimestamp: "2026-07-03T10:00:00.000Z",
+    });
+    const sendText = vi.spyOn(h.whatsappRuntime, "sendText");
+    const getCapabilities = vi.spyOn(h.whatsappRuntime, "getCapabilities");
+
+    const res = await request("/api/auth/magic-link", {
+      method: "POST",
+      body: JSON.stringify({ email: "alice@example.com" }),
+      headers: { "content-type": "application/json" },
+    });
+    const body = (await res.json()) as { channels: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.channels).toEqual(["whatsapp"]);
+    expect(sendTemplate).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+15551234567" },
+      expect.objectContaining({
+        key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        params: expect.objectContaining({
+          recipientName: "Alice",
+          botName: "Sketch",
+          magicLinkUrl: expect.stringContaining("/api/auth/magic-link/verify?token="),
+        }),
+      }),
+    );
+    expect(getCapabilities).not.toHaveBeenCalled();
+    expect(sendText).not.toHaveBeenCalled();
+    await expect(h.db.selectFrom("inbox_messages").selectAll().execute()).resolves.toEqual([]);
   });
 
   it("shutdown resolves without error", async () => {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -57,6 +57,7 @@ import { initTelemetry } from "./telemetry/setup";
 import { resolveVisionConfigFromAppConfig } from "./vision/service";
 import { wireWhatsAppHandlers } from "./whatsapp/adapter";
 import { WhatsAppBot } from "./whatsapp/bot";
+import { WORKFLOW_OUTPUT_INBOX_KIND, deliverProactiveDm } from "./whatsapp/proactive-delivery";
 import { whatsappDeliveryTargetFromTarget } from "./whatsapp/provider";
 import { createBaileysWhatsAppProviders } from "./whatsapp/providers/baileys";
 import { WHATSAPP_MANAGED_PROVIDER_ID, createManagedWhatsAppProvider } from "./whatsapp/providers/managed";
@@ -282,12 +283,18 @@ export async function createServer(config: Config, options?: CreateServerOptions
     userId,
     platform,
     message,
-    template,
+    senderUserId,
+    inboxKind,
+    inboxMetadata,
   }: {
     userId: string;
     platform: string;
     message: string;
     template?: WhatsAppTemplateRequest;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
   }) => {
     const recipient = await users.findById(userId);
 
@@ -309,17 +316,26 @@ export async function createServer(config: Config, options?: CreateServerOptions
 
     if (platform === "whatsapp") {
       if (!recipient?.whatsapp_number) throw new Error("No WhatsApp number for recipient");
-      if (config.WHATSAPP_DM_PROVIDER === WHATSAPP_WATI_PROVIDER_ID && !template) {
-        throw new Error("Wati WhatsApp DMs require an approved template for proactive delivery");
-      }
 
       const target = { kind: "dm" as const, phoneE164: recipient.whatsapp_number };
       const channelId = whatsappDeliveryTargetFromTarget(target);
-      const sent = template
-        ? await whatsappRuntime.sendTemplate(target, { ...template, fallbackText: template.fallbackText ?? message })
-        : await whatsappRuntime.sendText(target, message);
+      const result = await deliverProactiveDm({
+        target,
+        recipientUserId: userId,
+        senderUserId: senderUserId ?? userId,
+        text: message,
+        whatsapp: whatsappRuntime,
+        conversations: conversationsRepo,
+        inboxMessages: inboxMessagesRepo,
+        logger,
+        recipientName: recipient.name,
+        recipientPhoneE164: recipient.whatsapp_number,
+        inboxKind: inboxKind ?? (senderUserId ? "note" : WORKFLOW_OUTPUT_INBOX_KIND),
+        inboxMetadata: inboxMetadata ?? null,
+      });
+      const sent = result.sent;
 
-      if (sent?.providerMessageId) {
+      if (result.mode === "text" && sent?.providerMessageId) {
         const settingsRow = await settingsRepo.get();
         const conversation = await conversationsRepo.getOrCreate(
           { platform: "whatsapp", kind: "dm", providerConversationId: channelId },
@@ -337,7 +353,11 @@ export async function createServer(config: Config, options?: CreateServerOptions
         });
       }
 
-      return { channelId, messageRef: sent?.providerMessageId ?? "" };
+      return {
+        channelId,
+        messageRef: sent?.providerMessageId ?? "",
+        ...(result.inboxMessageId ? { inboxMessageId: result.inboxMessageId } : {}),
+      };
     }
 
     throw new Error(`Unsupported platform: ${platform}`);

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -63,6 +63,7 @@ import { createBaileysWhatsAppProviders } from "./whatsapp/providers/baileys";
 import { WHATSAPP_MANAGED_PROVIDER_ID, createManagedWhatsAppProvider } from "./whatsapp/providers/managed";
 import { WHATSAPP_WATI_PROVIDER_ID, createWatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import { createWhatsAppRuntime } from "./whatsapp/runtime";
+import type { WhatsAppTemplateRequest } from "./whatsapp/templates";
 
 export interface ServerHandle {
   config: Config;
@@ -282,6 +283,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     userId,
     platform,
     message,
+    template,
     senderUserId,
     inboxKind,
     inboxMetadata,
@@ -289,6 +291,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     userId: string;
     platform: string;
     message: string;
+    template?: WhatsAppTemplateRequest;
     senderUserId?: string;
     /**
      * This adapter does not create a duplicate inbox row for successful
@@ -324,6 +327,11 @@ export async function createServer(config: Config, options?: CreateServerOptions
 
       const target = { kind: "dm" as const, phoneE164: recipient.whatsapp_number };
       const channelId = whatsappDeliveryTargetFromTarget(target);
+      if (template) {
+        const sent = await whatsappRuntime.sendTemplate(target, template);
+        return { channelId, messageRef: sent?.providerMessageId ?? "" };
+      }
+
       const result = await deliverProactiveDm({
         target,
         recipientUserId: userId,

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -63,7 +63,6 @@ import { createBaileysWhatsAppProviders } from "./whatsapp/providers/baileys";
 import { WHATSAPP_MANAGED_PROVIDER_ID, createManagedWhatsAppProvider } from "./whatsapp/providers/managed";
 import { WHATSAPP_WATI_PROVIDER_ID, createWatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import { createWhatsAppRuntime } from "./whatsapp/runtime";
-import type { WhatsAppTemplateRequest } from "./whatsapp/templates";
 
 export interface ServerHandle {
   config: Config;
@@ -290,8 +289,14 @@ export async function createServer(config: Config, options?: CreateServerOptions
     userId: string;
     platform: string;
     message: string;
-    template?: WhatsAppTemplateRequest;
     senderUserId?: string;
+    /**
+     * This adapter does not create a duplicate inbox row for successful
+     * in-window WhatsApp text sends; callers that want sender-visible inbox
+     * bookkeeping own that after delivery. Out-of-window WhatsApp content is
+     * always parked by proactive delivery regardless of this flag so the full
+     * message is never silently dropped.
+     */
     storeInInbox?: boolean;
     inboxKind?: string;
     inboxMetadata?: Record<string, unknown> | null;

--- a/packages/server/src/db/repositories/conversations.integration.test.ts
+++ b/packages/server/src/db/repositories/conversations.integration.test.ts
@@ -37,6 +37,64 @@ function runRepositorySuite(label: string, getDb: () => Promise<Kysely<DB>>, opt
       }
     });
 
+    it("finds the latest non-bot inbound WhatsApp DM for a recipient", async () => {
+      const repo = createConversationRepository(db);
+      await db.insertInto("users").values({ id: "user-window", name: "Window User" }).execute();
+      const dm = await repo.getOrCreate({
+        platform: "whatsapp",
+        kind: "dm",
+        providerConversationId: "dm:+15551234567",
+      });
+      const group = await repo.getOrCreate({
+        platform: "whatsapp",
+        kind: "group",
+        providerConversationId: "group@g.us",
+      });
+
+      await repo.insertMessage({
+        conversationId: dm.id,
+        providerMessageId: "user-match",
+        senderJid: "legacy-sender",
+        senderName: "Alice",
+        senderUserId: "user-window",
+        text: "user match",
+        receivedAt: "2026-07-03T08:00:00.000Z",
+      });
+      await repo.insertMessage({
+        conversationId: dm.id,
+        providerMessageId: "phone-match",
+        senderJid: "15551234567@s.whatsapp.net",
+        senderName: "Alice",
+        text: "phone match",
+        receivedAt: "2026-07-03T09:00:00.000Z",
+      });
+      await repo.insertMessage({
+        conversationId: dm.id,
+        providerMessageId: "bot-latest",
+        senderJid: "bot",
+        senderName: "Sketch",
+        isBot: true,
+        text: "bot",
+        receivedAt: "2026-07-03T10:00:00.000Z",
+      });
+      await repo.insertMessage({
+        conversationId: group.id,
+        providerMessageId: "group-latest",
+        senderJid: "15551234567@s.whatsapp.net",
+        senderName: "Alice",
+        text: "group",
+        receivedAt: "2026-07-03T11:00:00.000Z",
+      });
+
+      const withPhone = await repo.findLatestInboundWhatsAppDmFromRecipient({
+        recipientUserId: "user-window",
+        phoneE164: "+15551234567",
+      });
+      const byUserOnly = await repo.findLatestInboundWhatsAppDmFromRecipient({ recipientUserId: "user-window" });
+
+      expect(withPhone?.providerMessageId).toBe("phone-match");
+      expect(byUserOnly?.providerMessageId).toBe("user-match");
+    });
     it("deduplicates provider messages by conversation, provider id, sender, and bot side", async () => {
       const repo = createConversationRepository(db);
       const conversation = await repo.getOrCreate({

--- a/packages/server/src/db/repositories/conversations.ts
+++ b/packages/server/src/db/repositories/conversations.ts
@@ -141,6 +141,14 @@ function mergeSeenMessageId(left: number | null, right: number | null): number |
   if (left === null || right === null) return null;
   return Math.min(left, right);
 }
+function whatsappPhoneSenderCandidates(phoneE164?: string | null): string[] {
+  const phone = phoneE164?.trim();
+  if (!phone) return [];
+  const digits = phone.replace(/\D/gu, "");
+  return [phone, digits ? `${digits}@s.whatsapp.net` : null, digits || null, `wati:${phone}`].filter(
+    (value, index, values): value is string => Boolean(value) && values.indexOf(value) === index,
+  );
+}
 
 export function createConversationRepository(db: Kysely<DB>) {
   async function mergeConversationRows(
@@ -336,6 +344,36 @@ export function createConversationRepository(db: Kysely<DB>) {
         .executeTakeFirst();
     },
 
+    async findLatestInboundWhatsAppDmFromRecipient(params: {
+      recipientUserId: string;
+      phoneE164?: string | null;
+    }): Promise<StoredConversationMessage | undefined> {
+      const senderJids = whatsappPhoneSenderCandidates(params.phoneE164);
+      let query = db
+        .selectFrom("conversation_messages")
+        .innerJoin("conversations", "conversations.id", "conversation_messages.conversation_id")
+        .selectAll("conversation_messages")
+        .where("conversations.platform", "=", "whatsapp")
+        .where("conversations.kind", "=", "dm")
+        .where("conversation_messages.is_bot", "=", 0);
+
+      if (senderJids.length > 0) {
+        query = query.where(({ eb, or }) =>
+          or([
+            eb("conversation_messages.sender_user_id", "=", params.recipientUserId),
+            eb("conversation_messages.sender_jid", "in", senderJids),
+          ]),
+        );
+      } else {
+        query = query.where("conversation_messages.sender_user_id", "=", params.recipientUserId);
+      }
+
+      const row = await query
+        .orderBy("conversation_messages.received_at", "desc")
+        .orderBy("conversation_messages.id", "desc")
+        .executeTakeFirst();
+      return row ? toStored(row) : undefined;
+    },
     async claimProviderConversationId(
       id: number,
       ref: ConversationRef,

--- a/packages/server/src/db/repositories/inbox-messages.integration.test.ts
+++ b/packages/server/src/db/repositories/inbox-messages.integration.test.ts
@@ -1,0 +1,96 @@
+import { type Kysely, sql } from "kysely";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTestDb, getSharedPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createInboxMessagesRepository } from "./inbox-messages";
+import { createUserRepository } from "./users";
+
+/**
+ * The Postgres arm uses the worker-shared PGlite instance with transaction
+ * rollback isolation. The query under test is data-only and exists specifically
+ * to keep proactive nudge dedupe portable across SQLite and Postgres.
+ */
+function runPendingByKindSuite(label: string, getDb: () => Promise<Kysely<DB>>, opts: { shared?: boolean } = {}) {
+  describe(label, () => {
+    let db!: Kysely<DB>;
+
+    if (opts.shared) {
+      beforeAll(async () => {
+        db = await getDb();
+      }, 30000);
+    }
+
+    beforeEach(async () => {
+      if (opts.shared) {
+        await sql`BEGIN`.execute(db);
+      } else {
+        db = await getDb();
+      }
+    }, 30000);
+
+    afterEach(async () => {
+      if (opts.shared) {
+        await sql`ROLLBACK`.execute(db);
+      } else {
+        await db.destroy();
+      }
+    });
+
+    it("orders pending rows by created_at then id", async () => {
+      const repo = createInboxMessagesRepository(db);
+      const users = createUserRepository(db);
+      const sender = await users.create({ name: "Alice" });
+      const recipient = await users.create({ name: "Bob" });
+
+      await db
+        .insertInto("inbox_messages")
+        .values([
+          {
+            id: "pending-b",
+            sender_user_id: sender.id,
+            recipient_user_id: recipient.id,
+            message: "Pending B",
+            kind: "workflow_output",
+            platform: "whatsapp",
+            created_at: "2026-07-03T10:00:00.000Z",
+          },
+          {
+            id: "pending-a",
+            sender_user_id: sender.id,
+            recipient_user_id: recipient.id,
+            message: "Pending A",
+            kind: "workflow_output",
+            platform: "whatsapp",
+            created_at: "2026-07-03T10:00:00.000Z",
+          },
+          {
+            id: "pending-old",
+            sender_user_id: sender.id,
+            recipient_user_id: recipient.id,
+            message: "Pending old",
+            kind: "workflow_output",
+            platform: "whatsapp",
+            created_at: "2026-07-03T09:00:00.000Z",
+          },
+          {
+            id: "pending-resolved",
+            sender_user_id: sender.id,
+            recipient_user_id: recipient.id,
+            message: "Resolved",
+            kind: "workflow_output",
+            platform: "whatsapp",
+            created_at: "2026-07-03T11:00:00.000Z",
+            resolved_at: "2026-07-03T11:00:00.000Z",
+          },
+        ])
+        .execute();
+
+      const rows = await repo.listPendingForRecipientByKind(recipient.id, "workflow_output");
+
+      expect(rows.map((row) => row.id)).toEqual(["pending-old", "pending-a", "pending-b"]);
+    });
+  });
+}
+
+runPendingByKindSuite("createInboxMessagesRepository sqlite", createTestDb);
+runPendingByKindSuite("createInboxMessagesRepository postgres", getSharedPgDb, { shared: true });

--- a/packages/server/src/db/repositories/inbox-messages.test.ts
+++ b/packages/server/src/db/repositories/inbox-messages.test.ts
@@ -236,6 +236,76 @@ describe("findById()", () => {
   });
 });
 
+describe("listPendingForRecipientByKind()", () => {
+  it("orders unresolved and unconsumed rows by created_at then id", async () => {
+    await db
+      .insertInto("inbox_messages")
+      .values([
+        {
+          id: "row-b",
+          sender_user_id: senderUserId,
+          recipient_user_id: recipientUserId,
+          message: "Second by id",
+          kind: "workflow_output",
+          platform: "whatsapp",
+          created_at: "2026-07-03T10:00:00.000Z",
+        },
+        {
+          id: "row-a",
+          sender_user_id: senderUserId,
+          recipient_user_id: recipientUserId,
+          message: "First by id",
+          kind: "workflow_output",
+          platform: "whatsapp",
+          created_at: "2026-07-03T10:00:00.000Z",
+        },
+        {
+          id: "row-old",
+          sender_user_id: senderUserId,
+          recipient_user_id: recipientUserId,
+          message: "First by time",
+          kind: "workflow_output",
+          platform: "whatsapp",
+          created_at: "2026-07-03T09:00:00.000Z",
+        },
+        {
+          id: "row-consumed",
+          sender_user_id: senderUserId,
+          recipient_user_id: recipientUserId,
+          message: "Consumed",
+          kind: "workflow_output",
+          platform: "whatsapp",
+          created_at: "2026-07-03T10:02:00.000Z",
+          consumed_at: "2026-07-03T10:10:00.000Z",
+        },
+        {
+          id: "row-resolved",
+          sender_user_id: senderUserId,
+          recipient_user_id: recipientUserId,
+          message: "Resolved",
+          kind: "workflow_output",
+          platform: "whatsapp",
+          created_at: "2026-07-03T10:03:00.000Z",
+          resolved_at: "2026-07-03T10:11:00.000Z",
+        },
+        {
+          id: "row-other-kind",
+          sender_user_id: senderUserId,
+          recipient_user_id: recipientUserId,
+          message: "Other kind",
+          kind: "note",
+          platform: "whatsapp",
+          created_at: "2026-07-03T10:04:00.000Z",
+        },
+      ])
+      .execute();
+
+    const rows = await repo.listPendingForRecipientByKind(recipientUserId, "workflow_output");
+
+    expect(rows.map((row) => row.id)).toEqual(["row-old", "row-a", "row-b"]);
+  });
+});
+
 describe("updateWorkflow()", () => {
   it("merges metadata into an explicit workflow row", async () => {
     const workflow = await repo.create({

--- a/packages/server/src/db/repositories/inbox-messages.ts
+++ b/packages/server/src/db/repositories/inbox-messages.ts
@@ -78,6 +78,19 @@ export function createInboxMessagesRepository(db: Kysely<DB>) {
       return Boolean(row);
     },
 
+    async listPendingForRecipientByKind(recipientUserId: string, kind: string) {
+      return db
+        .selectFrom("inbox_messages")
+        .selectAll()
+        .where("recipient_user_id", "=", recipientUserId)
+        .where("kind", "=", kind)
+        .where("consumed_at", "is", null)
+        .where("resolved_at", "is", null)
+        .orderBy("created_at", "asc")
+        .orderBy("id", "asc")
+        .execute();
+    },
+
     async findById(id: string) {
       return db.selectFrom("inbox_messages").selectAll().where("id", "=", id).executeTakeFirst();
     },

--- a/packages/server/src/db/repositories/inbox-messages.ts
+++ b/packages/server/src/db/repositories/inbox-messages.ts
@@ -65,6 +65,19 @@ export function createInboxMessagesRepository(db: Kysely<DB>) {
         .execute();
     },
 
+    async hasPendingForRecipientByKind(recipientUserId: string, kind: string) {
+      const row = await db
+        .selectFrom("inbox_messages")
+        .select("id")
+        .where("recipient_user_id", "=", recipientUserId)
+        .where("kind", "=", kind)
+        .where("consumed_at", "is", null)
+        .where("resolved_at", "is", null)
+        .limit(1)
+        .executeTakeFirst();
+      return Boolean(row);
+    },
+
     async findById(id: string) {
       return db.selectFrom("inbox_messages").selectAll().where("id", "=", id).executeTakeFirst();
     },

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -110,9 +110,14 @@ interface AppDeps {
     platform: string;
     message: string;
     template?: WhatsAppTemplateRequest;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
   }) => Promise<{
     channelId: string;
     messageRef: string;
+    inboxMessageId?: string;
   }>;
   localDeviceGateway?: LocalDeviceGateway;
   localClaudeSessionService?: LocalClaudeSessionService;

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -161,6 +161,7 @@ function buildDeps(
     inboxMessagesRepo: {
       create: vi.fn().mockResolvedValue({ id: "inbox-1" }),
       hasPendingForRecipientByKind: vi.fn().mockResolvedValue(false),
+      listPendingForRecipientByKind: vi.fn().mockResolvedValue([{ id: "inbox-1" }]),
     },
     sendDm: vi.fn().mockResolvedValue({ channelId: "D123", messageRef: "1111.0001" }),
     _mockRunAgent: mockRunAgent,

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -11,11 +11,13 @@
  */
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createConversationRepository } from "../db/repositories/conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import type { ScheduledTaskRow } from "../db/repositories/scheduled-tasks";
 import type { DB } from "../db/schema";
 import { QueueManager } from "../queue";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import { WHATSAPP_TEXT_LIMIT } from "../whatsapp/chunking";
 import type { ExecuteAutomationParams } from "../workflows/runtime";
 import { TaskScheduler } from "./service";
 
@@ -935,6 +937,63 @@ describe("executeTask() delivery routing", () => {
       is_bot: 1,
       text: "Group workflow result",
     });
+  });
+
+  it("WhatsApp DM: sendMessage chunks in-window text and captures one last-chunk ref", async () => {
+    const conversations = createConversationRepository(db);
+    const conversation = await conversations.getOrCreate(
+      { platform: "whatsapp", kind: "dm", providerConversationId: "5511999999999@s.whatsapp.net" },
+      "Requester",
+    );
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "wa-inbound-1",
+      senderJid: "+5511999999999",
+      senderName: "Requester",
+      isBot: false,
+      addressedToSketch: true,
+      text: "latest inbound",
+      providerTimestamp: new Date(Date.now() - 1_000).toISOString(),
+      receivedAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const whatsapp = buildMockWhatsApp();
+    whatsapp.sendText = vi.fn(async (_target: unknown, _text: string) => ({
+      providerMessageId: `wa-message-${whatsapp.sendText.mock.calls.length}`,
+      providerConversationId: "5511999999999@s.whatsapp.net",
+      providerTimestamp: "2024-06-04T10:00:00.000Z",
+    }));
+    const deps = buildDeps(db, { whatsapp });
+    const scheduler = new TaskScheduler(deps as never);
+    const row = await repo.add({
+      ...baseTaskFields,
+      platform: "whatsapp",
+      context_type: "dm",
+      delivery_target: "5511999999999@s.whatsapp.net",
+    });
+    const text = `${"a".repeat(WHATSAPP_TEXT_LIMIT)} ${"b".repeat(24)}`;
+
+    await scheduler.executeTask(row as ScheduledTaskRow);
+    await vi.waitFor(() => expect(lastExecuteAutomationParams).not.toBeNull());
+    await lastExecuteAutomationParams?.sendMessage?.(text);
+
+    expect(whatsapp.sendText).toHaveBeenCalledTimes(2);
+    expect(whatsapp.sendText).toHaveBeenNthCalledWith(
+      1,
+      { kind: "dm", phoneE164: "+5511999999999", providerConversationId: "5511999999999@s.whatsapp.net" },
+      "a".repeat(WHATSAPP_TEXT_LIMIT),
+    );
+    expect(whatsapp.sendText).toHaveBeenNthCalledWith(
+      2,
+      { kind: "dm", phoneE164: "+5511999999999", providerConversationId: "5511999999999@s.whatsapp.net" },
+      "b".repeat(24),
+    );
+    const captured = await db
+      .selectFrom("conversation_messages")
+      .select(["provider_message_id", "is_bot", "text"])
+      .where("is_bot", "=", 1)
+      .execute();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({ provider_message_id: "wa-message-2", is_bot: 1, text });
   });
 });
 

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -81,6 +81,7 @@ function buildMockSlack() {
 
 function buildMockWhatsApp(connected = true) {
   return {
+    getCapabilities: vi.fn().mockReturnValue({ templates: true }),
     sendText: vi.fn().mockResolvedValue({
       providerMessageId: "wa-message-1",
       providerConversationId: "5511999999999@s.whatsapp.net",
@@ -157,6 +158,7 @@ function buildDeps(
     },
     inboxMessagesRepo: {
       create: vi.fn().mockResolvedValue({ id: "inbox-1" }),
+      hasPendingForRecipientByKind: vi.fn().mockResolvedValue(false),
     },
     sendDm: vi.fn().mockResolvedValue({ channelId: "D123", messageRef: "1111.0001" }),
     _mockRunAgent: mockRunAgent,
@@ -850,7 +852,7 @@ describe("executeTask() delivery routing", () => {
     );
   });
 
-  it("WhatsApp DM: sendMessage calls sendTemplate", async () => {
+  it("WhatsApp DM: sendMessage parks output and sends a task nudge when no session window is open", async () => {
     const deps = buildDeps(db);
     const scheduler = new TaskScheduler(deps as never);
 
@@ -874,33 +876,22 @@ describe("executeTask() delivery routing", () => {
         providerConversationId: "5511999999999@s.whatsapp.net",
       },
       expect.objectContaining({
-        key: "whatsapp.proactive_update",
-        params: expect.objectContaining({ messageSummary: "WhatsApp message" }),
+        key: "whatsapp.task_nudge",
+        params: expect.objectContaining({ recipientName: "there" }),
+      }),
+    );
+    expect(deps.inboxMessagesRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientUserId: "U_USER1",
+        senderUserId: "U_USER1",
+        message: "WhatsApp message",
+        kind: "workflow_output",
+        resolutionMode: "auto_consume",
       }),
     );
 
-    const captured = await db
-      .selectFrom("conversation_messages")
-      .innerJoin("conversations", "conversations.id", "conversation_messages.conversation_id")
-      .select([
-        "conversations.platform",
-        "conversations.kind",
-        "conversations.provider_conversation_id",
-        "conversation_messages.provider_message_id",
-        "conversation_messages.sender_jid",
-        "conversation_messages.is_bot",
-        "conversation_messages.text",
-      ])
-      .executeTakeFirstOrThrow();
-    expect(captured).toMatchObject({
-      platform: "whatsapp",
-      kind: "dm",
-      provider_conversation_id: "dm:+5511999999999",
-      provider_message_id: "wa-template-1",
-      sender_jid: "bot",
-      is_bot: 1,
-      text: "WhatsApp message",
-    });
+    const captured = await db.selectFrom("conversation_messages").selectAll().execute();
+    expect(captured).toHaveLength(0);
   });
 
   it("WhatsApp group: sendMessage captures the delivered bot message", async () => {

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -33,9 +33,9 @@ import type { Logger } from "../logger";
 import type { QueueManager } from "../queue";
 import type { SlackBot } from "../slack/bot";
 import type { RecordWorkflowStep } from "../telemetry/agent-run-telemetry";
+import { deliverProactiveDm } from "../whatsapp/proactive-delivery";
 import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
-import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import { isSlackDmChannelId, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
 import { type AutomationExecutionResult, executeAutomation } from "../workflows/runtime";
 import { testAutomationStep } from "../workflows/runtime";
@@ -69,13 +69,15 @@ export class TaskScheduler {
   private cronInstances: Map<string, Cron> = new Map();
   private repo: ReturnType<typeof createScheduledTaskRepository>;
   private deliveryCapture: ReturnType<typeof createWorkflowDeliveryCapture>;
+  private conversations: ReturnType<typeof createConversationRepository>;
   private deps: TaskSchedulerDeps;
 
   constructor(deps: TaskSchedulerDeps) {
     this.deps = deps;
     this.repo = createScheduledTaskRepository(deps.db);
+    this.conversations = createConversationRepository(deps.db);
     this.deliveryCapture = createWorkflowDeliveryCapture({
-      conversations: createConversationRepository(deps.db),
+      conversations: this.conversations,
       settingsRepo: deps.settingsRepo,
       logger: deps.logger,
     });
@@ -305,27 +307,44 @@ export class TaskScheduler {
 
     return async (text) => {
       const target = whatsappTargetFromDeliveryTarget(delivery.targetId);
-      const sent =
+      const result =
         target.kind === "dm"
-          ? await whatsapp.sendTemplate(
-              target,
-              buildProactiveUpdateTemplate({
-                botName: (await this.deps.settingsRepo.get())?.bot_name,
-                messageSummary: text,
-              }),
-            )
-          : await whatsapp.sendText(target, text);
-      const messageRef = sent?.providerMessageId;
-      if (!messageRef) return;
+          ? await this.deliverWhatsAppDmForTask(task, target, text)
+          : { mode: "text" as const, sent: await whatsapp.sendText(target, text) };
+      const messageRef = result.sent?.providerMessageId;
+      if (!messageRef || result.mode !== "text") return;
       await this.deliveryCapture.captureWhatsApp({
         deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : delivery.targetId,
         messageRef,
-        providerTimestamp: sent.providerTimestamp,
+        providerTimestamp: result.sent?.providerTimestamp ?? null,
         text,
       });
     };
   }
 
+  private async deliverWhatsAppDmForTask(
+    task: ScheduledTaskRow,
+    target: ReturnType<typeof whatsappTargetFromDeliveryTarget>,
+    text: string,
+  ) {
+    if (target.kind !== "dm") throw new Error("Expected WhatsApp DM target");
+    if (!task.created_by) throw new Error(`Task ${task.id} has no creator for WhatsApp DM delivery`);
+    if (!this.deps.inboxMessagesRepo) throw new Error("Inbox storage is not available for WhatsApp DM delivery");
+    const recipient = await this.deps.userRepo.findById(task.created_by);
+    return deliverProactiveDm({
+      target,
+      recipientUserId: task.created_by,
+      senderUserId: task.created_by,
+      text,
+      whatsapp: this.deps.whatsapp,
+      conversations: this.conversations,
+      inboxMessages: this.deps.inboxMessagesRepo,
+      logger: this.deps.logger,
+      recipientName: recipient?.name,
+      recipientPhoneE164: recipient?.whatsapp_number ?? target.phoneE164,
+      inboxMetadata: { source: "scheduled_task", taskId: task.id },
+    });
+  }
   private getQueueKey(task: ScheduledTaskRow): string {
     return getScheduledTaskRowQueueKey(task);
   }

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -92,9 +92,14 @@ export interface WhatsAppAdapterDeps {
     platform: string;
     message: string;
     template?: WhatsAppTemplateRequest;
+    senderUserId?: string;
+    storeInInbox?: boolean;
+    inboxKind?: string;
+    inboxMetadata?: Record<string, unknown> | null;
   }) => Promise<{
     channelId: string;
     messageRef: string;
+    inboxMessageId?: string;
   }>;
 }
 

--- a/packages/server/src/whatsapp/proactive-delivery.test.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import { type DeliverProactiveDmParams, deliverProactiveDm } from "./proactive-delivery";
+import type { WhatsAppCapabilities, WhatsAppSendResult, WhatsAppTarget } from "./provider";
+import { WHATSAPP_TEMPLATE_KEYS } from "./templates";
+
+const templateCapabilities: WhatsAppCapabilities = {
+  text: true,
+  media: false,
+  quotedReply: false,
+  templates: true,
+  templateProvisioning: "manual",
+  interactive: false,
+  deliveryStatus: false,
+  typing: false,
+  reactions: false,
+  edit: false,
+  groups: false,
+};
+
+const textOnlyCapabilities: WhatsAppCapabilities = {
+  ...templateCapabilities,
+  templates: false,
+  templateProvisioning: "none",
+};
+
+const target: WhatsAppTarget = { kind: "dm", phoneE164: "+15551234567" };
+const sentText: WhatsAppSendResult = {
+  providerMessageId: "text-1",
+  providerConversationId: "dm:+15551234567",
+  providerTimestamp: "2026-07-03T10:00:00.000Z",
+};
+const sentNudge: WhatsAppSendResult = {
+  providerMessageId: "nudge-1",
+  providerConversationId: "dm:+15551234567",
+  providerTimestamp: "2026-07-03T10:00:01.000Z",
+};
+
+function buildDeps(
+  overrides: {
+    capabilities?: WhatsAppCapabilities;
+    lastInbound?: { receivedAt: string; providerTimestamp: string | null } | null;
+    sendText?: ReturnType<typeof vi.fn>;
+    hasPending?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
+  return {
+    whatsapp: {
+      getCapabilities: vi.fn(() => overrides.capabilities ?? templateCapabilities),
+      sendText: overrides.sendText ?? vi.fn().mockResolvedValue(sentText),
+      sendTemplate: vi.fn().mockResolvedValue(sentNudge),
+    } as unknown as DeliverProactiveDmParams["whatsapp"],
+    conversations: {
+      findLatestInboundWhatsAppDmFromRecipient: vi.fn().mockResolvedValue(overrides.lastInbound ?? null),
+    } as unknown as DeliverProactiveDmParams["conversations"],
+    inboxMessages: {
+      create: vi.fn().mockResolvedValue({ id: "inbox-1" }),
+      hasPendingForRecipientByKind: overrides.hasPending ?? vi.fn().mockResolvedValue(false),
+    } as unknown as DeliverProactiveDmParams["inboxMessages"],
+    logger: { debug: vi.fn() },
+  };
+}
+
+describe("deliverProactiveDm", () => {
+  it("passes through to sendText when the provider does not require templates", async () => {
+    const deps = buildDeps({ capabilities: textOnlyCapabilities });
+    const text = "line one\nline two";
+
+    const result = await deliverProactiveDm({
+      target,
+      recipientUserId: "user-1",
+      senderUserId: "user-1",
+      text,
+      ...deps,
+    });
+
+    expect(result.mode).toBe("text");
+    expect(deps.whatsapp.sendText).toHaveBeenCalledWith(target, text);
+    expect(deps.conversations.findLatestInboundWhatsAppDmFromRecipient).not.toHaveBeenCalled();
+    expect(deps.inboxMessages.create).not.toHaveBeenCalled();
+    expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("sends full multi-line text when the customer-service window is open", async () => {
+    const deps = buildDeps({ lastInbound: { receivedAt: "2026-07-03T09:00:00.000Z", providerTimestamp: null } });
+    const text = "first line\nsecond line\nthird line";
+
+    const result = await deliverProactiveDm({
+      target,
+      recipientUserId: "user-1",
+      senderUserId: "user-1",
+      text,
+      now: new Date("2026-07-03T10:00:00.000Z"),
+      ...deps,
+    });
+
+    expect(result).toEqual({ mode: "text", sent: sentText });
+    expect(deps.whatsapp.sendText).toHaveBeenCalledWith(target, text);
+    expect(deps.inboxMessages.create).not.toHaveBeenCalled();
+    expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("parks the output and sends a nudge when the window is closed", async () => {
+    const deps = buildDeps({ lastInbound: { receivedAt: "2026-07-02T00:00:00.000Z", providerTimestamp: null } });
+
+    const result = await deliverProactiveDm({
+      target,
+      recipientUserId: "user-1",
+      senderUserId: "user-1",
+      recipientName: "Alice",
+      text: "closed window output",
+      now: new Date("2026-07-03T10:00:00.000Z"),
+      ...deps,
+    });
+
+    expect(result.mode).toBe("nudge");
+    expect(result.inboxMessageId).toBe("inbox-1");
+    expect(deps.inboxMessages.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientUserId: "user-1",
+        senderUserId: "user-1",
+        message: "closed window output",
+        kind: "workflow_output",
+        resolutionMode: "auto_consume",
+        platform: "whatsapp",
+      }),
+    );
+    expect(deps.whatsapp.sendTemplate).toHaveBeenCalledWith(
+      target,
+      expect.objectContaining({
+        key: WHATSAPP_TEMPLATE_KEYS.taskNudge,
+        params: { recipientName: "Alice" },
+      }),
+    );
+  });
+
+  it("parks and nudges when there is no inbound history", async () => {
+    const deps = buildDeps();
+
+    await deliverProactiveDm({
+      target,
+      recipientUserId: "user-1",
+      senderUserId: "user-1",
+      text: "no history output",
+      ...deps,
+    });
+
+    expect(deps.inboxMessages.create).toHaveBeenCalledOnce();
+    expect(deps.whatsapp.sendTemplate).toHaveBeenCalledOnce();
+  });
+
+  it("skips duplicate nudges while another workflow output is pending", async () => {
+    const hasPending = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const deps = buildDeps({ hasPending });
+
+    await deliverProactiveDm({ target, recipientUserId: "user-1", senderUserId: "user-1", text: "first", ...deps });
+    await deliverProactiveDm({ target, recipientUserId: "user-1", senderUserId: "user-1", text: "second", ...deps });
+
+    expect(deps.inboxMessages.create).toHaveBeenCalledTimes(2);
+    expect(deps.whatsapp.sendTemplate).toHaveBeenCalledTimes(1);
+    expect(deps.logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientUserId: "user-1", inboxKind: "workflow_output", nudgeSent: false }),
+      "WhatsApp proactive delivery parked without duplicate nudge",
+    );
+  });
+
+  it.each(["contact_not_found", "window_expired"])(
+    "falls back to park-and-nudge for %s text errors",
+    async (providerCode) => {
+      const error = Object.assign(new Error("send failed"), { providerCode });
+      const deps = buildDeps({
+        lastInbound: { receivedAt: "2026-07-03T09:00:00.000Z", providerTimestamp: null },
+        sendText: vi.fn().mockRejectedValue(error),
+      });
+
+      const result = await deliverProactiveDm({
+        target,
+        recipientUserId: "user-1",
+        senderUserId: "user-1",
+        text: "fallback output",
+        now: new Date("2026-07-03T10:00:00.000Z"),
+        ...deps,
+      });
+
+      expect(result.mode).toBe("nudge");
+      expect(deps.inboxMessages.create).toHaveBeenCalledOnce();
+      expect(deps.whatsapp.sendTemplate).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["provider_rejected", undefined])("propagates non-window text errors: %s", async (providerCode) => {
+    const error = Object.assign(new Error("send failed"), providerCode ? { providerCode } : {});
+    const deps = buildDeps({
+      lastInbound: { receivedAt: "2026-07-03T09:00:00.000Z", providerTimestamp: null },
+      sendText: vi.fn().mockRejectedValue(error),
+    });
+
+    await expect(
+      deliverProactiveDm({
+        target,
+        recipientUserId: "user-1",
+        senderUserId: "user-1",
+        text: "propagate output",
+        now: new Date("2026-07-03T10:00:00.000Z"),
+        ...deps,
+      }),
+    ).rejects.toThrow("send failed");
+    expect(deps.inboxMessages.create).not.toHaveBeenCalled();
+    expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/whatsapp/proactive-delivery.test.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { WHATSAPP_TEXT_LIMIT } from "./chunking";
-import { type DeliverProactiveDmParams, deliverProactiveDm } from "./proactive-delivery";
+import {
+  type DeliverProactiveDmParams,
+  ProactiveDeliveryTextSendError,
+  deliverProactiveDm,
+} from "./proactive-delivery";
 import type { WhatsAppCapabilities, WhatsAppSendResult, WhatsAppTarget } from "./provider";
 import { WHATSAPP_TEMPLATE_KEYS } from "./templates";
 
@@ -41,7 +45,7 @@ function buildDeps(
     capabilities?: WhatsAppCapabilities;
     lastInbound?: { receivedAt: string; providerTimestamp: string | null } | null;
     sendText?: ReturnType<typeof vi.fn>;
-    hasPending?: ReturnType<typeof vi.fn>;
+    listPending?: ReturnType<typeof vi.fn>;
   } = {},
 ) {
   return {
@@ -55,7 +59,7 @@ function buildDeps(
     } as unknown as DeliverProactiveDmParams["conversations"],
     inboxMessages: {
       create: vi.fn().mockResolvedValue({ id: "inbox-1" }),
-      hasPendingForRecipientByKind: overrides.hasPending ?? vi.fn().mockResolvedValue(false),
+      listPendingForRecipientByKind: overrides.listPending ?? vi.fn().mockResolvedValue([{ id: "inbox-1" }]),
     } as unknown as DeliverProactiveDmParams["inboxMessages"],
     logger: { debug: vi.fn() },
   };
@@ -183,19 +187,80 @@ describe("deliverProactiveDm", () => {
     expect(deps.whatsapp.sendTemplate).toHaveBeenCalledOnce();
   });
 
-  it("skips duplicate nudges while another workflow output is pending", async () => {
-    const hasPending = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
-    const deps = buildDeps({ hasPending });
+  it("sends one deterministic nudge when concurrent deliveries park for the same recipient", async () => {
+    let releaseBothCreates!: () => void;
+    const bothCreates = new Promise<void>((resolve) => {
+      releaseBothCreates = resolve;
+    });
+    const createdRows: Array<{ id: string; created_at: string }> = [];
+    const create = vi.fn(async (data: { message: string }) => {
+      const row = {
+        id: data.message === "first" ? "inbox-b" : "inbox-a",
+        created_at: "2026-07-03T10:00:00.000Z",
+      };
+      createdRows.push(row);
+      if (createdRows.length === 2) releaseBothCreates();
+      return row;
+    });
+    const listPending = vi.fn(async () => {
+      await bothCreates;
+      return [...createdRows].sort((left, right) => {
+        const byCreatedAt = left.created_at.localeCompare(right.created_at);
+        return byCreatedAt === 0 ? left.id.localeCompare(right.id) : byCreatedAt;
+      });
+    });
+    const deps = buildDeps({ listPending });
+    deps.inboxMessages.create = create as unknown as DeliverProactiveDmParams["inboxMessages"]["create"];
 
-    await deliverProactiveDm({ target, recipientUserId: "user-1", senderUserId: "user-1", text: "first", ...deps });
-    await deliverProactiveDm({ target, recipientUserId: "user-1", senderUserId: "user-1", text: "second", ...deps });
+    const [first, second] = await Promise.all([
+      deliverProactiveDm({ target, recipientUserId: "user-1", senderUserId: "user-1", text: "first", ...deps }),
+      deliverProactiveDm({ target, recipientUserId: "user-1", senderUserId: "user-1", text: "second", ...deps }),
+    ]);
 
     expect(deps.inboxMessages.create).toHaveBeenCalledTimes(2);
     expect(deps.whatsapp.sendTemplate).toHaveBeenCalledTimes(1);
+    expect(first).toMatchObject({ mode: "parked", inboxMessageId: "inbox-b" });
+    expect(second).toMatchObject({ mode: "nudge", inboxMessageId: "inbox-a" });
     expect(deps.logger.debug).toHaveBeenCalledWith(
-      expect.objectContaining({ recipientUserId: "user-1", inboxKind: "workflow_output", nudgeSent: false }),
+      expect.objectContaining({
+        recipientUserId: "user-1",
+        inboxMessageId: "inbox-b",
+        inboxKind: "workflow_output",
+        nudgeSent: false,
+      }),
       "WhatsApp proactive delivery parked without duplicate nudge",
     );
+  });
+
+  it("throws chunked text failures with already-sent refs attached", async () => {
+    const firstSent = { ...sentText, providerMessageId: "text-1" };
+    const cause = new Error("second chunk failed");
+    const sendText = vi.fn().mockResolvedValueOnce(firstSent).mockRejectedValueOnce(cause);
+    const deps = buildDeps({
+      lastInbound: { receivedAt: "2026-07-03T09:00:00.000Z", providerTimestamp: null },
+      sendText,
+    });
+    const text = `${"a".repeat(WHATSAPP_TEXT_LIMIT)} ${"b".repeat(WHATSAPP_TEXT_LIMIT)} ${"c".repeat(12)}`;
+
+    let thrown: unknown;
+    try {
+      await deliverProactiveDm({
+        target,
+        recipientUserId: "user-1",
+        senderUserId: "user-1",
+        text,
+        now: new Date("2026-07-03T10:00:00.000Z"),
+        ...deps,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(ProactiveDeliveryTextSendError);
+    expect(thrown).toMatchObject({
+      cause,
+      textSends: [{ text: "a".repeat(WHATSAPP_TEXT_LIMIT), sent: firstSent }],
+    });
   });
 
   it.each(["contact_not_found", "window_expired"])(

--- a/packages/server/src/whatsapp/proactive-delivery.test.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { WHATSAPP_TEXT_LIMIT } from "./chunking";
 import { type DeliverProactiveDmParams, deliverProactiveDm } from "./proactive-delivery";
 import type { WhatsAppCapabilities, WhatsAppSendResult, WhatsAppTarget } from "./provider";
 import { WHATSAPP_TEMPLATE_KEYS } from "./templates";
@@ -93,8 +94,42 @@ describe("deliverProactiveDm", () => {
       ...deps,
     });
 
-    expect(result).toEqual({ mode: "text", sent: sentText });
+    expect(result).toEqual({ mode: "text", sent: sentText, textSends: [{ text, sent: sentText }] });
     expect(deps.whatsapp.sendText).toHaveBeenCalledWith(target, text);
+    expect(deps.inboxMessages.create).not.toHaveBeenCalled();
+    expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("chunks in-window session text sequentially", async () => {
+    const firstSent = { ...sentText, providerMessageId: "text-1" };
+    const secondSent = { ...sentText, providerMessageId: "text-2" };
+    const sendText = vi.fn().mockResolvedValueOnce(firstSent).mockResolvedValueOnce(secondSent);
+    const deps = buildDeps({
+      lastInbound: { receivedAt: "2026-07-03T09:00:00.000Z", providerTimestamp: null },
+      sendText,
+    });
+    const text = `${"a".repeat(WHATSAPP_TEXT_LIMIT)} ${"b".repeat(24)}`;
+
+    const result = await deliverProactiveDm({
+      target,
+      recipientUserId: "user-1",
+      senderUserId: "user-1",
+      text,
+      now: new Date("2026-07-03T10:00:00.000Z"),
+      ...deps,
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(sendText).toHaveBeenNthCalledWith(1, target, "a".repeat(WHATSAPP_TEXT_LIMIT));
+    expect(sendText).toHaveBeenNthCalledWith(2, target, "b".repeat(24));
+    expect(result).toEqual({
+      mode: "text",
+      sent: secondSent,
+      textSends: [
+        { text: "a".repeat(WHATSAPP_TEXT_LIMIT), sent: firstSent },
+        { text: "b".repeat(24), sent: secondSent },
+      ],
+    });
     expect(deps.inboxMessages.create).not.toHaveBeenCalled();
     expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
   });

--- a/packages/server/src/whatsapp/proactive-delivery.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.ts
@@ -1,0 +1,130 @@
+import type { createConversationRepository } from "../db/repositories/conversations";
+import type { createInboxMessagesRepository } from "../db/repositories/inbox-messages";
+import type { Logger } from "../logger";
+import type { WhatsAppSendResult, WhatsAppTarget } from "./provider";
+import type { WhatsAppRuntime } from "./runtime";
+import { buildTaskNudgeTemplate } from "./templates";
+
+export const WORKFLOW_OUTPUT_INBOX_KIND = "workflow_output";
+
+const CUSTOMER_SERVICE_WINDOW_MS = 23 * 60 * 60 * 1000;
+const FALLBACK_PROVIDER_CODES = new Set(["contact_not_found", "window_expired"]);
+
+export type ProactiveDeliveryMode = "text" | "nudge" | "parked";
+
+export interface ProactiveDeliveryResult {
+  mode: ProactiveDeliveryMode;
+  sent: WhatsAppSendResult | null;
+  inboxMessageId?: string | undefined;
+}
+
+export interface DeliverProactiveDmParams {
+  target: WhatsAppTarget;
+  recipientUserId: string;
+  senderUserId: string;
+  text: string;
+  whatsapp: Pick<WhatsAppRuntime, "getCapabilities" | "sendText" | "sendTemplate">;
+  conversations: Pick<ReturnType<typeof createConversationRepository>, "findLatestInboundWhatsAppDmFromRecipient">;
+  inboxMessages: Pick<ReturnType<typeof createInboxMessagesRepository>, "create" | "hasPendingForRecipientByKind">;
+  logger: Pick<Logger, "debug">;
+  recipientName?: string | null | undefined;
+  recipientPhoneE164?: string | null | undefined;
+  inboxKind?: string | undefined;
+  inboxMetadata?: Record<string, unknown> | null | undefined;
+  now?: Date | undefined;
+}
+
+export async function deliverProactiveDm(params: DeliverProactiveDmParams): Promise<ProactiveDeliveryResult> {
+  if (params.target.kind === "group") {
+    const sent = await params.whatsapp.sendText(params.target, params.text);
+    return { mode: "text", sent };
+  }
+
+  if (!params.whatsapp.getCapabilities(params.target).templates) {
+    const sent = await params.whatsapp.sendText(params.target, params.text);
+    return { mode: "text", sent };
+  }
+
+  const lastInbound = await params.conversations.findLatestInboundWhatsAppDmFromRecipient({
+    recipientUserId: params.recipientUserId,
+    phoneE164: params.recipientPhoneE164 ?? params.target.phoneE164,
+  });
+
+  if (lastInbound && isInsideCustomerServiceWindow(lastInbound, params.now ?? new Date())) {
+    try {
+      const sent = await params.whatsapp.sendText(params.target, params.text);
+      return { mode: "text", sent };
+    } catch (err) {
+      if (!shouldParkAfterTextError(err)) throw err;
+      return parkThenNudge(params);
+    }
+  }
+
+  return parkThenNudge(params);
+}
+
+async function parkThenNudge(params: DeliverProactiveDmParams): Promise<ProactiveDeliveryResult> {
+  const kind = params.inboxKind ?? WORKFLOW_OUTPUT_INBOX_KIND;
+  const hadPendingWorkflowOutput = await params.inboxMessages.hasPendingForRecipientByKind(
+    params.recipientUserId,
+    kind,
+  );
+  const inboxMessage = await params.inboxMessages.create({
+    senderUserId: params.senderUserId,
+    recipientUserId: params.recipientUserId,
+    message: params.text,
+    kind,
+    metadata: params.inboxMetadata ?? null,
+    resolutionMode: "auto_consume",
+    platform: "whatsapp",
+    channelId: params.target.kind === "dm" ? params.target.phoneE164 : params.target.groupId,
+  });
+
+  if (hadPendingWorkflowOutput) {
+    params.logger.debug(
+      {
+        recipientUserId: params.recipientUserId,
+        inboxMessageId: inboxMessage.id,
+        inboxKind: kind,
+        nudgeSent: false,
+      },
+      "WhatsApp proactive delivery parked without duplicate nudge",
+    );
+    return { mode: "parked", sent: null, inboxMessageId: inboxMessage.id };
+  }
+
+  const sent = await params.whatsapp.sendTemplate(
+    params.target,
+    buildTaskNudgeTemplate({ recipientName: params.recipientName }),
+  );
+  return { mode: "nudge", sent, inboxMessageId: inboxMessage.id };
+}
+
+function isInsideCustomerServiceWindow(
+  message: Awaited<
+    ReturnType<ReturnType<typeof createConversationRepository>["findLatestInboundWhatsAppDmFromRecipient"]>
+  >,
+  now: Date,
+): boolean {
+  if (!message) return false;
+  const timestamp = parseTimestamp(message.receivedAt) ?? parseTimestamp(message.providerTimestamp);
+  if (!timestamp) return false;
+  return now.getTime() - timestamp.getTime() <= CUSTOMER_SERVICE_WINDOW_MS;
+}
+
+function parseTimestamp(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const millis = Date.parse(value);
+  return Number.isFinite(millis) ? new Date(millis) : null;
+}
+
+function shouldParkAfterTextError(error: unknown): boolean {
+  const code = providerCodeFromError(error);
+  return Boolean(code && FALLBACK_PROVIDER_CODES.has(code));
+}
+
+function providerCodeFromError(error: unknown): string | null {
+  if (!error || typeof error !== "object" || !("providerCode" in error)) return null;
+  const code = (error as { providerCode?: unknown }).providerCode;
+  return typeof code === "string" ? code : null;
+}

--- a/packages/server/src/whatsapp/proactive-delivery.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.ts
@@ -1,6 +1,7 @@
 import type { createConversationRepository } from "../db/repositories/conversations";
 import type { createInboxMessagesRepository } from "../db/repositories/inbox-messages";
 import type { Logger } from "../logger";
+import { WHATSAPP_TEXT_LIMIT, chunkText } from "./chunking";
 import type { WhatsAppSendResult, WhatsAppTarget } from "./provider";
 import type { WhatsAppRuntime } from "./runtime";
 import { buildTaskNudgeTemplate } from "./templates";
@@ -12,9 +13,15 @@ const FALLBACK_PROVIDER_CODES = new Set(["contact_not_found", "window_expired"])
 
 export type ProactiveDeliveryMode = "text" | "nudge" | "parked";
 
+export interface ProactiveDeliveryTextSend {
+  text: string;
+  sent: WhatsAppSendResult | null;
+}
+
 export interface ProactiveDeliveryResult {
   mode: ProactiveDeliveryMode;
   sent: WhatsAppSendResult | null;
+  textSends: ProactiveDeliveryTextSend[];
   inboxMessageId?: string | undefined;
 }
 
@@ -36,13 +43,13 @@ export interface DeliverProactiveDmParams {
 
 export async function deliverProactiveDm(params: DeliverProactiveDmParams): Promise<ProactiveDeliveryResult> {
   if (params.target.kind === "group") {
-    const sent = await params.whatsapp.sendText(params.target, params.text);
-    return { mode: "text", sent };
+    const textSends = await sendTextChunks(params);
+    return { mode: "text", sent: lastSent(textSends), textSends };
   }
 
   if (!params.whatsapp.getCapabilities(params.target).templates) {
-    const sent = await params.whatsapp.sendText(params.target, params.text);
-    return { mode: "text", sent };
+    const textSends = await sendTextChunks(params);
+    return { mode: "text", sent: lastSent(textSends), textSends };
   }
 
   const lastInbound = await params.conversations.findLatestInboundWhatsAppDmFromRecipient({
@@ -52,8 +59,8 @@ export async function deliverProactiveDm(params: DeliverProactiveDmParams): Prom
 
   if (lastInbound && isInsideCustomerServiceWindow(lastInbound, params.now ?? new Date())) {
     try {
-      const sent = await params.whatsapp.sendText(params.target, params.text);
-      return { mode: "text", sent };
+      const textSends = await sendTextChunks(params);
+      return { mode: "text", sent: lastSent(textSends), textSends };
     } catch (err) {
       if (!shouldParkAfterTextError(err)) throw err;
       return parkThenNudge(params);
@@ -90,14 +97,33 @@ async function parkThenNudge(params: DeliverProactiveDmParams): Promise<Proactiv
       },
       "WhatsApp proactive delivery parked without duplicate nudge",
     );
-    return { mode: "parked", sent: null, inboxMessageId: inboxMessage.id };
+    return { mode: "parked", sent: null, textSends: [], inboxMessageId: inboxMessage.id };
   }
 
   const sent = await params.whatsapp.sendTemplate(
     params.target,
     buildTaskNudgeTemplate({ recipientName: params.recipientName }),
   );
-  return { mode: "nudge", sent, inboxMessageId: inboxMessage.id };
+  return { mode: "nudge", sent, textSends: [], inboxMessageId: inboxMessage.id };
+}
+
+async function sendTextChunks(
+  params: Pick<DeliverProactiveDmParams, "target" | "text" | "whatsapp">,
+): Promise<ProactiveDeliveryTextSend[]> {
+  const textSends: ProactiveDeliveryTextSend[] = [];
+  for (const chunk of chunkText(params.text, WHATSAPP_TEXT_LIMIT)) {
+    const sent = await params.whatsapp.sendText(params.target, chunk);
+    textSends.push({ text: chunk, sent });
+  }
+  return textSends;
+}
+
+function lastSent(textSends: ProactiveDeliveryTextSend[]): WhatsAppSendResult | null {
+  for (let index = textSends.length - 1; index >= 0; index--) {
+    const sent = textSends[index]?.sent;
+    if (sent) return sent;
+  }
+  return null;
 }
 
 function isInsideCustomerServiceWindow(

--- a/packages/server/src/whatsapp/proactive-delivery.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.ts
@@ -18,6 +18,18 @@ export interface ProactiveDeliveryTextSend {
   sent: WhatsAppSendResult | null;
 }
 
+export class ProactiveDeliveryTextSendError extends Error {
+  readonly cause: unknown;
+  readonly textSends: ProactiveDeliveryTextSend[];
+
+  constructor(cause: unknown, textSends: ProactiveDeliveryTextSend[]) {
+    super(cause instanceof Error ? cause.message : "WhatsApp text send failed");
+    this.name = "ProactiveDeliveryTextSendError";
+    this.cause = cause;
+    this.textSends = textSends;
+  }
+}
+
 export interface ProactiveDeliveryResult {
   mode: ProactiveDeliveryMode;
   sent: WhatsAppSendResult | null;
@@ -32,7 +44,7 @@ export interface DeliverProactiveDmParams {
   text: string;
   whatsapp: Pick<WhatsAppRuntime, "getCapabilities" | "sendText" | "sendTemplate">;
   conversations: Pick<ReturnType<typeof createConversationRepository>, "findLatestInboundWhatsAppDmFromRecipient">;
-  inboxMessages: Pick<ReturnType<typeof createInboxMessagesRepository>, "create" | "hasPendingForRecipientByKind">;
+  inboxMessages: Pick<ReturnType<typeof createInboxMessagesRepository>, "create" | "listPendingForRecipientByKind">;
   logger: Pick<Logger, "debug">;
   recipientName?: string | null | undefined;
   recipientPhoneE164?: string | null | undefined;
@@ -72,10 +84,6 @@ export async function deliverProactiveDm(params: DeliverProactiveDmParams): Prom
 
 async function parkThenNudge(params: DeliverProactiveDmParams): Promise<ProactiveDeliveryResult> {
   const kind = params.inboxKind ?? WORKFLOW_OUTPUT_INBOX_KIND;
-  const hadPendingWorkflowOutput = await params.inboxMessages.hasPendingForRecipientByKind(
-    params.recipientUserId,
-    kind,
-  );
   const inboxMessage = await params.inboxMessages.create({
     senderUserId: params.senderUserId,
     recipientUserId: params.recipientUserId,
@@ -87,7 +95,7 @@ async function parkThenNudge(params: DeliverProactiveDmParams): Promise<Proactiv
     channelId: params.target.kind === "dm" ? params.target.phoneE164 : params.target.groupId,
   });
 
-  if (hadPendingWorkflowOutput) {
+  if (!(await shouldSendNudgeForInboxMessage(params, kind, inboxMessage.id))) {
     params.logger.debug(
       {
         recipientUserId: params.recipientUserId,
@@ -107,13 +115,32 @@ async function parkThenNudge(params: DeliverProactiveDmParams): Promise<Proactiv
   return { mode: "nudge", sent, textSends: [], inboxMessageId: inboxMessage.id };
 }
 
+/**
+ * The nudge winner is the earliest unconsumed and unresolved row ordered by
+ * created_at, then id. Each delivery inserts its durable inbox row before this
+ * read, so concurrent contenders that can see the same pending set choose the
+ * same winner without dialect-specific locks or unique constraints.
+ */
+async function shouldSendNudgeForInboxMessage(
+  params: DeliverProactiveDmParams,
+  kind: string,
+  inboxMessageId: string,
+): Promise<boolean> {
+  const pending = await params.inboxMessages.listPendingForRecipientByKind(params.recipientUserId, kind);
+  return pending[0]?.id === inboxMessageId;
+}
+
 async function sendTextChunks(
   params: Pick<DeliverProactiveDmParams, "target" | "text" | "whatsapp">,
 ): Promise<ProactiveDeliveryTextSend[]> {
   const textSends: ProactiveDeliveryTextSend[] = [];
   for (const chunk of chunkText(params.text, WHATSAPP_TEXT_LIMIT)) {
-    const sent = await params.whatsapp.sendText(params.target, chunk);
-    textSends.push({ text: chunk, sent });
+    try {
+      const sent = await params.whatsapp.sendText(params.target, chunk);
+      textSends.push({ text: chunk, sent });
+    } catch (cause) {
+      throw new ProactiveDeliveryTextSendError(cause, textSends);
+    }
   }
   return textSends;
 }
@@ -150,6 +177,7 @@ function shouldParkAfterTextError(error: unknown): boolean {
 }
 
 function providerCodeFromError(error: unknown): string | null {
+  if (error instanceof ProactiveDeliveryTextSendError) return providerCodeFromError(error.cause);
   if (!error || typeof error !== "object" || !("providerCode" in error)) return null;
   const code = (error as { providerCode?: unknown }).providerCode;
   return typeof code === "string" ? code : null;

--- a/packages/server/src/whatsapp/providers/managed.test.ts
+++ b/packages/server/src/whatsapp/providers/managed.test.ts
@@ -4,7 +4,11 @@ import { createWhatsAppTemplateMappingRepository } from "../../db/repositories/w
 import { createTestDb, createTestLogger } from "../../test-utils";
 import type { WhatsAppInboundMessage } from "../provider";
 import { WHATSAPP_TEMPLATE_KEYS } from "../templates";
-import { InvalidManagedWhatsAppInboundEventError, createManagedWhatsAppProvider } from "./managed";
+import {
+  InvalidManagedWhatsAppInboundEventError,
+  ManagedWhatsAppRequestError,
+  createManagedWhatsAppProvider,
+} from "./managed";
 
 function inboundPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -106,6 +110,75 @@ describe("managed WhatsApp provider", () => {
     );
   });
 
+  it("exposes providerCode from structured platform failures", async () => {
+    const requestFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "SEND_FAILED",
+              message: "Window expired",
+              providerCode: "window_expired",
+              providerInfo: "wati detail",
+            },
+          }),
+          { status: 502 },
+        ),
+    );
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    await expect(
+      provider.dmProvider.sendText({ kind: "dm", phoneE164: "+15551234567" }, "hello"),
+    ).rejects.toMatchObject({
+      status: 502,
+      providerCode: "window_expired",
+      providerInfo: "wati detail",
+    });
+  });
+
+  it("tolerates structured platform failures without providerCode", async () => {
+    const requestFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { code: "SEND_FAILED", message: "Provider rejected" } }), { status: 502 }),
+    );
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    try {
+      await provider.dmProvider.sendText({ kind: "dm", phoneE164: "+15551234567" }, "hello");
+      throw new Error("expected send to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ManagedWhatsAppRequestError);
+      expect((error as ManagedWhatsAppRequestError).providerCode).toBeUndefined();
+      expect((error as ManagedWhatsAppRequestError).message).toContain("Provider rejected");
+    }
+  });
+
+  it("tolerates malformed JSON platform failures", async () => {
+    const requestFetch = vi.fn(async () => new Response("{not-json", { status: 502 }));
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    await expect(
+      provider.dmProvider.sendText({ kind: "dm", phoneE164: "+15551234567" }, "hello"),
+    ).rejects.toMatchObject({
+      status: 502,
+      providerCode: undefined,
+    });
+  });
   it("includes a bounded platform error response snippet in outbound failures", async () => {
     const requestFetch = vi.fn(async () => new Response(`platform failed ${"x".repeat(800)}`, { status: 502 }));
     const provider = createManagedWhatsAppProvider({

--- a/packages/server/src/whatsapp/providers/managed.ts
+++ b/packages/server/src/whatsapp/providers/managed.ts
@@ -12,6 +12,7 @@ import {
   type WhatsAppTarget,
   canonicalDmConversationId,
 } from "../provider";
+import { mapTemplateParams } from "../template-params";
 import type { WhatsAppTemplateParamValue, WhatsAppTemplateRequest } from "../templates";
 
 export const WHATSAPP_MANAGED_PROVIDER_ID = "managed";
@@ -91,6 +92,20 @@ export class InvalidManagedWhatsAppInboundEventError extends Error {
   constructor(readonly issues: z.ZodIssue[]) {
     super("Invalid managed WhatsApp inbound event");
     this.name = "InvalidManagedWhatsAppInboundEventError";
+  }
+}
+
+export class ManagedWhatsAppRequestError extends Error {
+  readonly status: number;
+  readonly providerCode?: string;
+  readonly providerInfo?: string;
+
+  constructor(message: string, params: { status: number; providerCode?: string | null; providerInfo?: string | null }) {
+    super(message);
+    this.name = "ManagedWhatsAppRequestError";
+    this.status = params.status;
+    if (params.providerCode) this.providerCode = params.providerCode;
+    if (params.providerInfo) this.providerInfo = params.providerInfo;
   }
 }
 
@@ -264,8 +279,7 @@ async function fetchManagedJson(requestFetch: typeof fetch, url: string, init: R
   const text = await response.text().catch(() => "");
 
   if (!response.ok) {
-    const snippet = boundedResponseSnippet(text);
-    throw new Error(`Managed WhatsApp request failed: HTTP ${response.status}${snippet ? `: ${snippet}` : ""}`);
+    throw managedRequestError(response.status, text);
   }
 
   if (!text) return null;
@@ -292,15 +306,30 @@ function providerTemplateParamRecord(
   parameterMap: Record<string, string> | null,
   params: Record<string, WhatsAppTemplateParamValue>,
 ): Record<string, string> {
-  const entries = parameterMap ? Object.entries(parameterMap) : Object.keys(params).map((key) => [key, key]);
-  return Object.fromEntries(
-    entries.map(([providerName, logicalName]) => [providerName, stringifyTemplateParam(params[logicalName])]),
+  return Object.fromEntries(mapTemplateParams(parameterMap, params));
+}
+
+function managedRequestError(status: number, text: string): ManagedWhatsAppRequestError {
+  const parsed = parseJsonObject(text);
+  const error = parsed && isRecord(parsed.error) ? parsed.error : null;
+  const providerMessage = optionalString(error?.message);
+  const providerCode = optionalString(error?.providerCode);
+  const providerInfo = optionalString(error?.providerInfo);
+  const snippet = boundedResponseSnippet(providerMessage ?? text);
+  return new ManagedWhatsAppRequestError(
+    `Managed WhatsApp request failed: HTTP ${status}${snippet ? `: ${snippet}` : ""}`,
+    { status, providerCode, providerInfo },
   );
 }
 
-function stringifyTemplateParam(value: WhatsAppTemplateParamValue): string {
-  if (value == null) return "";
-  return String(value);
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function boundedResponseSnippet(text: string): string {

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -19,6 +19,7 @@ import {
   type WhatsAppTarget,
   canonicalDmConversationId,
 } from "../provider";
+import { mapTemplateParams } from "../template-params";
 import type { WhatsAppTemplateParamValue, WhatsAppTemplateRequest } from "../templates";
 
 export const WHATSAPP_WATI_PROVIDER_ID = "wati";
@@ -493,16 +494,10 @@ function providerTemplateParameters(
   parameterMap: Record<string, string> | null,
   params: Record<string, WhatsAppTemplateParamValue>,
 ): Array<{ name: string; value: string }> {
-  const entries = parameterMap ? Object.entries(parameterMap) : Object.keys(params).map((key) => [key, key]);
-  return entries.map(([providerName, logicalName]) => ({
+  return mapTemplateParams(parameterMap, params).map(([providerName, value]) => ({
     name: providerName,
-    value: stringifyTemplateParam(params[logicalName]),
+    value,
   }));
-}
-
-function stringifyTemplateParam(value: WhatsAppTemplateParamValue): string {
-  if (value == null) return "";
-  return String(value);
 }
 
 function buildBroadcastName(key: string): string {

--- a/packages/server/src/whatsapp/runtime.ts
+++ b/packages/server/src/whatsapp/runtime.ts
@@ -1,6 +1,7 @@
 import type { Logger } from "../logger";
 import {
   WHATSAPP_NONE_PROVIDER_ID,
+  type WhatsAppCapabilities,
   type WhatsAppDmProvider,
   type WhatsAppDmProviderId,
   type WhatsAppGroupMetadata,
@@ -18,6 +19,7 @@ import type { WhatsAppTemplateRequest } from "./templates";
 export interface WhatsAppRuntime {
   isConnected: boolean;
   onMessage(handler: WhatsAppMessageHandler): void;
+  getCapabilities(target: WhatsAppTarget): WhatsAppCapabilities;
   sendText(target: WhatsAppTarget, text: string, options?: WhatsAppSendOptions): Promise<WhatsAppSendResult | null>;
   sendTemplate(target: WhatsAppTarget, template: WhatsAppTemplateRequest): Promise<WhatsAppSendResult | null>;
   sendFile(target: WhatsAppTarget, filePath: string, mimeType: string, fileName: string): Promise<void>;
@@ -90,6 +92,10 @@ export function createWhatsAppRuntime(config: WhatsAppRuntimeConfig): WhatsAppRu
           await handler(message);
         });
       }
+    },
+
+    getCapabilities(target) {
+      return resolveProviderForTarget(target).capabilities;
     },
 
     async sendText(target, text, options) {

--- a/packages/server/src/whatsapp/template-params.test.ts
+++ b/packages/server/src/whatsapp/template-params.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeTemplateParamValue } from "./template-params";
+
+describe("sanitizeTemplateParamValue", () => {
+  it("replaces newlines and tabs with spaces", () => {
+    expect(sanitizeTemplateParamValue("a\nb\rc\td")).toBe("a b c d");
+  });
+
+  it("collapses runs of three or more spaces to two spaces", () => {
+    expect(sanitizeTemplateParamValue("a   b    c  d")).toBe("a  b  c  d");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(sanitizeTemplateParamValue("  hello world  ")).toBe("hello world");
+  });
+
+  it("truncates to 300 characters", () => {
+    expect(
+      sanitizeTemplateParamValue(
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      ),
+    ).toHaveLength(300);
+  });
+
+  it("applies all transformations together", () => {
+    const input =
+      "  first\n\tsecond      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  ";
+    const result = sanitizeTemplateParamValue(input);
+
+    expect(result).toHaveLength(300);
+    expect(result.startsWith("first second  xxx")).toBe(true);
+    expect(result).not.toMatch(/[\n\r\t]/u);
+    expect(result).not.toMatch(/ {3,}/u);
+  });
+});

--- a/packages/server/src/whatsapp/template-params.ts
+++ b/packages/server/src/whatsapp/template-params.ts
@@ -1,0 +1,18 @@
+import type { WhatsAppTemplateParamValue } from "./templates";
+
+export function sanitizeTemplateParamValue(value: WhatsAppTemplateParamValue): string {
+  if (value == null) return "";
+  return String(value)
+    .replace(/[\n\r\t]+/gu, " ")
+    .replace(/ {3,}/gu, "  ")
+    .trim()
+    .slice(0, 300);
+}
+
+export function mapTemplateParams(
+  parameterMap: Record<string, string> | null,
+  params: Record<string, WhatsAppTemplateParamValue>,
+): Array<[string, string]> {
+  const entries = parameterMap ? Object.entries(parameterMap) : Object.keys(params).map((key) => [key, key]);
+  return entries.map(([providerName, logicalName]) => [providerName, sanitizeTemplateParamValue(params[logicalName])]);
+}

--- a/packages/server/src/whatsapp/templates.ts
+++ b/packages/server/src/whatsapp/templates.ts
@@ -1,5 +1,6 @@
 export const WHATSAPP_TEMPLATE_KEYS = {
   proactiveUpdate: "whatsapp.proactive_update",
+  taskNudge: "whatsapp.task_nudge",
   magicLink: "whatsapp.magic_link",
   introduction: "whatsapp.introduction",
 } as const;
@@ -30,6 +31,20 @@ export function buildProactiveUpdateTemplate(params: {
       messageSummary: params.messageSummary,
     },
     fallbackText: params.fallbackText ?? params.messageSummary,
+    language: params.language,
+  };
+}
+
+export function buildTaskNudgeTemplate(params: {
+  recipientName?: string | null;
+  language?: string;
+}): WhatsAppTemplateRequest {
+  return {
+    key: WHATSAPP_TEMPLATE_KEYS.taskNudge,
+    params: {
+      recipientName: params.recipientName ?? "there",
+    },
+    fallbackText: "Sketch just finished running one of your scheduled tasks. Reply to see the details.",
     language: params.language,
   };
 }


### PR DESCRIPTION
## What

SKE-262 (tenant half). Proactive WhatsApp DMs (scheduler reminders, workflow/automation outputs, agent-output deliveries, user-to-user messages) now try a normal session message first and only fall back to a template when WhatsApp's 24-hour customer-service window is closed.

- New `deliverProactiveDm` helper: Baileys/group passthrough → 23h window check against `conversation_messages` (last non-bot inbound) → chunked session text in-window → park-in-inbox + static nudge template out-of-window.
- Inbox row (existing `inbox_messages` mechanism, `workflow_output` kind, auto-consume) is written BEFORE the nudge, so delivery self-heals on the user's next message even if the nudge fails. Multiple pending outputs get a single nudge.
- New logical template `whatsapp.task_nudge` (maps to approved Wati template `utility_reminder_message`, one name param — no content interpolation, eliminating the newline-rejection failure breaking daily digests in production).
- Managed provider parses the platform's new `providerCode` (sketch-platform PR #52); `contact_not_found`/`window_expired` trigger the park+nudge fallback.
- Defensive single-line sanitization of all template params in both Wati and managed providers.

## Why

WhatsApp templates reject params containing newlines, so every multi-line proactive output failed (Goosebumps daily digests, prod). Session messages carry full multi-line content and cost nothing extra — templates are only required outside the 24h window. Design + evidence: SKE-262.

## Testing

`pnpm typecheck` / `pnpm test` (2968 + 316 passed) / `pnpm build` green. Decision-matrix tests for the helper (window open/closed, no history, chunking, nudge dedupe, providerCode fallback), PGlite integration test for the window query, per-chunk capture tests in output-delivery, updated tests across all four call sites. Rebased onto main preserving the User-Agent fix (#293) and the summarizer merge (#289).