### PR TITLE
feat: add commitment facts experiment

### DIFF
--- a/packages/server/src/connectors/sync-facts.ts
+++ b/packages/server/src/connectors/sync-facts.ts
@@ -1,4 +1,7 @@
+import type { Kysely } from "kysely";
+import { upsertCommitmentFact } from "../db/repositories/commitments";
 import type { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import type { DB } from "../db/schema";
 import { normalizeRelationType } from "../entities/graph";
 import type { Connector, ConnectorType, SyncedItem } from "./types";
 
@@ -12,6 +15,7 @@ export interface SyncFactContext {
 
 interface EmitFactsForSyncedItemParams {
   factRepo: IndexedFileFactRepository;
+  db?: Kysely<DB>;
   connector: Connector;
   connectorType: ConnectorType;
   factContext: SyncFactContext;
@@ -22,6 +26,7 @@ interface EmitFactsForSyncedItemParams {
 }
 
 export async function emitFactsForSyncedItem({
+  db,
   factRepo,
   connector,
   connectorType,
@@ -206,6 +211,28 @@ export async function emitFactsForSyncedItem({
       contextSnippet: item.sourcePath,
       raw: { indexedFileId, task: item.task },
     });
+  }
+
+  if (item.commitments && item.commitments.length > 0 && db) {
+    for (const commitment of item.commitments) {
+      await upsertCommitmentFact(db, {
+        experimentalFlag,
+        indexedFileId,
+        connectorConfigId: factContext.connectorConfigId,
+        createdByUserId: factContext.createdByUserId,
+        lastSeenSyncRunId: factContext.lastSeenSyncRunId,
+        contentHash: item.contentHash,
+        source: connectorType,
+        commitmentId: commitment.commitmentId,
+        parentRef: commitment.parentRef,
+        parentEntityId: commitment.parentEntityId,
+        title: commitment.title,
+        status: commitment.status,
+        dueAt: commitment.dueAt,
+        evidence: commitment.evidence,
+        contextSnippet: item.sourcePath,
+      });
+    }
   }
 
   if (item.authorEmail || item.authorName) {

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -317,6 +317,7 @@ export async function runConnectorSync(
         }
 
         await emitFactsForSyncedItem({
+          db,
           factRepo,
           connector,
           connectorType,

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -129,6 +129,7 @@ export interface SyncedItem {
     project?: { name: string; source: string; sourceId: string };
     assignee?: { name: string; email?: string; source?: string; sourceId?: string };
   };
+  commitments?: CommitmentSeed[];
   /**
    * People meaningfully attached to this item (meeting speakers, doc authors).
    * Sync seeds person entities from entries where `name` is present or can be
@@ -203,6 +204,16 @@ export interface ContactPointSeed {
   lastContactedAt?: string | null;
 }
 
+export interface CommitmentSeed {
+  commitmentId: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  title: string;
+  status: "open" | "done" | "dropped";
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+}
+
 export type EntitySeedCallback = (seed: EntitySeed) => Promise<void>;
 export type PersonEntitySeedCallback = (seed: PersonEntitySeed) => Promise<void>;
 
@@ -220,6 +231,7 @@ export type IndexedFileFactRaw =
       indexedFileId: string;
       task: NonNullable<SyncedItem["task"]>;
     }
+  | CommitmentSeed
   | { providerFileId: string; contactPoint: ContactPointSeed }
   | { sourceType: string; sourceUrl?: string; sourcePath?: string; metadata?: Record<string, unknown> }
   | { subtype: "internal" | "external" }

--- a/packages/server/src/db/repositories/commitments.integration.test.ts
+++ b/packages/server/src/db/repositories/commitments.integration.test.ts
@@ -1,0 +1,94 @@
+import { type Kysely, sql } from "kysely";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getSharedPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { markCommitmentDone, measureCommitmentStomp, upsertCommitmentFact } from "./commitments";
+import { createIndexedFileFactRepository } from "./indexed-file-facts";
+
+const USER_ID = "commitment-pg-user";
+const CONNECTOR_ID = "commitment-pg-config";
+
+describe("commitment stomp measurement postgres", () => {
+  let db: Kysely<DB>;
+
+  beforeAll(async () => {
+    db = await getSharedPgDb();
+  }, 30000);
+
+  beforeEach(async () => {
+    await sql`BEGIN`.execute(db);
+  });
+
+  afterEach(async () => {
+    await sql`ROLLBACK`.execute(db);
+  });
+
+  it("measures done markers stomped on re-sync with isolated overwrite and tombstone cohorts", async () => {
+    await seedBase(db);
+    await seedCommitment(db, "overwrite-1");
+    await seedCommitment(db, "overwrite-2");
+    await seedCommitment(db, "tombstone-1");
+    await seedCommitment(db, "tombstone-2");
+    await seedOtherFact(db, "other-1");
+    await seedOtherFact(db, "other-2");
+    await markCommitmentDone(db, "overwrite-1");
+    await markCommitmentDone(db, "overwrite-2");
+    await markCommitmentDone(db, "tombstone-1");
+    await markCommitmentDone(db, "tombstone-2");
+
+    const result = await measureCommitmentStomp(db, CONNECTOR_ID, {
+      overwriteCohort: ["overwrite-1", "overwrite-2"],
+      tombstoneCohort: ["tombstone-1", "tombstone-2"],
+      priorSyncRunId: "sync-prior",
+      nextSyncRunId: "sync-next",
+    });
+
+    expect(result).toEqual({ overwritten: 2, tombstoned: 2, survived: 0, reconcileSkipped: false });
+  });
+});
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: USER_ID, name: "Commitment PG User", email: "commitment-pg-user@example.com" })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedCommitment(db: Kysely<DB>, commitmentId: string): Promise<void> {
+  await upsertCommitmentFact(db, {
+    experimentalFlag: true,
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    lastSeenSyncRunId: "sync-prior",
+    source: "linear",
+    commitmentId,
+    title: commitmentId,
+    evidence: { fileIds: [], entityIds: [] },
+  });
+}
+
+async function seedOtherFact(db: Kysely<DB>, id: string): Promise<void> {
+  await createIndexedFileFactRepository(db).upsertFact({
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    lastSeenSyncRunId: "sync-prior",
+    source: "linear",
+    factType: "structural_seed",
+    relation: "seeded",
+    subjectName: id,
+    subjectSource: "linear",
+    subjectSourceId: id,
+    raw: { sourceType: "project", sourcePath: id },
+  });
+}

--- a/packages/server/src/db/repositories/commitments.test.ts
+++ b/packages/server/src/db/repositories/commitments.test.ts
@@ -1,0 +1,229 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { emitFactsForSyncedItem } from "../../connectors/sync-facts";
+import type { Connector, SyncedItem } from "../../connectors/types";
+import {
+  buildMaterializeDeps,
+  materializeFromFact,
+  materializeUnmaterializedFacts,
+  shouldMarkMaterialized,
+} from "../../entities/materialize";
+import { createTestDb, createTestLogger } from "../../test-utils";
+import type { DB } from "../schema";
+import { listOpenCommitments, markCommitmentDone, upsertCommitmentFact } from "./commitments";
+import { createEntityRepository } from "./entities";
+import { createIndexedFileFactRepository } from "./indexed-file-facts";
+import { TEST_ACCOUNT_ENTITY_ID } from "./tasks";
+
+const USER_ID = "commitment-user";
+const CONNECTOR_ID = "commitment-config";
+
+describe("commitment facts", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("materializes with parent and due date while flag-gating emission and materialization counters", async () => {
+    await seedBase(db);
+    const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
+    await seedProject(db, { id: TEST_ACCOUNT_ENTITY_ID, name: "Test Account" });
+    const connector = { type: "linear" } as Connector;
+    const item = commitmentItem(project.id);
+
+    await emitFactsForSyncedItem({
+      db,
+      factRepo: createIndexedFileFactRepository(db),
+      connector,
+      connectorType: "linear",
+      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-off" },
+      item,
+      indexedFileId: "commitment-file-1",
+      experimentalFlag: false,
+    });
+    let count = await db
+      .selectFrom("indexed_file_facts")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .where("fact_type", "=", "commitment")
+      .executeTakeFirstOrThrow();
+    expect(Number(count.count)).toBe(0);
+
+    await emitFactsForSyncedItem({
+      db,
+      factRepo: createIndexedFileFactRepository(db),
+      connector,
+      connectorType: "linear",
+      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-on" },
+      item,
+      indexedFileId: "commitment-file-1",
+      experimentalFlag: true,
+    });
+    const fact = await db
+      .selectFrom("indexed_file_facts")
+      .selectAll()
+      .where("fact_type", "=", "commitment")
+      .executeTakeFirstOrThrow();
+    const depsOff = await buildMaterializeDeps(db, { experimentalFlag: false });
+    const offResult = await materializeFromFact(depsOff, fact);
+    expect(offResult).toEqual({ kind: "skipped", reason: "experimental_off" });
+    expect(shouldMarkMaterialized(offResult)).toBe(true);
+
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const materializedFact = await db
+      .selectFrom("indexed_file_facts")
+      .selectAll()
+      .where("fact_type", "=", "commitment")
+      .executeTakeFirstOrThrow();
+    const raw = JSON.parse(materializedFact.raw ?? "{}");
+    expect(raw).toMatchObject({
+      commitmentId: "commitment-1",
+      parentEntityId: project.id,
+      parent_entity_id: project.id,
+      dueAt: "2026-07-01T00:00:00.000Z",
+      status: "open",
+    });
+    expect(raw.parentEntityId).not.toBe(TEST_ACCOUNT_ENTITY_ID);
+    expect(materializedFact.materialized_at).not.toBeNull();
+    expect(summary).toMatchObject({
+      factsRead: 1,
+      entitiesCreated: 0,
+      entitiesLinked: 0,
+      queued: 0,
+      mentionsWritten: 0,
+      relationshipsWritten: 0,
+      skipped: 0,
+      materialized: 1,
+      deferred: 0,
+      deferredBelowThreshold: 0,
+    });
+    count = await db
+      .selectFrom("tasks")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .executeTakeFirstOrThrow();
+    expect(Number(count.count)).toBe(0);
+  });
+
+  it("mark-done persists within a run and removes the row from open commitments", async () => {
+    await seedBase(db);
+    const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
+    await upsertCommitmentFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "commitment-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-1",
+      source: "linear",
+      commitmentId: "commitment-1",
+      parentEntityId: project.id,
+      title: "Send the follow-up",
+      dueAt: "2026-07-01T00:00:00.000Z",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    });
+
+    await expect(listOpenCommitments(db, { parentEntityId: project.id })).resolves.toHaveLength(1);
+    await expect(markCommitmentDone(db, "commitment-1")).resolves.toBe(true);
+    await expect(listOpenCommitments(db, { parentEntityId: project.id })).resolves.toHaveLength(0);
+    const fact = await db.selectFrom("indexed_file_facts").selectAll().executeTakeFirstOrThrow();
+    expect(JSON.parse(fact.raw ?? "{}").status).toBe("done");
+  });
+});
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: USER_ID,
+      name: "Commitment User",
+      email: "commitment-user@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: "commitment-file-1",
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: "commitment-file-1",
+      provider_url: null,
+      file_name: "Commitment file",
+      file_type: "issue",
+      content_category: "structured",
+      content: "Commitment file",
+      source: "linear",
+      source_path: null,
+      content_hash: "hash-1",
+      source_created_at: now,
+      source_updated_at: now,
+      synced_at: now,
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) {
+  const repo = createEntityRepository(db);
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await repo.upsertSourceRef({ entityId: input.id, source: "linear", sourceId: `${input.id}-source` });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
+}
+
+function commitmentItem(projectId: string): SyncedItem {
+  return {
+    providerFileId: "commitment-file-1",
+    providerUrl: null,
+    fileName: "Commitment file",
+    fileType: "issue",
+    contentCategory: "structured",
+    content: "Commitment file",
+    sourcePath: null,
+    contentHash: "hash-1",
+    sourceCreatedAt: null,
+    sourceUpdatedAt: null,
+    commitments: [
+      {
+        commitmentId: "commitment-1",
+        parentRef: { source: "linear", sourceId: `${projectId}-source` },
+        title: "Send the follow-up",
+        status: "open",
+        dueAt: "2026-07-01T00:00:00.000Z",
+        evidence: { fileIds: ["commitment-file-1"], entityIds: [projectId, TEST_ACCOUNT_ENTITY_ID] },
+      },
+    ],
+  };
+}

--- a/packages/server/src/db/repositories/commitments.ts
+++ b/packages/server/src/db/repositories/commitments.ts
@@ -1,0 +1,322 @@
+import type { Kysely } from "kysely";
+import type { CommitmentSeed, IndexedFileFactRaw } from "../../connectors/types";
+import type { DB, IndexedFileFactsTable } from "../schema";
+import {
+  type IndexedFileFactRelation,
+  type IndexedFileFactType,
+  createIndexedFileFactRepository,
+} from "./indexed-file-facts";
+
+export type CommitmentStatus = "open" | "done" | "dropped";
+
+export interface CommitmentFactRaw extends CommitmentSeed {
+  parent_entity_id?: string;
+}
+
+export interface UpsertCommitmentFactInput {
+  experimentalFlag?: boolean;
+  indexedFileId?: string | null;
+  connectorConfigId: string;
+  createdByUserId?: string | null;
+  lastSeenSyncRunId?: string | null;
+  contentHash?: string | null;
+  source: string;
+  commitmentId: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  title: string;
+  status?: CommitmentStatus;
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  contextSnippet?: string | null;
+}
+
+export interface OpenCommitment {
+  factId: string;
+  commitmentId: string;
+  parentEntityId: string | null;
+  title: string;
+  status: "open";
+  dueAt: string | null;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  raw: CommitmentFactRaw;
+}
+
+export interface MeasureCommitmentStompInput {
+  overwriteCohort: string[];
+  tombstoneCohort: string[];
+  priorSyncRunId: string;
+  nextSyncRunId: string;
+}
+
+export interface MeasureCommitmentStompResult {
+  overwritten: number;
+  tombstoned: number;
+  survived: number;
+  reconcileSkipped: boolean;
+}
+
+export async function upsertCommitmentFact(
+  db: Kysely<DB>,
+  input: UpsertCommitmentFactInput,
+): Promise<{ emitted: boolean }> {
+  const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
+  const source = requireNonEmpty(input.source, "source");
+  const commitmentId = requireNonEmpty(input.commitmentId, "commitmentId");
+  if (!input.experimentalFlag) return { emitted: false };
+
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: input.indexedFileId ?? null,
+    connectorConfigId,
+    createdByUserId: input.createdByUserId ?? null,
+    lastSeenSyncRunId: input.lastSeenSyncRunId ?? null,
+    contentHash: input.contentHash ?? null,
+    source,
+    factType: "commitment",
+    relation: "mentioned",
+    subjectName: input.title,
+    subjectSource: source,
+    subjectSourceId: commitmentId,
+    contextSnippet: input.contextSnippet ?? null,
+    raw: buildCommitmentRaw(input, commitmentId),
+  });
+  return { emitted: true };
+}
+
+export async function markCommitmentDone(db: Kysely<DB>, commitmentId: string): Promise<boolean> {
+  const fact = await findActiveCommitmentFact(db, commitmentId);
+  if (!fact) return false;
+  const raw = readCommitmentRaw(fact.raw);
+  if (!raw) return false;
+  await db
+    .updateTable("indexed_file_facts")
+    .set({ raw: JSON.stringify({ ...raw, status: "done" }), updated_at: new Date().toISOString() })
+    .where("id", "=", fact.id)
+    .execute();
+  return true;
+}
+
+export async function listOpenCommitments(
+  db: Kysely<DB>,
+  opts: { parentEntityId?: string | null } = {},
+): Promise<OpenCommitment[]> {
+  const rows = await db
+    .selectFrom("indexed_file_facts")
+    .selectAll()
+    .where("fact_type", "=", "commitment")
+    .where("deleted_at", "is", null)
+    .execute();
+  const out: OpenCommitment[] = [];
+  for (const row of rows) {
+    const raw = readCommitmentRaw(row.raw);
+    if (!raw || raw.status === "done" || raw.status === "dropped") continue;
+    const parentEntityId = readParentEntityId(raw);
+    if (opts.parentEntityId && parentEntityId !== opts.parentEntityId) continue;
+    out.push({
+      factId: row.id,
+      commitmentId: raw.commitmentId,
+      parentEntityId,
+      title: raw.title,
+      status: "open",
+      dueAt: raw.dueAt ?? null,
+      evidence: raw.evidence,
+      raw,
+    });
+  }
+  return out;
+}
+
+export async function measureCommitmentStomp(
+  db: Kysely<DB>,
+  connectorConfigId: string,
+  input: MeasureCommitmentStompInput,
+): Promise<MeasureCommitmentStompResult> {
+  requireNonEmpty(connectorConfigId, "connectorConfigId");
+  assertDisjoint(input.overwriteCohort, input.tombstoneCohort);
+  const repo = createIndexedFileFactRepository(db);
+  const overwriteSet = new Set(input.overwriteCohort);
+  const tombstoneSet = new Set(input.tombstoneCohort);
+  const allIds = [...overwriteSet, ...tombstoneSet];
+
+  for (const commitmentId of allIds) {
+    await markCommitmentDone(db, commitmentId);
+  }
+  if (input.tombstoneCohort.length > 0) {
+    await db
+      .updateTable("indexed_file_facts")
+      .set({ last_seen_sync_run_id: input.priorSyncRunId, updated_at: new Date().toISOString() })
+      .where("connector_config_id", "=", connectorConfigId)
+      .where("fact_type", "=", "commitment")
+      .where("subject_source_id", "in", input.tombstoneCohort)
+      .execute();
+  }
+
+  const overwriteFacts = await selectCommitmentFacts(db, connectorConfigId, input.overwriteCohort);
+  for (const fact of overwriteFacts) {
+    const raw = readCommitmentRaw(fact.raw);
+    if (!raw) continue;
+    await repo.upsertFact({
+      indexedFileId: fact.indexed_file_id,
+      connectorConfigId,
+      createdByUserId: fact.created_by_user_id,
+      lastSeenSyncRunId: input.nextSyncRunId,
+      contentHash: fact.content_hash,
+      source: fact.source,
+      factType: "commitment",
+      relation: "mentioned",
+      subjectName: fact.subject_name,
+      subjectSource: fact.subject_source,
+      subjectSourceId: fact.subject_source_id,
+      contextSnippet: fact.context_snippet,
+      raw: { ...raw, status: "open" },
+    });
+  }
+
+  const otherFacts = await selectOtherActiveFacts(db, connectorConfigId, allIds, input.tombstoneCohort.length);
+  for (const fact of otherFacts) {
+    const raw = readRaw(fact.raw);
+    await repo.upsertFact({
+      indexedFileId: fact.indexed_file_id,
+      connectorConfigId,
+      createdByUserId: fact.created_by_user_id,
+      lastSeenSyncRunId: input.nextSyncRunId,
+      contentHash: fact.content_hash,
+      source: fact.source,
+      factType: fact.fact_type as IndexedFileFactType,
+      relation: fact.relation as IndexedFileFactRelation,
+      subjectName: fact.subject_name,
+      subjectEmail: fact.subject_email,
+      subjectSource: fact.subject_source,
+      subjectSourceId: fact.subject_source_id,
+      contextSnippet: fact.context_snippet,
+      raw,
+    });
+  }
+
+  const reconcile = await repo.reconcileStaleFacts(
+    { kind: "connector", connectorConfigId, syncRunId: input.nextSyncRunId },
+    null,
+  );
+  const after = await selectCommitmentFacts(db, connectorConfigId, allIds);
+  const afterById = new Map(after.map((fact) => [fact.subject_source_id, fact]));
+  let overwritten = 0;
+  let tombstoned = 0;
+  let survived = 0;
+  for (const commitmentId of input.overwriteCohort) {
+    const fact = afterById.get(commitmentId);
+    const raw = readCommitmentRaw(fact?.raw ?? null);
+    if (fact && raw?.status === "open") overwritten++;
+    if (fact && raw?.status === "done" && fact.deleted_at === null) survived++;
+  }
+  for (const commitmentId of input.tombstoneCohort) {
+    const fact = afterById.get(commitmentId);
+    const raw = readCommitmentRaw(fact?.raw ?? null);
+    if (fact?.deleted_at !== null && fact?.deleted_at !== undefined) tombstoned++;
+    if (fact && raw?.status === "done" && fact.deleted_at === null) survived++;
+  }
+  return {
+    overwritten,
+    tombstoned,
+    survived,
+    reconcileSkipped: reconcile.skipped?.reason === "delta_exceeds_threshold",
+  };
+}
+
+function buildCommitmentRaw(input: UpsertCommitmentFactInput, commitmentId: string): CommitmentFactRaw {
+  return {
+    commitmentId,
+    parentRef: input.parentRef,
+    parentEntityId: input.parentEntityId,
+    title: input.title,
+    status: input.status ?? "open",
+    dueAt: input.dueAt,
+    evidence: input.evidence,
+  };
+}
+
+function requireNonEmpty(value: string | null | undefined, name: string): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) throw new Error(`commitment ${name} is required`);
+  return trimmed;
+}
+
+async function findActiveCommitmentFact(db: Kysely<DB>, commitmentId: string) {
+  return db
+    .selectFrom("indexed_file_facts")
+    .selectAll()
+    .where("fact_type", "=", "commitment")
+    .where("subject_source_id", "=", commitmentId)
+    .where("deleted_at", "is", null)
+    .executeTakeFirst();
+}
+
+async function selectCommitmentFacts(db: Kysely<DB>, connectorConfigId: string, commitmentIds: string[]) {
+  if (commitmentIds.length === 0) return [];
+  return db
+    .selectFrom("indexed_file_facts")
+    .selectAll()
+    .where("connector_config_id", "=", connectorConfigId)
+    .where("fact_type", "=", "commitment")
+    .where("subject_source_id", "in", commitmentIds)
+    .execute();
+}
+
+async function selectOtherActiveFacts(
+  db: Kysely<DB>,
+  connectorConfigId: string,
+  excludedCommitmentIds: string[],
+  minimum: number,
+) {
+  if (minimum === 0) return [];
+  const rows = await db
+    .selectFrom("indexed_file_facts")
+    .selectAll()
+    .where("connector_config_id", "=", connectorConfigId)
+    .where("deleted_at", "is", null)
+    .execute();
+  return rows
+    .filter(
+      (row) =>
+        row.fact_type !== "commitment" ||
+        !row.subject_source_id ||
+        !excludedCommitmentIds.includes(row.subject_source_id),
+    )
+    .slice(0, minimum);
+}
+
+function assertDisjoint(left: string[], right: string[]): void {
+  const seen = new Set(left);
+  for (const value of right) {
+    if (seen.has(value)) throw new Error("overwriteCohort and tombstoneCohort must be disjoint");
+  }
+}
+
+function readRaw(raw: string | null): IndexedFileFactRaw | undefined {
+  if (!raw) return undefined;
+  const parsed = JSON.parse(raw) as IndexedFileFactRaw;
+  return parsed;
+}
+
+function readCommitmentRaw(raw: string | null): CommitmentFactRaw | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CommitmentFactRaw>;
+    if (
+      typeof parsed.commitmentId !== "string" ||
+      typeof parsed.title !== "string" ||
+      (parsed.status !== "open" && parsed.status !== "done" && parsed.status !== "dropped") ||
+      !parsed.evidence ||
+      !Array.isArray(parsed.evidence.fileIds) ||
+      !Array.isArray(parsed.evidence.entityIds)
+    ) {
+      return null;
+    }
+    return parsed as CommitmentFactRaw;
+  } catch {
+    return null;
+  }
+}
+
+function readParentEntityId(raw: CommitmentFactRaw): string | null {
+  return raw.parentEntityId ?? raw.parent_entity_id ?? null;
+}

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -12,6 +12,7 @@ export type IndexedFileFactType =
   | "contact_point"
   | "structural_seed"
   | "structural_task"
+  | "commitment"
   | "person_seed"
   | "llm_extracted"
   | "llm_relation"
@@ -133,6 +134,13 @@ export function buildIndexedFileFactKey(input: UpsertIndexedFileFactInput): stri
       .update([input.connectorConfigId ?? "", input.factType, input.source, sourceTaskId].join("|"))
       .digest("hex");
   }
+  if (input.factType === "commitment") {
+    const raw = input.raw as Record<string, unknown> | undefined;
+    const commitmentId = typeof raw?.commitmentId === "string" ? raw.commitmentId.trim().toLowerCase() : "";
+    return createHash("sha256")
+      .update([input.connectorConfigId ?? "", input.factType, input.source, commitmentId].join("|"))
+      .digest("hex");
+  }
   const parts = [
     input.connectorConfigId ?? "",
     input.source,
@@ -248,6 +256,29 @@ function validateRaw(input: UpsertIndexedFileFactInput): string | null {
     const task = raw.task as Record<string, unknown>;
     if (!hasString(task, "sourceTaskId") || !hasString(task, "title") || !hasString(task, "statusType")) {
       throw new Error("structural_task facts require sourceTaskId, title, and statusType");
+    }
+  } else if (input.factType === "commitment") {
+    if (
+      !hasString(raw, "commitmentId") ||
+      !hasString(raw, "title") ||
+      !hasString(raw, "status") ||
+      !isRecord(raw.evidence)
+    ) {
+      throw new Error("commitment facts require commitmentId, title, status, and evidence");
+    }
+    if (raw.status !== "open" && raw.status !== "done" && raw.status !== "dropped") {
+      throw new Error("commitment status must be open, done, or dropped");
+    }
+    const evidence = raw.evidence as Record<string, unknown>;
+    if (!Array.isArray(evidence.fileIds) || !Array.isArray(evidence.entityIds)) {
+      throw new Error("commitment evidence requires fileIds and entityIds arrays");
+    }
+    if (raw.parentRef !== undefined && !isRecord(raw.parentRef)) {
+      throw new Error("commitment parentRef must be an object");
+    }
+    const parentRef = raw.parentRef as Record<string, unknown> | undefined;
+    if (parentRef && (!hasString(parentRef, "source") || !hasString(parentRef, "sourceId"))) {
+      throw new Error("commitment parentRef requires source and sourceId");
     }
   } else if (input.factType === "person_seed") {
     if (!hasString(raw, "source") && !hasString(raw, "subtype")) {

--- a/packages/server/src/entities/materialize-commitment.ts
+++ b/packages/server/src/entities/materialize-commitment.ts
@@ -1,0 +1,103 @@
+import { TEST_ACCOUNT_ENTITY_ID } from "../db/repositories/tasks";
+import { readJsonObject } from "./materialize-json";
+import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+
+export async function materializeCommitment(
+  deps: MaterializeDeps,
+  fact: IndexedFileFactRow,
+): Promise<MaterializeResult> {
+  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
+  const raw = readJsonObject(fact.raw);
+  const commitment = readCommitment(raw);
+  if (!commitment) return { kind: "skipped", reason: "invalid_commitment" };
+
+  const parent = resolveParent(deps, commitment);
+  await deps.db
+    .updateTable("indexed_file_facts")
+    .set({
+      raw: JSON.stringify({
+        ...raw,
+        status: commitment.status,
+        parentEntityId: parent?.id ?? null,
+        parent_entity_id: parent?.id ?? null,
+      }),
+      updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", fact.id)
+    .execute();
+  return { kind: "commitment_materialized" };
+}
+
+function resolveParent(deps: MaterializeDeps, commitment: CommitmentInput): EntityRow | null {
+  if (commitment.parentRef) {
+    const byRef = deps.index.bySourceRef.get(`${commitment.parentRef.source}:${commitment.parentRef.sourceId}`);
+    if (isAllowedParent(byRef)) return byRef;
+  }
+  if (commitment.parentEntityId) {
+    const byId = findEntityById(deps, commitment.parentEntityId);
+    if (isAllowedParent(byId)) return byId;
+  }
+  for (const entityId of commitment.evidence.entityIds) {
+    const byId = findEntityById(deps, entityId);
+    if (isAllowedParent(byId)) return byId;
+  }
+  return null;
+}
+
+function findEntityById(deps: MaterializeDeps, entityId: string): EntityRow | undefined {
+  for (const type of ["project", "person"] as const) {
+    const found = deps.index.entitiesByType.get(type)?.find((entity) => entity.id === entityId);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function isAllowedParent(entity: EntityRow | undefined): entity is EntityRow {
+  return Boolean(
+    entity &&
+      entity.id !== TEST_ACCOUNT_ENTITY_ID &&
+      (entity.source_type === "project" || entity.source_type === "person"),
+  );
+}
+
+interface CommitmentInput {
+  commitmentId: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  status: "open" | "done" | "dropped";
+  evidence: { entityIds: string[] };
+}
+
+function readCommitment(raw: Record<string, unknown>): CommitmentInput | null {
+  if (
+    typeof raw.commitmentId !== "string" ||
+    (raw.status !== "open" && raw.status !== "done" && raw.status !== "dropped") ||
+    !isEvidence(raw.evidence)
+  ) {
+    return null;
+  }
+  return {
+    commitmentId: raw.commitmentId,
+    parentRef: readParentRef(raw.parentRef),
+    parentEntityId: readOptionalString(raw.parentEntityId),
+    status: raw.status,
+    evidence: { entityIds: raw.evidence.entityIds },
+  };
+}
+
+function readParentRef(value: unknown): { source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || typeof record.sourceId !== "string") return undefined;
+  return { source: record.source, sourceId: record.sourceId };
+}
+
+function isEvidence(value: unknown): value is { entityIds: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return Array.isArray(record.entityIds) && record.entityIds.every((id) => typeof id === "string");
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -3,6 +3,7 @@ import type { Logger } from "pino";
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
 import type { DB } from "../db/schema";
 import { yieldToEventLoop } from "../lib/event-loop";
+import { materializeCommitment } from "./materialize-commitment";
 import { materializeContactPointFact } from "./materialize-contact-points";
 import { buildMaterializeDeps } from "./materialize-deps";
 import { readJsonObject } from "./materialize-json";
@@ -35,6 +36,7 @@ const FACT_REPLAY_ORDER = [
   "llm_extracted",
   "llm_relation",
   "structural_task",
+  "commitment",
 ] as const;
 
 export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
@@ -74,6 +76,9 @@ export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFi
   if (fact.fact_type === "structural_task") {
     return materializeStructuralTask(deps, fact);
   }
+  if (fact.fact_type === "commitment") {
+    return materializeCommitment(deps, fact);
+  }
   return { kind: "skipped", reason: "unknown_fact_type" };
 }
 
@@ -104,6 +109,10 @@ function accumulate(summary: ReplayFactsSummary, result: MaterializeResult): voi
     return;
   }
   if (result.kind === "task_materialized") {
+    if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
+    return;
+  }
+  if (result.kind === "commitment_materialized") {
     if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
     return;
   }
@@ -240,7 +249,7 @@ async function materializeUnmaterializedFactsInner(
           .set({ materialized_at: new Date().toISOString() })
           .where("id", "=", fact.id)
           .execute();
-        if (result.kind !== "task_materialized") summary.materialized++;
+        if (result.kind !== "task_materialized" && result.kind !== "commitment_materialized") summary.materialized++;
       } else {
         summary.deferred++;
       }
@@ -265,6 +274,7 @@ export function shouldMarkMaterialized(result: MaterializeResult): boolean {
     result.kind === "queued" ||
     result.kind === "relationship_materialized" ||
     result.kind === "task_materialized" ||
+    result.kind === "commitment_materialized" ||
     result.kind === "structural"
   ) {
     return true;

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -71,6 +71,7 @@ export type MaterializeResult =
       relationshipsWritten: number;
     }
   | { kind: "task_materialized"; taskId: string; created: boolean }
+  | { kind: "commitment_materialized" }
   | { kind: "structural"; entity: EntityRow }
   | { kind: "skipped_missing_owner"; reason: string }
   | { kind: "deferred_below_threshold"; reason: string }


### PR DESCRIPTION
Stacked context-graph slice 08/27.

Base: `feat/context-graph-07-brief-tasks`
Head: `feat/context-graph-08-commitment-facts`

Adds commitment fact capture for mutable-status validation.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`