### PR TITLE
fix: preserve scoped person matching in name dedup

### DIFF
--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -517,6 +517,7 @@ export async function handleCandidates(
           {
             entityRepo: materializeDeps.entityRepo,
             reviewRepo: materializeDeps.reviewRepo,
+            domainsRepo: materializeDeps.domainsRepo,
             lookup: materializeDeps.lookup,
             readEmail: materializeDeps.readEmail,
           },

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -1307,6 +1307,49 @@ export function createEntityRepository(db: Kysely<DB>) {
         .executeTakeFirstOrThrow();
     },
 
+    async createPersonEntity(data: UpsertPersonEntityData) {
+      const id = randomUUID();
+      const now = new Date().toISOString();
+      const metadata = data.email ? { email: data.email } : {};
+      const initialAliases = data.email ? JSON.stringify([data.email]) : null;
+
+      await db
+        .insertInto("entities")
+        .values({
+          id,
+          name: data.name,
+          source_type: "person",
+          subtype: data.subtype,
+          aliases: initialAliases,
+          metadata: JSON.stringify(metadata),
+          source_ref_id: null,
+          status: "confirmed",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+
+      await db
+        .insertInto("entity_source_refs")
+        .values({
+          id: randomUUID(),
+          entity_id: id,
+          source: data.source,
+          source_id: data.sourceId,
+          source_url: null,
+          last_seen_at: now,
+        })
+        .execute();
+
+      return await db
+        .selectFrom("entities")
+        .selectAll()
+        .where("id", "=", id)
+        .where(whereLiveEntity())
+        .executeTakeFirstOrThrow();
+    },
+
     // ── Archive / Cleanup ──
 
     async archiveEntitiesForArchivedFiles() {

--- a/packages/server/src/db/repositories/entity-domains.ts
+++ b/packages/server/src/db/repositories/entity-domains.ts
@@ -200,6 +200,19 @@ export function createEntityDomainsRepository(db: Kysely<DB>) {
       return (row ?? null) as EntitiesTable | null;
     },
 
+    async getCompanyIdsByDomain(domain: string): Promise<string[]> {
+      const rows = await db
+        .selectFrom("entity_domains")
+        .innerJoin("entities", "entities.id", "entity_domains.entity_id")
+        .select("entity_domains.entity_id")
+        .where("entity_domains.domain", "=", domain.toLowerCase())
+        .where("entity_domains.kind", "=", "corporate")
+        .where("entity_domains.entity_id", "is not", null)
+        .where(whereLiveEntity())
+        .execute();
+      return rows.flatMap((row) => (row.entity_id ? [row.entity_id] : []));
+    },
+
     async upsertDomain(input: UpsertDomainInput): Promise<void> {
       const existing = await db
         .selectFrom("entity_domains")

--- a/packages/server/src/entities/affiliations.test.ts
+++ b/packages/server/src/entities/affiliations.test.ts
@@ -432,11 +432,12 @@ describe("ELP-02: affiliation inference", () => {
     // test 18 — recreate must reproduce the same graph shape (one promoted
     // company, one corporate domain row, five works_at edges) as live sync
     // crossing the threshold organically.
-    for (let i = 0; i < 5; i++) {
+    const names = ["Charlie Adams", "Priya Rao", "Mateo Silva", "Noor Khan", "Elena Ivers"];
+    for (let i = 0; i < names.length; i++) {
       const fileId = await seedFile(db, `charlie-file-${i}`);
       await seedPersonSeedFact(db, {
         fileId,
-        name: `Charlie Person ${i}`,
+        name: names[i],
         email: `person${i}@charlie.com`,
         sourceId: `charlie-${i}`,
       });
@@ -511,11 +512,12 @@ describe("ELP-02: affiliation inference", () => {
       })
       .execute();
 
-    for (let i = 0; i < 5; i++) {
+    const names = ["Manual Charlie", "Iris Quinn", "Omar Reed", "Lina Soto", "Victor Tan"];
+    for (let i = 0; i < names.length; i++) {
       const fileId = await seedFile(db, `manual-charlie-file-${i}`);
       await seedPersonSeedFact(db, {
         fileId,
-        name: `Manual Charlie Person ${i}`,
+        name: names[i],
         email: `manual${i}@charlie.com`,
         sourceId: `manual-charlie-${i}`,
       });

--- a/packages/server/src/entities/affiliations.ts
+++ b/packages/server/src/entities/affiliations.ts
@@ -21,6 +21,28 @@ export interface InferAffiliationInput {
   firstObservedByUserId?: string | null;
 }
 
+export type PersonScopeKey = { kind: "company"; value: string } | { kind: "domain"; value: string };
+
+export function personScopeKeyId(scope: PersonScopeKey): string {
+  return `${scope.kind}:${scope.value}`;
+}
+
+export function isTrustedPersonScopeKey(scopeKey: string): boolean {
+  return scopeKey.startsWith("company:");
+}
+
+export async function personScopeKey(
+  email: string | null | undefined,
+  domainsRepo: EntityDomainsRepository,
+): Promise<PersonScopeKey | null> {
+  const domain = domainsRepo.normalizeEmailDomain(email);
+  if (!domain) return null;
+  if (await domainsRepo.isPersonalOrShared(domain)) return null;
+  const companyIds = await domainsRepo.getCompanyIdsByDomain(domain);
+  if (companyIds.length > 0) return { kind: "company", value: [...companyIds].sort()[0] };
+  return { kind: "domain", value: domain };
+}
+
 /**
  * Role-account local-parts: shared mailboxes, not real people. A single
  * `hello@stripe.com` notification email should NOT promote Stripe as a

--- a/packages/server/src/entities/domain-promotion.ts
+++ b/packages/server/src/entities/domain-promotion.ts
@@ -216,6 +216,7 @@ export async function sweepDomainPromotions(db: Kysely<DB>, logger: Logger): Pro
       {
         entityRepo,
         reviewRepo: createEntityReviewRepo(db),
+        domainsRepo,
         lookup,
         readEmail,
       },

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -15,6 +15,7 @@ import {
   buildCandidatePool,
   findFuzzyMatches,
   findStrictMatches,
+  findTokenSetMatches,
   removeFromCandidatePool,
 } from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
@@ -239,19 +240,25 @@ export async function buildMaterializeDeps(
       const entitiesById = new Map((index.entitiesByType.get(entityType) ?? []).map((entity) => [entity.id, entity]));
       const strict = findStrictMatches(name, pool);
       const strictEntityIds = new Set(strict.map((match) => match.entityId));
+      const tokenSet = findTokenSetMatches(name, pool);
+      const tokenSetEntityIds = new Set(tokenSet.map((match) => match.entityId));
       const fuzzy = findFuzzyMatches(name, pool);
       const byEntity = new Map<
         string,
         {
           entity: EntityRow;
           score: number;
-          reason: "strict-normalized" | "minhash";
+          reason: "strict-normalized" | "token-set" | "minhash";
         }
       >();
-      for (const match of [...strict, ...fuzzy]) {
+      for (const match of [...strict, ...tokenSet, ...fuzzy]) {
         const entity = entitiesById.get(match.entityId);
         if (!entity) continue;
-        const reason = strictEntityIds.has(match.entityId) ? "strict-normalized" : "minhash";
+        const reason = strictEntityIds.has(match.entityId)
+          ? "strict-normalized"
+          : tokenSetEntityIds.has(match.entityId)
+            ? "token-set"
+            : "minhash";
         const existing = byEntity.get(match.entityId);
         if (!existing || match.score > existing.score)
           byEntity.set(match.entityId, { entity, score: match.score, reason });

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -9,6 +9,14 @@ import type { DB } from "../db/schema";
 import { type MentionType, normalizeMentionType } from "./graph";
 import { parseAliasesString, readJsonObject, readPersonEmailFromMetadata } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, LookupIndex, MaterializeDeps } from "./materialize-types";
+import {
+  type CandidatePoolEntry,
+  addToCandidatePool,
+  buildCandidatePool,
+  findFuzzyMatches,
+  findStrictMatches,
+  removeFromCandidatePool,
+} from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
 
 const DEFAULT_LLM_PROMOTION_THRESHOLD = 2;
@@ -48,9 +56,12 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
   for (const t of supportedTypes) entitiesByType.set(t, []);
   const byNormalizedName = new Map<string, EntityRow[]>();
   const byNormalizedAlias = new Map<string, EntityRow[]>();
+  const dedupEntriesByType = new Map<ProposeEntityType, CandidatePoolEntry[]>();
+  for (const t of supportedTypes) dedupEntriesByType.set(t, []);
   for (const e of entities) {
     const entityType = e.source_type as ProposeEntityType;
     entitiesByType.get(entityType)?.push(e);
+    dedupEntriesByType.get(entityType)?.push({ entityId: e.id, valueKind: "name", value: e.name });
     const nameKey = normalizeEntityMatchName(entityType, e.name);
     if (nameKey) {
       const bucket = byNormalizedName.get(nameKey);
@@ -58,6 +69,7 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
       else byNormalizedName.set(nameKey, [e]);
     }
     for (const alias of parseAliasesString(e.aliases)) {
+      dedupEntriesByType.get(entityType)?.push({ entityId: e.id, valueKind: "alias", value: alias });
       const aliasKey = normalizeEntityMatchName(entityType, alias);
       if (!aliasKey) continue;
       const bucket = byNormalizedAlias.get(aliasKey);
@@ -91,7 +103,9 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
     if (bucket) bucket.push(row.entity_id);
     else companyIdsByDomain.set(domain, [row.entity_id]);
   }
-  return { entitiesByType, byNormalizedName, byNormalizedAlias, bySourceRef, companyIdsByDomain };
+  const dedupPoolsByType = new Map<ProposeEntityType, ReturnType<typeof buildCandidatePool>>();
+  for (const t of supportedTypes) dedupPoolsByType.set(t, buildCandidatePool(dedupEntriesByType.get(t) ?? []));
+  return { entitiesByType, byNormalizedName, byNormalizedAlias, dedupPoolsByType, bySourceRef, companyIdsByDomain };
 }
 
 export function registerEntity(index: LookupIndex, entity: EntityRow): void {
@@ -118,6 +132,17 @@ export function registerEntity(index: LookupIndex, entity: EntityRow): void {
       index.byNormalizedAlias.set(aliasKey, [entity]);
     }
   }
+  const pool = index.dedupPoolsByType.get(entityType);
+  if (pool) {
+    addToCandidatePool(pool, [
+      { entityId: entity.id, valueKind: "name", value: entity.name },
+      ...parseAliasesString(entity.aliases).map((value) => ({
+        entityId: entity.id,
+        valueKind: "alias" as const,
+        value,
+      })),
+    ]);
+  }
 }
 
 function removeEntityFromMapBuckets<T extends EntityRow>(map: Map<string, T[]>, entityId: string): void {
@@ -135,6 +160,9 @@ function unregisterEntity(index: LookupIndex, entityId: string): void {
   }
   removeEntityFromMapBuckets(index.byNormalizedName, entityId);
   removeEntityFromMapBuckets(index.byNormalizedAlias, entityId);
+  for (const pool of index.dedupPoolsByType.values()) {
+    removeFromCandidatePool(pool, entityId);
+  }
 }
 
 function llmFileCountKey(normalizedName: string, mentionType: MentionType): string {
@@ -205,6 +233,31 @@ export async function buildMaterializeDeps(
     getByNormalizedName: (n) => index.byNormalizedName.get(n) ?? [],
     getByAlias: (n) => index.byNormalizedAlias.get(n) ?? [],
     listByType: (t: ProposeEntityType) => index.entitiesByType.get(t) ?? [],
+    findNameDedupCandidates: (entityType, name) => {
+      const pool = index.dedupPoolsByType.get(entityType);
+      if (!pool) return [];
+      const entitiesById = new Map((index.entitiesByType.get(entityType) ?? []).map((entity) => [entity.id, entity]));
+      const strict = findStrictMatches(name, pool);
+      const strictEntityIds = new Set(strict.map((match) => match.entityId));
+      const fuzzy = findFuzzyMatches(name, pool);
+      const byEntity = new Map<
+        string,
+        {
+          entity: EntityRow;
+          score: number;
+          reason: "strict-normalized" | "minhash";
+        }
+      >();
+      for (const match of [...strict, ...fuzzy]) {
+        const entity = entitiesById.get(match.entityId);
+        if (!entity) continue;
+        const reason = strictEntityIds.has(match.entityId) ? "strict-normalized" : "minhash";
+        const existing = byEntity.get(match.entityId);
+        if (!existing || match.score > existing.score)
+          byEntity.set(match.entityId, { entity, score: match.score, reason });
+      }
+      return [...byEntity.values()].sort((a, b) => b.score - a.score || a.entity.id.localeCompare(b.entity.id));
+    },
     getCompanyIdsByDomain: (domain) => index.companyIdsByDomain.get(domain.toLowerCase()) ?? [],
   };
 

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -6,6 +6,7 @@ import { createEntityDomainsRepository } from "../db/repositories/entity-domains
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
 import { createEntitySuppressionRepository } from "../db/repositories/entity-suppressions";
 import type { DB } from "../db/schema";
+import { personScopeKey, personScopeKeyId } from "./affiliations";
 import { type MentionType, normalizeMentionType } from "./graph";
 import { parseAliasesString, readJsonObject, readPersonEmailFromMetadata } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, LookupIndex, MaterializeDeps } from "./materialize-types";
@@ -106,10 +107,51 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
   }
   const dedupPoolsByType = new Map<ProposeEntityType, ReturnType<typeof buildCandidatePool>>();
   for (const t of supportedTypes) dedupPoolsByType.set(t, buildCandidatePool(dedupEntriesByType.get(t) ?? []));
-  return { entitiesByType, byNormalizedName, byNormalizedAlias, dedupPoolsByType, bySourceRef, companyIdsByDomain };
+  const personScopeKeysByEntityId = await buildPersonScopeKeys(
+    db,
+    entities.filter((entity) => entity.source_type === "person"),
+  );
+  return {
+    entitiesByType,
+    byNormalizedName,
+    byNormalizedAlias,
+    dedupPoolsByType,
+    bySourceRef,
+    companyIdsByDomain,
+    personScopeKeysByEntityId,
+  };
+}
+
+async function buildPersonScopeKeys(db: Kysely<DB>, persons: EntityRow[]): Promise<Map<string, string[]>> {
+  const scopeKeys = new Map<string, Set<string>>();
+  for (const person of persons) scopeKeys.set(person.id, new Set());
+  const domainsRepo = createEntityDomainsRepository(db);
+  for (const person of persons) {
+    const email = readPersonEmailFromMetadata(person.metadata);
+    const scope = await personScopeKey(email, domainsRepo);
+    if (scope) scopeKeys.get(person.id)?.add(personScopeKeyId(scope));
+  }
+
+  const personIds = persons.map((person) => person.id);
+  const worksAtRows =
+    personIds.length > 0
+      ? await db
+          .selectFrom("entity_relationships")
+          .select(["source_entity_id", "target_entity_id"])
+          .where("relationship_type", "=", "works_at")
+          .where("source_entity_id", "in", personIds)
+          .where("valid_to", "is", null)
+          .execute()
+      : [];
+  for (const row of worksAtRows) {
+    scopeKeys.get(row.source_entity_id)?.add(personScopeKeyId({ kind: "company", value: row.target_entity_id }));
+  }
+
+  return new Map([...scopeKeys].map(([entityId, keys]) => [entityId, [...keys]]));
 }
 
 export function registerEntity(index: LookupIndex, entity: EntityRow): void {
+  const existingPersonScopeKeys = index.personScopeKeysByEntityId.get(entity.id);
   unregisterEntity(index, entity.id);
   const entityType = entity.source_type as ProposeEntityType;
   const typeBucket = index.entitiesByType.get(entityType);
@@ -144,6 +186,9 @@ export function registerEntity(index: LookupIndex, entity: EntityRow): void {
       })),
     ]);
   }
+  if (entityType === "person" && existingPersonScopeKeys) {
+    index.personScopeKeysByEntityId.set(entity.id, existingPersonScopeKeys);
+  }
 }
 
 function removeEntityFromMapBuckets<T extends EntityRow>(map: Map<string, T[]>, entityId: string): void {
@@ -164,6 +209,7 @@ function unregisterEntity(index: LookupIndex, entityId: string): void {
   for (const pool of index.dedupPoolsByType.values()) {
     removeFromCandidatePool(pool, entityId);
   }
+  index.personScopeKeysByEntityId.delete(entityId);
 }
 
 function llmFileCountKey(normalizedName: string, mentionType: MentionType): string {
@@ -205,6 +251,9 @@ export async function refreshResolvedEntityIndex(db: Kysely<DB>, index: LookupIn
     if (indexedEntity.id === entity.id) index.bySourceRef.delete(key);
   }
   registerEntity(index, row);
+  const scopeKeys = await buildPersonScopeKeys(db, row.source_type === "person" ? [row] : []);
+  const personScopeKeys = scopeKeys.get(row.id);
+  if (personScopeKeys) index.personScopeKeysByEntityId.set(row.id, personScopeKeys);
   for (const ref of sourceRefs) {
     index.bySourceRef.set(`${ref.source}:${ref.source_id}`, row);
   }
@@ -266,6 +315,7 @@ export async function buildMaterializeDeps(
       return [...byEntity.values()].sort((a, b) => b.score - a.score || a.entity.id.localeCompare(b.entity.id));
     },
     getCompanyIdsByDomain: (domain) => index.companyIdsByDomain.get(domain.toLowerCase()) ?? [],
+    getPersonScopeKeys: (entityId) => index.personScopeKeysByEntityId.get(entityId) ?? [],
   };
 
   const fileToConnector = new Map<string, string>();

--- a/packages/server/src/entities/materialize-llm-mentions.ts
+++ b/packages/server/src/entities/materialize-llm-mentions.ts
@@ -54,6 +54,7 @@ export async function materializeNonPersonLlmEntity(
     {
       entityRepo: deps.entityRepo,
       reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-person-scope.test.ts
+++ b/packages/server/src/entities/materialize-person-scope.test.ts
@@ -144,6 +144,31 @@ describe("materializePersonSeed company-scoped dedup", () => {
     expect(await people(db)).toHaveLength(2);
   });
 
+  it("preserves the matching company-scoped person when linking a new source ref", async () => {
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+    await createCompanyWithDomain(db, "company-globex", "Globex", "globex.com");
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@globex.com", sourceId: "person-2" });
+
+    await materializeUnmaterializedFacts(db, createTestLogger());
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish.alt@globex.com", sourceId: "person-3" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    const rows = await people(db);
+    expect(rows).toHaveLength(2);
+    const globexPerson = rows.find((row) => JSON.parse(row.metadata ?? "{}").email === "ashish@globex.com");
+    const sourceRef = await db
+      .selectFrom("entity_source_refs")
+      .selectAll()
+      .where("source", "=", "connector")
+      .where("source_id", "=", "person-3")
+      .executeTakeFirstOrThrow();
+    expect(sourceRef.entity_id).toBe(globexPerson?.id);
+    expect(JSON.parse(globexPerson?.aliases ?? "[]")).toContain("ashish.alt@globex.com");
+  });
+
   it("queues personal, candidate-unscoped, and name-only same-name seeds", async () => {
     const domainsRepo = createEntityDomainsRepository(db);
     await domainsRepo.upsertDomain({ entityId: null, domain: "gmail.com", kind: "personal", source: "test" });

--- a/packages/server/src/entities/materialize-person-scope.test.ts
+++ b/packages/server/src/entities/materialize-person-scope.test.ts
@@ -1,0 +1,188 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import type { DB } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { materializeUnmaterializedFacts } from "./materialize-replay";
+
+const ADMIN_ID = "admin-1";
+const CONNECTOR_ID = "cfg-person-scope";
+
+async function seedFile(db: Kysely<DB>): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: ADMIN_ID,
+      name: "Admin",
+      email: "admin@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "google_drive",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: ADMIN_ID,
+    })
+    .execute();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: "file-1",
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: "file-1",
+      file_name: "file-1",
+      file_type: "doc",
+      content_category: "document",
+      source: "google_drive",
+      content_hash: "hash-1",
+      is_archived: 0,
+      synced_at: now,
+    })
+    .execute();
+}
+
+async function upsertPersonSeed(
+  db: Kysely<DB>,
+  input: { name: string; email?: string | null; sourceId: string },
+): Promise<void> {
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: "file-1",
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: ADMIN_ID,
+    contentHash: "hash-1",
+    source: "connector",
+    factType: "person_seed",
+    relation: "seeded",
+    subjectName: input.name,
+    subjectEmail: input.email ?? null,
+    subjectSource: "connector",
+    subjectSourceId: input.sourceId,
+    raw: { subtype: "external" },
+  });
+}
+
+async function createCompanyWithDomain(db: Kysely<DB>, id: string, name: string, domain: string): Promise<void> {
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: "company",
+      subtype: "external",
+      aliases: null,
+      metadata: "{}",
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .execute();
+  await createEntityDomainsRepository(db).upsertDomain({
+    entityId: id,
+    domain,
+    kind: "corporate",
+    source: "test",
+  });
+}
+
+async function people(db: Kysely<DB>) {
+  return db.selectFrom("entities").selectAll().where("source_type", "=", "person").orderBy("name").execute();
+}
+
+describe("materializePersonSeed company-scoped dedup", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedFile(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("links same-name seeds at the same mapped company even when the incoming email is new", async () => {
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "ASHISH BANKA", email: "ashish.alt@acme.com", sourceId: "person-2" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    expect(await people(db)).toHaveLength(1);
+  });
+
+  it("links same-name seeds at the same unmapped corporate domain using the weak bare-domain scope", async () => {
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "ASHISH BANKA", email: "ashish.alt@acme.com", sourceId: "person-2" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    expect(await people(db)).toHaveLength(1);
+  });
+
+  it("creates a second same-name person when mapped corporate domains point to different companies", async () => {
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+    await createCompanyWithDomain(db, "company-globex", "Globex", "globex.com");
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@acme.com", sourceId: "person-1" });
+    await upsertPersonSeed(db, { name: "Ashish Banka", email: "ashish@globex.com", sourceId: "person-2" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    expect(await people(db)).toHaveLength(2);
+  });
+
+  it("queues personal, candidate-unscoped, and name-only same-name seeds", async () => {
+    const domainsRepo = createEntityDomainsRepository(db);
+    await domainsRepo.upsertDomain({ entityId: null, domain: "gmail.com", kind: "personal", source: "test" });
+    await createCompanyWithDomain(db, "company-acme", "Acme", "acme.com");
+
+    const entityRepo = createEntityRepository(db);
+    await entityRepo.createPersonEntity({
+      name: "Gmail Ashish",
+      email: "ashish@acme.com",
+      subtype: "external",
+      source: "existing",
+      sourceId: "gmail-existing",
+    });
+    await upsertPersonSeed(db, { name: "Gmail Ashish", email: "ashish@gmail.com", sourceId: "gmail-incoming" });
+
+    await entityRepo.createPersonEntity({
+      name: "Unscoped Ashish",
+      subtype: "external",
+      source: "existing",
+      sourceId: "unscoped-existing",
+    });
+    await upsertPersonSeed(db, {
+      name: "Unscoped Ashish",
+      email: "unscoped@acme.com",
+      sourceId: "unscoped-incoming",
+    });
+
+    await entityRepo.createPersonEntity({
+      name: "Name Only Ashish",
+      email: "nameonly@acme.com",
+      subtype: "external",
+      source: "existing",
+      sourceId: "name-only-existing",
+    });
+    await upsertPersonSeed(db, { name: "Name Only Ashish", sourceId: "name-only-incoming" });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(3);
+    expect(await db.selectFrom("entity_review_queue").selectAll().execute()).toHaveLength(3);
+  });
+});

--- a/packages/server/src/entities/materialize-person-scope.test.ts
+++ b/packages/server/src/entities/materialize-person-scope.test.ts
@@ -70,6 +70,23 @@ async function upsertPersonSeed(
   });
 }
 
+async function upsertAttendee(db: Kysely<DB>, input: { name: string; email: string; sourceId: string }): Promise<void> {
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: "file-1",
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: ADMIN_ID,
+    contentHash: "hash-1",
+    source: "google_drive",
+    factType: "attendee",
+    relation: "attended",
+    subjectName: input.name,
+    subjectEmail: input.email,
+    subjectSource: "google_drive",
+    subjectSourceId: input.sourceId,
+    raw: { providerFileId: "file-1", attendee: { name: input.name, email: input.email } },
+  });
+}
+
 async function createCompanyWithDomain(db: Kysely<DB>, id: string, name: string, domain: string): Promise<void> {
   await db
     .insertInto("entities")
@@ -142,6 +159,26 @@ describe("materializePersonSeed company-scoped dedup", () => {
 
     expect(summary.queued).toBe(0);
     expect(await people(db)).toHaveLength(2);
+  });
+
+  it("creates separate email-backed fuzzy attendees under the same weak bare-domain scope", async () => {
+    await upsertAttendee(db, {
+      name: "Safe Person 0-0",
+      email: "safe-0-0@example.com",
+      sourceId: "safe-0-0",
+    });
+    await upsertAttendee(db, {
+      name: "Safe Person 0-1",
+      email: "safe-0-1@example.com",
+      sourceId: "safe-0-1",
+    });
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+
+    expect(summary.queued).toBe(0);
+    expect(await people(db)).toHaveLength(2);
+    const mentions = await db.selectFrom("entity_mentions").selectAll().execute();
+    expect(mentions).toHaveLength(2);
   });
 
   it("preserves the matching company-scoped person when linking a new source ref", async () => {

--- a/packages/server/src/entities/materialize-person.ts
+++ b/packages/server/src/entities/materialize-person.ts
@@ -22,15 +22,33 @@ export async function materializePersonSeed(
   if (!fact.subject_name || !fact.subject_source || !fact.subject_source_id) {
     return { kind: "skipped", reason: "missing_person_seed_subject" };
   }
+  const triggeredByUserId = deps.resolveOwner(fact);
+  if (!triggeredByUserId) return { kind: "skipped_missing_owner", reason: "missing_fact_owner" };
   const raw = readJsonObject(fact.raw);
   const subtype = raw.subtype === "internal" ? "internal" : "external";
-  const entity = (await deps.entityRepo.upsertPersonEntity({
-    name: fact.subject_name,
-    email: fact.subject_email ?? undefined,
-    subtype,
-    source: fact.subject_source,
-    sourceId: fact.subject_source_id,
-  })) as unknown as EntityRow;
+  const result = await proposeEntity(
+    {
+      entityRepo: deps.entityRepo,
+      reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
+      lookup: deps.lookup,
+      readEmail: deps.readEmail,
+      onEntityResolved: deps.onEntityResolved,
+    },
+    {
+      name: fact.subject_name,
+      email: fact.subject_email ?? null,
+      entityType: "person",
+      subtype,
+      source: fact.subject_source,
+      sourceId: fact.subject_source_id,
+      evidence: fact.indexed_file_id ? [{ indexedFileId: fact.indexed_file_id }] : [],
+      triggeredByUserId,
+      strictPersonScopeGate: true,
+    },
+  );
+  if (result.kind === "queued") return { kind: "queued", reviewId: result.reviewId };
+  const entity = result.entity as unknown as EntityRow;
   deps.index.bySourceRef.set(`${fact.subject_source}:${fact.subject_source_id}`, entity);
   registerEntity(deps.index, entity);
   await inferAffiliationFromEmail(
@@ -39,9 +57,10 @@ export async function materializePersonSeed(
       personEntityId: entity.id,
       email: fact.subject_email,
       evidenceFileId: fact.indexed_file_id,
-      firstObservedByUserId: fact.created_by_user_id,
+      firstObservedByUserId: triggeredByUserId,
     },
   );
+  await deps.onEntityResolved(entity);
   return { kind: "structural", entity };
 }
 
@@ -92,7 +111,10 @@ async function buildPersonRankerContext(
   };
 }
 
-async function loadWorksAtCompanies(deps: MaterializeDeps, personEntityIds: string[]): Promise<Map<string, string>> {
+async function loadWorksAtCompanies(
+  deps: MaterializeDeps,
+  personEntityIds: string[],
+): Promise<Map<string, Set<string>>> {
   if (personEntityIds.length === 0) return new Map();
   const rows = await deps.db
     .selectFrom("entity_relationships")
@@ -101,7 +123,13 @@ async function loadWorksAtCompanies(deps: MaterializeDeps, personEntityIds: stri
     .where("source_entity_id", "in", personEntityIds)
     .where("valid_to", "is", null)
     .execute();
-  return new Map(rows.map((row) => [row.source_entity_id, row.target_entity_id]));
+  const out = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const bucket = out.get(row.source_entity_id);
+    if (bucket) bucket.add(row.target_entity_id);
+    else out.set(row.source_entity_id, new Set([row.target_entity_id]));
+  }
+  return out;
 }
 
 export async function materializePersonFact(
@@ -152,7 +180,7 @@ export async function materializePersonFact(
         { name: fact.subject_name, aliases: variations, entityType: "person" },
         candidates,
         context,
-        (entityId) => worksAtByPerson.get(entityId) ?? null,
+        (entityId) => [...(worksAtByPerson.get(entityId) ?? [])],
       );
       if (decision.kind === "confident_match") {
         entity = decision.entity as unknown as EntityRow;
@@ -171,6 +199,7 @@ export async function materializePersonFact(
         {
           entityRepo: deps.entityRepo,
           reviewRepo: deps.reviewRepo,
+          domainsRepo: deps.domainsRepo,
           lookup: deps.lookup,
           readEmail: deps.readEmail,
           onEntityResolved: deps.onEntityResolved,
@@ -214,6 +243,7 @@ export async function materializePersonFact(
         firstObservedByUserId: fact.created_by_user_id,
       },
     );
+    await deps.onEntityResolved(entity);
   }
 
   if (!entity || !fact.indexed_file_id) return { kind: resultKind, entity, mentionWritten: false };

--- a/packages/server/src/entities/materialize-project.ts
+++ b/packages/server/src/entities/materialize-project.ts
@@ -21,6 +21,7 @@ export async function materializeProjectSeed(
     {
       entityRepo: deps.entityRepo,
       reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-relations.ts
+++ b/packages/server/src/entities/materialize-relations.ts
@@ -226,6 +226,7 @@ async function materializeRelationEndpoint(
     {
       entityRepo: deps.entityRepo,
       reviewRepo: deps.reviewRepo,
+      domainsRepo: deps.domainsRepo,
       lookup: deps.lookup,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -36,6 +36,7 @@ export interface LookupIndex {
   dedupPoolsByType: Map<ProposeEntityType, CandidatePool>;
   bySourceRef: Map<string, EntityRow>;
   companyIdsByDomain: Map<string, string[]>;
+  personScopeKeysByEntityId: Map<string, string[]>;
 }
 
 export interface MaterializeDeps {

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -7,6 +7,7 @@ import type { EntitySuppressionRepository } from "../db/repositories/entity-supp
 import type { IndexedFileFactType } from "../db/repositories/indexed-file-facts";
 import type { DB, EntitiesTable, IndexedFileFactsTable } from "../db/schema";
 import type { MentionType } from "./graph";
+import type { CandidatePool } from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
 
 export interface ReplayFactsSummary {
@@ -32,6 +33,7 @@ export interface LookupIndex {
   entitiesByType: Map<ProposeEntityType, EntityRow[]>;
   byNormalizedName: Map<string, EntityRow[]>;
   byNormalizedAlias: Map<string, EntityRow[]>;
+  dedupPoolsByType: Map<ProposeEntityType, CandidatePool>;
   bySourceRef: Map<string, EntityRow>;
   companyIdsByDomain: Map<string, string[]>;
 }

--- a/packages/server/src/entities/materialize.test.ts
+++ b/packages/server/src/entities/materialize.test.ts
@@ -849,6 +849,11 @@ describe("materializeFromFact — llm_relation typed edges", () => {
       confidenceScore: 0.9,
       source: "email_domain",
     });
+    await entityRepo.upsertSourceRef({
+      entityId: person.id,
+      source: "llm_relation",
+      sourceId: "file-1:hash-file-1:source:Sarah Chen",
+    });
     await domainsRepo.addEvidence({
       relationshipId,
       indexedFileId: "file-1",
@@ -896,7 +901,24 @@ describe("materializeFromFact — llm_relation typed edges", () => {
 
   it("removes relationships that lose their last source-fact evidence row", async () => {
     await seedFiles(db, 2);
-    await createEntityRepository(db).upsertEntityFromTool({
+    const entityRepo = createEntityRepository(db);
+    const person = await entityRepo.upsertPersonEntity({
+      name: "Sarah Chen",
+      subtype: "external",
+      source: "google_drive",
+      sourceId: "person:sarah",
+    });
+    await entityRepo.upsertSourceRef({
+      entityId: person.id,
+      source: "llm_relation",
+      sourceId: "file-1:hash-file-1:source:Sarah Chen",
+    });
+    await entityRepo.upsertSourceRef({
+      entityId: person.id,
+      source: "llm_relation",
+      sourceId: "file-2:hash-file-2:source:Sarah Chen",
+    });
+    await entityRepo.upsertEntityFromTool({
       name: "Project Atlas",
       sourceType: "project",
       source: "google_drive",

--- a/packages/server/src/entities/name-dedup.test.ts
+++ b/packages/server/src/entities/name-dedup.test.ts
@@ -3,9 +3,13 @@ import {
   buildCandidatePool,
   findDedupCandidates,
   findFuzzyMatch,
+  findStrictMatches,
+  findTokenSetMatches,
   jaccard,
   lshBands,
   minhashSignature,
+  normalizeTokenSet,
+  removeFromCandidatePool,
   shingles,
 } from "./name-dedup";
 
@@ -44,5 +48,28 @@ describe("name-dedup", () => {
 
     expect(findFuzzyMatch("Sarah", sarahPool)).toBeNull();
     expect(findFuzzyMatch("KT", initialsPool)).toBeNull();
+  });
+
+  it("unifies a word-order permutation the strict key misses", () => {
+    const pool = buildCandidatePool([{ entityId: "ohoud", valueKind: "name", value: "Ohoud Zitan" }]);
+
+    expect(findStrictMatches("Zitan, Ohoud", pool)).toEqual([]);
+    expect(findTokenSetMatches("Zitan, Ohoud", pool)).toEqual([
+      { entityId: "ohoud", score: 1, valueKind: "name", value: "Ohoud Zitan" },
+    ]);
+  });
+
+  it("does not key bare single-token names", () => {
+    expect(normalizeTokenSet("Sanaa")).toBe("");
+    const pool = buildCandidatePool([{ entityId: "sanaa-a", valueKind: "name", value: "Sanaa" }]);
+    expect(findTokenSetMatches("Sanaa", pool)).toEqual([]);
+  });
+
+  it("prunes token-set buckets when an entity is removed", () => {
+    const pool = buildCandidatePool([{ entityId: "ohoud", valueKind: "name", value: "Ohoud Zitan" }]);
+    removeFromCandidatePool(pool, "ohoud");
+
+    expect(findTokenSetMatches("Zitan, Ohoud", pool)).toEqual([]);
+    expect(pool.byTokenSetKey.size).toBe(0);
   });
 });

--- a/packages/server/src/entities/name-dedup.test.ts
+++ b/packages/server/src/entities/name-dedup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCandidatePool,
+  findDedupCandidates,
+  findFuzzyMatch,
+  jaccard,
+  lshBands,
+  minhashSignature,
+  shingles,
+} from "./name-dedup";
+
+describe("name-dedup", () => {
+  it("strict-normalizes whitespace, casing, and punctuation", () => {
+    const pool = buildCandidatePool([{ entityId: "redseer", valueKind: "name", value: "Redseer Consulting" }]);
+
+    expect(findFuzzyMatch("RedseerConsulting", pool)).toMatchObject({ entityId: "redseer", score: 1 });
+    expect(findFuzzyMatch("REDSEER consulting", pool)).toMatchObject({ entityId: "redseer", score: 1 });
+    expect(findFuzzyMatch("Redseer  Consulting", pool)).toMatchObject({ entityId: "redseer", score: 1 });
+  });
+
+  it("uses spaces-in, no-padding 3-grams for the typo acceptance case", () => {
+    const existing = shingles("Apperture Technologies");
+    const proposed = shingles("Aperture Technologies");
+    const score = jaccard(existing, proposed);
+
+    expect(score).toBeCloseTo(18 / 21, 6);
+
+    const existingBands = new Set(lshBands(minhashSignature(existing)));
+    const proposedBands = lshBands(minhashSignature(proposed));
+    expect(proposedBands.some((band) => existingBands.has(band))).toBe(true);
+    const pinnedSharedBand = "2:012805ecd75c9f08:05afe1752c9b0fe1:1709b7f28c96be6d:117d40be1d2ccf14";
+    expect(existingBands.has(pinnedSharedBand)).toBe(true);
+    expect(proposedBands).toContain(pinnedSharedBand);
+
+    const pool = buildCandidatePool([{ entityId: "apperture", valueKind: "name", value: "Apperture Technologies" }]);
+    expect(findDedupCandidates("Aperture Technologies", pool, { threshold: 0.85 })).toEqual([
+      { entityId: "apperture", score, valueKind: "name", value: "Apperture Technologies" },
+    ]);
+  });
+
+  it("does not collide short or low-entropy names", () => {
+    const sarahPool = buildCandidatePool([{ entityId: "saran", valueKind: "name", value: "Saran" }]);
+    const initialsPool = buildCandidatePool([{ entityId: "kp", valueKind: "name", value: "KP" }]);
+
+    expect(findFuzzyMatch("Sarah", sarahPool)).toBeNull();
+    expect(findFuzzyMatch("KT", initialsPool)).toBeNull();
+  });
+});

--- a/packages/server/src/entities/name-dedup.ts
+++ b/packages/server/src/entities/name-dedup.ts
@@ -14,6 +14,7 @@ interface IndexedCandidatePoolEntry extends CandidatePoolEntry {
 
 export interface CandidatePool {
   byStrictKey: Map<string, CandidatePoolEntry[]>;
+  byTokenSetKey: Map<string, CandidatePoolEntry[]>;
   shinglesByEntryKey: Map<string, Set<string>>;
   entriesByKey: Map<string, CandidatePoolEntry>;
   lshBucketsByBand: Map<string, string[]>;
@@ -38,6 +39,27 @@ export function normalizeStrict(name: string): string {
   return stripDomainSuffix(name)
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Order-insensitive key: lowercase, strip non-alphanumerics to spaces, then
+ * sort the tokens. `Ohoud Zitan` and `Zitan, Ohoud` both collapse to
+ * `ohoud zitan`, catching the "Last, First" vs "First Last" permutation class
+ * that {@link normalizeStrict} (order-preserving) misses.
+ *
+ * Returns `""` for fewer than two tokens. A single-token bag carries no
+ * reordering signal, so keying it would over-collapse bare first names
+ * (`Sanaa` vs an unrelated `Sanaa`). The caller treats `""` as "no key".
+ */
+export function normalizeTokenSet(name: string): string {
+  const tokens = stripDomainSuffix(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+  if (tokens.length < 2) return "";
+  return tokens.sort().join(" ");
 }
 
 export function normalizeFuzzy(name: string): string {
@@ -112,6 +134,7 @@ export function lshBands(signature: BigUint64Array, bandSize = BAND_SIZE): strin
 export function buildCandidatePool(entries: CandidatePoolEntry[]): CandidatePool {
   const pool: CandidatePool = {
     byStrictKey: new Map(),
+    byTokenSetKey: new Map(),
     shinglesByEntryKey: new Map(),
     entriesByKey: new Map(),
     lshBucketsByBand: new Map(),
@@ -128,6 +151,13 @@ export function addToCandidatePool(pool: CandidatePool, entries: CandidatePoolEn
       const bucket = pool.byStrictKey.get(strictKey);
       if (bucket) bucket.push(indexed);
       else pool.byStrictKey.set(strictKey, [indexed]);
+    }
+
+    const tokenSetKey = normalizeTokenSet(indexed.value);
+    if (tokenSetKey) {
+      const bucket = pool.byTokenSetKey.get(tokenSetKey);
+      if (bucket) bucket.push(indexed);
+      else pool.byTokenSetKey.set(tokenSetKey, [indexed]);
     }
 
     const entryShingles = shingles(indexed.value);
@@ -151,6 +181,12 @@ export function removeFromCandidatePool(pool: CandidatePool, entityId: string): 
     else if (filtered.length !== bucket.length) pool.byStrictKey.set(key, filtered);
   }
 
+  for (const [key, bucket] of pool.byTokenSetKey) {
+    const filtered = bucket.filter((entry) => entry.entityId !== entityId);
+    if (filtered.length === 0) pool.byTokenSetKey.delete(key);
+    else if (filtered.length !== bucket.length) pool.byTokenSetKey.set(key, filtered);
+  }
+
   const removedKeys = new Set<string>();
   for (const [entryKey, entry] of pool.entriesByKey) {
     if (entry.entityId === entityId) {
@@ -170,6 +206,20 @@ export function removeFromCandidatePool(pool: CandidatePool, entityId: string): 
 
 export function findStrictMatches(name: string, pool: CandidatePool): DedupHit[] {
   const matches = pool.byStrictKey.get(normalizeStrict(name)) ?? [];
+  return dedupeEntityMatches(matches.map((entry) => ({ ...entry, score: 1 })));
+}
+
+/**
+ * Order-insensitive matches: entities whose name/alias is a token-permutation
+ * of `name` (e.g. `Zitan, Ohoud` against an existing `Ohoud Zitan`). Score 1 —
+ * the token bag is identical — but unlike a strict match this is genuinely
+ * ambiguous (a reorder vs two namesakes like `Li Wang` / `Wang Li`), so callers
+ * must treat it as a recall candidate to adjudicate, not an auto-link.
+ */
+export function findTokenSetMatches(name: string, pool: CandidatePool): DedupHit[] {
+  const key = normalizeTokenSet(name);
+  if (!key) return [];
+  const matches = pool.byTokenSetKey.get(key) ?? [];
   return dedupeEntityMatches(matches.map((entry) => ({ ...entry, score: 1 })));
 }
 
@@ -199,7 +249,11 @@ export function findFuzzyMatches(name: string, pool: CandidatePool, opts: { thre
 
 export function findDedupCandidates(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit[] {
   const byEntity = new Map<string, DedupHit>();
-  for (const match of [...findStrictMatches(name, pool), ...findFuzzyMatches(name, pool, opts)]) {
+  for (const match of [
+    ...findStrictMatches(name, pool),
+    ...findTokenSetMatches(name, pool),
+    ...findFuzzyMatches(name, pool, opts),
+  ]) {
     const existing = byEntity.get(match.entityId);
     if (!existing || match.score > existing.score) byEntity.set(match.entityId, match);
   }

--- a/packages/server/src/entities/name-dedup.ts
+++ b/packages/server/src/entities/name-dedup.ts
@@ -1,0 +1,263 @@
+import { createHash } from "node:crypto";
+
+export type CandidateValueKind = "name" | "alias";
+
+export interface CandidatePoolEntry {
+  entityId: string;
+  valueKind: CandidateValueKind;
+  value: string;
+}
+
+interface IndexedCandidatePoolEntry extends CandidatePoolEntry {
+  entryKey: string;
+}
+
+export interface CandidatePool {
+  byStrictKey: Map<string, CandidatePoolEntry[]>;
+  shinglesByEntryKey: Map<string, Set<string>>;
+  entriesByKey: Map<string, CandidatePoolEntry>;
+  lshBucketsByBand: Map<string, string[]>;
+  nextEntryId: number;
+}
+
+export interface DedupHit {
+  entityId: string;
+  score: number;
+  valueKind: CandidateValueKind;
+  value: string;
+}
+
+const DEFAULT_THRESHOLD = 0.85;
+const SHINGLE_SIZE = 3;
+const SIGNATURE_SIZE = 32;
+const BAND_SIZE = 4;
+const MAX_UINT64 = 0xffffffffffffffffn;
+const BLAKE2B64_OUTPUT_LENGTH_SUPPORTED = canCreateBlake2b64();
+
+export function normalizeStrict(name: string): string {
+  return stripDomainSuffix(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+export function normalizeFuzzy(name: string): string {
+  return stripDomainSuffix(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9'\s]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function shingles(name: string, n = SHINGLE_SIZE): Set<string> {
+  const normalized = normalizeFuzzy(name);
+  const out = new Set<string>();
+  if (!normalized) return out;
+  if (normalized.length < n) {
+    out.add(normalized);
+    return out;
+  }
+  for (let i = 0; i <= normalized.length - n; i += 1) {
+    out.add(normalized.slice(i, i + n));
+  }
+  return out;
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const value of a) {
+    if (b.has(value)) intersection += 1;
+  }
+  return intersection / (a.size + b.size - intersection);
+}
+
+export function hasHighEntropy(normalized: string): boolean {
+  const compact = normalized.replace(/\s+/g, "");
+  if (!compact) return false;
+  const counts = new Map<string, number>();
+  for (const ch of compact) counts.set(ch, (counts.get(ch) ?? 0) + 1);
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const p = count / compact.length;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy >= 1.5;
+}
+
+export function minhashSignature(values: Set<string>): BigUint64Array {
+  const signature = new BigUint64Array(SIGNATURE_SIZE);
+  signature.fill(MAX_UINT64);
+  for (const value of values) {
+    for (let seed = 0; seed < SIGNATURE_SIZE; seed += 1) {
+      const hash = blake2b64(`${seed}:${value}`);
+      if (hash < signature[seed]) signature[seed] = hash;
+    }
+  }
+  return signature;
+}
+
+export function lshBands(signature: BigUint64Array, bandSize = BAND_SIZE): string[] {
+  const bands: string[] = [];
+  for (let start = 0; start < signature.length; start += bandSize) {
+    const bandIndex = start / bandSize;
+    const values = Array.from(signature.slice(start, start + bandSize), (value) =>
+      value.toString(16).padStart(16, "0"),
+    ).join(":");
+    bands.push(`${bandIndex}:${values}`);
+  }
+  return bands;
+}
+
+export function buildCandidatePool(entries: CandidatePoolEntry[]): CandidatePool {
+  const pool: CandidatePool = {
+    byStrictKey: new Map(),
+    shinglesByEntryKey: new Map(),
+    entriesByKey: new Map(),
+    lshBucketsByBand: new Map(),
+    nextEntryId: 0,
+  };
+  addToCandidatePool(pool, entries);
+  return pool;
+}
+
+export function addToCandidatePool(pool: CandidatePool, entries: CandidatePoolEntry[]): void {
+  for (const indexed of indexEntries(entries, pool)) {
+    const strictKey = normalizeStrict(indexed.value);
+    if (strictKey) {
+      const bucket = pool.byStrictKey.get(strictKey);
+      if (bucket) bucket.push(indexed);
+      else pool.byStrictKey.set(strictKey, [indexed]);
+    }
+
+    const entryShingles = shingles(indexed.value);
+    pool.entriesByKey.set(indexed.entryKey, indexed);
+    pool.shinglesByEntryKey.set(indexed.entryKey, entryShingles);
+    if (!shouldUseMinhash(indexed.value, entryShingles)) continue;
+
+    const signature = minhashSignature(entryShingles);
+    for (const band of lshBands(signature)) {
+      const bucket = pool.lshBucketsByBand.get(band);
+      if (bucket) bucket.push(indexed.entryKey);
+      else pool.lshBucketsByBand.set(band, [indexed.entryKey]);
+    }
+  }
+}
+
+export function removeFromCandidatePool(pool: CandidatePool, entityId: string): void {
+  for (const [key, bucket] of pool.byStrictKey) {
+    const filtered = bucket.filter((entry) => entry.entityId !== entityId);
+    if (filtered.length === 0) pool.byStrictKey.delete(key);
+    else if (filtered.length !== bucket.length) pool.byStrictKey.set(key, filtered);
+  }
+
+  const removedKeys = new Set<string>();
+  for (const [entryKey, entry] of pool.entriesByKey) {
+    if (entry.entityId === entityId) {
+      removedKeys.add(entryKey);
+      pool.entriesByKey.delete(entryKey);
+      pool.shinglesByEntryKey.delete(entryKey);
+    }
+  }
+
+  if (removedKeys.size === 0) return;
+  for (const [band, bucket] of pool.lshBucketsByBand) {
+    const filtered = bucket.filter((entryKey) => !removedKeys.has(entryKey));
+    if (filtered.length === 0) pool.lshBucketsByBand.delete(band);
+    else if (filtered.length !== bucket.length) pool.lshBucketsByBand.set(band, filtered);
+  }
+}
+
+export function findStrictMatches(name: string, pool: CandidatePool): DedupHit[] {
+  const matches = pool.byStrictKey.get(normalizeStrict(name)) ?? [];
+  return dedupeEntityMatches(matches.map((entry) => ({ ...entry, score: 1 })));
+}
+
+export function findFuzzyMatches(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit[] {
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+  const queryShingles = shingles(name);
+  if (!shouldUseMinhash(name, queryShingles)) return [];
+
+  const signature = minhashSignature(queryShingles);
+  const candidateKeys = new Set<string>();
+  for (const band of lshBands(signature)) {
+    for (const entryKey of pool.lshBucketsByBand.get(band) ?? []) {
+      candidateKeys.add(entryKey);
+    }
+  }
+
+  const matches: DedupHit[] = [];
+  for (const entryKey of candidateKeys) {
+    const candidateShingles = pool.shinglesByEntryKey.get(entryKey);
+    const candidate = pool.entriesByKey.get(entryKey);
+    if (!candidateShingles || !candidate) continue;
+    const score = jaccard(queryShingles, candidateShingles);
+    if (score >= threshold) matches.push({ ...candidate, score });
+  }
+  return dedupeEntityMatches(matches).sort((a, b) => b.score - a.score || a.entityId.localeCompare(b.entityId));
+}
+
+export function findDedupCandidates(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit[] {
+  const byEntity = new Map<string, DedupHit>();
+  for (const match of [...findStrictMatches(name, pool), ...findFuzzyMatches(name, pool, opts)]) {
+    const existing = byEntity.get(match.entityId);
+    if (!existing || match.score > existing.score) byEntity.set(match.entityId, match);
+  }
+  return [...byEntity.values()].sort((a, b) => b.score - a.score || a.entityId.localeCompare(b.entityId));
+}
+
+export function findFuzzyMatch(name: string, pool: CandidatePool, opts: { threshold?: number } = {}): DedupHit | null {
+  return findDedupCandidates(name, pool, opts)[0] ?? null;
+}
+
+function shouldUseMinhash(value: string, valueShingles: Set<string>): boolean {
+  const normalized = normalizeFuzzy(value);
+  if (valueShingles.size === 0) return false;
+  if (normalized.length < 6 && normalized.split(" ").filter(Boolean).length < 2) return false;
+  if (!hasHighEntropy(normalized)) return false;
+  return true;
+}
+
+function indexEntries(entries: CandidatePoolEntry[], pool: CandidatePool): IndexedCandidatePoolEntry[] {
+  return entries.map((entry) => ({
+    ...entry,
+    entryKey: `${entry.entityId}:${entry.valueKind}:${pool.nextEntryId++}`,
+  }));
+}
+
+function dedupeEntityMatches(matches: DedupHit[]): DedupHit[] {
+  const byEntity = new Map<string, DedupHit>();
+  for (const match of matches) {
+    const clean = {
+      entityId: match.entityId,
+      score: match.score,
+      valueKind: match.valueKind,
+      value: match.value,
+    };
+    const existing = byEntity.get(match.entityId);
+    if (!existing || match.score > existing.score) byEntity.set(match.entityId, clean);
+  }
+  return [...byEntity.values()];
+}
+
+function blake2b64(value: string): bigint {
+  const digest = createBlake2b64().update(value).digest();
+  return digest.readBigUInt64BE(0);
+}
+
+function createBlake2b64() {
+  return BLAKE2B64_OUTPUT_LENGTH_SUPPORTED ? createHash("blake2b512", { outputLength: 8 }) : createHash("blake2b512");
+}
+
+function canCreateBlake2b64(): boolean {
+  try {
+    createHash("blake2b512", { outputLength: 8 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stripDomainSuffix(value: string): string {
+  return value.trim().replace(/\.(com|org|net|io|ai|co|in|dev|app)\b\.?$/i, "");
+}

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1390,4 +1390,42 @@ describe("proposeEntity", () => {
     expect(second.kind).toBe("linked");
     expect(projects).toHaveLength(1);
   });
+
+  it("27. strict name dedup links and appends the incoming spelling as an alias", async () => {
+    const entityRepo = createEntityRepository(db);
+    const redseer = await entityRepo.upsertEntity({
+      name: "Redseer Consulting",
+      sourceType: "company",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const materializeDeps = await buildMaterializeDeps(db);
+
+    const result = await proposeEntity(
+      {
+        entityRepo: materializeDeps.entityRepo,
+        reviewRepo: materializeDeps.reviewRepo,
+        lookup: materializeDeps.lookup,
+        readEmail: materializeDeps.readEmail,
+        onEntityResolved: materializeDeps.onEntityResolved,
+      },
+      {
+        name: "RedseerConsulting",
+        entityType: "company",
+        subtype: "external",
+        source: "llm",
+        sourceId: "mention-redseer",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("linked");
+    if (result.kind !== "linked") throw new Error("unreachable");
+    expect(result.entity.id).toBe(redseer.id);
+    expect(JSON.parse(result.entity.aliases ?? "[]")).toContain("RedseerConsulting");
+    expect(materializeDeps.index.byNormalizedAlias.get(normalizeName("RedseerConsulting"))?.map((e) => e.id)).toContain(
+      redseer.id,
+    );
+  });
 });

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1287,7 +1287,7 @@ describe("proposeEntity", () => {
     expect(refreshed.aliases ? JSON.parse(refreshed.aliases) : []).toContain("Project Atlas");
   });
 
-  it("25. person source-ref is skipped so email identity semantics still win", async () => {
+  it("25. person source-ref links before email identity", async () => {
     const entityRepo = createEntityRepository(db);
     const bob = await entityRepo.upsertPersonEntity({
       name: "Bob Chen",
@@ -1326,8 +1326,8 @@ describe("proposeEntity", () => {
 
     expect(result.kind).toBe("linked");
     if (result.kind !== "linked") throw new Error("unreachable");
-    expect(result.entity.id).toBe(alice.id);
-    expect(result.entity.id).not.toBe(bob.id);
+    expect(result.entity.id).toBe(bob.id);
+    expect(result.entity.id).not.toBe(alice.id);
   });
 
   it("26. same-batch source-ref link refreshes materialization index and avoids double-create", async () => {

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1459,6 +1459,7 @@ describe("proposeEntity", () => {
     );
 
     expect(result.kind).toBe("queued");
+    if (result.kind !== "queued") throw new Error("unreachable");
     expect(result.candidateEntityId).toBe(ann.id);
     const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
     expect(queue.candidate_entity_id).toBe(ann.id);
@@ -1495,6 +1496,7 @@ describe("proposeEntity", () => {
     );
 
     expect(result.kind).toBe("queued");
+    if (result.kind !== "queued") throw new Error("unreachable");
     expect(result.candidateEntityId).toBe(ohoud.id);
     const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
     expect(queue.candidate_entity_id).toBe(ohoud.id);

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1428,4 +1428,76 @@ describe("proposeEntity", () => {
       redseer.id,
     );
   });
+
+  it("28. compact person strict-name collisions queue instead of auto-linking", async () => {
+    const entityRepo = createEntityRepository(db);
+    const ann = await entityRepo.upsertEntity({
+      name: "Ann A",
+      sourceType: "person",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const materializeDeps = await buildMaterializeDeps(db);
+
+    const result = await proposeEntity(
+      {
+        entityRepo: materializeDeps.entityRepo,
+        reviewRepo: materializeDeps.reviewRepo,
+        lookup: materializeDeps.lookup,
+        readEmail: materializeDeps.readEmail,
+        onEntityResolved: materializeDeps.onEntityResolved,
+      },
+      {
+        name: "Anna",
+        entityType: "person",
+        subtype: "external",
+        source: "llm",
+        sourceId: "mention-anna",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("queued");
+    expect(result.candidateEntityId).toBe(ann.id);
+    const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(queue.candidate_entity_id).toBe(ann.id);
+    expect(queue.candidate_reason).toBe("strict-normalized");
+  });
+
+  it("29. materialized lookup queues token-set reorder matches", async () => {
+    const entityRepo = createEntityRepository(db);
+    const ohoud = await entityRepo.upsertEntity({
+      name: "Ohoud Zitan",
+      sourceType: "person",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const materializeDeps = await buildMaterializeDeps(db);
+
+    const result = await proposeEntity(
+      {
+        entityRepo: materializeDeps.entityRepo,
+        reviewRepo: materializeDeps.reviewRepo,
+        lookup: materializeDeps.lookup,
+        readEmail: materializeDeps.readEmail,
+        onEntityResolved: materializeDeps.onEntityResolved,
+      },
+      {
+        name: "Zitan, Ohoud",
+        entityType: "person",
+        subtype: "external",
+        source: "llm",
+        sourceId: "mention-zitan-ohoud",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("queued");
+    expect(result.candidateEntityId).toBe(ohoud.id);
+    const queue = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(queue.candidate_entity_id).toBe(ohoud.id);
+    expect(queue.candidate_reason).toBe("token-set");
+  });
 });

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -21,8 +21,10 @@
 import type { Selectable } from "kysely";
 import { normalizeName } from "../connectors/name-normalize";
 import type { UpsertPersonEntityData, createEntityRepository } from "../db/repositories/entities";
+import type { EntityDomainsRepository } from "../db/repositories/entity-domains";
 import type { EntityReviewRepository } from "../db/repositories/entity-review";
 import type { EntitiesTable } from "../db/schema";
+import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "./affiliations";
 
 export type Entity = Selectable<EntitiesTable>;
 
@@ -67,6 +69,11 @@ export interface ProposeInput {
    * entity and queuing an ambiguous match are unaffected.
    */
   queueInsteadOfCreate?: boolean;
+  /**
+   * Applies the person seed creation gate for name-only proposals. When true,
+   * an unscoped incoming person proposal queues instead of linking by name.
+   */
+  strictPersonScopeGate?: boolean;
 }
 
 export type ProposeResult =
@@ -108,11 +115,13 @@ export type EntityLookup = {
   }>;
   /** Company ids associated with a normalized corporate domain. */
   getCompanyIdsByDomain?(domain: string): string[];
+  getPersonScopeKeys?(entityId: string): string[];
 };
 
 export interface ProposeDeps {
   entityRepo: ReturnType<typeof createEntityRepository>;
   reviewRepo: EntityReviewRepository;
+  domainsRepo?: EntityDomainsRepository;
   lookup: EntityLookup;
   /** Read an entity's email from its metadata JSON. */
   readEmail: (entity: Entity) => string | null;
@@ -240,15 +249,28 @@ async function persistEntity(
   matched?: Entity,
 ): Promise<{ entity: Entity; created: boolean }> {
   if (input.entityType === "person") {
+    if (matched) {
+      await deps.entityRepo.upsertSourceRef({
+        entityId: matched.id,
+        source: input.source,
+        sourceId: input.sourceId,
+      });
+      if (input.email) {
+        await deps.entityRepo.attachEmailIfAbsent(matched.id, input.email);
+        await deps.entityRepo.appendAlias(matched.id, input.email);
+      }
+      const entity = (await deps.entityRepo.getEntity(matched.id)) ?? matched;
+      return { entity, created: false };
+    }
     const personData: UpsertPersonEntityData = {
-      name: matched?.name ?? input.name,
+      name: input.name,
       email: input.email ?? undefined,
       subtype: input.subtype,
       source: input.source,
       sourceId: input.sourceId,
     };
-    const entity = await deps.entityRepo.upsertPersonEntity(personData);
-    return { entity, created: !matched };
+    const entity = await deps.entityRepo.createPersonEntity(personData);
+    return { entity, created: true };
   }
 
   if (matched) {
@@ -335,6 +357,15 @@ function pickConfirmedCanonical(candidates: Entity[], input: ProposeInput, looku
   return sorted[0];
 }
 
+function isSingleStrictPersonReference(ranked: RankedCandidate[]): boolean {
+  return (
+    ranked.length === 1 &&
+    (ranked[0].reason === "exact-ambiguous" ||
+      ranked[0].reason === "strict-normalized" ||
+      ranked[0].reason === "minhash")
+  );
+}
+
 async function queueProposal(
   deps: ProposeDeps,
   input: ProposeInput,
@@ -377,8 +408,95 @@ async function queueProposal(
   };
 }
 
+async function decideScopedPersonCandidates(
+  deps: ProposeDeps,
+  input: ProposeInput,
+  normalized: string,
+  ranked: RankedCandidate[],
+): Promise<ProposeResult> {
+  if (!deps.domainsRepo) {
+    if (input.email) {
+      const { entity } = await persistEntity(deps, input);
+      return { kind: "created", entity };
+    }
+    if (ranked.length === 1 && isSingleStrictPersonReference(ranked) && canAutoLinkNameDedupCandidate(input, ranked[0])) {
+      return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    }
+    return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+  }
+  const incomingScope = deps.domainsRepo ? await personScopeKey(input.email ?? null, deps.domainsRepo) : null;
+  if (!incomingScope) {
+    if (
+      !input.strictPersonScopeGate &&
+      isSingleStrictPersonReference(ranked) &&
+      canAutoLinkNameDedupCandidate(input, ranked[0])
+    ) {
+      return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    }
+    return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+  }
+  const incomingScopeId = personScopeKeyId(incomingScope);
+  const candidatesWithScopes = ranked.map((candidate) => {
+    const scopeKeys = new Set(deps.lookup.getPersonScopeKeys?.(candidate.entity.id) ?? []);
+    return { candidate, scopeKeys };
+  });
+  const matching = candidatesWithScopes.filter(({ scopeKeys }) => scopeKeys.has(incomingScopeId));
+  if (matching.length === 1) return linkNameDedupCandidate(deps, input, matching[0].candidate.entity);
+  if (matching.length >= 2) {
+    return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+  }
+  const allCandidatesTrusted = candidatesWithScopes.every(
+    ({ scopeKeys }) => scopeKeys.size > 0 && [...scopeKeys].some(isTrustedPersonScopeKey),
+  );
+  if (allCandidatesTrusted) {
+    if (input.queueInsteadOfCreate) {
+      return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+    }
+    const { entity } = await persistEntity(deps, input);
+    return { kind: "created", entity };
+  }
+  return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+}
+
+async function decideNameCandidates(
+  deps: ProposeDeps,
+  input: ProposeInput,
+  normalized: string,
+  ranked: RankedCandidate[],
+): Promise<ProposeResult> {
+  if (input.entityType === "person") return decideScopedPersonCandidates(deps, input, normalized, ranked);
+  if (ranked.length === 1) return linkNameDedupCandidate(deps, input, ranked[0].entity);
+  const winner = pickConfirmedCanonical(
+    ranked.map((candidate) => candidate.entity),
+    input,
+    deps.lookup,
+  );
+  if (winner) {
+    const { entity } = await persistEntity(deps, input, winner);
+    return { kind: "linked", entity };
+  }
+  return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+}
+
 export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Promise<ProposeResult> {
   const normalized = normalizeMatchName(input.entityType, input.name);
+
+  if (input.source && input.sourceId) {
+    const found = await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId);
+    if (found && found.source_type === input.entityType) {
+      await deps.entityRepo.upsertSourceRef({
+        entityId: found.id,
+        source: input.source,
+        sourceId: input.sourceId,
+      });
+      if (found.name.trim().toLowerCase() !== input.name.trim().toLowerCase()) {
+        await deps.entityRepo.appendAlias(found.id, input.name);
+      }
+      const entity = (await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId)) ?? found;
+      await deps.onEntityResolved?.(entity);
+      return { kind: "linked", entity };
+    }
+  }
 
   // 1) Email fast-path — exact match against existing entity's stored email.
   if (input.entityType === "person" && input.email) {
@@ -398,29 +516,6 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
         await deps.onEntityResolved?.(entity);
         return { kind: "linked", entity };
       }
-    }
-
-    // 2) Email present but no entity matched it. An email is identity-grade;
-    //    a name collision against a different email is a different person.
-    //    Auto-create instead of queuing.
-    const { entity } = await persistEntity(deps, input);
-    return { kind: "created", entity };
-  }
-
-  if (input.entityType !== "person" && input.source && input.sourceId) {
-    const found = await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId);
-    if (found && found.source_type === input.entityType) {
-      await deps.entityRepo.upsertSourceRef({
-        entityId: found.id,
-        source: input.source,
-        sourceId: input.sourceId,
-      });
-      if (found.name.trim().toLowerCase() !== input.name.trim().toLowerCase()) {
-        await deps.entityRepo.appendAlias(found.id, input.name);
-      }
-      const entity = (await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId)) ?? found;
-      await deps.onEntityResolved?.(entity);
-      return { kind: "linked", entity };
     }
   }
 
@@ -449,21 +544,14 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
   }
   if (exactById.size === 1) {
     const matched = exactById.values().next().value as Entity;
-    const { entity } = await persistEntity(deps, input, matched);
-    return { kind: "linked", entity };
+    return decideNameCandidates(deps, input, normalized, [{ entity: matched, score: 1, reason: "exact-ambiguous" }]);
   }
   if (exactById.size > 1) {
-    const winner = pickConfirmedCanonical([...exactById.values()], input, deps.lookup);
-    if (winner) {
-      const { entity } = await persistEntity(deps, input, winner);
-      return { kind: "linked", entity };
-    }
-    return queueProposal(
+    return decideNameCandidates(
       deps,
       input,
       normalized,
       [...exactById.values()].map((entity) => ({ entity, score: 1, reason: "exact-ambiguous" })),
-      "exact-ambiguous",
     );
   }
 
@@ -511,11 +599,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
       if (!rejected) filtered.push(r);
     }
     ranked = filtered;
-    if (ranked.length === 1 && canAutoLinkNameDedupCandidate(input, ranked[0])) {
-      return linkNameDedupCandidate(deps, input, ranked[0].entity);
-    }
-    if (ranked.length === 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
-    if (ranked.length > 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
+    if (ranked.length > 0) return decideNameCandidates(deps, input, normalized, ranked);
   }
 
   if (input.precomputedCandidates && input.precomputedCandidates.length > 0) {
@@ -561,5 +645,6 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
     const { entity } = await persistEntity(deps, input);
     return { kind: "created", entity };
   }
+  if (input.entityType === "person") return decideScopedPersonCandidates(deps, input, normalized, ranked);
   return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
 }

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -27,7 +27,14 @@ import type { EntitiesTable } from "../db/schema";
 export type Entity = Selectable<EntitiesTable>;
 
 export type ProposeEntityType = "person" | "company" | "product" | "project" | "team" | "deal";
-export type CandidateReason = "token-superset" | "prefix" | "exact-ambiguous" | "llm-ambiguous" | "birth-gated";
+export type CandidateReason =
+  | "token-superset"
+  | "prefix"
+  | "exact-ambiguous"
+  | "llm-ambiguous"
+  | "birth-gated"
+  | "strict-normalized"
+  | "minhash";
 
 export interface ProposeInput {
   name: string;
@@ -89,6 +96,11 @@ export type EntityLookup = {
   getByAlias?(normalized: string): Entity[];
   /** All entities of the given type (used for prefix/token-superset scan). */
   listByType(entityType: ProposeEntityType): Entity[];
+  /** Same-type normalized-strict or MinHash candidates over names and aliases. */
+  findNameDedupCandidates?(
+    entityType: ProposeEntityType,
+    name: string,
+  ): Array<{ entity: Entity; score: number; reason: Extract<CandidateReason, "strict-normalized" | "minhash"> }>;
   /** Company ids associated with a normalized corporate domain. */
   getCompanyIdsByDomain?(domain: string): string[];
 };
@@ -251,6 +263,19 @@ async function persistEntity(
     sourceId: input.sourceId,
   });
   return { entity, created: true };
+}
+
+async function linkNameDedupCandidate(deps: ProposeDeps, input: ProposeInput, matched: Entity): Promise<ProposeResult> {
+  const { entity } = await persistEntity(deps, input, matched);
+  const aliasesToAppend = [input.name, ...(input.aliases ?? [])].filter(
+    (alias) => alias.trim() && alias.trim().toLowerCase() !== matched.name.trim().toLowerCase(),
+  );
+  for (const alias of aliasesToAppend) {
+    await deps.entityRepo.appendAlias(entity.id, alias);
+  }
+  const refreshed = (await deps.entityRepo.getEntity(entity.id)) ?? entity;
+  await deps.onEntityResolved?.(refreshed);
+  return { kind: "linked", entity: refreshed };
 }
 
 /**
@@ -460,6 +485,23 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
         );
       }
     }
+  }
+
+  const dedupCandidates = deps.lookup.findNameDedupCandidates?.(input.entityType, input.name) ?? [];
+  if (dedupCandidates.length > 0) {
+    let ranked: RankedCandidate[] = dedupCandidates.map((candidate) => ({
+      entity: candidate.entity,
+      score: candidate.score,
+      reason: candidate.reason,
+    }));
+    const filtered: RankedCandidate[] = [];
+    for (const r of ranked) {
+      const rejected = await deps.reviewRepo.isRejected(r.entity.id, normalized);
+      if (!rejected) filtered.push(r);
+    }
+    ranked = filtered;
+    if (ranked.length === 1) return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    if (ranked.length > 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
   }
 
   if (input.precomputedCandidates && input.precomputedCandidates.length > 0) {

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -366,6 +366,13 @@ function isSingleStrictPersonReference(ranked: RankedCandidate[]): boolean {
   );
 }
 
+function canAutoLinkScopedPersonCandidate(input: ProposeInput, candidate: RankedCandidate): boolean {
+  return (
+    (candidate.reason === "exact-ambiguous" || candidate.reason === "strict-normalized") &&
+    canAutoLinkNameDedupCandidate(input, candidate)
+  );
+}
+
 async function queueProposal(
   deps: ProposeDeps,
   input: ProposeInput,
@@ -430,12 +437,12 @@ async function decideScopedPersonCandidates(
   }
   const incomingScope = deps.domainsRepo ? await personScopeKey(input.email ?? null, deps.domainsRepo) : null;
   if (!incomingScope) {
-    if (
-      !input.strictPersonScopeGate &&
-      isSingleStrictPersonReference(ranked) &&
-      canAutoLinkNameDedupCandidate(input, ranked[0])
-    ) {
+    if (!input.strictPersonScopeGate && ranked.length === 1 && canAutoLinkScopedPersonCandidate(input, ranked[0])) {
       return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    }
+    if (input.email && !input.strictPersonScopeGate && !input.queueInsteadOfCreate) {
+      const { entity } = await persistEntity(deps, input);
+      return { kind: "created", entity };
     }
     return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
   }
@@ -445,7 +452,17 @@ async function decideScopedPersonCandidates(
     return { candidate, scopeKeys };
   });
   const matching = candidatesWithScopes.filter(({ scopeKeys }) => scopeKeys.has(incomingScopeId));
-  if (matching.length === 1) return linkNameDedupCandidate(deps, input, matching[0].candidate.entity);
+  if (matching.length === 1) {
+    const match = matching[0];
+    if (canAutoLinkScopedPersonCandidate(input, match.candidate)) {
+      return linkNameDedupCandidate(deps, input, match.candidate.entity);
+    }
+    if (input.email && !input.queueInsteadOfCreate) {
+      const { entity } = await persistEntity(deps, input);
+      return { kind: "created", entity };
+    }
+    return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
+  }
   if (matching.length >= 2) {
     return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");
   }

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -34,6 +34,7 @@ export type CandidateReason =
   | "llm-ambiguous"
   | "birth-gated"
   | "strict-normalized"
+  | "token-set"
   | "minhash";
 
 export interface ProposeInput {
@@ -96,11 +97,15 @@ export type EntityLookup = {
   getByAlias?(normalized: string): Entity[];
   /** All entities of the given type (used for prefix/token-superset scan). */
   listByType(entityType: ProposeEntityType): Entity[];
-  /** Same-type normalized-strict or MinHash candidates over names and aliases. */
+  /** Same-type normalized-strict, token-set, or MinHash candidates over names and aliases. */
   findNameDedupCandidates?(
     entityType: ProposeEntityType,
     name: string,
-  ): Array<{ entity: Entity; score: number; reason: Extract<CandidateReason, "strict-normalized" | "minhash"> }>;
+  ): Array<{
+    entity: Entity;
+    score: number;
+    reason: Extract<CandidateReason, "strict-normalized" | "token-set" | "minhash">;
+  }>;
   /** Company ids associated with a normalized corporate domain. */
   getCompanyIdsByDomain?(domain: string): string[];
 };
@@ -164,6 +169,12 @@ function hasTokenOverlap(a: string[], b: string[]): boolean {
   if (a.length === 0 || b.length === 0) return false;
   const bSet = new Set(b);
   return a.some((token) => bSet.has(token));
+}
+
+function canAutoLinkNameDedupCandidate(input: ProposeInput, candidate: RankedCandidate): boolean {
+  if (candidate.reason === "token-set") return false;
+  if (input.entityType === "person" && candidate.reason === "strict-normalized" && !input.email) return false;
+  return true;
 }
 
 /**
@@ -500,7 +511,10 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
       if (!rejected) filtered.push(r);
     }
     ranked = filtered;
-    if (ranked.length === 1) return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    if (ranked.length === 1 && canAutoLinkNameDedupCandidate(input, ranked[0])) {
+      return linkNameDedupCandidate(deps, input, ranked[0].entity);
+    }
+    if (ranked.length === 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
     if (ranked.length > 1) return queueProposal(deps, input, normalized, ranked, ranked[0].reason);
   }
 

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -419,7 +419,11 @@ async function decideScopedPersonCandidates(
       const { entity } = await persistEntity(deps, input);
       return { kind: "created", entity };
     }
-    if (ranked.length === 1 && isSingleStrictPersonReference(ranked) && canAutoLinkNameDedupCandidate(input, ranked[0])) {
+    if (
+      ranked.length === 1 &&
+      isSingleStrictPersonReference(ranked) &&
+      canAutoLinkNameDedupCandidate(input, ranked[0])
+    ) {
       return linkNameDedupCandidate(deps, input, ranked[0].entity);
     }
     return queueProposal(deps, input, normalized, ranked, ranked[0]?.reason ?? "exact-ambiguous");

--- a/packages/server/src/entities/rank.test.ts
+++ b/packages/server/src/entities/rank.test.ts
@@ -35,7 +35,7 @@ describe("rankPersonLlmMention", () => {
         extractedCompanies: [],
         contextCompanies: [],
       },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("confident_match");
@@ -54,7 +54,7 @@ describe("rankPersonLlmMention", () => {
         extractedCompanies: [{ entityId: "company-1" }],
         contextCompanies: [],
       },
-      (entityId) => (entityId === "b" ? "company-1" : null),
+      (entityId) => (entityId === "b" ? ["company-1"] : []),
     );
 
     expect(decision.kind).toBe("confident_match");
@@ -66,7 +66,7 @@ describe("rankPersonLlmMention", () => {
       { name: "Sam", entityType: "person" },
       [person("a", "Sam Patel"), person("b", "Sam Prakash")],
       { fileId: "file-1", extractedPersons: [], extractedCompanies: [], contextCompanies: [] },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("ambiguous_existing");
@@ -77,7 +77,7 @@ describe("rankPersonLlmMention", () => {
       { name: "Sarah Cheng", entityType: "person" },
       [person("a", "Sarah C")],
       { fileId: "file-1", extractedPersons: [], extractedCompanies: [], contextCompanies: [] },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("ambiguous_new_entity");
@@ -88,7 +88,7 @@ describe("rankPersonLlmMention", () => {
       { name: "Priya Shah", entityType: "person" },
       [person("a", "Sarah Chen")],
       { fileId: "file-1", extractedPersons: [], extractedCompanies: [], contextCompanies: [] },
-      () => null,
+      () => [],
     );
 
     expect(decision.kind).toBe("confident_no_match");

--- a/packages/server/src/entities/rank.ts
+++ b/packages/server/src/entities/rank.ts
@@ -50,7 +50,7 @@ function scoreCandidate(
   mentionTokens: string[],
   entity: Entity,
   ctx: RankerContext,
-  worksAtLookup: (entityId: string) => string | null,
+  worksAtLookup: (entityId: string) => readonly string[],
 ): number | null {
   const entityTokens = tokens(entity.name);
   if (!hasTokenOverlap(mentionTokens, entityTokens)) return null;
@@ -58,8 +58,8 @@ function scoreCandidate(
   let score = 0;
   if (ctx.extractedPersons.some((p) => p.entityId === entity.id)) score += 10;
 
-  const companyId = worksAtLookup(entity.id);
-  if (companyId) {
+  const companyIds = worksAtLookup(entity.id);
+  for (const companyId of companyIds) {
     if (ctx.extractedCompanies.some((c) => c.entityId === companyId)) score += 5;
     else if (ctx.contextCompanies.some((c) => c.entityId === companyId)) score += 2;
   }
@@ -72,7 +72,7 @@ export function rankPersonLlmMention(
   mention: ExtractedMention,
   candidates: Entity[],
   ctx: RankerContext,
-  worksAtLookup: (entityId: string) => string | null,
+  worksAtLookup: (entityId: string) => readonly string[],
 ): LlmMentionDecision {
   const mentionTokens = tokens(mention.name);
   const ranked = candidates

--- a/packages/server/src/entities/replay.test.ts
+++ b/packages/server/src/entities/replay.test.ts
@@ -125,6 +125,7 @@ async function seedRawCorpus(db: Kysely<DB>) {
 
   // Person seed (file-less, e.g. ClickUp directory).
   await factRepo.upsertFact({
+    createdByUserId: TEST_USER_ID,
     source: "clickup",
     factType: "person_seed",
     relation: "seeded",
@@ -437,6 +438,7 @@ describe("replaySourceFacts", () => {
      */
     for (let i = 0; i < 25; i++) {
       await repo.upsertFact({
+        createdByUserId: TEST_USER_ID,
         source: "manual",
         factType: "person_seed",
         relation: "seeded",
@@ -452,6 +454,7 @@ describe("replaySourceFacts", () => {
     await first;
 
     await repo.upsertFact({
+      createdByUserId: TEST_USER_ID,
       source: "manual",
       factType: "person_seed",
       relation: "seeded",


### PR DESCRIPTION
Stacked context-graph slice 01/27.

Base: `main`
Head: `feat/context-graph-01-name-dedup`

Preserves scoped person matching and keeps the name-dedup base small.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`