### PR TITLE
feat: add structural task core

### DIFF
--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -330,6 +330,7 @@ export function buildSystemContext(params: {
   indexedSources?: Array<{ source: string; fileCount: number }>;
   agentInstructions?: string | null;
   visionAnalysisEnabled?: boolean;
+  experimentalFlag?: boolean;
 }): string {
   const sections: string[] = [];
 
@@ -498,6 +499,11 @@ export function buildSystemContext(params: {
       "- **SearchEntities** — find projects, people, teams, companies, and products across connected sources. " +
         "Pass multiple name variations to maximize matches. Returns entity IDs.",
       "- **GetEntityContext** — get a cross-source timeline of mentions for an entity (from SearchEntities).",
+      ...(params.experimentalFlag
+        ? [
+            "- **ListTasks** — list current tracker-owned tasks by project entity or assignee entity, including status, source, priority, and due date.",
+          ]
+        : []),
       "",
       'Recency questions ("latest", "most recent", "last X"):',
       '- Always pass `sortBy: "recency"`. Default `limit` becomes 3 (small disambiguation set).',

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -236,6 +236,7 @@ export interface RunAgentParams {
   agentInstructions?: string | null;
   agentAllowedTools?: string[] | null;
   agentOutputWriter?: AgentOutputWriter;
+  experimentalFlag?: boolean;
   conversationRepo?: ReturnType<typeof createConversationRepository>;
   conversationContext?: {
     conversationId: number;
@@ -332,6 +333,7 @@ export async function runAgent(params: RunAgentParams): Promise<RunAgentResult> 
     indexedSources,
     agentInstructions: params.agentInstructions,
     visionAnalysisEnabled: visualAnalysisAllowed,
+    experimentalFlag: params.experimentalFlag,
   });
 
   const sdkBuiltInTools = params.agentAllowedTools
@@ -435,6 +437,7 @@ export async function runAgent(params: RunAgentParams): Promise<RunAgentResult> 
     agentInstructions: params.agentInstructions,
     agentAllowedTools: params.agentAllowedTools,
     agentOutputWriter: params.agentOutputWriter,
+    experimentalFlag: params.experimentalFlag,
     originOrgContextEnabled: params.claudeConfigDir !== undefined,
   });
 

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -4,6 +4,7 @@ import { createWriteAgentOutputTool } from "./tools/agent-output";
 import { createReadChatHistoryTool, createSearchChatHistoryTool } from "./tools/chat-history";
 import { createSearchDeliveryTargetsTool } from "./tools/delivery-targets";
 import { createInboxWorkflowTools } from "./tools/inbox-workflows";
+import { createListTasksTool } from "./tools/list-tasks";
 import { createLocalClaudeSessionTool } from "./tools/local-claude-session";
 import { createLocalRunCommandTool } from "./tools/local-command";
 import { createMessagingTools } from "./tools/messaging";
@@ -77,6 +78,7 @@ export function createSketchMcpServer(deps: SketchMcpDeps) {
         ]
       : []),
     ...createSearchTools(deps),
+    ...(deps.experimentalFlag ? [createListTasksTool(deps)] : []),
   ];
 
   return createSdkMcpServer({ name: "sketch", tools });

--- a/packages/server/src/agent/tools/list-tasks.ts
+++ b/packages/server/src/agent/tools/list-tasks.ts
@@ -1,0 +1,61 @@
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod/v4";
+import { type TaskStatus, createTaskRepository } from "../../db/repositories/tasks";
+import type { SketchMcpDeps, ToolResult } from "./types";
+
+export const listTasksToolDescription =
+  "List current structural tasks from connected trackers by project entity or assignee entity. Returns tracker-owned status, assignee, project, and source references.";
+
+export const listTasksToolSchema = {
+  parentEntityId: z.string().optional().describe("Project entity ID whose tasks should be listed."),
+  assigneeEntityId: z.string().optional().describe("Person entity ID whose assigned tasks should be listed."),
+  status: z.enum(["open", "in_progress", "done", "dropped"]).optional().describe("Optional status filter."),
+  limit: z.number().optional().describe("Maximum tasks to return. Default 50."),
+};
+
+type ListTasksArgs = z.infer<z.ZodObject<typeof listTasksToolSchema>>;
+
+export async function handleListTasks(
+  { parentEntityId, assigneeEntityId, status, limit }: ListTasksArgs,
+  deps: SketchMcpDeps,
+): Promise<ToolResult> {
+  if (!deps.db) return { content: [{ type: "text", text: "Tasks are not available." }] };
+  if (!parentEntityId && !assigneeEntityId) {
+    return { content: [{ type: "text", text: "Provide parentEntityId or assigneeEntityId." }] };
+  }
+  const viewer = {
+    email: await resolvePrimaryEmail(deps),
+    isAdmin: false,
+  };
+  const repo = createTaskRepository(deps.db);
+  const opts = { viewer, status: status as TaskStatus | undefined, limit: Math.min(limit ?? 50, 100) };
+  const tasks = parentEntityId
+    ? await repo.listTasksByParent(parentEntityId, opts)
+    : await repo.listTasksByAssignee(assigneeEntityId as string, opts);
+  if (tasks.length === 0) return { content: [{ type: "text", text: "No visible tasks found." }] };
+  const lines = tasks.map((task) =>
+    [
+      `- ${task.title}`,
+      `status=${task.status}`,
+      task.status_raw ? `raw=${task.status_raw}` : null,
+      task.external_ref ? `ref=${task.external_ref}` : null,
+      task.source ? `source=${task.source}` : null,
+      task.priority ? `priority=${task.priority}` : null,
+      task.due_at ? `due=${task.due_at}` : null,
+    ]
+      .filter(Boolean)
+      .join(" | "),
+  );
+  return { content: [{ type: "text", text: lines.join("\n") }] };
+}
+
+export function createListTasksTool(deps: SketchMcpDeps) {
+  return tool("ListTasks", listTasksToolDescription, listTasksToolSchema, (args) => handleListTasks(args, deps));
+}
+
+async function resolvePrimaryEmail(deps: SketchMcpDeps): Promise<string | null> {
+  if (deps.publicMcp?.userEmails?.length) return deps.publicMcp.userEmails[0];
+  if (!deps.currentUserId || !deps.userRepo?.getAllEmailsForUser) return null;
+  const emails = await deps.userRepo.getAllEmailsForUser(deps.currentUserId);
+  return emails[0] ?? null;
+}

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -141,6 +141,7 @@ export interface SketchMcpDeps {
   agentInstructions?: string | null;
   agentAllowedTools?: string[] | null;
   agentOutputWriter?: AgentOutputWriter;
+  experimentalFlag?: boolean;
   originOrgContextEnabled?: boolean;
   publicMcp?: {
     userEmails?: string[];

--- a/packages/server/src/api/entities.ts
+++ b/packages/server/src/api/entities.ts
@@ -5,6 +5,7 @@ import { createEntityBindingRoutes } from "./entities/binding-routes";
 import { createEntityMaintenanceRoutes } from "./entities/maintenance-routes";
 import { createEntityMergeRoutes } from "./entities/merge-routes";
 import { createEntityProfileRoutes } from "./entities/profile-routes";
+import { createTaskRoutes } from "./entities/task-routes";
 import type { EntityRoutesDeps } from "./entities/types";
 
 export { _setCurrentReenrichJobForTests, _setCurrentResetJobForTests } from "./entities/jobs";
@@ -16,5 +17,6 @@ export function entityRoutes(db: Kysely<DB>, deps: EntityRoutesDeps) {
   routes.route("/", createEntityMergeRoutes(db));
   routes.route("/", createEntityBindingRoutes(db));
   routes.route("/", createEntityProfileRoutes(db, deps));
+  if (deps.config.EXPERIMENTAL_FLAG) routes.route("/", createTaskRoutes(db));
   return routes;
 }

--- a/packages/server/src/api/entities/task-routes.ts
+++ b/packages/server/src/api/entities/task-routes.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { createEntityRepository } from "../../db/repositories/entities";
+import { type TaskStatus, createTaskRepository } from "../../db/repositories/tasks";
+import type { DB } from "../../db/schema";
+import { getContentViewer } from "../auth-helpers";
+
+const TASK_STATUSES = new Set(["open", "in_progress", "done", "dropped"]);
+
+export function createTaskRoutes(db: Kysely<DB>) {
+  const routes = new Hono();
+  const entityRepo = createEntityRepository(db);
+  const taskRepo = createTaskRepository(db);
+
+  routes.get("/:id/tasks", async (c) => {
+    const viewer = getContentViewer(c);
+    const entity = await entityRepo.getEntity(c.req.param("id"), viewer);
+    if (!entity) return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
+    const status = c.req.query("status");
+    if (status && !TASK_STATUSES.has(status)) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "Invalid status" } }, 400);
+    }
+    const limit = Math.min(Number(c.req.query("limit")) || 100, 200);
+    const tasks = await taskRepo.listTasksByParent(entity.id, {
+      viewer,
+      status: status as TaskStatus | undefined,
+      limit,
+    });
+    return c.json({ tasks });
+  });
+
+  return routes;
+}

--- a/packages/server/src/api/entities/task-routes.ts
+++ b/packages/server/src/api/entities/task-routes.ts
@@ -6,6 +6,15 @@ import type { DB } from "../../db/schema";
 import { getContentViewer } from "../auth-helpers";
 
 const TASK_STATUSES = new Set(["open", "in_progress", "done", "dropped"]);
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 200;
+
+function parseTaskLimit(value: string | undefined): number {
+  if (value === undefined) return DEFAULT_LIMIT;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
 
 export function createTaskRoutes(db: Kysely<DB>) {
   const routes = new Hono();
@@ -20,7 +29,7 @@ export function createTaskRoutes(db: Kysely<DB>) {
     if (status && !TASK_STATUSES.has(status)) {
       return c.json({ error: { code: "BAD_REQUEST", message: "Invalid status" } }, 400);
     }
-    const limit = Math.min(Number(c.req.query("limit")) || 100, 200);
+    const limit = parseTaskLimit(c.req.query("limit"));
     const tasks = await taskRepo.listTasksByParent(entity.id, {
       viewer,
       status: status as TaskStatus | undefined,

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -202,6 +202,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
       settingsEncryptionKey: params.settingsEncryptionKey ?? config.ENCRYPTION_KEY,
       localDeviceInvoker: params.localDeviceInvoker ?? localDeviceGateway,
       localClaudeSessionService: params.localClaudeSessionService ?? localClaudeSessionService,
+      experimentalFlag: params.experimentalFlag ?? config.EXPERIMENTAL_FLAG,
       ...(Object.keys(resolvedAgentEnv).length > 0
         ? {
             agentEnv: resolvedAgentEnv,

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -257,6 +257,13 @@ function taskToSyncedItem(
       contextSnippet: `In list: ${listProjectParent.name}`,
     });
   }
+  const taskProject =
+    folderId && folderName
+      ? { name: folderName, source: "clickup", sourceId: folderId }
+      : listProjectParent
+        ? { name: listProjectParent.name, source: "clickup", sourceId: listProjectParent.id }
+        : undefined;
+  const primaryAssignee = task.assignees.find((assignee) => assignee.username);
 
   return {
     providerFileId: task.id,
@@ -271,6 +278,24 @@ function taskToSyncedItem(
     sourceUpdatedAt: parseClickUpTimestamp(task.date_updated ?? null),
     accessScope,
     assignees: task.assignees.filter((a) => a.username).map((a) => ({ name: a.username })),
+    task: {
+      sourceTaskId: task.id,
+      externalRef: task.id,
+      title: task.name,
+      statusType: task.status.type,
+      statusRaw: task.status.status,
+      priority: task.priority?.priority,
+      dueAt: parseClickUpTimestamp(task.due_date) ?? undefined,
+      project: taskProject,
+      assignee: primaryAssignee
+        ? {
+            name: primaryAssignee.username,
+            email: primaryAssignee.email,
+            source: "clickup",
+            sourceId: `assignee:${primaryAssignee.username}`,
+          }
+        : undefined,
+    },
     authorEmail: task.creator?.email,
     authorName: task.creator?.username,
     authorSourceId: task.creator?.id === undefined ? undefined : `user:${String(task.creator.id)}`,

--- a/packages/server/src/connectors/linear.ts
+++ b/packages/server/src/connectors/linear.ts
@@ -218,6 +218,17 @@ function issueToSyncedItem(issue: LinearIssue): SyncedItem {
     sourceCreatedAt: issue.createdAt,
     sourceUpdatedAt: issue.updatedAt,
     assignees: issue.assignee ? [{ name: issue.assignee.displayName }] : [],
+    task: {
+      sourceTaskId: issue.id,
+      externalRef: issue.identifier,
+      title: issue.title,
+      statusType: issue.state?.type ?? "unstarted",
+      statusRaw: issue.state?.name,
+      priority: issue.priorityLabel || PRIORITY_LABELS[issue.priority] || undefined,
+      dueAt: issue.dueDate ?? undefined,
+      project: issue.project ? { name: issue.project.name, source: "linear", sourceId: issue.project.id } : undefined,
+      assignee: issue.assignee ? { name: issue.assignee.displayName } : undefined,
+    },
     parentEntities: [
       ...(issue.team
         ? [{ source: "linear", sourceId: issue.team.id, contextSnippet: `Linear issue in team: ${issue.team.name}` }]

--- a/packages/server/src/connectors/post-sync.ts
+++ b/packages/server/src/connectors/post-sync.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
+import { createTaskRepository } from "../db/repositories/tasks";
 import type { DB } from "../db/schema";
 import { sweepCoMentionContributesTo } from "../entities/co-mention-sweep";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
@@ -12,6 +13,7 @@ export interface PostSyncGraphPipelineParams {
   affectedIndexedFileIds: string[];
   coMentionContributesToThreshold?: number;
   floorRetryMaxFilesPerDomain?: number;
+  source?: string;
 }
 
 export async function runPostSyncGraphPipeline({
@@ -20,10 +22,17 @@ export async function runPostSyncGraphPipeline({
   affectedIndexedFileIds,
   coMentionContributesToThreshold,
   floorRetryMaxFilesPerDomain,
+  source,
 }: PostSyncGraphPipelineParams): Promise<void> {
   const materializeSummary = await materializeUnmaterializedFacts(db, syncLogger);
   if (materializeSummary.factsRead > 0) {
     syncLogger.info({ materializeSummary }, "Post-sync fact materialization complete");
+  }
+  const taskRepo = createTaskRepository(db);
+  const reanchoredTasks = await taskRepo.reanchorNullParentTasks();
+  const expiredTasks = await taskRepo.expireOrphanedTasks(source);
+  if (reanchoredTasks > 0 || expiredTasks > 0) {
+    syncLogger.info({ reanchoredTasks, expiredTasks }, "Post-sync task sweep complete");
   }
 
   const domainSweep = await sweepDomainPromotions(db, syncLogger.child({ component: "domain-sweep" }));

--- a/packages/server/src/connectors/sync-facts.ts
+++ b/packages/server/src/connectors/sync-facts.ts
@@ -18,6 +18,7 @@ interface EmitFactsForSyncedItemParams {
   item: SyncedItem;
   indexedFileId: string;
   emitCorrespondentFacts?: boolean;
+  experimentalFlag?: boolean;
 }
 
 export async function emitFactsForSyncedItem({
@@ -28,6 +29,7 @@ export async function emitFactsForSyncedItem({
   item,
   indexedFileId,
   emitCorrespondentFacts = false,
+  experimentalFlag = false,
 }: EmitFactsForSyncedItemParams): Promise<void> {
   if (item.entitySeeds && item.entitySeeds.length > 0) {
     for (const seed of item.entitySeeds) {
@@ -188,6 +190,22 @@ export async function emitFactsForSyncedItem({
         contentHash: item.contentHash,
       });
     }
+  }
+
+  if (experimentalFlag && item.task) {
+    await factRepo.upsertFact({
+      ...factContext,
+      indexedFileId,
+      contentHash: item.contentHash,
+      source: connectorType,
+      factType: "structural_task",
+      relation: "mentioned",
+      subjectName: item.task.title,
+      subjectSource: connectorType,
+      subjectSourceId: item.task.sourceTaskId,
+      contextSnippet: item.sourcePath,
+      raw: { indexedFileId, task: item.task },
+    });
   }
 
   if (item.authorEmail || item.authorName) {

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -128,6 +128,7 @@ export async function runConnectorSync(
       | "MICROSOFT_CLIENT_ID"
       | "MICROSOFT_CLIENT_SECRET"
       | "MICROSOFT_TENANT"
+      | "EXPERIMENTAL_FLAG"
     >
   >,
 ): Promise<SyncResult> {
@@ -323,6 +324,7 @@ export async function runConnectorSync(
           item,
           indexedFileId: itemResult.indexedFileId,
           emitCorrespondentFacts: connector.emitsCorrespondentFacts ?? false,
+          experimentalFlag: appConfig?.EXPERIMENTAL_FLAG ?? false,
         });
 
         if (itemResult.kind === "unchanged") {
@@ -379,6 +381,7 @@ export async function runConnectorSync(
       affectedIndexedFileIds: [...affectedIndexedFileIds],
       coMentionContributesToThreshold: appConfig?.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
       floorRetryMaxFilesPerDomain: appConfig?.FLOOR_RETRY_MAX_FILES_PER_DOMAIN,
+      source: connectorType,
     });
 
     if (connectorType === "zoho_crm") {

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -118,6 +118,17 @@ export interface SyncedItem {
    * Each assignee is matched to a person entity and linked via entity_mentions.
    */
   assignees?: Array<{ name: string; email?: string; source?: string; sourceId?: string }>;
+  task?: {
+    sourceTaskId: string;
+    externalRef?: string;
+    title: string;
+    statusType: string;
+    statusRaw?: string;
+    priority?: string;
+    dueAt?: string;
+    project?: { name: string; source: string; sourceId: string };
+    assignee?: { name: string; email?: string; source?: string; sourceId?: string };
+  };
   /**
    * People meaningfully attached to this item (meeting speakers, doc authors).
    * Sync seeds person entities from entries where `name` is present or can be
@@ -205,6 +216,10 @@ export type IndexedFileFactRaw =
     }
   | { providerFileId: string; author: { name?: string; email?: string; sourceId?: string } }
   | { providerFileId: string; parent: { source: string; sourceId: string; contextSnippet?: string } }
+  | {
+      indexedFileId: string;
+      task: NonNullable<SyncedItem["task"]>;
+    }
   | { providerFileId: string; contactPoint: ContactPointSeed }
   | { sourceType: string; sourceUrl?: string; sourcePath?: string; metadata?: Record<string, unknown> }
   | { subtype: "internal" | "external" }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -120,6 +120,7 @@ import * as m117 from "./migrations/117-conversation-message-window-index";
 import * as m118 from "./migrations/118-whatsapp-window-keepalives";
 import * as m119 from "./migrations/119-agent-outputs-source-scope";
 import * as m120 from "./migrations/120-agent-output-period-key";
+import * as m121 from "./migrations/121-tasks";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -244,6 +245,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "118-whatsapp-window-keepalives": m118,
           "119-agent-outputs-source-scope": m119,
           "120-agent-output-period-key": m120,
+          "121-tasks": m121,
         };
       },
     },

--- a/packages/server/src/db/migrations/121-tasks.ts
+++ b/packages/server/src/db/migrations/121-tasks.ts
@@ -1,0 +1,56 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("tasks")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("parent_entity_id", "text", (col) => col.references("entities.id").onDelete("set null"))
+    .addColumn("parent_source_ref", "text")
+    .addColumn("parent_name", "text")
+    .addColumn("source", "text", (col) => col.notNull())
+    .addColumn("external_ref", "text")
+    .addColumn("title", "text", (col) => col.notNull())
+    .addColumn("normalized_title", "text", (col) => col.notNull())
+    .addColumn("status", "text", (col) => col.notNull())
+    .addColumn("status_raw", "text")
+    .addColumn("status_authority", "text", (col) => col.notNull())
+    .addColumn("assignee_entity_id", "text", (col) => col.references("entities.id").onDelete("set null"))
+    .addColumn("priority", "text")
+    .addColumn("due_at", "text")
+    .addColumn("provenance", "text", (col) => col.notNull())
+    .addColumn("source_task_id", "text", (col) => col.notNull())
+    .addColumn("status_changed_at", "text")
+    .addColumn("completed_at", "text")
+    .addColumn("valid_from", "text")
+    .addColumn("valid_to", "text")
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createTable("task_evidence")
+    .addColumn("task_id", "text", (col) => col.notNull().references("tasks.id").onDelete("cascade"))
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("ref_id", "text", (col) => col.notNull())
+    .addPrimaryKeyConstraint("task_evidence_pkey", ["task_id", "kind", "ref_id"])
+    .execute();
+
+  await db.schema
+    .createIndex("idx_tasks_source_task")
+    .on("tasks")
+    .columns(["source", "source_task_id"])
+    .unique()
+    .execute();
+  await db.schema.createIndex("idx_tasks_parent_status").on("tasks").columns(["parent_entity_id", "status"]).execute();
+  await db.schema
+    .createIndex("idx_tasks_assignee_status")
+    .on("tasks")
+    .columns(["assignee_entity_id", "status"])
+    .execute();
+  await db.schema.createIndex("idx_task_evidence_kind_ref").on("task_evidence").columns(["kind", "ref_id"]).execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("task_evidence").execute();
+  await db.schema.dropTable("tasks").execute();
+}

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -11,6 +11,7 @@ export type IndexedFileFactType =
   | "parent_entity"
   | "contact_point"
   | "structural_seed"
+  | "structural_task"
   | "person_seed"
   | "llm_extracted"
   | "llm_relation"
@@ -124,6 +125,14 @@ function rawEndpointIdentity(
 }
 
 export function buildIndexedFileFactKey(input: UpsertIndexedFileFactInput): string {
+  if (input.factType === "structural_task") {
+    const raw = input.raw as Record<string, unknown> | undefined;
+    const task = isRecord(raw?.task) ? raw.task : undefined;
+    const sourceTaskId = typeof task?.sourceTaskId === "string" ? task.sourceTaskId.trim().toLowerCase() : "";
+    return createHash("sha256")
+      .update([input.connectorConfigId ?? "", input.factType, input.source, sourceTaskId].join("|"))
+      .digest("hex");
+  }
   const parts = [
     input.connectorConfigId ?? "",
     input.source,
@@ -231,6 +240,14 @@ function validateRaw(input: UpsertIndexedFileFactInput): string | null {
   } else if (input.factType === "structural_seed") {
     if (!hasString(raw, "sourceType") && (!hasString(raw, "providerFileId") || !hasString(raw, "fileType"))) {
       throw new Error("structural_seed facts require raw.sourceType or raw provider file metadata");
+    }
+  } else if (input.factType === "structural_task") {
+    if (!isRecord(raw.task) || !hasString(raw, "indexedFileId")) {
+      throw new Error("structural_task facts require raw.task and raw.indexedFileId");
+    }
+    const task = raw.task as Record<string, unknown>;
+    if (!hasString(task, "sourceTaskId") || !hasString(task, "title") || !hasString(task, "statusType")) {
+      throw new Error("structural_task facts require sourceTaskId, title, and statusType");
     }
   } else if (input.factType === "person_seed") {
     if (!hasString(raw, "source") && !hasString(raw, "subtype")) {

--- a/packages/server/src/db/repositories/tasks.integration.test.ts
+++ b/packages/server/src/db/repositories/tasks.integration.test.ts
@@ -1,0 +1,62 @@
+import { type Kysely, sql } from "kysely";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getSharedPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createTaskRepository } from "./tasks";
+
+describe("createTaskRepository postgres", () => {
+  let db: Kysely<DB>;
+
+  beforeAll(async () => {
+    db = await getSharedPgDb();
+  }, 30000);
+
+  beforeEach(async () => {
+    await sql`BEGIN`.execute(db);
+  });
+
+  afterEach(async () => {
+    await sql`ROLLBACK`.execute(db);
+  });
+
+  it("upserts on source and source task id without duplicating rows", async () => {
+    const repo = createTaskRepository(db);
+    const first = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-PG-1",
+      title: "PG first title",
+      status: "open",
+      statusRaw: "Backlog",
+      statusAuthority: "external",
+      assigneeEntityId: null,
+      priority: null,
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "pg-issue-1",
+    });
+    const second = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-PG-1",
+      title: "PG renamed title",
+      status: "done",
+      statusRaw: "Done",
+      statusAuthority: "external",
+      assigneeEntityId: null,
+      priority: null,
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "pg-issue-1",
+    });
+    const rows = await db.selectFrom("tasks").selectAll().where("source_task_id", "=", "pg-issue-1").execute();
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: first.taskId, title: "PG renamed title", status: "done", valid_to: null });
+  });
+});

--- a/packages/server/src/db/repositories/tasks.test.ts
+++ b/packages/server/src/db/repositories/tasks.test.ts
@@ -1,0 +1,58 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createTaskRepository } from "./tasks";
+
+describe("createTaskRepository sqlite", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("upserts on source and source task id without duplicating rows", async () => {
+    const repo = createTaskRepository(db);
+    const first = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-1",
+      title: "First title",
+      status: "open",
+      statusRaw: "Backlog",
+      statusAuthority: "external",
+      assigneeEntityId: null,
+      priority: null,
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "issue-1",
+    });
+    const second = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-1",
+      title: "Renamed title",
+      status: "done",
+      statusRaw: "Done",
+      statusAuthority: "external",
+      assigneeEntityId: null,
+      priority: null,
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "issue-1",
+    });
+    const rows = await db.selectFrom("tasks").selectAll().execute();
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: first.taskId, title: "Renamed title", status: "done", valid_to: null });
+  });
+});

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -168,19 +168,22 @@ export function createTaskRepository(db: Kysely<DB>) {
 }
 
 function visibleTaskQuery(db: Kysely<DB>, viewer: FileViewer) {
-  return db
+  const query = db
     .selectFrom("tasks")
     .selectAll("tasks")
-    .where("tasks.valid_to", "is", null)
-    .where((eb) =>
-      eb.exists(sql<boolean>`(
+    .where("tasks.valid_to", "is", null);
+
+  if (viewer.isAdmin) return query;
+
+  return query.where((eb) =>
+    eb.exists(sql<boolean>`(
         SELECT 1 FROM task_evidence
         INNER JOIN indexed_files ON indexed_files.id = task_evidence.ref_id
         WHERE task_evidence.task_id = tasks.id
           AND task_evidence.kind = 'file'
           AND ${fileVisibilityPredicate(viewer)}
       )`),
-    );
+  );
 }
 
 async function findLiveProjectForTask(db: Kysely<DB>, parentSourceRef: string | null, parentName: string | null) {

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -1,0 +1,215 @@
+import { randomUUID } from "node:crypto";
+import { type Kysely, type Selectable, sql } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+import type { DB, TasksTable } from "../schema";
+import type { FileViewer } from "./connectors";
+import { fileVisibilityPredicate } from "./connectors";
+import { whereLiveEntity } from "./entities";
+
+export const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
+
+export type TaskStatus = "open" | "in_progress" | "done" | "dropped";
+
+export interface UpsertTaskInput {
+  parentEntityId: string | null;
+  parentSourceRef: string | null;
+  parentName: string | null;
+  source: string;
+  externalRef: string | null;
+  title: string;
+  status: TaskStatus;
+  statusRaw: string | null;
+  statusAuthority: "external" | "local";
+  assigneeEntityId: string | null;
+  priority: string | null;
+  dueAt: string | null;
+  provenance: "structural";
+  sourceTaskId: string;
+}
+
+export interface TaskListOptions {
+  viewer: FileViewer;
+  status?: TaskStatus;
+  limit?: number;
+}
+
+export function createTaskRepository(db: Kysely<DB>) {
+  return {
+    async upsertTask(input: UpsertTaskInput): Promise<{ taskId: string; created: boolean }> {
+      const now = new Date().toISOString();
+      const existing = await db
+        .selectFrom("tasks")
+        .selectAll()
+        .where("source", "=", input.source)
+        .where("source_task_id", "=", input.sourceTaskId)
+        .executeTakeFirst();
+      const statusChanged = existing ? existing.status !== input.status : true;
+      const completedAt =
+        input.status === "done"
+          ? existing?.status === "done" && existing.completed_at
+            ? existing.completed_at
+            : now
+          : null;
+      const values = {
+        parent_entity_id: input.parentEntityId,
+        parent_source_ref: input.parentSourceRef,
+        parent_name: input.parentName,
+        source: input.source,
+        external_ref: input.externalRef,
+        title: input.title,
+        normalized_title: normalizeName(input.title),
+        status: input.status,
+        status_raw: input.statusRaw,
+        status_authority: input.statusAuthority,
+        assignee_entity_id: input.assigneeEntityId,
+        priority: input.priority,
+        due_at: input.dueAt,
+        provenance: input.provenance,
+        source_task_id: input.sourceTaskId,
+        status_changed_at: statusChanged ? now : (existing?.status_changed_at ?? null),
+        completed_at: completedAt,
+        valid_from: existing?.valid_from ?? now,
+        valid_to: null,
+        updated_at: now,
+      };
+
+      await db
+        .insertInto("tasks")
+        .values({
+          id: existing?.id ?? randomUUID(),
+          ...values,
+        })
+        .onConflict((oc) =>
+          oc.columns(["source", "source_task_id"]).doUpdateSet({
+            ...values,
+          }),
+        )
+        .execute();
+
+      const row = await db
+        .selectFrom("tasks")
+        .select("id")
+        .where("source", "=", input.source)
+        .where("source_task_id", "=", input.sourceTaskId)
+        .executeTakeFirstOrThrow();
+      return { taskId: row.id, created: !existing };
+    },
+
+    async upsertEvidence(taskId: string, kind: string, refId: string): Promise<void> {
+      await db
+        .insertInto("task_evidence")
+        .values({ task_id: taskId, kind, ref_id: refId })
+        .onConflict((oc) => oc.columns(["task_id", "kind", "ref_id"]).doNothing())
+        .execute();
+    },
+
+    async reanchorNullParentTasks(): Promise<number> {
+      const rows = await db
+        .selectFrom("tasks")
+        .select(["id", "parent_source_ref", "parent_name"])
+        .where("parent_entity_id", "is", null)
+        .where("valid_to", "is", null)
+        .execute();
+      let count = 0;
+      for (const task of rows) {
+        const parent = await findLiveProjectForTask(db, task.parent_source_ref, task.parent_name);
+        if (!parent || parent.id === TEST_ACCOUNT_ENTITY_ID) continue;
+        await db
+          .updateTable("tasks")
+          .set({ parent_entity_id: parent.id, updated_at: new Date().toISOString() })
+          .where("id", "=", task.id)
+          .where("parent_entity_id", "is", null)
+          .execute();
+        count++;
+      }
+      return count;
+    },
+
+    async expireOrphanedTasks(source?: string): Promise<number> {
+      const now = new Date().toISOString();
+      let query = db
+        .updateTable("tasks")
+        .set({ valid_to: now, updated_at: now })
+        .where("valid_to", "is", null)
+        .where((eb) =>
+          eb.not(sql<boolean>`EXISTS (
+            SELECT 1 FROM indexed_file_facts iff
+            WHERE iff.source = tasks.source
+              AND iff.subject_source_id = tasks.source_task_id
+              AND iff.fact_type = 'structural_task'
+              AND iff.deleted_at IS NULL
+          )`),
+        );
+      if (source) query = query.where("source", "=", source);
+      const result = await query.executeTakeFirst();
+      return Number(result.numUpdatedRows ?? 0);
+    },
+
+    async listTasksByParent(entityId: string, opts: TaskListOptions): Promise<Selectable<TasksTable>[]> {
+      let query = visibleTaskQuery(db, opts.viewer)
+        .where("tasks.parent_entity_id", "=", entityId)
+        .orderBy("tasks.status", "asc")
+        .orderBy("tasks.updated_at", "desc")
+        .limit(opts.limit ?? 100);
+      if (opts.status) query = query.where("tasks.status", "=", opts.status);
+      return query.execute();
+    },
+
+    async listTasksByAssignee(entityId: string, opts: TaskListOptions): Promise<Selectable<TasksTable>[]> {
+      let query = visibleTaskQuery(db, opts.viewer)
+        .where("tasks.assignee_entity_id", "=", entityId)
+        .orderBy("tasks.status", "asc")
+        .orderBy("tasks.updated_at", "desc")
+        .limit(opts.limit ?? 100);
+      if (opts.status) query = query.where("tasks.status", "=", opts.status);
+      return query.execute();
+    },
+  };
+}
+
+function visibleTaskQuery(db: Kysely<DB>, viewer: FileViewer) {
+  return db
+    .selectFrom("tasks")
+    .selectAll("tasks")
+    .where("tasks.valid_to", "is", null)
+    .where((eb) =>
+      eb.exists(sql<boolean>`(
+        SELECT 1 FROM task_evidence
+        INNER JOIN indexed_files ON indexed_files.id = task_evidence.ref_id
+        WHERE task_evidence.task_id = tasks.id
+          AND task_evidence.kind = 'file'
+          AND ${fileVisibilityPredicate(viewer)}
+      )`),
+    );
+}
+
+async function findLiveProjectForTask(db: Kysely<DB>, parentSourceRef: string | null, parentName: string | null) {
+  if (parentSourceRef) {
+    const [source, ...sourceIdParts] = parentSourceRef.split(":");
+    const sourceId = sourceIdParts.join(":");
+    if (source && sourceId) {
+      const byRef = await db
+        .selectFrom("entity_source_refs")
+        .innerJoin("entities", "entities.id", "entity_source_refs.entity_id")
+        .selectAll("entities")
+        .where("entity_source_refs.source", "=", source)
+        .where("entity_source_refs.source_id", "=", sourceId)
+        .where("entities.source_type", "=", "project")
+        .where("entities.id", "!=", TEST_ACCOUNT_ENTITY_ID)
+        .where(whereLiveEntity())
+        .executeTakeFirst();
+      if (byRef) return byRef;
+    }
+  }
+
+  const nameKey = parentName ? normalizeName(parentName) : "";
+  if (!nameKey) return null;
+  const candidates = await db
+    .selectFrom("entities")
+    .selectAll()
+    .where("source_type", "=", "project")
+    .where("id", "!=", TEST_ACCOUNT_ENTITY_ID)
+    .where(whereLiveEntity())
+    .execute();
+  return candidates.find((entity) => normalizeName(entity.name) === nameKey) ?? null;
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -922,6 +922,37 @@ export interface IndexedFileFactsTable {
   updated_at: Generated<string>;
 }
 
+export interface TasksTable {
+  id: string;
+  parent_entity_id: string | null;
+  parent_source_ref: string | null;
+  parent_name: string | null;
+  source: string;
+  external_ref: string | null;
+  title: string;
+  normalized_title: string;
+  status: string;
+  status_raw: string | null;
+  status_authority: string;
+  assignee_entity_id: string | null;
+  priority: string | null;
+  due_at: string | null;
+  provenance: string;
+  source_task_id: string;
+  status_changed_at: string | null;
+  completed_at: string | null;
+  valid_from: string | null;
+  valid_to: string | null;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
+export interface TaskEvidenceTable {
+  task_id: string;
+  kind: string;
+  ref_id: string;
+}
+
 export interface DB {
   users: UsersTable;
   channels: ChannelsTable;
@@ -987,6 +1018,8 @@ export interface DB {
   entity_review_domain_candidates: EntityReviewDomainCandidatesTable;
   entity_alias_rejections: EntityAliasRejectionsTable;
   indexed_file_facts: IndexedFileFactsTable;
+  tasks: TasksTable;
+  task_evidence: TaskEvidenceTable;
   entity_domains: EntityDomainsTable;
   entity_project_bindings: EntityProjectBindingsTable;
   entity_project_member_overrides: EntityProjectMemberOverridesTable;

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -11,6 +11,7 @@ import { materializePersonFact, materializePersonSeed } from "./materialize-pers
 import { materializeProjectSeed } from "./materialize-project";
 import { materializeCrmRelationFact, materializeLlmRelationFact } from "./materialize-relations";
 import { materializeParentEntity, materializeStructuralSeed } from "./materialize-structural";
+import { materializeStructuralTask } from "./materialize-task";
 import type {
   IndexedFileFactRow,
   MaterializeDeps,
@@ -33,6 +34,7 @@ const FACT_REPLAY_ORDER = [
   "crm_relation",
   "llm_extracted",
   "llm_relation",
+  "structural_task",
 ] as const;
 
 export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
@@ -69,6 +71,9 @@ export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFi
   if (fact.fact_type === "parent_entity") {
     return materializeParentEntity(deps, fact);
   }
+  if (fact.fact_type === "structural_task") {
+    return materializeStructuralTask(deps, fact);
+  }
   return { kind: "skipped", reason: "unknown_fact_type" };
 }
 
@@ -96,6 +101,10 @@ function accumulate(summary: ReplayFactsSummary, result: MaterializeResult): voi
     summary.entitiesLinked += result.entitiesLinked;
     summary.mentionsWritten += result.mentionsWritten;
     summary.relationshipsWritten += result.relationshipsWritten;
+    return;
+  }
+  if (result.kind === "task_materialized") {
+    if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
     return;
   }
   if (
@@ -231,7 +240,7 @@ async function materializeUnmaterializedFactsInner(
           .set({ materialized_at: new Date().toISOString() })
           .where("id", "=", fact.id)
           .execute();
-        summary.materialized++;
+        if (result.kind !== "task_materialized") summary.materialized++;
       } else {
         summary.deferred++;
       }
@@ -255,6 +264,7 @@ export function shouldMarkMaterialized(result: MaterializeResult): boolean {
     result.kind === "entity_linked" ||
     result.kind === "queued" ||
     result.kind === "relationship_materialized" ||
+    result.kind === "task_materialized" ||
     result.kind === "structural"
   ) {
     return true;

--- a/packages/server/src/entities/materialize-task.test.ts
+++ b/packages/server/src/entities/materialize-task.test.ts
@@ -1,0 +1,336 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { emitFactsForSyncedItem } from "../connectors/sync-facts";
+import type { Connector, SyncedItem } from "../connectors/types";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import { TEST_ACCOUNT_ENTITY_ID, createTaskRepository } from "../db/repositories/tasks";
+import type { DB } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import {
+  buildMaterializeDeps,
+  materializeFromFact,
+  materializeUnmaterializedFacts,
+  shouldMarkMaterialized,
+} from "./materialize";
+
+const USER_ID = "task-user";
+const CONNECTOR_ID = "task-config";
+
+async function seedBase(db: Kysely<DB>, source = "linear") {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: USER_ID,
+      name: "Task User",
+      email: "task-user@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: source,
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: "file-1",
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: "task-1",
+      provider_url: null,
+      file_name: "Task one",
+      file_type: "issue",
+      content_category: "structured",
+      content: "Task one",
+      source,
+      source_path: null,
+      content_hash: "hash-1",
+      source_created_at: now,
+      source_updated_at: now,
+      synced_at: now,
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function seedProject(db: Kysely<DB>, input: { id?: string; name: string; source: string; sourceId: string }) {
+  const repo = createEntityRepository(db);
+  const entity = input.id
+    ? await insertEntity(db, input.id, input.name, "project")
+    : await repo.upsertEntity({ name: input.name, sourceType: "project", subtype: "external" });
+  await repo.upsertSourceRef({ entityId: entity.id, source: input.source, sourceId: input.sourceId });
+  return entity;
+}
+
+async function seedPerson(db: Kysely<DB>, input: { id?: string; name: string; source: string; sourceId: string }) {
+  const repo = createEntityRepository(db);
+  const entity = input.id
+    ? await insertEntity(db, input.id, input.name, "person")
+    : await repo.upsertPersonEntity({
+        name: input.name,
+        subtype: "external",
+        source: input.source,
+        sourceId: input.sourceId,
+      });
+  if (input.id) await repo.upsertSourceRef({ entityId: entity.id, source: input.source, sourceId: input.sourceId });
+  return entity;
+}
+
+async function insertEntity(db: Kysely<DB>, id: string, name: string, sourceType: string) {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: sourceType,
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  return db.selectFrom("entities").selectAll().where("id", "=", id).executeTakeFirstOrThrow();
+}
+
+async function upsertTaskFact(
+  db: Kysely<DB>,
+  input: {
+    source?: string;
+    sourceTaskId?: string;
+    statusType: string;
+    statusRaw: string;
+    title?: string;
+    project?: { name: string; source: string; sourceId: string };
+    assignee?: { name: string; source?: string; sourceId?: string };
+    fileId?: string;
+  },
+) {
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: input.fileId ?? "file-1",
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    lastSeenSyncRunId: "sync-1",
+    source: input.source ?? "linear",
+    factType: "structural_task",
+    relation: "mentioned",
+    subjectName: input.title ?? "Task one",
+    subjectSource: input.source ?? "linear",
+    subjectSourceId: input.sourceTaskId ?? "task-1",
+    raw: {
+      indexedFileId: input.fileId ?? "file-1",
+      task: {
+        sourceTaskId: input.sourceTaskId ?? "task-1",
+        externalRef: "SKE-1",
+        title: input.title ?? "Task one",
+        statusType: input.statusType,
+        statusRaw: input.statusRaw,
+        project: input.project,
+        assignee: input.assignee,
+      },
+    },
+  });
+}
+
+describe("structural task materialization", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("mirrors status, falls unknown types back to open, and resolves ClickUp folder and folderless parents", async () => {
+    await seedBase(db, "linear");
+    const linearProject = await seedProject(db, { name: "Sketch OSS", source: "linear", sourceId: "proj-1" });
+    await upsertTaskFact(db, {
+      statusType: "completed",
+      statusRaw: "Done",
+      project: { name: "Sketch OSS", source: "linear", sourceId: "proj-1" },
+    });
+    await upsertTaskFact(db, {
+      sourceTaskId: "task-unknown",
+      statusType: "mystery",
+      statusRaw: "Needs Design",
+      title: "Unknown status",
+      project: { name: "Sketch OSS", source: "linear", sourceId: "proj-1" },
+    });
+    await seedProject(db, { name: "Delivery Folder", source: "clickup", sourceId: "folder-1" });
+    await seedProject(db, { name: "Launch List", source: "clickup", sourceId: "list-1" });
+    await upsertTaskFact(db, {
+      source: "clickup",
+      sourceTaskId: "cu-folder-task",
+      statusType: "done",
+      statusRaw: "closed",
+      title: "Folder task",
+      project: { name: "Delivery Folder", source: "clickup", sourceId: "folder-1" },
+    });
+    await upsertTaskFact(db, {
+      source: "clickup",
+      sourceTaskId: "cu-list-task",
+      statusType: "custom",
+      statusRaw: "In Progress",
+      title: "Folderless list task",
+      project: { name: "Launch List", source: "clickup", sourceId: "list-1" },
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const rows = await db.selectFrom("tasks").selectAll().orderBy("source_task_id").execute();
+    const byId = new Map(rows.map((row) => [row.source_task_id, row]));
+    expect(byId.get("task-1")).toMatchObject({
+      status: "done",
+      status_authority: "external",
+      status_raw: "Done",
+      parent_entity_id: linearProject.id,
+    });
+    expect(byId.get("task-unknown")).toMatchObject({ status: "open", status_raw: "Needs Design" });
+    expect(byId.get("cu-folder-task")?.parent_source_ref).toBe("clickup:folder-1");
+    expect(byId.get("cu-list-task")?.parent_source_ref).toBe("clickup:list-1");
+    expect(byId.get("cu-folder-task")?.parent_source_ref).not.toContain("space");
+    const evidence = await db.selectFrom("task_evidence").selectAll().execute();
+    expect(evidence.some((row) => row.kind === "file" && row.ref_id === "file-1")).toBe(true);
+  });
+
+  it("reanchors null parents through the sweep and resolves assignees without linking the test account", async () => {
+    await seedBase(db, "linear");
+    const assignee = await seedPerson(db, { name: "Priya Shah", source: "linear", sourceId: "user-1" });
+    await seedPerson(db, { id: TEST_ACCOUNT_ENTITY_ID, name: "Test Account", source: "linear", sourceId: "user-test" });
+    await upsertTaskFact(db, {
+      statusType: "started",
+      statusRaw: "In Progress",
+      project: { name: "Queued Project", source: "linear", sourceId: "proj-queued" },
+      assignee: { name: "Priya Shah", source: "linear", sourceId: "user-1" },
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const before = await db.selectFrom("tasks").selectAll().executeTakeFirstOrThrow();
+    expect(before.parent_entity_id).toBeNull();
+    expect(before.parent_source_ref).toBe("linear:proj-queued");
+    expect(before.assignee_entity_id).toBe(assignee.id);
+    expect(before.assignee_entity_id).not.toBe(TEST_ACCOUNT_ENTITY_ID);
+    const projectCount = await db
+      .selectFrom("entities")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .where("source_type", "=", "project")
+      .executeTakeFirstOrThrow();
+    expect(Number(projectCount.count)).toBe(0);
+
+    const project = await seedProject(db, { name: "Queued Project", source: "linear", sourceId: "proj-queued" });
+    const reanchored = await createTaskRepository(db).reanchorNullParentTasks();
+    const after = await db.selectFrom("tasks").selectAll().executeTakeFirstOrThrow();
+    expect(reanchored).toBe(1);
+    expect(after.parent_entity_id).toBe(project.id);
+  });
+
+  it("keeps flag-off parity, updates status idempotently, and expires deleted structural tasks", async () => {
+    await seedBase(db, "linear");
+    const connector = { type: "linear" } as Connector;
+    const item: SyncedItem = {
+      providerFileId: "task-1",
+      providerUrl: null,
+      fileName: "Flag task",
+      fileType: "issue",
+      contentCategory: "structured",
+      content: "Flag task",
+      sourcePath: null,
+      contentHash: "hash-flag",
+      sourceCreatedAt: null,
+      sourceUpdatedAt: null,
+      task: { sourceTaskId: "flag-task", title: "Flag task", statusType: "started", statusRaw: "Started" },
+    };
+    await emitFactsForSyncedItem({
+      factRepo: createIndexedFileFactRepository(db),
+      connector,
+      connectorType: "linear",
+      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-off" },
+      item,
+      indexedFileId: "file-1",
+      experimentalFlag: false,
+    });
+    let factCount = await db
+      .selectFrom("indexed_file_facts")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .where("fact_type", "=", "structural_task")
+      .executeTakeFirstOrThrow();
+    expect(Number(factCount.count)).toBe(0);
+
+    await upsertTaskFact(db, { sourceTaskId: "flag-task", statusType: "started", statusRaw: "Started" });
+    const depsOff = await buildMaterializeDeps(db, { experimentalFlag: false });
+    const fact = await db.selectFrom("indexed_file_facts").selectAll().executeTakeFirstOrThrow();
+    const offResult = await materializeFromFact(depsOff, fact);
+    expect(offResult).toEqual({ kind: "skipped", reason: "experimental_off" });
+    expect(shouldMarkMaterialized(offResult)).toBe(true);
+    await db.updateTable("indexed_file_facts").set({ materialized_at: new Date().toISOString() }).execute();
+    let taskCount = await db
+      .selectFrom("tasks")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .executeTakeFirstOrThrow();
+    expect(Number(taskCount.count)).toBe(0);
+
+    await upsertTaskFact(db, { sourceTaskId: "flag-task", statusType: "started", statusRaw: "Started" });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const started = await db.selectFrom("tasks").selectAll().executeTakeFirstOrThrow();
+    await upsertTaskFact(db, {
+      sourceTaskId: "flag-task",
+      statusType: "completed",
+      statusRaw: "Done",
+      title: "Flag task renamed",
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const completedRows = await db.selectFrom("tasks").selectAll().execute();
+    expect(completedRows).toHaveLength(1);
+    expect(completedRows[0]).toMatchObject({
+      id: started.id,
+      title: "Flag task renamed",
+      status: "done",
+      valid_to: null,
+    });
+    expect(completedRows[0].completed_at).not.toBeNull();
+    expect(completedRows[0].status_changed_at).not.toBeNull();
+
+    await db
+      .updateTable("indexed_file_facts")
+      .set({ deleted_at: new Date().toISOString(), materialized_at: null })
+      .where("fact_type", "=", "structural_task")
+      .execute();
+    const expired = await createTaskRepository(db).expireOrphanedTasks("linear");
+    const expiredRow = await db.selectFrom("tasks").selectAll().executeTakeFirstOrThrow();
+    const visible = await createTaskRepository(db).listTasksByParent("missing", {
+      viewer: { email: "task-user@example.com", isAdmin: true },
+    });
+    factCount = await db
+      .selectFrom("indexed_file_facts")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .where("fact_type", "=", "structural_task")
+      .executeTakeFirstOrThrow();
+    taskCount = await db
+      .selectFrom("tasks")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .executeTakeFirstOrThrow();
+    expect(Number(factCount.count)).toBe(1);
+    expect(Number(taskCount.count)).toBe(1);
+    expect(expired).toBe(1);
+    expect(expiredRow.valid_to).not.toBeNull();
+    expect(visible).toHaveLength(0);
+  });
+});

--- a/packages/server/src/entities/materialize-task.ts
+++ b/packages/server/src/entities/materialize-task.ts
@@ -1,0 +1,143 @@
+import { normalizeName } from "../connectors/name-normalize";
+import { TEST_ACCOUNT_ENTITY_ID, type TaskStatus, createTaskRepository } from "../db/repositories/tasks";
+import { readJsonObject } from "./materialize-json";
+import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+
+const STATUS_TYPE_MAP: Record<string, Record<string, TaskStatus>> = {
+  linear: {
+    backlog: "open",
+    unstarted: "open",
+    triage: "open",
+    started: "in_progress",
+    completed: "done",
+    canceled: "dropped",
+  },
+  clickup: {
+    open: "open",
+    custom: "open",
+    closed: "done",
+    done: "done",
+  },
+};
+
+export async function materializeStructuralTask(
+  deps: MaterializeDeps,
+  fact: IndexedFileFactRow,
+): Promise<MaterializeResult> {
+  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
+  const raw = readJsonObject(fact.raw);
+  const task = readTask(raw.task);
+  const indexedFileId = typeof raw.indexedFileId === "string" ? raw.indexedFileId : fact.indexed_file_id;
+  if (!task || !indexedFileId) return { kind: "skipped", reason: "invalid_structural_task" };
+
+  const parent = resolveProject(deps, task.project);
+  const assignee = resolveAssignee(deps, task.assignee);
+  const repo = createTaskRepository(deps.db);
+  const parentSourceRef = task.project ? `${task.project.source}:${task.project.sourceId}` : null;
+  const result = await repo.upsertTask({
+    parentEntityId: parent?.id ?? null,
+    parentSourceRef,
+    parentName: task.project?.name ?? null,
+    source: fact.source,
+    externalRef: task.externalRef ?? null,
+    title: task.title,
+    status: normalizeStatus(fact.source, task.statusType),
+    statusRaw: task.statusRaw ?? null,
+    statusAuthority: "external",
+    assigneeEntityId: assignee?.id ?? null,
+    priority: task.priority ?? null,
+    dueAt: task.dueAt ?? null,
+    provenance: "structural",
+    sourceTaskId: task.sourceTaskId,
+  });
+  await repo.upsertEvidence(result.taskId, "file", indexedFileId);
+  return { kind: "task_materialized", taskId: result.taskId, created: result.created };
+}
+
+function normalizeStatus(source: string, statusType: string): TaskStatus {
+  return STATUS_TYPE_MAP[source]?.[statusType] ?? "open";
+}
+
+function resolveProject(
+  deps: MaterializeDeps,
+  project: { name: string; source: string; sourceId: string } | undefined,
+): EntityRow | null {
+  if (!project) return null;
+  const byRef = deps.index.bySourceRef.get(`${project.source}:${project.sourceId}`);
+  if (byRef && byRef.source_type === "project" && byRef.id !== TEST_ACCOUNT_ENTITY_ID) return byRef;
+  const matches = deps.index.byNormalizedName.get(normalizeName(project.name)) ?? [];
+  return matches.find((entity) => entity.source_type === "project" && entity.id !== TEST_ACCOUNT_ENTITY_ID) ?? null;
+}
+
+function resolveAssignee(
+  deps: MaterializeDeps,
+  assignee: { name: string; email?: string; source?: string; sourceId?: string } | undefined,
+): EntityRow | null {
+  if (!assignee) return null;
+  if (assignee.source && assignee.sourceId) {
+    const byRef = deps.index.bySourceRef.get(`${assignee.source}:${assignee.sourceId}`);
+    if (byRef && byRef.source_type === "person" && byRef.id !== TEST_ACCOUNT_ENTITY_ID) return byRef;
+  }
+  const matches = deps.index.byNormalizedName.get(normalizeName(assignee.name)) ?? [];
+  return matches.find((entity) => entity.source_type === "person" && entity.id !== TEST_ACCOUNT_ENTITY_ID) ?? null;
+}
+
+function readTask(value: unknown): {
+  sourceTaskId: string;
+  externalRef?: string;
+  title: string;
+  statusType: string;
+  statusRaw?: string;
+  priority?: string;
+  dueAt?: string;
+  project?: { name: string; source: string; sourceId: string };
+  assignee?: { name: string; email?: string; source?: string; sourceId?: string };
+} | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.sourceTaskId !== "string" ||
+    typeof record.title !== "string" ||
+    typeof record.statusType !== "string"
+  ) {
+    return null;
+  }
+  return {
+    sourceTaskId: record.sourceTaskId,
+    externalRef: readOptionalString(record.externalRef),
+    title: record.title,
+    statusType: record.statusType,
+    statusRaw: readOptionalString(record.statusRaw),
+    priority: readOptionalString(record.priority),
+    dueAt: readOptionalString(record.dueAt),
+    project: readProject(record.project),
+    assignee: readAssignee(record.assignee),
+  };
+}
+
+function readProject(value: unknown): { name: string; source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.name !== "string" || typeof record.source !== "string" || typeof record.sourceId !== "string") {
+    return undefined;
+  }
+  return { name: record.name, source: record.source, sourceId: record.sourceId };
+}
+
+function readAssignee(
+  value: unknown,
+): { name: string; email?: string; source?: string; sourceId?: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.name !== "string") return undefined;
+  return {
+    name: record.name,
+    email: readOptionalString(record.email),
+    source: readOptionalString(record.source),
+    sourceId: readOptionalString(record.sourceId),
+  };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -70,6 +70,7 @@ export type MaterializeResult =
       mentionsWritten: number;
       relationshipsWritten: number;
     }
+  | { kind: "task_materialized"; taskId: string; created: boolean }
   | { kind: "structural"; entity: EntityRow }
   | { kind: "skipped_missing_owner"; reason: string }
   | { kind: "deferred_below_threshold"; reason: string }


### PR DESCRIPTION
Stacked context-graph slice 05/27.

Base: `feat/context-graph-04-birth-gate-classification-context`
Head: `feat/context-graph-05-tasks-core`

Introduces the structural tasks tier and tracker promotion base.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`