### PR TITLE
feat: add graph-adjacency dedup adjudication

### DIFF
--- a/packages/server/src/entities/adjacency.ts
+++ b/packages/server/src/entities/adjacency.ts
@@ -1,0 +1,166 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+import type { DB } from "../db/schema";
+import { LLM_RELATION_CONFIDENCE_THRESHOLD } from "./graph";
+
+export type NeighborSet = Set<string>;
+
+export interface BuildAdjacencyIndexOptions {
+  coMentionMinShared?: number;
+  coMentionTopK?: number;
+  hubDegreeCap?: number;
+}
+
+const DEFAULT_CO_MENTION_MIN_SHARED = 2;
+const DEFAULT_CO_MENTION_TOP_K = 25;
+const DEFAULT_HUB_DEGREE_CAP = 30;
+
+/**
+ * Builds a typed adjacency fingerprint for each entity from current
+ * high-confidence graph relationships and repeated distinct-file co-mentions.
+ * High-degree keys are removed after indexing so ubiquitous people, parents, or
+ * broad file co-mentions cannot dominate overlap.
+ */
+export async function buildAdjacencyIndex(
+  db: Kysely<DB>,
+  entityIds: string[],
+  options: BuildAdjacencyIndexOptions = {},
+): Promise<Map<string, NeighborSet>> {
+  const uniqueIds = [...new Set(entityIds)].sort();
+  const index = new Map<string, NeighborSet>(uniqueIds.map((id) => [id, new Set<string>()]));
+  if (uniqueIds.length === 0) return index;
+
+  const coMentionMinShared = options.coMentionMinShared ?? DEFAULT_CO_MENTION_MIN_SHARED;
+  const coMentionTopK = options.coMentionTopK ?? DEFAULT_CO_MENTION_TOP_K;
+  const hubDegreeCap = options.hubDegreeCap ?? DEFAULT_HUB_DEGREE_CAP;
+
+  const relationshipRows = await db
+    .selectFrom("entity_relationships")
+    .select(["source_entity_id", "target_entity_id", "relationship_type"])
+    .where((eb) => eb.or([eb("source_entity_id", "in", uniqueIds), eb("target_entity_id", "in", uniqueIds)]))
+    .where("valid_to", "is", null)
+    .where("confidence", "!=", "AMBIGUOUS")
+    .where("confidence_score", ">=", LLM_RELATION_CONFIDENCE_THRESHOLD)
+    .execute();
+
+  const requested = new Set(uniqueIds);
+  for (const row of relationshipRows) {
+    if (requested.has(row.source_entity_id)) {
+      index.get(row.source_entity_id)?.add(`rel:${row.relationship_type}:${row.target_entity_id}`);
+    }
+    if (requested.has(row.target_entity_id)) {
+      index.get(row.target_entity_id)?.add(`rel:${row.relationship_type}:${row.source_entity_id}`);
+    }
+  }
+
+  const coMentionRows = await db
+    .selectFrom("entity_mentions as subject_mention")
+    .innerJoin("entity_mentions as other_mention", "other_mention.indexed_file_id", "subject_mention.indexed_file_id")
+    .innerJoin("indexed_files", "indexed_files.id", "subject_mention.indexed_file_id")
+    .innerJoin("entities as other_entity", "other_entity.id", "other_mention.entity_id")
+    .select([
+      "subject_mention.entity_id as subjectEntityId",
+      "other_mention.entity_id as otherEntityId",
+      sql<number>`COUNT(DISTINCT subject_mention.indexed_file_id)`.as("sharedFileCount"),
+    ])
+    .where("subject_mention.entity_id", "in", uniqueIds)
+    .whereRef("other_mention.entity_id", "!=", "subject_mention.entity_id")
+    .where("indexed_files.is_archived", "=", 0)
+    .where("other_entity.deleted_at", "is", null)
+    .where("other_entity.merged_into_entity_id", "is", null)
+    .groupBy(["subject_mention.entity_id", "other_mention.entity_id"])
+    .having(sql<number>`COUNT(DISTINCT subject_mention.indexed_file_id)`, ">=", coMentionMinShared)
+    .orderBy("subject_mention.entity_id", "asc")
+    .orderBy("sharedFileCount", "desc")
+    .orderBy("other_mention.entity_id", "asc")
+    .execute();
+
+  const coMentionCountsBySubject = new Map<string, number>();
+  for (const row of coMentionRows) {
+    const used = coMentionCountsBySubject.get(row.subjectEntityId) ?? 0;
+    if (used >= coMentionTopK) continue;
+    index.get(row.subjectEntityId)?.add(`co:${row.otherEntityId}`);
+    coMentionCountsBySubject.set(row.subjectEntityId, used + 1);
+  }
+
+  pruneHubNeighbors(index, hubDegreeCap);
+  return index;
+}
+
+export function overlapCoefficient(a: NeighborSet, b: NeighborSet): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a];
+  for (const key of smaller) {
+    if (larger.has(key)) intersection += 1;
+  }
+  return intersection / smaller.size;
+}
+
+/**
+ * Returns a determinate canonical company scope only for current
+ * high-confidence ownership/client relationships. Multiple distinct canonical
+ * company ids intentionally collapse to null instead of guessing.
+ */
+export async function owningCompanyScope(db: Kysely<DB>, entityId: string): Promise<string | null> {
+  const rows = await db
+    .selectFrom("entity_relationships")
+    .innerJoin("entities as source_entity", "source_entity.id", "entity_relationships.source_entity_id")
+    .innerJoin("entities as target_entity", "target_entity.id", "entity_relationships.target_entity_id")
+    .select([
+      "entity_relationships.source_entity_id",
+      "entity_relationships.target_entity_id",
+      "entity_relationships.relationship_type",
+      "source_entity.source_type as sourceType",
+      "source_entity.merged_into_entity_id as sourceMergedIntoEntityId",
+      "target_entity.source_type as targetType",
+      "target_entity.merged_into_entity_id as targetMergedIntoEntityId",
+    ])
+    .where((eb) => eb.or([eb("source_entity_id", "=", entityId), eb("target_entity_id", "=", entityId)]))
+    .where("entity_relationships.valid_to", "is", null)
+    .where("entity_relationships.confidence", "!=", "AMBIGUOUS")
+    .where("entity_relationships.confidence_score", ">=", LLM_RELATION_CONFIDENCE_THRESHOLD)
+    .execute();
+
+  const companyIds = new Set<string>();
+  for (const row of rows) {
+    if (row.relationship_type === "builds" && row.target_entity_id === entityId && row.sourceType === "company") {
+      companyIds.add(row.sourceMergedIntoEntityId ?? row.source_entity_id);
+    }
+    if (
+      row.relationship_type === "engagement_for" &&
+      row.source_entity_id === entityId &&
+      row.targetType === "company"
+    ) {
+      companyIds.add(row.targetMergedIntoEntityId ?? row.target_entity_id);
+    }
+    if (row.relationship_type === "part_of" && row.source_entity_id === entityId && row.targetType === "company") {
+      companyIds.add(row.targetMergedIntoEntityId ?? row.target_entity_id);
+    }
+    if (row.relationship_type === "part_of" && row.target_entity_id === entityId && row.sourceType === "company") {
+      companyIds.add(row.sourceMergedIntoEntityId ?? row.source_entity_id);
+    }
+  }
+
+  return companyIds.size === 1 ? [...companyIds][0] : null;
+}
+
+function pruneHubNeighbors(index: Map<string, NeighborSet>, hubDegreeCap: number): void {
+  const degreeByNeighbor = new Map<string, Set<string>>();
+  for (const [entityId, neighbors] of index) {
+    for (const neighbor of neighbors) {
+      const degree = degreeByNeighbor.get(neighbor);
+      if (degree) degree.add(entityId);
+      else degreeByNeighbor.set(neighbor, new Set([entityId]));
+    }
+  }
+
+  const hubs = new Set(
+    [...degreeByNeighbor].filter(([, entityIds]) => entityIds.size > hubDegreeCap).map(([neighbor]) => neighbor),
+  );
+  if (hubs.size === 0) return;
+
+  for (const neighbors of index.values()) {
+    for (const hub of hubs) neighbors.delete(hub);
+  }
+}

--- a/packages/server/src/entities/adjudicate.ts
+++ b/packages/server/src/entities/adjudicate.ts
@@ -1,6 +1,8 @@
 import type { Kysely } from "kysely";
 import { whereLiveEntity } from "../db/repositories/entities";
 import type { DB } from "../db/schema";
+import { owningCompanyScope } from "./adjacency";
+import { LLM_RELATION_CONFIDENCE_THRESHOLD } from "./graph";
 import { readPersonEmailFromMetadata } from "./materialize-json";
 
 export type EntityAdjudicationConfidence = "high" | "medium" | "low";
@@ -35,6 +37,9 @@ export interface EntityContext {
   email: string | null;
   corporateDomains: string[];
   worksAtCompanies: string[];
+  contributors: string[];
+  owningCompany: string | null;
+  partOfParent: string | null;
   mentionFiles: EntityMentionFileContext[];
   coMentionedEntities: EntityCoMentionContext[];
 }
@@ -81,6 +86,9 @@ function renderContext(context: EntityContext): string {
     email: context.email,
     corporateDomains: context.corporateDomains,
     worksAtCompanies: context.worksAtCompanies,
+    contributors: context.contributors,
+    owningCompany: context.owningCompany,
+    partOfParent: context.partOfParent,
     mentionFiles: context.mentionFiles,
     coMentionedEntities: context.coMentionedEntities,
   });
@@ -117,6 +125,45 @@ export async function buildEntityAdjudicationContext(db: Kysely<DB>, entityId: s
     .limit(5)
     .execute();
 
+  const contributors = await db
+    .selectFrom("entity_relationships")
+    .innerJoin("entities as contributor", "contributor.id", "entity_relationships.source_entity_id")
+    .select("contributor.name")
+    .where("entity_relationships.target_entity_id", "=", entityId)
+    .where("entity_relationships.relationship_type", "in", ["contributes_to", "leads"])
+    .where("entity_relationships.valid_to", "is", null)
+    .where("entity_relationships.confidence", "!=", "AMBIGUOUS")
+    .where("entity_relationships.confidence_score", ">=", LLM_RELATION_CONFIDENCE_THRESHOLD)
+    .where("contributor.source_type", "in", ["person", "team"])
+    .where(whereLiveEntity("contributor"))
+    .orderBy("contributor.name", "asc")
+    .limit(5)
+    .execute();
+
+  const owningCompanyId = await owningCompanyScope(db, entityId);
+  const owningCompany = owningCompanyId
+    ? await db
+        .selectFrom("entities")
+        .select("name")
+        .where("id", "=", owningCompanyId)
+        .where(whereLiveEntity())
+        .executeTakeFirst()
+    : null;
+
+  const partOfParent = await db
+    .selectFrom("entity_relationships")
+    .innerJoin("entities as parent", "parent.id", "entity_relationships.target_entity_id")
+    .select("parent.name")
+    .where("entity_relationships.source_entity_id", "=", entityId)
+    .where("entity_relationships.relationship_type", "=", "part_of")
+    .where("entity_relationships.valid_to", "is", null)
+    .where("entity_relationships.confidence", "!=", "AMBIGUOUS")
+    .where("entity_relationships.confidence_score", ">=", LLM_RELATION_CONFIDENCE_THRESHOLD)
+    .where("parent.source_type", "in", ["project", "product"])
+    .where(whereLiveEntity("parent"))
+    .orderBy("parent.name", "asc")
+    .executeTakeFirst();
+
   const mentionFiles = await db
     .selectFrom("entity_mentions")
     .innerJoin("indexed_files", "indexed_files.id", "entity_mentions.indexed_file_id")
@@ -149,6 +196,9 @@ export async function buildEntityAdjudicationContext(db: Kysely<DB>, entityId: s
     email: readPersonEmailFromMetadata(entity.metadata),
     corporateDomains: corporateDomains.map((row) => row.domain),
     worksAtCompanies: worksAtCompanies.map((row) => row.name),
+    contributors: contributors.map((row) => row.name),
+    owningCompany: owningCompany?.name ?? null,
+    partOfParent: partOfParent?.name ?? null,
     mentionFiles: mentionFiles.map((row) => ({
       fileName: row.file_name,
       sourcePath: row.source_path,

--- a/packages/server/src/entities/adjudicate.ts
+++ b/packages/server/src/entities/adjudicate.ts
@@ -1,0 +1,193 @@
+import type { Kysely } from "kysely";
+import { whereLiveEntity } from "../db/repositories/entities";
+import type { DB } from "../db/schema";
+import { readPersonEmailFromMetadata } from "./materialize-json";
+
+export type EntityAdjudicationConfidence = "high" | "medium" | "low";
+
+/**
+ * Minimal structured-generation surface the adjudicator needs. Satisfied by
+ * the enrichment Gemini generator (`createGeminiGenerator`) — the same model
+ * the rest of the entity pipeline runs on — and by a fake in tests.
+ */
+export interface AdjudicationGenerator {
+  generateJSON<T>(prompt: string, opts?: { systemPrompt?: string; maxTokens?: number; label?: string }): Promise<T>;
+}
+
+export interface EntityMentionFileContext {
+  fileName: string;
+  sourcePath: string | null;
+  summary: string | null;
+}
+
+export interface EntityCoMentionContext {
+  entityId: string;
+  name: string;
+  count: number;
+}
+
+export interface EntityContext {
+  entityId: string;
+  entityType: string;
+  name: string;
+  aliases: string[];
+  subtype: string | null;
+  email: string | null;
+  corporateDomains: string[];
+  worksAtCompanies: string[];
+  mentionFiles: EntityMentionFileContext[];
+  coMentionedEntities: EntityCoMentionContext[];
+}
+
+export interface EntityAdjudicationVerdict {
+  matchEntityId: string | null;
+  confidence: EntityAdjudicationConfidence;
+  reason: string;
+}
+
+function parseAliases(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function validateVerdict(parsed: {
+  match?: unknown;
+  confidence?: unknown;
+  reason?: unknown;
+}): EntityAdjudicationVerdict {
+  const confidence =
+    parsed.confidence === "high" || parsed.confidence === "medium" || parsed.confidence === "low"
+      ? parsed.confidence
+      : "low";
+  return {
+    matchEntityId: typeof parsed.match === "string" ? parsed.match : null,
+    confidence,
+    reason: typeof parsed.reason === "string" ? parsed.reason : "No parseable reason returned.",
+  };
+}
+
+function renderContext(context: EntityContext): string {
+  return JSON.stringify({
+    id: context.entityId,
+    type: context.entityType,
+    name: context.name,
+    aliases: context.aliases,
+    subtype: context.subtype,
+    email: context.email,
+    corporateDomains: context.corporateDomains,
+    worksAtCompanies: context.worksAtCompanies,
+    mentionFiles: context.mentionFiles,
+    coMentionedEntities: context.coMentionedEntities,
+  });
+}
+
+export async function buildEntityAdjudicationContext(db: Kysely<DB>, entityId: string): Promise<EntityContext> {
+  const entity = await db
+    .selectFrom("entities")
+    .selectAll()
+    .where("id", "=", entityId)
+    .where(whereLiveEntity())
+    .executeTakeFirstOrThrow();
+
+  const corporateDomains = await db
+    .selectFrom("entity_domains")
+    .select("domain")
+    .where("entity_id", "=", entityId)
+    .where("kind", "=", "corporate")
+    .orderBy("is_primary", "desc")
+    .orderBy("confidence", "desc")
+    .orderBy("domain", "asc")
+    .limit(5)
+    .execute();
+
+  const worksAtCompanies = await db
+    .selectFrom("entity_relationships")
+    .innerJoin("entities as company", "company.id", "entity_relationships.target_entity_id")
+    .select("company.name")
+    .where("entity_relationships.source_entity_id", "=", entityId)
+    .where("entity_relationships.relationship_type", "=", "works_at")
+    .where("entity_relationships.valid_to", "is", null)
+    .where(whereLiveEntity("company"))
+    .orderBy("company.name", "asc")
+    .limit(5)
+    .execute();
+
+  const mentionFiles = await db
+    .selectFrom("entity_mentions")
+    .innerJoin("indexed_files", "indexed_files.id", "entity_mentions.indexed_file_id")
+    .select(["indexed_files.file_name", "indexed_files.source_path", "indexed_files.summary"])
+    .where("entity_mentions.entity_id", "=", entityId)
+    .orderBy("entity_mentions.mentioned_at", "desc")
+    .limit(5)
+    .execute();
+
+  const coMentionedEntities = await db
+    .selectFrom("entity_mentions as subject_mention")
+    .innerJoin("entity_mentions as other_mention", "other_mention.indexed_file_id", "subject_mention.indexed_file_id")
+    .innerJoin("entities as other_entity", "other_entity.id", "other_mention.entity_id")
+    .select(["other_mention.entity_id as entityId", "other_entity.name as name", db.fn.countAll<number>().as("count")])
+    .where("subject_mention.entity_id", "=", entityId)
+    .where("other_mention.entity_id", "!=", entityId)
+    .where(whereLiveEntity("other_entity"))
+    .groupBy(["other_mention.entity_id", "other_entity.name"])
+    .orderBy("count", "desc")
+    .orderBy("other_entity.name", "asc")
+    .limit(5)
+    .execute();
+
+  return {
+    entityId: entity.id,
+    entityType: entity.source_type,
+    name: entity.name,
+    aliases: parseAliases(entity.aliases).slice(0, 5),
+    subtype: entity.subtype,
+    email: readPersonEmailFromMetadata(entity.metadata),
+    corporateDomains: corporateDomains.map((row) => row.domain),
+    worksAtCompanies: worksAtCompanies.map((row) => row.name),
+    mentionFiles: mentionFiles.map((row) => ({
+      fileName: row.file_name,
+      sourcePath: row.source_path,
+      summary: row.summary,
+    })),
+    coMentionedEntities: coMentionedEntities.map((row) => ({
+      entityId: row.entityId,
+      name: row.name,
+      count: Number(row.count),
+    })),
+  };
+}
+
+export async function adjudicateEntityMatch(
+  generator: AdjudicationGenerator,
+  subject: EntityContext,
+  candidates: EntityContext[],
+): Promise<EntityAdjudicationVerdict> {
+  const prompt = [
+    `Are the subject and any candidate the same real-world ${subject.entityType}?`,
+    "The subject is the entity being considered for merge into one candidate.",
+    "Reorder or formatting differences alone are not sufficient. Require corroborating signals such as email, domain, workplace, shared files, aliases, or co-mentions.",
+    "Bias to different or uncertain when evidence is thin.",
+    'Return only strict JSON in this shape: {"match":"<candidate id>"|null,"confidence":"high"|"medium"|"low","reason":"short reason"}.',
+    `Subject: ${renderContext(subject)}`,
+    `Candidates: ${JSON.stringify(candidates.map((candidate) => JSON.parse(renderContext(candidate))))}`,
+  ].join("\n");
+
+  try {
+    const parsed = await generator.generateJSON<{ match?: unknown; confidence?: unknown; reason?: unknown }>(prompt, {
+      maxTokens: 512,
+      label: "entity-dedup-adjudicator",
+    });
+    const verdict = validateVerdict(parsed);
+    if (verdict.matchEntityId && !candidates.some((candidate) => candidate.entityId === verdict.matchEntityId)) {
+      return { matchEntityId: null, confidence: "low", reason: "Model returned a candidate id outside the prompt." };
+    }
+    return verdict;
+  } catch {
+    return { matchEntityId: null, confidence: "low", reason: "Entity adjudication failed." };
+  }
+}

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -37,7 +37,8 @@ export type CandidateReason =
   | "birth-gated"
   | "strict-normalized"
   | "token-set"
-  | "minhash";
+  | "minhash"
+  | "adjacency";
 
 export interface ProposeInput {
   name: string;

--- a/packages/server/src/scripts/entity-dedup-backfill.test.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.test.ts
@@ -1,11 +1,24 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { DB } from "../db/schema";
+import type { AdjudicationGenerator } from "../entities/adjudicate";
 import { unmergeEntities } from "../entities/merge";
 import { createTestDb } from "../test-utils";
 import { runEntityDedupBackfill } from "./entity-dedup-backfill";
 
 const USER_ID = "entity-dedup-backfill-user";
+
+function fakeGenerator(verdict: { match: string | null; confidence: string; reason: string }): AdjudicationGenerator {
+  return { generateJSON: async <T>() => verdict as T };
+}
+
+function throwingGenerator(): AdjudicationGenerator {
+  return {
+    generateJSON: async () => {
+      throw new Error("timeout");
+    },
+  };
+}
 
 async function seedUser(db: Kysely<DB>): Promise<void> {
   await db.insertInto("users").values({ id: USER_ID, name: "Backfill User", email: "backfill@example.com" }).execute();
@@ -18,6 +31,8 @@ async function seedEntity(
     name: string;
     type: string;
     metadata?: Record<string, unknown>;
+    hotness?: number;
+    createdAt?: string;
   },
 ): Promise<void> {
   await db
@@ -31,8 +46,8 @@ async function seedEntity(
       metadata: input.metadata ? JSON.stringify(input.metadata) : null,
       source_ref_id: null,
       status: "confirmed",
-      hotness: 0,
-      created_at: new Date().toISOString(),
+      hotness: input.hotness ?? 0,
+      created_at: input.createdAt ?? new Date().toISOString(),
       updated_at: new Date().toISOString(),
     })
     .execute();
@@ -141,7 +156,7 @@ describe("entity dedup backfill", () => {
       metadata: { email: "alex@beta.com" },
     });
 
-    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID });
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, useLlm: false });
 
     expect(result.merged).toHaveLength(0);
     expect(result.queued).toEqual([
@@ -174,5 +189,81 @@ describe("entity dedup backfill", () => {
     expect(result.queued.some((pair) => pair.survivorId === "redseer-b" || pair.loserId === "redseer-b")).toBe(false);
     const queue = await db.selectFrom("entity_review_queue").selectAll().execute();
     expect(queue.some((row) => row.candidate_entity_id === "redseer-b")).toBe(false);
+  });
+
+  it("merges a confident token-set reorder through LLM adjudication", async () => {
+    await seedEntity(db, { id: "ohoud-survivor", name: "Ohoud Zitan", type: "person", hotness: 10 });
+    await seedEntity(db, { id: "ohoud-loser", name: "Zitan, Ohoud", type: "person" });
+    const generator = fakeGenerator({
+      match: "ohoud-survivor",
+      confidence: "high",
+      reason: "matching workplace context",
+    });
+
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, generator });
+
+    expect(result.merged).toEqual([
+      expect.objectContaining({ survivorId: "ohoud-survivor", loserId: "ohoud-loser", reason: "token-set" }),
+    ]);
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(1);
+    await expect(
+      db.selectFrom("entities").select("merged_into_entity_id").where("id", "=", "ohoud-loser").executeTakeFirst(),
+    ).resolves.toMatchObject({ merged_into_entity_id: "ohoud-survivor" });
+    const survivor = await db
+      .selectFrom("entities")
+      .select("aliases")
+      .where("id", "=", "ohoud-survivor")
+      .executeTakeFirstOrThrow();
+    expect(JSON.parse(survivor.aliases ?? "[]")).toContain("Zitan, Ohoud");
+  });
+
+  it("records a confident token-set namesake rejection both ways without merging", async () => {
+    await seedEntity(db, { id: "li-survivor", name: "Li Wang", type: "person" });
+    await seedEntity(db, { id: "li-loser", name: "Wang Li", type: "person" });
+    const generator = fakeGenerator({ match: null, confidence: "high", reason: "plausible namesake" });
+
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, generator });
+
+    expect(result.merged).toHaveLength(0);
+    await expect(db.selectFrom("entities").selectAll().where("deleted_at", "is", null).execute()).resolves.toHaveLength(
+      2,
+    );
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(0);
+    await expect(
+      db.selectFrom("entity_alias_rejections").select(["entity_id", "rejected_name"]).orderBy("entity_id").execute(),
+    ).resolves.toEqual([
+      { entity_id: "li-loser", rejected_name: "Li Wang" },
+      { entity_id: "li-survivor", rejected_name: "Wang Li" },
+    ]);
+  });
+
+  it("queues uncertain token-set pairs for manual review", async () => {
+    await seedEntity(db, { id: "li-survivor", name: "Li Wang", type: "person" });
+    await seedEntity(db, { id: "li-loser", name: "Wang Li", type: "person" });
+    const generator = fakeGenerator({ match: null, confidence: "low", reason: "thin evidence" });
+
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, generator });
+
+    expect(result.merged).toHaveLength(0);
+    expect(result.queued).toEqual([expect.objectContaining({ reason: "token-set" })]);
+    await expect(db.selectFrom("entities").selectAll().where("deleted_at", "is", null).execute()).resolves.toHaveLength(
+      2,
+    );
+    await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(1);
+    await expect(db.selectFrom("entity_alias_rejections").selectAll().execute()).resolves.toHaveLength(0);
+  });
+
+  it("queues token-set pairs when adjudication generation fails", async () => {
+    await seedEntity(db, { id: "li-survivor", name: "Li Wang", type: "person" });
+    await seedEntity(db, { id: "li-loser", name: "Wang Li", type: "person" });
+
+    const result = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, generator: throwingGenerator() });
+
+    expect(result.adjudicated).toEqual([
+      expect.objectContaining({ matchEntityId: null, confidence: "low", reason: "Entity adjudication failed." }),
+    ]);
+    expect(result.queued).toHaveLength(1);
+    await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(1);
+    await expect(db.selectFrom("entity_alias_rejections").selectAll().execute()).resolves.toHaveLength(0);
   });
 });

--- a/packages/server/src/scripts/entity-dedup-backfill.test.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.test.ts
@@ -12,9 +12,10 @@ function fakeGenerator(verdict: { match: string | null; confidence: string; reas
   return { generateJSON: async <T>() => verdict as T };
 }
 
-function throwingGenerator(): AdjudicationGenerator {
+function throwingGenerator(counter?: { calls: number }): AdjudicationGenerator {
   return {
     generateJSON: async () => {
+      if (counter) counter.calls += 1;
       throw new Error("timeout");
     },
   };
@@ -22,6 +23,20 @@ function throwingGenerator(): AdjudicationGenerator {
 
 async function seedUser(db: Kysely<DB>): Promise<void> {
   await db.insertInto("users").values({ id: USER_ID, name: "Backfill User", email: "backfill@example.com" }).execute();
+}
+
+async function seedConnector(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: "connector-1",
+      connector_type: "test",
+      auth_type: "api_key",
+      credentials: "{}",
+      scope_config: "{}",
+      created_by: USER_ID,
+    })
+    .execute();
 }
 
 async function seedEntity(
@@ -33,6 +48,9 @@ async function seedEntity(
     metadata?: Record<string, unknown>;
     hotness?: number;
     createdAt?: string;
+    status?: string;
+    mergedIntoEntityId?: string | null;
+    deletedAt?: string | null;
   },
 ): Promise<void> {
   await db
@@ -45,10 +63,12 @@ async function seedEntity(
       aliases: null,
       metadata: input.metadata ? JSON.stringify(input.metadata) : null,
       source_ref_id: null,
-      status: "confirmed",
+      status: input.status ?? "confirmed",
       hotness: input.hotness ?? 0,
       created_at: input.createdAt ?? new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      deleted_at: input.deletedAt ?? null,
+      merged_into_entity_id: input.mergedIntoEntityId ?? null,
     })
     .execute();
 }
@@ -68,12 +88,78 @@ async function seedCorporateDomain(db: Kysely<DB>, id: string, entityId: string,
     .execute();
 }
 
+async function seedFile(db: Kysely<DB>, id: string): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: "connector-1",
+      provider_file_id: `provider-${id}`,
+      file_name: `${id}.md`,
+      file_type: "document",
+      content_category: "document",
+      source: "test",
+      provider_url: `https://example.com/${id}`,
+      synced_at: new Date().toISOString(),
+      is_archived: 0,
+    })
+    .execute();
+}
+
+async function seedMention(db: Kysely<DB>, entityId: string, fileId: string): Promise<void> {
+  await db
+    .insertInto("entity_mentions")
+    .values({
+      id: `mention-${entityId}-${fileId}`,
+      entity_id: entityId,
+      indexed_file_id: fileId,
+      confidence: "EXTRACTED",
+      source: "test",
+      relation: "mentioned",
+      mentioned_at: new Date().toISOString(),
+    })
+    .execute();
+}
+
+async function seedRelationship(
+  db: Kysely<DB>,
+  id: string,
+  input: { source: string; target: string; type: string; confidenceScore?: number },
+): Promise<void> {
+  await db
+    .insertInto("entity_relationships")
+    .values({
+      id,
+      source_entity_id: input.source,
+      target_entity_id: input.target,
+      relationship_type: input.type,
+      confidence: "EXTRACTED",
+      confidence_score: input.confidenceScore ?? 0.95,
+      source: "test",
+    })
+    .execute();
+}
+
+async function seedSharedCoMentionAnchor(
+  db: Kysely<DB>,
+  input: { leftId: string; rightId: string; anchorId: string; filePrefix: string },
+): Promise<void> {
+  for (const suffix of ["a", "b"]) {
+    const fileId = `${input.filePrefix}-${suffix}`;
+    await seedFile(db, fileId);
+    await seedMention(db, input.leftId, fileId);
+    await seedMention(db, input.rightId, fileId);
+    await seedMention(db, input.anchorId, fileId);
+  }
+}
+
 describe("entity dedup backfill", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
     db = await createTestDb();
     await seedUser(db);
+    await seedConnector(db);
   });
 
   afterEach(async () => {
@@ -265,5 +351,234 @@ describe("entity dedup backfill", () => {
     expect(result.queued).toHaveLength(1);
     await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(1);
     await expect(db.selectFrom("entity_alias_rejections").selectAll().execute()).resolves.toHaveLength(0);
+  });
+
+  it("recalls adjacency pairs while pruning hubs and enforcing structural evidence", async () => {
+    await seedEntity(db, { id: "real-a", name: "Orchid Runtime", type: "project", hotness: 10 });
+    await seedEntity(db, { id: "real-b", name: "Cobalt Launch", type: "project", hotness: 1 });
+    await seedEntity(db, { id: "hub-only-a", name: "Copper Matrix", type: "project" });
+    await seedEntity(db, { id: "hub-only-b", name: "Silver Orbit", type: "project" });
+    await seedEntity(db, { id: "contributor", name: "Shared Builder", type: "person" });
+    await seedEntity(db, { id: "contributor-2", name: "Second Builder", type: "person" });
+    await seedEntity(db, { id: "hub", name: "Universal Contributor", type: "person" });
+    await seedEntity(db, { id: "anchor", name: "Context Anchor", type: "company" });
+    const fillerNames = [
+      "Alder",
+      "Banyan",
+      "Cedar",
+      "Daphne",
+      "Elm",
+      "Fern",
+      "Ginkgo",
+      "Hazel",
+      "Iris",
+      "Juniper",
+      "Koa",
+      "Laurel",
+      "Maple",
+      "Nettle",
+      "Olive",
+      "Pine",
+      "Quince",
+      "Rowan",
+      "Sage",
+      "Tamarind",
+      "Ulmus",
+      "Verbena",
+      "Willow",
+      "Xenia",
+      "Yarrow",
+      "Zinnia",
+      "Acacia",
+      "Birch",
+      "Cypress",
+      "Dogwood",
+      "Elder",
+    ];
+    for (let i = 0; i < fillerNames.length; i += 1) {
+      const fillerId = `hub-filler-${i}`;
+      await seedEntity(db, { id: fillerId, name: fillerNames[i], type: "product" });
+      await seedRelationship(db, `rel-hub-${fillerId}`, {
+        source: "hub",
+        target: fillerId,
+        type: "contributes_to",
+      });
+    }
+    for (const target of ["real-a", "real-b", "hub-only-a", "hub-only-b"]) {
+      await seedRelationship(db, `rel-hub-${target}`, { source: "hub", target, type: "contributes_to" });
+    }
+    for (const target of ["real-a", "real-b"]) {
+      await seedRelationship(db, `rel-contributor-${target}`, {
+        source: "contributor",
+        target,
+        type: "contributes_to",
+      });
+      await seedRelationship(db, `rel-contributor-2-${target}`, {
+        source: "contributor-2",
+        target,
+        type: "contributes_to",
+      });
+    }
+    await seedSharedCoMentionAnchor(db, {
+      leftId: "real-a",
+      rightId: "real-b",
+      anchorId: "anchor",
+      filePrefix: "real-shared",
+    });
+    await seedSharedCoMentionAnchor(db, {
+      leftId: "hub-only-a",
+      rightId: "hub-only-b",
+      anchorId: "anchor",
+      filePrefix: "hub-only-shared",
+    });
+
+    const result = await runEntityDedupBackfill(db, {
+      execute: true,
+      userId: USER_ID,
+      generator: fakeGenerator({ match: "real-a", confidence: "high", reason: "shared contributor and files" }),
+    });
+
+    expect(result.autoMergeCandidates).toHaveLength(0);
+    expect(result.queuedCandidates).toEqual([
+      expect.objectContaining({ survivorId: "real-a", loserId: "real-b", reason: "adjacency" }),
+    ]);
+    expect(result.counts.adjacencyCandidates).toBe(1);
+    expect(result.merged).toEqual([
+      expect.objectContaining({ survivorId: "real-a", loserId: "real-b", reason: "adjacency" }),
+    ]);
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(1);
+    const survivor = await db
+      .selectFrom("entities")
+      .select("aliases")
+      .where("id", "=", "real-a")
+      .executeTakeFirstOrThrow();
+    expect(JSON.parse(survivor.aliases ?? "[]")).toContain("Cobalt Launch");
+  });
+
+  it("owner-gates project candidates without durable rejection or LLM calls", async () => {
+    const calls = { calls: 0 };
+    await seedEntity(db, { id: "company-a", name: "Maaden", type: "company" });
+    await seedEntity(db, { id: "company-b", name: "GCC", type: "company" });
+    await seedEntity(db, { id: "project-a", name: "Maaden Dashboard", type: "project" });
+    await seedEntity(db, { id: "project-b", name: "Dashboard Maaden", type: "project" });
+    await seedRelationship(db, "rel-project-a-owner", {
+      source: "project-a",
+      target: "company-a",
+      type: "engagement_for",
+    });
+    await seedRelationship(db, "rel-project-b-owner", {
+      source: "project-b",
+      target: "company-b",
+      type: "engagement_for",
+    });
+
+    const result = await runEntityDedupBackfill(db, {
+      execute: true,
+      userId: USER_ID,
+      generator: throwingGenerator(calls),
+    });
+
+    expect(result.merged).toHaveLength(0);
+    expect(result.adjudicated).toEqual([
+      expect.objectContaining({
+        pair: expect.objectContaining({ survivorId: "project-a", loserId: "project-b", reason: "token-set" }),
+        matchEntityId: null,
+        confidence: "low",
+        reason: "owner-scope mismatch",
+      }),
+    ]);
+    expect(result.counts.ownerGateBlocked).toBe(1);
+    expect(calls.calls).toBe(0);
+    await expect(db.selectFrom("entity_alias_rejections").selectAll().execute()).resolves.toHaveLength(0);
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(0);
+  });
+
+  it("owner-gates strict project and team pairs before auto-merge", async () => {
+    const calls = { calls: 0 };
+    await seedEntity(db, { id: "company-a", name: "Maaden", type: "company" });
+    await seedEntity(db, { id: "company-b", name: "GCC", type: "company" });
+    await seedEntity(db, { id: "project-a", name: "Shared Dashboard", type: "project" });
+    await seedEntity(db, { id: "project-b", name: "SharedDashboard", type: "project" });
+    await seedEntity(db, { id: "team-a", name: "Platform Team", type: "team" });
+    await seedEntity(db, { id: "team-b", name: "PlatformTeam", type: "team" });
+    await seedRelationship(db, "rel-project-a-owner", {
+      source: "project-a",
+      target: "company-a",
+      type: "engagement_for",
+    });
+    await seedRelationship(db, "rel-project-b-owner", {
+      source: "project-b",
+      target: "company-b",
+      type: "engagement_for",
+    });
+    await seedRelationship(db, "rel-team-a-owner", { source: "team-a", target: "company-a", type: "part_of" });
+    await seedRelationship(db, "rel-team-b-owner", { source: "team-b", target: "company-b", type: "part_of" });
+
+    const result = await runEntityDedupBackfill(db, {
+      execute: true,
+      userId: USER_ID,
+      generator: throwingGenerator(calls),
+    });
+
+    expect(result.autoMergeCandidates).toHaveLength(0);
+    expect(result.queuedCandidates).toEqual([
+      expect.objectContaining({
+        entityType: "project",
+        survivorId: "project-a",
+        loserId: "project-b",
+        reason: "strict",
+      }),
+      expect.objectContaining({ entityType: "team", survivorId: "team-a", loserId: "team-b", reason: "strict" }),
+    ]);
+    expect(result.merged).toHaveLength(0);
+    expect(result.counts.ownerGateBlocked).toBe(2);
+    expect(calls.calls).toBe(0);
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(0);
+    await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(2);
+  });
+
+  it("resolves a three-node adjacency cluster over two runs", async () => {
+    await seedEntity(db, { id: "cluster-a", name: "Atlas Boreal One", type: "project", hotness: 10 });
+    await seedEntity(db, { id: "cluster-b", name: "Zephyr Atlas Boreal", type: "project", hotness: 5 });
+    await seedEntity(db, { id: "cluster-c", name: "Boreal Three", type: "project", hotness: 1 });
+    await seedEntity(db, { id: "contributor-ab", name: "Contributor AB", type: "person" });
+    await seedEntity(db, { id: "contributor-bc", name: "Contributor BC", type: "person" });
+    await seedEntity(db, { id: "anchor-ab", name: "Anchor AB", type: "company" });
+    await seedEntity(db, { id: "anchor-bc", name: "Anchor BC", type: "company" });
+    for (const target of ["cluster-a", "cluster-b"]) {
+      await seedRelationship(db, `rel-ab-${target}`, { source: "contributor-ab", target, type: "contributes_to" });
+    }
+    for (const target of ["cluster-b", "cluster-c"]) {
+      await seedRelationship(db, `rel-bc-${target}`, { source: "contributor-bc", target, type: "contributes_to" });
+    }
+    await seedSharedCoMentionAnchor(db, {
+      leftId: "cluster-a",
+      rightId: "cluster-b",
+      anchorId: "anchor-ab",
+      filePrefix: "cluster-ab",
+    });
+    await seedSharedCoMentionAnchor(db, {
+      leftId: "cluster-b",
+      rightId: "cluster-c",
+      anchorId: "anchor-bc",
+      filePrefix: "cluster-bc",
+    });
+
+    const generator = fakeGenerator({ match: "cluster-a", confidence: "high", reason: "same adjacency cluster" });
+    const first = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, generator });
+
+    expect(first.merged).toEqual([
+      expect.objectContaining({ survivorId: "cluster-a", loserId: "cluster-b", reason: "adjacency" }),
+      expect.objectContaining({ survivorId: "cluster-a", loserId: "cluster-c", reason: "adjacency" }),
+    ]);
+    expect(first.skipped).toHaveLength(0);
+    await expect(
+      db.selectFrom("entities").select("merged_into_entity_id").where("id", "=", "cluster-c").executeTakeFirst(),
+    ).resolves.toMatchObject({ merged_into_entity_id: "cluster-a" });
+
+    const second = await runEntityDedupBackfill(db, { execute: true, userId: USER_ID, generator });
+
+    expect(second.merged).toHaveLength(0);
+    await expect(db.selectFrom("entity_merges").selectAll().execute()).resolves.toHaveLength(2);
   });
 });

--- a/packages/server/src/scripts/entity-dedup-backfill.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.ts
@@ -9,6 +9,7 @@ import { createEntityDomainsRepository } from "../db/repositories/entity-domains
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
 import { createSettingsRepository } from "../db/repositories/settings";
 import type { DB, EntitiesTable } from "../db/schema";
+import { type NeighborSet, buildAdjacencyIndex, overlapCoefficient, owningCompanyScope } from "../entities/adjacency";
 import {
   type AdjudicationGenerator,
   type EntityAdjudicationConfidence,
@@ -18,7 +19,13 @@ import {
 import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "../entities/affiliations";
 import { readPersonEmailFromMetadata } from "../entities/materialize-json";
 import { mergeEntities, previewMerge } from "../entities/merge";
-import { type CandidatePoolEntry, buildCandidatePool, findFuzzyMatches, normalizeStrict } from "../entities/name-dedup";
+import {
+  type CandidatePoolEntry,
+  buildCandidatePool,
+  findFuzzyMatches,
+  normalizeFuzzy,
+  normalizeStrict,
+} from "../entities/name-dedup";
 import type { ProposeEntityType } from "../entities/propose";
 import { yieldToEventLoop } from "../lib/event-loop";
 
@@ -31,6 +38,10 @@ export interface EntityDedupBackfillOptions {
   sampleLimit?: number;
   batchSize?: number;
   useLlm?: boolean;
+  adjacencyThreshold?: number;
+  noAdjacency?: boolean;
+  adjacencyMinShared?: number;
+  adjacencyThresholdNoLexical?: number;
   /** Entity ids to leave untouched — any pair where either side matches is dropped. */
   excludeEntityIds?: string[];
   /** Structured generator for adjudication (Gemini in prod; a fake in tests). */
@@ -43,7 +54,14 @@ export interface EntityDedupBackfillPair {
   loserId: string;
   survivorName: string;
   loserName: string;
-  reason: "strict" | "fuzzy" | "token-set" | "ambiguous" | "person_scope_missing" | "person_scope_mismatch";
+  reason:
+    | "strict"
+    | "fuzzy"
+    | "token-set"
+    | "adjacency"
+    | "ambiguous"
+    | "person_scope_missing"
+    | "person_scope_mismatch";
   score: number;
 }
 
@@ -62,6 +80,10 @@ export interface EntityDedupBackfillResult {
   merged: EntityDedupBackfillPair[];
   queued: EntityDedupBackfillPair[];
   skipped: EntityDedupBackfillPair[];
+  counts: {
+    adjacencyCandidates: number;
+    ownerGateBlocked: number;
+  };
   samples: {
     autoMerge: EntityDedupBackfillPair[];
     queue: EntityDedupBackfillPair[];
@@ -73,6 +95,7 @@ interface TypeScan {
   entityType: string;
   entities: Entity[];
   entries: CandidatePoolEntry[];
+  evidenceCounts: Map<string, number>;
 }
 
 interface PersonScopes {
@@ -81,13 +104,20 @@ interface PersonScopes {
 
 const SUPPORTED_TYPES: ProposeEntityType[] = ["person", "company", "product", "project", "team", "deal"];
 const DEFAULT_FUZZY_THRESHOLD = 0.85;
+const DEFAULT_ADJACENCY_THRESHOLD = 0.5;
+const DEFAULT_ADJACENCY_MIN_SHARED = 2;
+const DEFAULT_ADJACENCY_THRESHOLD_NO_LEXICAL = 0.7;
 const DEFAULT_SAMPLE_LIMIT = 10;
 const DEFAULT_BATCH_SIZE = 100;
 const BACKFILL_SOURCE = "entity_dedup_backfill";
+const ADJACENCY_TYPES = new Set<ProposeEntityType>(["product", "project", "team"]);
+const OWNER_GATE_TYPES = new Set<ProposeEntityType>(["product", "project", "team"]);
+const SIGNIFICANT_TOKEN_STOPWORDS = new Set(["a", "an", "and", "for", "in", "of", "on", "or", "the", "to"]);
 const REASON_RANK: Record<EntityDedupBackfillPair["reason"], number> = {
   strict: 3,
   "token-set": 2,
   fuzzy: 1,
+  adjacency: -1,
   ambiguous: 0,
   person_scope_missing: 0,
   person_scope_mismatch: 0,
@@ -111,8 +141,77 @@ function persistedPairKey(a: string, b: string): string {
   return [a, b].sort().map(encodeURIComponent).join("~");
 }
 
-function chooseSurvivor(a: Entity, b: Entity): { survivor: Entity; loser: Entity } {
+function significantNameTokens(name: string): Set<string> {
+  return new Set(
+    normalizeFuzzy(name)
+      .split(" ")
+      .filter((token) => token.length >= 3 && !SIGNIFICANT_TOKEN_STOPWORDS.has(token)),
+  );
+}
+
+function nameTokenCount(name: string): number {
+  return normalizeFuzzy(name).split(" ").filter(Boolean).length;
+}
+
+async function buildEvidenceCounts(db: Kysely<DB>, entityIds: string[]): Promise<Map<string, number>> {
+  const uniqueIds = [...new Set(entityIds)];
+  const counts = new Map<string, number>(uniqueIds.map((id) => [id, 0]));
+  if (uniqueIds.length === 0) return counts;
+
+  const relationshipRows = await db
+    .selectFrom("entity_relationships")
+    .select(["source_entity_id", "target_entity_id", db.fn.count<number>("id").distinct().as("count")])
+    .where((eb) => eb.or([eb("source_entity_id", "in", uniqueIds), eb("target_entity_id", "in", uniqueIds)]))
+    .where("valid_to", "is", null)
+    .groupBy(["source_entity_id", "target_entity_id"])
+    .execute();
+  for (const row of relationshipRows) {
+    const count = Number(row.count);
+    if (counts.has(row.source_entity_id))
+      counts.set(row.source_entity_id, (counts.get(row.source_entity_id) ?? 0) + count);
+    if (counts.has(row.target_entity_id))
+      counts.set(row.target_entity_id, (counts.get(row.target_entity_id) ?? 0) + count);
+  }
+
+  const mentionRows = await db
+    .selectFrom("entity_mentions")
+    .innerJoin("indexed_files", "indexed_files.id", "entity_mentions.indexed_file_id")
+    .select([
+      "entity_mentions.entity_id",
+      db.fn.count<number>("entity_mentions.indexed_file_id").distinct().as("count"),
+    ])
+    .where("entity_mentions.entity_id", "in", uniqueIds)
+    .where("indexed_files.is_archived", "=", 0)
+    .groupBy("entity_mentions.entity_id")
+    .execute();
+  for (const row of mentionRows) {
+    counts.set(row.entity_id, (counts.get(row.entity_id) ?? 0) + Number(row.count));
+  }
+
+  return counts;
+}
+
+function chooseSurvivor(
+  a: Entity,
+  b: Entity,
+  evidenceCounts: Map<string, number> = new Map(),
+): { survivor: Entity; loser: Entity } {
   const sorted = [a, b].sort((left, right) => {
+    if (ADJACENCY_TYPES.has(left.source_type as ProposeEntityType) && left.source_type === right.source_type) {
+      if (left.status !== right.status) {
+        if (left.status === "confirmed") return -1;
+        if (right.status === "confirmed") return 1;
+      }
+      if (right.hotness !== left.hotness) return right.hotness - left.hotness;
+      const leftEvidenceCount = evidenceCounts.get(left.id) ?? 0;
+      const rightEvidenceCount = evidenceCounts.get(right.id) ?? 0;
+      if (rightEvidenceCount !== leftEvidenceCount) return rightEvidenceCount - leftEvidenceCount;
+      if (left.created_at !== right.created_at) return left.created_at.localeCompare(right.created_at);
+      const leftTokenCount = nameTokenCount(left.name);
+      const rightTokenCount = nameTokenCount(right.name);
+      if (rightTokenCount !== leftTokenCount) return rightTokenCount - leftTokenCount;
+      return left.id.localeCompare(right.id);
+    }
     if (right.hotness !== left.hotness) return right.hotness - left.hotness;
     if (left.status !== right.status) {
       if (left.status === "confirmed") return -1;
@@ -130,8 +229,9 @@ function toPair(
   b: Entity,
   reason: EntityDedupBackfillPair["reason"],
   score: number,
+  evidenceCounts?: Map<string, number>,
 ): EntityDedupBackfillPair {
-  const { survivor, loser } = chooseSurvivor(a, b);
+  const { survivor, loser } = chooseSurvivor(a, b, evidenceCounts);
   return {
     entityType,
     survivorId: survivor.id,
@@ -154,6 +254,10 @@ async function loadTypeScans(db: Kysely<DB>): Promise<TypeScan[]> {
   const byType = new Map<string, Entity[]>();
   for (const type of SUPPORTED_TYPES) byType.set(type, []);
   for (const entity of entities) byType.get(entity.source_type)?.push(entity);
+  const evidenceCounts = await buildEvidenceCounts(
+    db,
+    entities.map((entity) => entity.id),
+  );
 
   return [...byType].map(([entityType, rows]) => ({
     entityType,
@@ -162,6 +266,7 @@ async function loadTypeScans(db: Kysely<DB>): Promise<TypeScan[]> {
       { entityId: entity.id, valueKind: "name" as const, value: entity.name },
       ...parseAliases(entity.aliases).map((value) => ({ entityId: entity.id, valueKind: "alias" as const, value })),
     ]),
+    evidenceCounts,
   }));
 }
 
@@ -213,10 +318,59 @@ function addUniquePair(map: Map<string, EntityDedupBackfillPair>, pair: EntityDe
   if (pair.score === existing.score && REASON_RANK[pair.reason] > REASON_RANK[existing.reason]) map.set(key, pair);
 }
 
+async function ownerGateBlocksPair(db: Kysely<DB>, pair: EntityDedupBackfillPair): Promise<boolean> {
+  if (!OWNER_GATE_TYPES.has(pair.entityType as ProposeEntityType)) return false;
+  const survivorOwner = await owningCompanyScope(db, pair.survivorId);
+  const loserOwner = await owningCompanyScope(db, pair.loserId);
+  return Boolean(survivorOwner && loserOwner && survivorOwner !== loserOwner);
+}
+
+function sharedAdjacencyNeighbors(a: NeighborSet, b: NeighborSet): Set<string> {
+  const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a];
+  const shared = new Set<string>();
+  for (const key of smaller) {
+    if (larger.has(key)) shared.add(key);
+  }
+  return shared;
+}
+
+function passesAdjacencyFloors(
+  a: Entity,
+  b: Entity,
+  sharedNeighbors: Set<string>,
+  opts: Required<
+    Pick<EntityDedupBackfillOptions, "adjacencyThreshold" | "adjacencyMinShared" | "adjacencyThresholdNoLexical">
+  > & {
+    adjacencyIndex: Map<string, NeighborSet>;
+  },
+): boolean {
+  if (sharedNeighbors.size < opts.adjacencyMinShared) return false;
+  const overlap = overlapCoefficient(
+    opts.adjacencyIndex.get(a.id) ?? new Set(),
+    opts.adjacencyIndex.get(b.id) ?? new Set(),
+  );
+  const hasSharedRelNeighbor = [...sharedNeighbors].some((neighbor) => neighbor.startsWith("rel:"));
+  const aTokens = significantNameTokens(a.name);
+  const bTokens = significantNameTokens(b.name);
+  const hasSharedNameToken = [...aTokens].some((token) => bTokens.has(token));
+  if (overlap < opts.adjacencyThreshold) return false;
+  if (hasSharedNameToken) return true;
+  if (hasSharedRelNeighbor) return overlap >= opts.adjacencyThresholdNoLexical;
+  return false;
+}
+
 async function discoverPairs(
   db: Kysely<DB>,
   scans: TypeScan[],
-  opts: Required<Pick<EntityDedupBackfillOptions, "fuzzyThreshold" | "batchSize">>,
+  opts: Required<
+    Pick<
+      EntityDedupBackfillOptions,
+      "fuzzyThreshold" | "batchSize" | "adjacencyThreshold" | "adjacencyMinShared" | "adjacencyThresholdNoLexical"
+    >
+  > & {
+    adjacencyIndex: Map<string, NeighborSet>;
+    noAdjacency: boolean;
+  },
 ): Promise<{ autoMerge: EntityDedupBackfillPair[]; queue: EntityDedupBackfillPair[] }> {
   const autoMerge = new Map<string, EntityDedupBackfillPair>();
   const queue = new Map<string, EntityDedupBackfillPair>();
@@ -241,8 +395,8 @@ async function discoverPairs(
         const pair =
           scan.entityType === "person"
             ? classifyPersonStrictPair(toPair(scan.entityType, a, b, "strict", 1), personScopes)
-            : toPair(scan.entityType, a, b, "strict", 1);
-        if (pair.reason === "strict") addUniquePair(autoMerge, pair);
+            : toPair(scan.entityType, a, b, "strict", 1, scan.evidenceCounts);
+        if (pair.reason === "strict" && !(await ownerGateBlocksPair(db, pair))) addUniquePair(autoMerge, pair);
         else addUniquePair(queue, pair);
         continue;
       }
@@ -250,7 +404,7 @@ async function discoverPairs(
         for (let j = i + 1; j < ids.length; j += 1) {
           const a = entitiesById.get(ids[i]);
           const b = entitiesById.get(ids[j]);
-          if (a && b) addUniquePair(queue, toPair(scan.entityType, a, b, "ambiguous", 1));
+          if (a && b) addUniquePair(queue, toPair(scan.entityType, a, b, "ambiguous", 1, scan.evidenceCounts));
         }
       }
     }
@@ -265,7 +419,10 @@ async function discoverPairs(
           const a = entitiesById.get(ids[i]);
           const b = entitiesById.get(ids[j]);
           if (!a || !b) continue;
-          addUniquePair(queue, toPair(scan.entityType, a, b, ids.length === 2 ? "token-set" : "ambiguous", 1));
+          addUniquePair(
+            queue,
+            toPair(scan.entityType, a, b, ids.length === 2 ? "token-set" : "ambiguous", 1, scan.evidenceCounts),
+          );
           seenExactPairKeys.add(key);
         }
       }
@@ -282,7 +439,28 @@ async function discoverPairs(
         if (seenExactPairKeys.has(pairKey(entry.entityId, match.entityId))) continue;
         const matched = entitiesById.get(match.entityId);
         if (!matched) continue;
-        addUniquePair(queue, toPair(scan.entityType, entity, matched, "fuzzy", match.score));
+        addUniquePair(queue, toPair(scan.entityType, entity, matched, "fuzzy", match.score, scan.evidenceCounts));
+      }
+    }
+
+    if (!opts.noAdjacency && ADJACENCY_TYPES.has(scan.entityType as ProposeEntityType)) {
+      for (let i = 0; i < scan.entities.length; i += 1) {
+        for (let j = i + 1; j < scan.entities.length; j += 1) {
+          const a = scan.entities[i];
+          const b = scan.entities[j];
+          const key = pairKey(a.id, b.id);
+          if (autoMerge.has(key) || queue.has(key)) continue;
+          const sharedNeighbors = sharedAdjacencyNeighbors(
+            opts.adjacencyIndex.get(a.id) ?? new Set(),
+            opts.adjacencyIndex.get(b.id) ?? new Set(),
+          );
+          if (!passesAdjacencyFloors(a, b, sharedNeighbors, opts)) continue;
+          const score = overlapCoefficient(
+            opts.adjacencyIndex.get(a.id) ?? new Set(),
+            opts.adjacencyIndex.get(b.id) ?? new Set(),
+          );
+          addUniquePair(queue, toPair(scan.entityType, a, b, "adjacency", score, scan.evidenceCounts));
+        }
       }
     }
   }
@@ -314,7 +492,13 @@ async function queuePair(db: Kysely<DB>, pair: EntityDedupBackfillPair, userId: 
     candidateEntityId: pair.reason === "ambiguous" ? null : pair.survivorId,
     candidateScore: pair.reason === "ambiguous" ? null : pair.score,
     candidateReason:
-      pair.reason === "fuzzy" ? "minhash" : pair.reason === "token-set" ? "token-set" : "strict-normalized",
+      pair.reason === "fuzzy"
+        ? "minhash"
+        : pair.reason === "token-set"
+          ? "token-set"
+          : pair.reason === "adjacency"
+            ? "adjacency"
+            : "strict-normalized",
     triggeredByUserId: userId,
   });
 }
@@ -356,6 +540,14 @@ async function adjudicatePair(
   pair: EntityDedupBackfillPair,
   generator: AdjudicationGenerator,
 ): Promise<EntityDedupBackfillAdjudication> {
+  if (await ownerGateBlocksPair(db, pair)) {
+    return {
+      pair,
+      matchEntityId: null,
+      confidence: "low",
+      reason: "owner-scope mismatch",
+    };
+  }
   const loserContext = await buildEntityAdjudicationContext(db, pair.loserId);
   const survivorContext = await buildEntityAdjudicationContext(db, pair.survivorId);
   const verdict = await adjudicateEntityMatch(generator, loserContext, [survivorContext]);
@@ -452,6 +644,7 @@ async function adjudicateCandidates(
     }
     const adjudication = await adjudicatePair(db, pair, generator);
     result.adjudicated.push(adjudication);
+    if (adjudication.reason === "owner-scope mismatch") result.counts.ownerGateBlocked++;
     result.samples.adjudicated = result.adjudicated.slice(0, sampleLimit);
     processed += 1;
     if (processed % batchSize === 0) await yieldToEventLoop();
@@ -466,9 +659,29 @@ export async function runEntityDedupBackfill(
   const sampleLimit = options.sampleLimit ?? DEFAULT_SAMPLE_LIMIT;
   const fuzzyThreshold = options.fuzzyThreshold ?? DEFAULT_FUZZY_THRESHOLD;
   const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const adjacencyThreshold = options.adjacencyThreshold ?? DEFAULT_ADJACENCY_THRESHOLD;
+  const adjacencyMinShared = options.adjacencyMinShared ?? DEFAULT_ADJACENCY_MIN_SHARED;
+  const adjacencyThresholdNoLexical = options.adjacencyThresholdNoLexical ?? DEFAULT_ADJACENCY_THRESHOLD_NO_LEXICAL;
+  const noAdjacency = options.noAdjacency === true;
   const useLlm = options.useLlm !== false;
   const scans = await loadTypeScans(db);
-  const discovered = await discoverPairs(db, scans, { fuzzyThreshold, batchSize });
+  const adjacencyIndex = noAdjacency
+    ? new Map<string, NeighborSet>()
+    : await buildAdjacencyIndex(
+        db,
+        scans
+          .flatMap((scan) => (ADJACENCY_TYPES.has(scan.entityType as ProposeEntityType) ? scan.entities : []))
+          .map((entity) => entity.id),
+      );
+  const discovered = await discoverPairs(db, scans, {
+    fuzzyThreshold,
+    batchSize,
+    adjacencyThreshold,
+    adjacencyMinShared,
+    adjacencyThresholdNoLexical,
+    adjacencyIndex,
+    noAdjacency,
+  });
   const excludeIds = new Set(options.excludeEntityIds ?? []);
   const keepPair = (pair: EntityDedupBackfillPair): boolean =>
     !excludeIds.has(pair.survivorId) && !excludeIds.has(pair.loserId);
@@ -482,6 +695,10 @@ export async function runEntityDedupBackfill(
     merged: [],
     queued: [],
     skipped: [],
+    counts: {
+      adjacencyCandidates: queueCandidates.filter((pair) => pair.reason === "adjacency").length,
+      ownerGateBlocked: 0,
+    },
     samples: {
       autoMerge: autoMerge.slice(0, sampleLimit),
       queue: queueCandidates.slice(0, sampleLimit),
@@ -506,6 +723,7 @@ export async function runEntityDedupBackfill(
       }
       const adjudication = await adjudicatePair(db, resolved, generator);
       result.adjudicated.push(adjudication);
+      if (adjudication.reason === "owner-scope mismatch") result.counts.ownerGateBlocked++;
       result.samples.adjudicated = result.adjudicated.slice(0, sampleLimit);
       const handled = await applyAdjudication(db, adjudication, result, options, mergedAway);
       if (!handled) {
@@ -555,6 +773,8 @@ function printResult(result: EntityDedupBackfillResult): void {
         merged: result.merged.length,
         queued: result.queued.length,
         skipped: result.skipped.length,
+        adjacencyCandidates: result.counts.adjacencyCandidates,
+        ownerGateBlocked: result.counts.ownerGateBlocked,
         samples: result.samples,
       },
       null,
@@ -569,6 +789,8 @@ async function main(): Promise<void> {
       execute: { type: "boolean", default: false },
       "user-id": { type: "string", default: "entity-dedup-backfill" },
       "fuzzy-threshold": { type: "string", default: String(DEFAULT_FUZZY_THRESHOLD) },
+      "adjacency-threshold": { type: "string", default: String(DEFAULT_ADJACENCY_THRESHOLD) },
+      "no-adjacency": { type: "boolean", default: false },
       "sample-limit": { type: "string", default: String(DEFAULT_SAMPLE_LIMIT) },
       "exclude-entity": { type: "string" },
       "no-llm": { type: "boolean", default: false },
@@ -593,6 +815,8 @@ async function main(): Promise<void> {
       execute: parsed.values.execute,
       userId: parsed.values["user-id"],
       fuzzyThreshold: Number(parsed.values["fuzzy-threshold"]),
+      adjacencyThreshold: Number(parsed.values["adjacency-threshold"]),
+      noAdjacency: parsed.values["no-adjacency"] === true,
       sampleLimit: Number(parsed.values["sample-limit"]),
       useLlm,
       generator,

--- a/packages/server/src/scripts/entity-dedup-backfill.ts
+++ b/packages/server/src/scripts/entity-dedup-backfill.ts
@@ -1,12 +1,20 @@
 import { parseArgs } from "node:util";
 import type { Kysely, Selectable } from "kysely";
 import { loadConfig, validateConfig } from "../config";
+import { createGeminiGenerator } from "../connectors/gemini-generate";
 import { createDatabase } from "../db";
 import { runMigrations } from "../db/migrate";
 import { whereLiveEntity } from "../db/repositories/entities";
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
+import { createSettingsRepository } from "../db/repositories/settings";
 import type { DB, EntitiesTable } from "../db/schema";
+import {
+  type AdjudicationGenerator,
+  type EntityAdjudicationConfidence,
+  adjudicateEntityMatch,
+  buildEntityAdjudicationContext,
+} from "../entities/adjudicate";
 import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "../entities/affiliations";
 import { readPersonEmailFromMetadata } from "../entities/materialize-json";
 import { mergeEntities, previewMerge } from "../entities/merge";
@@ -22,8 +30,11 @@ export interface EntityDedupBackfillOptions {
   fuzzyThreshold?: number;
   sampleLimit?: number;
   batchSize?: number;
+  useLlm?: boolean;
   /** Entity ids to leave untouched — any pair where either side matches is dropped. */
   excludeEntityIds?: string[];
+  /** Structured generator for adjudication (Gemini in prod; a fake in tests). */
+  generator?: AdjudicationGenerator;
 }
 
 export interface EntityDedupBackfillPair {
@@ -32,20 +43,29 @@ export interface EntityDedupBackfillPair {
   loserId: string;
   survivorName: string;
   loserName: string;
-  reason: "strict" | "fuzzy" | "ambiguous" | "person_scope_missing" | "person_scope_mismatch";
+  reason: "strict" | "fuzzy" | "token-set" | "ambiguous" | "person_scope_missing" | "person_scope_mismatch";
   score: number;
+}
+
+export interface EntityDedupBackfillAdjudication {
+  pair: EntityDedupBackfillPair;
+  matchEntityId: string | null;
+  confidence: EntityAdjudicationConfidence;
+  reason: string;
 }
 
 export interface EntityDedupBackfillResult {
   mode: "dry-run" | "execute";
   autoMergeCandidates: EntityDedupBackfillPair[];
   queuedCandidates: EntityDedupBackfillPair[];
+  adjudicated: EntityDedupBackfillAdjudication[];
   merged: EntityDedupBackfillPair[];
   queued: EntityDedupBackfillPair[];
   skipped: EntityDedupBackfillPair[];
   samples: {
     autoMerge: EntityDedupBackfillPair[];
     queue: EntityDedupBackfillPair[];
+    adjudicated: EntityDedupBackfillAdjudication[];
   };
 }
 
@@ -64,6 +84,14 @@ const DEFAULT_FUZZY_THRESHOLD = 0.85;
 const DEFAULT_SAMPLE_LIMIT = 10;
 const DEFAULT_BATCH_SIZE = 100;
 const BACKFILL_SOURCE = "entity_dedup_backfill";
+const REASON_RANK: Record<EntityDedupBackfillPair["reason"], number> = {
+  strict: 3,
+  "token-set": 2,
+  fuzzy: 1,
+  ambiguous: 0,
+  person_scope_missing: 0,
+  person_scope_mismatch: 0,
+};
 
 function parseAliases(raw: string | null): string[] {
   if (!raw) return [];
@@ -178,7 +206,11 @@ function classifyPersonStrictPair(pair: EntityDedupBackfillPair, scopes: PersonS
 function addUniquePair(map: Map<string, EntityDedupBackfillPair>, pair: EntityDedupBackfillPair): void {
   const key = pairKey(pair.survivorId, pair.loserId);
   const existing = map.get(key);
-  if (!existing || pair.score > existing.score) map.set(key, pair);
+  if (!existing || pair.score > existing.score) {
+    map.set(key, pair);
+    return;
+  }
+  if (pair.score === existing.score && REASON_RANK[pair.reason] > REASON_RANK[existing.reason]) map.set(key, pair);
 }
 
 async function discoverPairs(
@@ -194,15 +226,13 @@ async function discoverPairs(
   for (const scan of scans) {
     const entitiesById = new Map(scan.entities.map((entity) => [entity.id, entity]));
     const pool = buildCandidatePool(scan.entries);
-    const strictPairKeys = new Set<string>();
+    const seenExactPairKeys = new Set<string>();
 
     for (const bucket of pool.byStrictKey.values()) {
       const ids = [...new Set(bucket.map((entry) => entry.entityId))].sort();
       if (ids.length < 2) continue;
       for (let i = 0; i < ids.length; i += 1) {
-        for (let j = i + 1; j < ids.length; j += 1) {
-          strictPairKeys.add(pairKey(ids[i], ids[j]));
-        }
+        for (let j = i + 1; j < ids.length; j += 1) seenExactPairKeys.add(pairKey(ids[i], ids[j]));
       }
       if (ids.length === 2) {
         const a = entitiesById.get(ids[0]);
@@ -225,6 +255,22 @@ async function discoverPairs(
       }
     }
 
+    for (const bucket of pool.byTokenSetKey.values()) {
+      const ids = [...new Set(bucket.map((entry) => entry.entityId))].sort();
+      if (ids.length < 2) continue;
+      for (let i = 0; i < ids.length; i += 1) {
+        for (let j = i + 1; j < ids.length; j += 1) {
+          const key = pairKey(ids[i], ids[j]);
+          if (seenExactPairKeys.has(key)) continue;
+          const a = entitiesById.get(ids[i]);
+          const b = entitiesById.get(ids[j]);
+          if (!a || !b) continue;
+          addUniquePair(queue, toPair(scan.entityType, a, b, ids.length === 2 ? "token-set" : "ambiguous", 1));
+          seenExactPairKeys.add(key);
+        }
+      }
+    }
+
     let scanned = 0;
     for (const entry of scan.entries) {
       scanned += 1;
@@ -233,7 +279,7 @@ async function discoverPairs(
       if (!entity) continue;
       for (const match of findFuzzyMatches(entry.value, pool, { threshold: opts.fuzzyThreshold })) {
         if (match.entityId === entry.entityId) continue;
-        if (strictPairKeys.has(pairKey(entry.entityId, match.entityId))) continue;
+        if (seenExactPairKeys.has(pairKey(entry.entityId, match.entityId))) continue;
         const matched = entitiesById.get(match.entityId);
         if (!matched) continue;
         addUniquePair(queue, toPair(scan.entityType, entity, matched, "fuzzy", match.score));
@@ -267,7 +313,8 @@ async function queuePair(db: Kysely<DB>, pair: EntityDedupBackfillPair, userId: 
     sourceId: persistedPairKey(pair.survivorId, pair.loserId),
     candidateEntityId: pair.reason === "ambiguous" ? null : pair.survivorId,
     candidateScore: pair.reason === "ambiguous" ? null : pair.score,
-    candidateReason: pair.reason === "fuzzy" ? "minhash" : "strict-normalized",
+    candidateReason:
+      pair.reason === "fuzzy" ? "minhash" : pair.reason === "token-set" ? "token-set" : "strict-normalized",
     triggeredByUserId: userId,
   });
 }
@@ -304,6 +351,113 @@ async function resolveQueuedPair(
   };
 }
 
+async function adjudicatePair(
+  db: Kysely<DB>,
+  pair: EntityDedupBackfillPair,
+  generator: AdjudicationGenerator,
+): Promise<EntityDedupBackfillAdjudication> {
+  const loserContext = await buildEntityAdjudicationContext(db, pair.loserId);
+  const survivorContext = await buildEntityAdjudicationContext(db, pair.survivorId);
+  const verdict = await adjudicateEntityMatch(generator, loserContext, [survivorContext]);
+  return {
+    pair,
+    matchEntityId: verdict.matchEntityId,
+    confidence: verdict.confidence,
+    reason: verdict.reason,
+  };
+}
+
+async function applyAutoMerges(
+  db: Kysely<DB>,
+  pairs: EntityDedupBackfillPair[],
+  result: EntityDedupBackfillResult,
+  options: EntityDedupBackfillOptions,
+  mergedAway: Set<string>,
+  batchSize: number,
+): Promise<void> {
+  let processed = 0;
+  for (const pair of pairs) {
+    if (pair.survivorId === pair.loserId || mergedAway.has(pair.survivorId) || mergedAway.has(pair.loserId)) {
+      result.skipped.push(pair);
+      continue;
+    }
+    processed += 1;
+    const preview = await previewMerge(db, { survivorId: pair.survivorId, loserId: pair.loserId });
+    if (preview.blocked) {
+      result.skipped.push(pair);
+      continue;
+    }
+    await mergeEntities(db, { survivorId: pair.survivorId, loserId: pair.loserId, userId: options.userId });
+    mergedAway.add(pair.loserId);
+    result.merged.push(pair);
+    if (processed % batchSize === 0) await yieldToEventLoop();
+  }
+}
+
+async function applyAdjudication(
+  db: Kysely<DB>,
+  adjudication: EntityDedupBackfillAdjudication,
+  result: EntityDedupBackfillResult,
+  options: EntityDedupBackfillOptions,
+  mergedAway: Set<string>,
+): Promise<boolean> {
+  const pair = adjudication.pair;
+  if (pair.survivorId === pair.loserId || mergedAway.has(pair.survivorId) || mergedAway.has(pair.loserId)) {
+    result.skipped.push(pair);
+    return true;
+  }
+  if (adjudication.confidence !== "high") return false;
+  if (adjudication.matchEntityId === pair.survivorId) {
+    const preview = await previewMerge(db, { survivorId: pair.survivorId, loserId: pair.loserId });
+    if (preview.blocked) {
+      result.skipped.push(pair);
+      return true;
+    }
+    await mergeEntities(db, { survivorId: pair.survivorId, loserId: pair.loserId, userId: options.userId });
+    mergedAway.add(pair.loserId);
+    result.merged.push(pair);
+    return true;
+  }
+  if (adjudication.matchEntityId === null) {
+    const reviewRepo = createEntityReviewRepo(db);
+    await reviewRepo.addRejection({
+      entityId: pair.survivorId,
+      rejectedName: pair.loserName,
+      rejectedBy: options.userId,
+    });
+    await reviewRepo.addRejection({
+      entityId: pair.loserId,
+      rejectedName: pair.survivorName,
+      rejectedBy: options.userId,
+    });
+    return true;
+  }
+  return false;
+}
+
+async function adjudicateCandidates(
+  db: Kysely<DB>,
+  result: EntityDedupBackfillResult,
+  queueCandidates: EntityDedupBackfillPair[],
+  generator: AdjudicationGenerator,
+  sampleLimit: number,
+  batchSize: number,
+  mergedAway: Set<string>,
+): Promise<void> {
+  let processed = 0;
+  for (const pair of queueCandidates) {
+    if (pair.survivorId === pair.loserId || mergedAway.has(pair.survivorId) || mergedAway.has(pair.loserId)) {
+      result.skipped.push(pair);
+      continue;
+    }
+    const adjudication = await adjudicatePair(db, pair, generator);
+    result.adjudicated.push(adjudication);
+    result.samples.adjudicated = result.adjudicated.slice(0, sampleLimit);
+    processed += 1;
+    if (processed % batchSize === 0) await yieldToEventLoop();
+  }
+}
+
 export async function runEntityDedupBackfill(
   db: Kysely<DB>,
   options: EntityDedupBackfillOptions,
@@ -312,6 +466,7 @@ export async function runEntityDedupBackfill(
   const sampleLimit = options.sampleLimit ?? DEFAULT_SAMPLE_LIMIT;
   const fuzzyThreshold = options.fuzzyThreshold ?? DEFAULT_FUZZY_THRESHOLD;
   const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const useLlm = options.useLlm !== false;
   const scans = await loadTypeScans(db);
   const discovered = await discoverPairs(db, scans, { fuzzyThreshold, batchSize });
   const excludeIds = new Set(options.excludeEntityIds ?? []);
@@ -323,31 +478,57 @@ export async function runEntityDedupBackfill(
     mode: execute ? "execute" : "dry-run",
     autoMergeCandidates: autoMerge,
     queuedCandidates: queueCandidates,
+    adjudicated: [],
     merged: [],
     queued: [],
     skipped: [],
     samples: {
       autoMerge: autoMerge.slice(0, sampleLimit),
       queue: queueCandidates.slice(0, sampleLimit),
+      adjudicated: [],
     },
   };
 
+  const generator = options.generator;
+  if (useLlm && generator && queueCandidates.length > 0) {
+    if (!execute) {
+      await adjudicateCandidates(db, result, queueCandidates, generator, sampleLimit, batchSize, new Set());
+      return result;
+    }
+    const mergedAway = new Set<string>();
+    await applyAutoMerges(db, autoMerge, result, options, mergedAway, batchSize);
+    let processed = 0;
+    for (const pair of queueCandidates) {
+      const resolved = await resolveQueuedPair(db, pair);
+      if (!resolved) {
+        result.skipped.push(pair);
+        continue;
+      }
+      const adjudication = await adjudicatePair(db, resolved, generator);
+      result.adjudicated.push(adjudication);
+      result.samples.adjudicated = result.adjudicated.slice(0, sampleLimit);
+      const handled = await applyAdjudication(db, adjudication, result, options, mergedAway);
+      if (!handled) {
+        await queuePair(db, resolved, options.userId);
+        result.queued.push(resolved);
+      }
+      processed += 1;
+      if (processed % batchSize === 0) await yieldToEventLoop();
+    }
+    return result;
+  }
+
   if (!execute) return result;
 
+  const mergedAway = new Set<string>();
+  await applyAutoMerges(db, autoMerge, result, options, mergedAway, batchSize);
+
   let processed = 0;
-  for (const pair of autoMerge) {
-    processed += 1;
-    const preview = await previewMerge(db, { survivorId: pair.survivorId, loserId: pair.loserId });
-    if (preview.blocked) {
+  for (const pair of queueCandidates) {
+    if (pair.survivorId === pair.loserId || mergedAway.has(pair.survivorId) || mergedAway.has(pair.loserId)) {
       result.skipped.push(pair);
       continue;
     }
-    await mergeEntities(db, { survivorId: pair.survivorId, loserId: pair.loserId, userId: options.userId });
-    result.merged.push(pair);
-    if (processed % batchSize === 0) await yieldToEventLoop();
-  }
-
-  for (const pair of queueCandidates) {
     processed += 1;
     const resolved = await resolveQueuedPair(db, pair);
     if (!resolved) {
@@ -370,6 +551,7 @@ function printResult(result: EntityDedupBackfillResult): void {
         mode: result.mode,
         autoMergeCandidates: result.autoMergeCandidates.length,
         queuedCandidates: result.queuedCandidates.length,
+        adjudicated: result.adjudicated.length,
         merged: result.merged.length,
         queued: result.queued.length,
         skipped: result.skipped.length,
@@ -389,6 +571,7 @@ async function main(): Promise<void> {
       "fuzzy-threshold": { type: "string", default: String(DEFAULT_FUZZY_THRESHOLD) },
       "sample-limit": { type: "string", default: String(DEFAULT_SAMPLE_LIMIT) },
       "exclude-entity": { type: "string" },
+      "no-llm": { type: "boolean", default: false },
     },
   });
   const config = loadConfig();
@@ -396,11 +579,23 @@ async function main(): Promise<void> {
   const db = await createDatabase(config);
   try {
     await runMigrations(db);
+    const useLlm = parsed.values["no-llm"] !== true;
+    let generator: AdjudicationGenerator | undefined;
+    if (useLlm) {
+      const settingsRow = await createSettingsRepository(db, config.ENCRYPTION_KEY).get();
+      if (settingsRow?.gemini_api_key) {
+        generator = createGeminiGenerator(settingsRow.gemini_api_key);
+      } else {
+        console.warn("No Gemini API key in settings; adjudication disabled — pairs fall back to the review queue.");
+      }
+    }
     const result = await runEntityDedupBackfill(db, {
       execute: parsed.values.execute,
       userId: parsed.values["user-id"],
       fuzzyThreshold: Number(parsed.values["fuzzy-threshold"]),
       sampleLimit: Number(parsed.values["sample-limit"]),
+      useLlm,
+      generator,
       excludeEntityIds: parsed.values["exclude-entity"]
         ?.split(",")
         .map((id) => id.trim())


### PR DESCRIPTION
Stacked context-graph slice 03/27.

Base: `feat/context-graph-02-dedup-merge-backfill`
Head: `feat/context-graph-03-dedup-adjudicator-adjacency`

Adds the project/product/team adjacency dedup path.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`