### PR TITLE
fix: stabilize entity dedup merge backfill

### DIFF
--- a/packages/server/src/entities/merge.test.ts
+++ b/packages/server/src/entities/merge.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createEntityRepository, whereLiveEntity } from "../db/repositories/entities";
 import type { DB } from "../db/schema";
 import { createTestDb } from "../test-utils";
+import { buildMaterializeDeps } from "./materialize-deps";
 import { EntityMergeError, mergeEntities, unmergeEntities } from "./merge";
+import { proposeEntity } from "./propose";
 
 const USER_ID = "merge-user";
 
@@ -387,6 +389,70 @@ describe("entity merge core", () => {
         expect.objectContaining({ id: "cp-loser", is_primary: 0 }),
       ]),
     );
+  });
+
+  it("carries loser names into survivor aliases, links future proposals, and reverses only recorded additions", async () => {
+    await seedEntity(db, "survivor", "Acme Corporation", "company");
+    await seedEntity(db, "loser", "Acme Corp", "company");
+    await db
+      .updateTable("entities")
+      .set({ aliases: JSON.stringify(["Acme Corporation Inc"]) })
+      .where("id", "=", "survivor")
+      .execute();
+    await db
+      .updateTable("entities")
+      .set({ aliases: JSON.stringify(["ACME Corp Ltd", "acmecorp"]) })
+      .where("id", "=", "loser")
+      .execute();
+
+    const result = await mergeEntities(db, { survivorId: "survivor", loserId: "loser", userId: USER_ID });
+
+    const mergedSurvivor = await db
+      .selectFrom("entities")
+      .select(["aliases"])
+      .where("id", "=", "survivor")
+      .executeTakeFirstOrThrow();
+    expect(JSON.parse(mergedSurvivor.aliases ?? "[]")).toEqual(["Acme Corporation Inc", "Acme Corp", "ACME Corp Ltd"]);
+
+    const ledger = await db
+      .selectFrom("entity_merges")
+      .select("moves")
+      .where("id", "=", result.mergeId)
+      .executeTakeFirstOrThrow();
+    expect(JSON.parse(ledger.moves)).toEqual(
+      expect.arrayContaining([
+        { kind: "alias_added", value: "Acme Corp", normalizedKey: "acmecorp" },
+        { kind: "alias_added", value: "ACME Corp Ltd", normalizedKey: "acmecorpltd" },
+      ]),
+    );
+
+    const deps = await buildMaterializeDeps(db);
+    const proposal = await proposeEntity(deps, {
+      name: "Acme Corp",
+      entityType: "company",
+      subtype: "external",
+      source: "test",
+      sourceId: "test:acme-corp",
+      evidence: [{ indexedFileId: "file-a" }],
+      triggeredByUserId: USER_ID,
+    });
+    expect(proposal.kind).toBe("linked");
+    if (proposal.kind !== "linked") throw new Error("expected linked proposal");
+    expect(proposal.entity.id).toBe("survivor");
+
+    await db
+      .updateTable("entities")
+      .set({ aliases: JSON.stringify(["Acme Corporation Inc", "Acme Corp", "ACME Corp Ltd", "Post Merge Alias"]) })
+      .where("id", "=", "survivor")
+      .execute();
+    await unmergeEntities(db, { mergeId: result.mergeId, userId: USER_ID });
+
+    const unmergedSurvivor = await db
+      .selectFrom("entities")
+      .select(["aliases"])
+      .where("id", "=", "survivor")
+      .executeTakeFirstOrThrow();
+    expect(JSON.parse(unmergedSurvivor.aliases ?? "[]")).toEqual(["Acme Corporation Inc", "Post Merge Alias"]);
   });
 
   it("does not steal source refs that moved after merge", async () => {

--- a/packages/server/src/entities/merge.ts
+++ b/packages/server/src/entities/merge.ts
@@ -14,6 +14,8 @@ import type {
   EntityReviewQueueTable,
   EntityShareEmailsTable,
 } from "../db/schema";
+import { parseAliasesString } from "./materialize-json";
+import { normalizeStrict } from "./name-dedup";
 
 type Entity = Selectable<EntitiesTable>;
 type Mention = Selectable<EntityMentionsTable>;
@@ -35,7 +37,8 @@ export type EntityMergeMove =
       table: "entity_candidates";
       rowId: string;
       colChanges: Record<string, { before: string | null; after: string | null }>;
-    };
+    }
+  | { kind: "alias_added"; value: string; normalizedKey: string };
 
 export type EntityMergeErrorCode =
   | "ENTITY_NOT_FOUND"
@@ -101,6 +104,10 @@ export interface MergePreview {
 
 function rowPayload(row: Record<string, unknown>): Record<string, unknown> {
   return { ...row };
+}
+
+function isAliasAddedMove(move: EntityMergeMove): move is Extract<EntityMergeMove, { kind: "alias_added" }> {
+  return "kind" in move && move.kind === "alias_added";
 }
 
 function updatedCount(result: { numUpdatedRows?: bigint | number | string } | undefined): number {
@@ -676,6 +683,42 @@ async function applyMergeMoves(
   await repointReviewQueue(db, loserId, survivorId, moves);
 }
 
+async function carryLoserAliasesToSurvivor(
+  db: Kysely<DB>,
+  loser: Entity,
+  survivor: Entity,
+  moves: EntityMergeMove[],
+): Promise<void> {
+  const aliases = parseAliasesString(survivor.aliases);
+  const existingKeys = new Set<string>();
+  const survivorNameKey = normalizeStrict(survivor.name);
+  if (survivorNameKey) existingKeys.add(survivorNameKey);
+  for (const alias of aliases) {
+    const key = normalizeStrict(alias);
+    if (key) existingKeys.add(key);
+  }
+
+  const added: string[] = [];
+  for (const raw of [loser.name, ...parseAliasesString(loser.aliases)]) {
+    const value = raw.trim();
+    const normalizedKey = normalizeStrict(value);
+    if (!value || !normalizedKey || existingKeys.has(normalizedKey)) continue;
+    existingKeys.add(normalizedKey);
+    aliases.push(value);
+    added.push(value);
+    moves.push({ kind: "alias_added", value, normalizedKey });
+  }
+
+  if (added.length === 0) return;
+  await db
+    .updateTable("entities")
+    .set({ aliases: JSON.stringify(aliases), updated_at: new Date().toISOString() })
+    .where("id", "=", survivor.id)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .execute();
+}
+
 function emptyMergePreview(
   input: { survivorId: string; loserId: string },
   blocked?: EntityMergeErrorCode,
@@ -812,6 +855,7 @@ async function insertPayload(db: Kysely<DB>, table: string, payload: Record<stri
 }
 
 async function reverseMove(db: Kysely<DB>, move: EntityMergeMove): Promise<void> {
+  if (isAliasAddedMove(move)) return;
   if ("collided" in move) {
     await insertPayload(db, move.table, move.payload);
     return;
@@ -934,6 +978,31 @@ async function reverseMove(db: Kysely<DB>, move: EntityMergeMove): Promise<void>
   }
 }
 
+async function reverseAliasAdditions(db: Kysely<DB>, survivorId: string, moves: EntityMergeMove[]): Promise<void> {
+  const aliasMoves = moves.filter(isAliasAddedMove);
+  if (aliasMoves.length === 0) return;
+
+  const row = await db
+    .selectFrom("entities")
+    .select("aliases")
+    .where("id", "=", survivorId)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .executeTakeFirst();
+  if (!row) return;
+
+  const toRemove = new Set(aliasMoves.map((move) => `${move.normalizedKey}\0${move.value}`));
+  const aliases = parseAliasesString(row.aliases);
+  const next = aliases.filter((alias) => !toRemove.has(`${normalizeStrict(alias)}\0${alias}`));
+  if (next.length === aliases.length) return;
+
+  await db
+    .updateTable("entities")
+    .set({ aliases: next.length > 0 ? JSON.stringify(next) : null, updated_at: new Date().toISOString() })
+    .where("id", "=", survivorId)
+    .execute();
+}
+
 export async function mergeEntitiesInTransaction(
   db: Kysely<DB>,
   input: MergeEntitiesInput,
@@ -944,6 +1013,7 @@ export async function mergeEntitiesInTransaction(
 
   const moves: EntityMergeMove[] = [];
   await applyMergeMoves(db, input.loserId, input.survivorId, moves);
+  if (survivor && loser) await carryLoserAliasesToSurvivor(db, loser, survivor, moves);
 
   const now = new Date().toISOString();
   const tombstone = await db
@@ -1020,6 +1090,7 @@ export async function unmergeEntities(db: Kysely<DB>, input: UnmergeEntitiesInpu
     }
 
     const moves = JSON.parse(merge.moves) as EntityMergeMove[];
+    await reverseAliasAdditions(trx, merge.survivor_entity_id, moves);
     for (const move of [...moves].reverse()) {
       await reverseMove(trx, move);
     }

--- a/packages/server/src/scripts/entity-dedup-backfill.test.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.test.ts
@@ -1,0 +1,157 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DB } from "../db/schema";
+import { unmergeEntities } from "../entities/merge";
+import { createTestDb } from "../test-utils";
+import { runEntityDedupBackfill } from "./entity-dedup-backfill";
+
+const USER_ID = "entity-dedup-backfill-user";
+
+async function seedUser(db: Kysely<DB>): Promise<void> {
+  await db.insertInto("users").values({ id: USER_ID, name: "Backfill User", email: "backfill@example.com" }).execute();
+}
+
+async function seedEntity(
+  db: Kysely<DB>,
+  input: {
+    id: string;
+    name: string;
+    type: string;
+    metadata?: Record<string, unknown>;
+  },
+): Promise<void> {
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: input.type,
+      subtype: null,
+      aliases: null,
+      metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .execute();
+}
+
+async function seedCorporateDomain(db: Kysely<DB>, id: string, entityId: string, domain: string): Promise<void> {
+  await db
+    .insertInto("entity_domains")
+    .values({
+      id,
+      entity_id: entityId,
+      domain,
+      kind: "corporate",
+      is_primary: 1,
+      confidence: 1,
+      source: "test",
+    })
+    .execute();
+}
+
+describe("entity dedup backfill", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUser(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("dry-run reports a strict Redseer pair without mutating the graph", async () => {
+    await seedEntity(db, { id: "redseer-a", name: "Redseer Consulting", type: "company" });
+    await seedEntity(db, { id: "redseer-b", name: "RedseerConsulting", type: "company" });
+
+    const result = await runEntityDedupBackfill(db, { userId: USER_ID });
+
+    expect(result.mode).toBe("dry-run");
+    expect(result.autoMergeCandidates).toEqual([
+      expect.objectContaining({
+        survivorId: "redseer-a",
+        loserId: "redseer-b",
+        survivorName: "Redseer Consulting",
+        loserName: "RedseerConsulting",
+        reason: "strict",
+      }),
+    ]);
+    expect(result.queuedCandidates).toHaveLength(0);
+    await expect(db.selectFrom("entities").selectAll().where("deleted_at", "is", null).execute()).resolves.toHaveLength(
+      2,
+    );
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(0);
+  });
+
+  it("execute merges a strict pair, writes the ledger, and unmerge reverses it", async () => {
+    await seedEntity(db, { id: "redseer-a", name: "Redseer Consulting", type: "company" });
+    await seedEntity(db, { id: "redseer-b", name: "RedseerConsulting", type: "company" });
+
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID });
+
+    expect(result.merged).toEqual([
+      expect.objectContaining({
+        survivorId: "redseer-a",
+        loserId: "redseer-b",
+        reason: "strict",
+      }),
+    ]);
+    const merge = await db.selectFrom("entity_merges").selectAll().executeTakeFirstOrThrow();
+    expect(merge.survivor_entity_id).toBe("redseer-a");
+    expect(merge.merged_entity_id).toBe("redseer-b");
+    await expect(
+      db
+        .selectFrom("entities")
+        .select(["deleted_at", "merged_into_entity_id"])
+        .where("id", "=", "redseer-b")
+        .executeTakeFirst(),
+    ).resolves.toMatchObject({ merged_into_entity_id: "redseer-a" });
+
+    await unmergeEntities(db, { mergeId: merge.id, userId: USER_ID });
+
+    await expect(
+      db
+        .selectFrom("entities")
+        .select(["deleted_at", "merged_into_entity_id"])
+        .where("id", "=", "redseer-b")
+        .executeTakeFirst(),
+    ).resolves.toMatchObject({ deleted_at: null, merged_into_entity_id: null });
+  });
+
+  it("queues same-name people with different mapped companies instead of merging them", async () => {
+    await seedEntity(db, { id: "company-a", name: "Acme", type: "company" });
+    await seedEntity(db, { id: "company-b", name: "Beta", type: "company" });
+    await seedCorporateDomain(db, "domain-a", "company-a", "acme.com");
+    await seedCorporateDomain(db, "domain-b", "company-b", "beta.com");
+    await seedEntity(db, {
+      id: "person-a",
+      name: "Alex Rao",
+      type: "person",
+      metadata: { email: "alex@acme.com" },
+    });
+    await seedEntity(db, {
+      id: "person-b",
+      name: "AlexRao",
+      type: "person",
+      metadata: { email: "alex@beta.com" },
+    });
+
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID });
+
+    expect(result.merged).toHaveLength(0);
+    expect(result.queued).toEqual([
+      expect.objectContaining({
+        survivorId: "person-a",
+        loserId: "person-b",
+        reason: "person_scope_mismatch",
+      }),
+    ]);
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(0);
+    await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(1);
+  });
+});

--- a/packages/server/src/scripts/entity-dedup-backfill.test.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.test.ts
@@ -152,6 +152,27 @@ describe("entity dedup backfill", () => {
       }),
     ]);
     await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(0);
-    await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(1);
+    const queue = await db.selectFrom("entity_review_queue").selectAll().execute();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.source_id).not.toContain("\0");
+  });
+
+  it("re-resolves queued pairs after strict auto-merges", async () => {
+    await seedEntity(db, { id: "redseer-a", name: "Redseer Consulting", type: "company" });
+    await seedEntity(db, { id: "redseer-b", name: "RedseerConsulting", type: "company" });
+    await seedEntity(db, { id: "redseer-c", name: "Redseer Consultng", type: "company" });
+
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, fuzzyThreshold: 0.7 });
+
+    await expect(
+      db
+        .selectFrom("entities")
+        .select(["deleted_at", "merged_into_entity_id"])
+        .where("id", "=", "redseer-b")
+        .executeTakeFirst(),
+    ).resolves.toMatchObject({ merged_into_entity_id: "redseer-a" });
+    expect(result.queued.some((pair) => pair.survivorId === "redseer-b" || pair.loserId === "redseer-b")).toBe(false);
+    const queue = await db.selectFrom("entity_review_queue").selectAll().execute();
+    expect(queue.some((row) => row.candidate_entity_id === "redseer-b")).toBe(false);
   });
 });

--- a/packages/server/src/scripts/entity-dedup-backfill.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.ts
@@ -1,0 +1,363 @@
+import { parseArgs } from "node:util";
+import type { Kysely, Selectable } from "kysely";
+import { loadConfig, validateConfig } from "../config";
+import { createDatabase } from "../db";
+import { runMigrations } from "../db/migrate";
+import { whereLiveEntity } from "../db/repositories/entities";
+import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
+import { createEntityReviewRepo } from "../db/repositories/entity-review";
+import type { DB, EntitiesTable } from "../db/schema";
+import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "../entities/affiliations";
+import { readPersonEmailFromMetadata } from "../entities/materialize-json";
+import { mergeEntities, previewMerge } from "../entities/merge";
+import { type CandidatePoolEntry, buildCandidatePool, findFuzzyMatches, normalizeStrict } from "../entities/name-dedup";
+import type { ProposeEntityType } from "../entities/propose";
+import { yieldToEventLoop } from "../lib/event-loop";
+
+type Entity = Selectable<EntitiesTable>;
+
+export interface EntityDedupBackfillOptions {
+  execute?: boolean;
+  userId: string;
+  fuzzyThreshold?: number;
+  sampleLimit?: number;
+  batchSize?: number;
+}
+
+export interface EntityDedupBackfillPair {
+  entityType: string;
+  survivorId: string;
+  loserId: string;
+  survivorName: string;
+  loserName: string;
+  reason: "strict" | "fuzzy" | "ambiguous" | "person_scope_missing" | "person_scope_mismatch";
+  score: number;
+}
+
+export interface EntityDedupBackfillResult {
+  mode: "dry-run" | "execute";
+  autoMergeCandidates: EntityDedupBackfillPair[];
+  queuedCandidates: EntityDedupBackfillPair[];
+  merged: EntityDedupBackfillPair[];
+  queued: EntityDedupBackfillPair[];
+  skipped: EntityDedupBackfillPair[];
+  samples: {
+    autoMerge: EntityDedupBackfillPair[];
+    queue: EntityDedupBackfillPair[];
+  };
+}
+
+interface TypeScan {
+  entityType: string;
+  entities: Entity[];
+  entries: CandidatePoolEntry[];
+}
+
+interface PersonScopes {
+  byEntityId: Map<string, Set<string>>;
+}
+
+const SUPPORTED_TYPES: ProposeEntityType[] = ["person", "company", "product", "project", "team", "deal"];
+const DEFAULT_FUZZY_THRESHOLD = 0.85;
+const DEFAULT_SAMPLE_LIMIT = 10;
+const DEFAULT_BATCH_SIZE = 100;
+const BACKFILL_SOURCE = "entity_dedup_backfill";
+
+function parseAliases(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function pairKey(a: string, b: string): string {
+  return [a, b].sort().join("\0");
+}
+
+function chooseSurvivor(a: Entity, b: Entity): { survivor: Entity; loser: Entity } {
+  const sorted = [a, b].sort((left, right) => {
+    if (right.hotness !== left.hotness) return right.hotness - left.hotness;
+    if (left.status !== right.status) {
+      if (left.status === "confirmed") return -1;
+      if (right.status === "confirmed") return 1;
+    }
+    if (left.created_at !== right.created_at) return left.created_at.localeCompare(right.created_at);
+    return left.id.localeCompare(right.id);
+  });
+  return { survivor: sorted[0], loser: sorted[1] };
+}
+
+function toPair(
+  entityType: string,
+  a: Entity,
+  b: Entity,
+  reason: EntityDedupBackfillPair["reason"],
+  score: number,
+): EntityDedupBackfillPair {
+  const { survivor, loser } = chooseSurvivor(a, b);
+  return {
+    entityType,
+    survivorId: survivor.id,
+    loserId: loser.id,
+    survivorName: survivor.name,
+    loserName: loser.name,
+    reason,
+    score,
+  };
+}
+
+async function loadTypeScans(db: Kysely<DB>): Promise<TypeScan[]> {
+  const entities = await db
+    .selectFrom("entities")
+    .selectAll()
+    .where("source_type", "in", SUPPORTED_TYPES)
+    .where(whereLiveEntity())
+    .execute();
+
+  const byType = new Map<string, Entity[]>();
+  for (const type of SUPPORTED_TYPES) byType.set(type, []);
+  for (const entity of entities) byType.get(entity.source_type)?.push(entity);
+
+  return [...byType].map(([entityType, rows]) => ({
+    entityType,
+    entities: rows,
+    entries: rows.flatMap((entity) => [
+      { entityId: entity.id, valueKind: "name" as const, value: entity.name },
+      ...parseAliases(entity.aliases).map((value) => ({ entityId: entity.id, valueKind: "alias" as const, value })),
+    ]),
+  }));
+}
+
+async function buildPersonScopes(db: Kysely<DB>, persons: Entity[]): Promise<PersonScopes> {
+  const domainsRepo = createEntityDomainsRepository(db);
+  const byEntityId = new Map<string, Set<string>>();
+  for (const person of persons) byEntityId.set(person.id, new Set());
+
+  for (const person of persons) {
+    const scope = await personScopeKey(readPersonEmailFromMetadata(person.metadata), domainsRepo);
+    if (scope) byEntityId.get(person.id)?.add(personScopeKeyId(scope));
+  }
+
+  const personIds = persons.map((person) => person.id);
+  const worksAtRows =
+    personIds.length > 0
+      ? await db
+          .selectFrom("entity_relationships")
+          .select(["source_entity_id", "target_entity_id"])
+          .where("relationship_type", "=", "works_at")
+          .where("source_entity_id", "in", personIds)
+          .where("valid_to", "is", null)
+          .execute()
+      : [];
+  for (const row of worksAtRows) {
+    byEntityId.get(row.source_entity_id)?.add(personScopeKeyId({ kind: "company", value: row.target_entity_id }));
+  }
+
+  return { byEntityId };
+}
+
+function classifyPersonStrictPair(pair: EntityDedupBackfillPair, scopes: PersonScopes): EntityDedupBackfillPair {
+  const survivorScopes = scopes.byEntityId.get(pair.survivorId) ?? new Set();
+  const loserScopes = scopes.byEntityId.get(pair.loserId) ?? new Set();
+  const survivorTrusted = [...survivorScopes].filter(isTrustedPersonScopeKey);
+  const loserTrusted = [...loserScopes].filter(isTrustedPersonScopeKey);
+  if (survivorTrusted.length === 0 || loserTrusted.length === 0) return { ...pair, reason: "person_scope_missing" };
+  if (survivorTrusted.some((scope) => loserScopes.has(scope))) return pair;
+  return { ...pair, reason: "person_scope_mismatch" };
+}
+
+function addUniquePair(map: Map<string, EntityDedupBackfillPair>, pair: EntityDedupBackfillPair): void {
+  const key = pairKey(pair.survivorId, pair.loserId);
+  const existing = map.get(key);
+  if (!existing || pair.score > existing.score) map.set(key, pair);
+}
+
+async function discoverPairs(
+  db: Kysely<DB>,
+  scans: TypeScan[],
+  opts: Required<Pick<EntityDedupBackfillOptions, "fuzzyThreshold" | "batchSize">>,
+): Promise<{ autoMerge: EntityDedupBackfillPair[]; queue: EntityDedupBackfillPair[] }> {
+  const autoMerge = new Map<string, EntityDedupBackfillPair>();
+  const queue = new Map<string, EntityDedupBackfillPair>();
+  const personScan = scans.find((scan) => scan.entityType === "person");
+  const personScopes = personScan ? await buildPersonScopes(db, personScan.entities) : { byEntityId: new Map() };
+
+  for (const scan of scans) {
+    const entitiesById = new Map(scan.entities.map((entity) => [entity.id, entity]));
+    const pool = buildCandidatePool(scan.entries);
+    const strictPairKeys = new Set<string>();
+
+    for (const bucket of pool.byStrictKey.values()) {
+      const ids = [...new Set(bucket.map((entry) => entry.entityId))].sort();
+      if (ids.length < 2) continue;
+      for (let i = 0; i < ids.length; i += 1) {
+        for (let j = i + 1; j < ids.length; j += 1) {
+          strictPairKeys.add(pairKey(ids[i], ids[j]));
+        }
+      }
+      if (ids.length === 2) {
+        const a = entitiesById.get(ids[0]);
+        const b = entitiesById.get(ids[1]);
+        if (!a || !b) continue;
+        const pair =
+          scan.entityType === "person"
+            ? classifyPersonStrictPair(toPair(scan.entityType, a, b, "strict", 1), personScopes)
+            : toPair(scan.entityType, a, b, "strict", 1);
+        if (pair.reason === "strict") addUniquePair(autoMerge, pair);
+        else addUniquePair(queue, pair);
+        continue;
+      }
+      for (let i = 0; i < ids.length; i += 1) {
+        for (let j = i + 1; j < ids.length; j += 1) {
+          const a = entitiesById.get(ids[i]);
+          const b = entitiesById.get(ids[j]);
+          if (a && b) addUniquePair(queue, toPair(scan.entityType, a, b, "ambiguous", 1));
+        }
+      }
+    }
+
+    let scanned = 0;
+    for (const entry of scan.entries) {
+      scanned += 1;
+      if (scanned % opts.batchSize === 0) await yieldToEventLoop();
+      const entity = entitiesById.get(entry.entityId);
+      if (!entity) continue;
+      for (const match of findFuzzyMatches(entry.value, pool, { threshold: opts.fuzzyThreshold })) {
+        if (match.entityId === entry.entityId) continue;
+        if (strictPairKeys.has(pairKey(entry.entityId, match.entityId))) continue;
+        const matched = entitiesById.get(match.entityId);
+        if (!matched) continue;
+        addUniquePair(queue, toPair(scan.entityType, entity, matched, "fuzzy", match.score));
+      }
+    }
+  }
+
+  return {
+    autoMerge: [...autoMerge.values()].sort(sortPairs),
+    queue: [...queue.values()].sort(sortPairs),
+  };
+}
+
+function sortPairs(a: EntityDedupBackfillPair, b: EntityDedupBackfillPair): number {
+  return (
+    a.entityType.localeCompare(b.entityType) ||
+    a.survivorName.localeCompare(b.survivorName) ||
+    a.loserName.localeCompare(b.loserName) ||
+    a.survivorId.localeCompare(b.survivorId) ||
+    a.loserId.localeCompare(b.loserId)
+  );
+}
+
+async function queuePair(db: Kysely<DB>, pair: EntityDedupBackfillPair, userId: string): Promise<void> {
+  const reviewRepo = createEntityReviewRepo(db);
+  await reviewRepo.upsertQueueRow({
+    proposedName: pair.loserName,
+    normalizedName: `${BACKFILL_SOURCE}:${pair.entityType}:${normalizeStrict(pair.survivorName || pair.loserName)}`,
+    entityType: pair.entityType,
+    source: BACKFILL_SOURCE,
+    sourceId: pairKey(pair.survivorId, pair.loserId),
+    candidateEntityId: pair.reason === "ambiguous" ? null : pair.survivorId,
+    candidateScore: pair.reason === "ambiguous" ? null : pair.score,
+    candidateReason: pair.reason === "fuzzy" ? "minhash" : "strict-normalized",
+    triggeredByUserId: userId,
+  });
+}
+
+export async function runEntityDedupBackfill(
+  db: Kysely<DB>,
+  options: EntityDedupBackfillOptions,
+): Promise<EntityDedupBackfillResult> {
+  const execute = options.execute === true;
+  const sampleLimit = options.sampleLimit ?? DEFAULT_SAMPLE_LIMIT;
+  const fuzzyThreshold = options.fuzzyThreshold ?? DEFAULT_FUZZY_THRESHOLD;
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const scans = await loadTypeScans(db);
+  const discovered = await discoverPairs(db, scans, { fuzzyThreshold, batchSize });
+  const result: EntityDedupBackfillResult = {
+    mode: execute ? "execute" : "dry-run",
+    autoMergeCandidates: discovered.autoMerge,
+    queuedCandidates: discovered.queue,
+    merged: [],
+    queued: [],
+    skipped: [],
+    samples: {
+      autoMerge: discovered.autoMerge.slice(0, sampleLimit),
+      queue: discovered.queue.slice(0, sampleLimit),
+    },
+  };
+
+  if (!execute) return result;
+
+  let processed = 0;
+  for (const pair of discovered.autoMerge) {
+    processed += 1;
+    const preview = await previewMerge(db, { survivorId: pair.survivorId, loserId: pair.loserId });
+    if (preview.blocked) {
+      result.skipped.push(pair);
+      continue;
+    }
+    await mergeEntities(db, { survivorId: pair.survivorId, loserId: pair.loserId, userId: options.userId });
+    result.merged.push(pair);
+    if (processed % batchSize === 0) await yieldToEventLoop();
+  }
+
+  for (const pair of discovered.queue) {
+    processed += 1;
+    await queuePair(db, pair, options.userId);
+    result.queued.push(pair);
+    if (processed % batchSize === 0) await yieldToEventLoop();
+  }
+
+  return result;
+}
+
+function printResult(result: EntityDedupBackfillResult): void {
+  console.log(
+    JSON.stringify(
+      {
+        mode: result.mode,
+        autoMergeCandidates: result.autoMergeCandidates.length,
+        queuedCandidates: result.queuedCandidates.length,
+        merged: result.merged.length,
+        queued: result.queued.length,
+        skipped: result.skipped.length,
+        samples: result.samples,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs({
+    options: {
+      execute: { type: "boolean", default: false },
+      "user-id": { type: "string", default: "entity-dedup-backfill" },
+      "fuzzy-threshold": { type: "string", default: String(DEFAULT_FUZZY_THRESHOLD) },
+      "sample-limit": { type: "string", default: String(DEFAULT_SAMPLE_LIMIT) },
+    },
+  });
+  const config = loadConfig();
+  validateConfig(config);
+  const db = await createDatabase(config);
+  try {
+    await runMigrations(db);
+    const result = await runEntityDedupBackfill(db, {
+      execute: parsed.values.execute,
+      userId: parsed.values["user-id"],
+      fuzzyThreshold: Number(parsed.values["fuzzy-threshold"]),
+      sampleLimit: Number(parsed.values["sample-limit"]),
+    });
+    printResult(result);
+  } finally {
+    await db.destroy();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/packages/server/src/scripts/entity-dedup-backfill.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.ts
@@ -22,6 +22,8 @@ export interface EntityDedupBackfillOptions {
   fuzzyThreshold?: number;
   sampleLimit?: number;
   batchSize?: number;
+  /** Entity ids to leave untouched — any pair where either side matches is dropped. */
+  excludeEntityIds?: string[];
 }
 
 export interface EntityDedupBackfillPair {
@@ -276,23 +278,28 @@ export async function runEntityDedupBackfill(
   const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
   const scans = await loadTypeScans(db);
   const discovered = await discoverPairs(db, scans, { fuzzyThreshold, batchSize });
+  const excludeIds = new Set(options.excludeEntityIds ?? []);
+  const keepPair = (pair: EntityDedupBackfillPair): boolean =>
+    !excludeIds.has(pair.survivorId) && !excludeIds.has(pair.loserId);
+  const autoMerge = discovered.autoMerge.filter(keepPair);
+  const queueCandidates = discovered.queue.filter(keepPair);
   const result: EntityDedupBackfillResult = {
     mode: execute ? "execute" : "dry-run",
-    autoMergeCandidates: discovered.autoMerge,
-    queuedCandidates: discovered.queue,
+    autoMergeCandidates: autoMerge,
+    queuedCandidates: queueCandidates,
     merged: [],
     queued: [],
     skipped: [],
     samples: {
-      autoMerge: discovered.autoMerge.slice(0, sampleLimit),
-      queue: discovered.queue.slice(0, sampleLimit),
+      autoMerge: autoMerge.slice(0, sampleLimit),
+      queue: queueCandidates.slice(0, sampleLimit),
     },
   };
 
   if (!execute) return result;
 
   let processed = 0;
-  for (const pair of discovered.autoMerge) {
+  for (const pair of autoMerge) {
     processed += 1;
     const preview = await previewMerge(db, { survivorId: pair.survivorId, loserId: pair.loserId });
     if (preview.blocked) {
@@ -304,7 +311,7 @@ export async function runEntityDedupBackfill(
     if (processed % batchSize === 0) await yieldToEventLoop();
   }
 
-  for (const pair of discovered.queue) {
+  for (const pair of queueCandidates) {
     processed += 1;
     await queuePair(db, pair, options.userId);
     result.queued.push(pair);
@@ -339,6 +346,7 @@ async function main(): Promise<void> {
       "user-id": { type: "string", default: "entity-dedup-backfill" },
       "fuzzy-threshold": { type: "string", default: String(DEFAULT_FUZZY_THRESHOLD) },
       "sample-limit": { type: "string", default: String(DEFAULT_SAMPLE_LIMIT) },
+      "exclude-entity": { type: "string" },
     },
   });
   const config = loadConfig();
@@ -351,6 +359,10 @@ async function main(): Promise<void> {
       userId: parsed.values["user-id"],
       fuzzyThreshold: Number(parsed.values["fuzzy-threshold"]),
       sampleLimit: Number(parsed.values["sample-limit"]),
+      excludeEntityIds: parsed.values["exclude-entity"]
+        ?.split(",")
+        .map((id) => id.trim())
+        .filter(Boolean),
     });
     printResult(result);
   } finally {

--- a/packages/server/src/scripts/entity-dedup-backfill.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.ts
@@ -79,6 +79,10 @@ function pairKey(a: string, b: string): string {
   return [a, b].sort().join("\0");
 }
 
+function persistedPairKey(a: string, b: string): string {
+  return [a, b].sort().map(encodeURIComponent).join("~");
+}
+
 function chooseSurvivor(a: Entity, b: Entity): { survivor: Entity; loser: Entity } {
   const sorted = [a, b].sort((left, right) => {
     if (right.hotness !== left.hotness) return right.hotness - left.hotness;
@@ -260,12 +264,44 @@ async function queuePair(db: Kysely<DB>, pair: EntityDedupBackfillPair, userId: 
     normalizedName: `${BACKFILL_SOURCE}:${pair.entityType}:${normalizeStrict(pair.survivorName || pair.loserName)}`,
     entityType: pair.entityType,
     source: BACKFILL_SOURCE,
-    sourceId: pairKey(pair.survivorId, pair.loserId),
+    sourceId: persistedPairKey(pair.survivorId, pair.loserId),
     candidateEntityId: pair.reason === "ambiguous" ? null : pair.survivorId,
     candidateScore: pair.reason === "ambiguous" ? null : pair.score,
     candidateReason: pair.reason === "fuzzy" ? "minhash" : "strict-normalized",
     triggeredByUserId: userId,
   });
+}
+
+async function resolveLiveEntity(db: Kysely<DB>, entityId: string): Promise<Entity | null> {
+  const seen = new Set<string>();
+  let currentId: string | null = entityId;
+
+  while (currentId) {
+    if (seen.has(currentId)) return null;
+    seen.add(currentId);
+    const row = await db.selectFrom("entities").selectAll().where("id", "=", currentId).executeTakeFirst();
+    if (!row) return null;
+    if (!row.deleted_at && !row.merged_into_entity_id) return row;
+    currentId = row.merged_into_entity_id;
+  }
+
+  return null;
+}
+
+async function resolveQueuedPair(
+  db: Kysely<DB>,
+  pair: EntityDedupBackfillPair,
+): Promise<EntityDedupBackfillPair | null> {
+  const survivor = await resolveLiveEntity(db, pair.survivorId);
+  const loser = await resolveLiveEntity(db, pair.loserId);
+  if (!survivor || !loser || survivor.id === loser.id) return null;
+  return {
+    ...pair,
+    survivorId: survivor.id,
+    loserId: loser.id,
+    survivorName: survivor.name,
+    loserName: loser.name,
+  };
 }
 
 export async function runEntityDedupBackfill(
@@ -313,8 +349,14 @@ export async function runEntityDedupBackfill(
 
   for (const pair of queueCandidates) {
     processed += 1;
-    await queuePair(db, pair, options.userId);
-    result.queued.push(pair);
+    const resolved = await resolveQueuedPair(db, pair);
+    if (!resolved) {
+      result.skipped.push(pair);
+      if (processed % batchSize === 0) await yieldToEventLoop();
+      continue;
+    }
+    await queuePair(db, resolved, options.userId);
+    result.queued.push(resolved);
     if (processed % batchSize === 0) await yieldToEventLoop();
   }
 


### PR DESCRIPTION
Stacked context-graph slice 02/27.

Base: `feat/context-graph-01-name-dedup`
Head: `feat/context-graph-02-dedup-merge-backfill`

Stabilizes merge/backfill queueing before larger adjudication work.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`