### PR TITLE
feat: add commitment sub-entities

### DIFF
--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -122,6 +122,7 @@ import * as m119 from "./migrations/119-agent-outputs-source-scope";
 import * as m120 from "./migrations/120-agent-output-period-key";
 import * as m121 from "./migrations/121-tasks";
 import * as m122 from "./migrations/122-tasks-owner";
+import * as m123 from "./migrations/123-sub-entities";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -248,6 +249,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "120-agent-output-period-key": m120,
           "121-tasks": m121,
           "122-tasks-owner": m122,
+          "123-sub-entities": m123,
         };
       },
     },

--- a/packages/server/src/db/migrations/123-sub-entities.ts
+++ b/packages/server/src/db/migrations/123-sub-entities.ts
@@ -1,0 +1,56 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("sub_entities")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("parent_entity_id", "text", (col) => col.references("entities.id").onDelete("set null"))
+    .addColumn("parent_scope_key", "text", (col) => col.notNull())
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("normalized_name", "text", (col) => col.notNull())
+    .addColumn("display_name", "text", (col) => col.notNull())
+    .addColumn("status", "text", (col) => col.notNull())
+    .addColumn("status_authority", "text", (col) => col.notNull().defaultTo("local"))
+    .addColumn("valid_from", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("valid_to", "text")
+    .addColumn("provenance", "text", (col) => col.notNull())
+    .addColumn("due_at", "text")
+    .addColumn("created_by_user_id", "text", (col) => col.references("users.id"))
+    .addColumn("source_fact_id", "text")
+    .addColumn("metadata_json", "text")
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+
+  await db.schema
+    .createTable("sub_entity_evidence")
+    .addColumn("sub_entity_id", "text", (col) => col.notNull().references("sub_entities.id").onDelete("cascade"))
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("ref_id", "text", (col) => col.notNull())
+    .addPrimaryKeyConstraint("sub_entity_evidence_pkey", ["sub_entity_id", "kind", "ref_id"])
+    .execute();
+
+  await sql`
+    CREATE UNIQUE INDEX idx_sub_entities_current_scope_kind_name
+    ON sub_entities(parent_scope_key, kind, normalized_name)
+    WHERE valid_to IS NULL
+  `.execute(db);
+  await db.schema
+    .createIndex("idx_sub_entities_parent_kind_status")
+    .on("sub_entities")
+    .columns(["parent_entity_id", "kind", "status"])
+    .execute();
+  await db.schema
+    .createIndex("idx_sub_entity_evidence_kind_ref")
+    .on("sub_entity_evidence")
+    .columns(["kind", "ref_id"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_sub_entity_evidence_kind_ref").ifExists().execute();
+  await db.schema.dropIndex("idx_sub_entities_parent_kind_status").ifExists().execute();
+  await sql`DROP INDEX IF EXISTS idx_sub_entities_current_scope_kind_name`.execute(db);
+  await db.schema.dropTable("sub_entity_evidence").execute();
+  await db.schema.dropTable("sub_entities").execute();
+}

--- a/packages/server/src/db/migrations/123-sub-entities.ts
+++ b/packages/server/src/db/migrations/123-sub-entities.ts
@@ -6,6 +6,7 @@ interface CommitmentBackfillDb {
   indexed_file_facts: {
     id: string;
     source: string;
+    fact_type: string;
     raw: string | null;
     created_by_user_id: string | null;
     deleted_at: string | null;

--- a/packages/server/src/db/migrations/123-sub-entities.ts
+++ b/packages/server/src/db/migrations/123-sub-entities.ts
@@ -1,4 +1,46 @@
+import { randomUUID } from "node:crypto";
 import { type Kysely, sql } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+
+interface CommitmentBackfillDb {
+  indexed_file_facts: {
+    id: string;
+    source: string;
+    raw: string | null;
+    created_by_user_id: string | null;
+    deleted_at: string | null;
+  };
+  sub_entities: {
+    id: string;
+    parent_entity_id: string | null;
+    parent_scope_key: string;
+    kind: string;
+    normalized_name: string;
+    display_name: string;
+    status: string;
+    status_authority: string;
+    valid_to: string | null;
+    provenance: string;
+    due_at: string | null;
+    created_by_user_id: string | null;
+    source_fact_id: string | null;
+    metadata_json: string | null;
+    updated_at: string;
+  };
+  sub_entity_evidence: {
+    sub_entity_id: string;
+    kind: string;
+    ref_id: string;
+  };
+}
+
+interface CommitmentRaw {
+  parentEntityId?: string;
+  title: string;
+  status: string;
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+}
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -30,6 +72,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addPrimaryKeyConstraint("sub_entity_evidence_pkey", ["sub_entity_id", "kind", "ref_id"])
     .execute();
 
+  await backfillCommitmentSubEntities(db as Kysely<CommitmentBackfillDb>);
+
   await sql`
     CREATE UNIQUE INDEX idx_sub_entities_current_scope_kind_name
     ON sub_entities(parent_scope_key, kind, normalized_name)
@@ -45,6 +89,105 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .on("sub_entity_evidence")
     .columns(["kind", "ref_id"])
     .execute();
+}
+
+async function backfillCommitmentSubEntities(db: Kysely<CommitmentBackfillDb>): Promise<void> {
+  const facts = await db
+    .selectFrom("indexed_file_facts")
+    .select(["id", "source", "raw", "created_by_user_id"])
+    .where("fact_type", "=", "commitment")
+    .where("deleted_at", "is", null)
+    .execute();
+  const subEntityIdsByKey = new Map<string, string>();
+  const now = new Date().toISOString();
+  for (const fact of facts) {
+    const raw = readCommitmentRaw(fact.raw);
+    if (!raw) continue;
+    const parentScopeKey = raw.parentEntityId ?? "global";
+    const normalizedName = normalizeName(raw.title);
+    const key = `${parentScopeKey}\u001fcommitment\u001f${normalizedName}`;
+    let subEntityId = subEntityIdsByKey.get(key);
+    if (!subEntityId) {
+      subEntityId = randomUUID();
+      subEntityIdsByKey.set(key, subEntityId);
+      await db
+        .insertInto("sub_entities")
+        .values({
+          id: subEntityId,
+          parent_entity_id: raw.parentEntityId ?? null,
+          parent_scope_key: parentScopeKey,
+          kind: "commitment",
+          normalized_name: normalizedName,
+          display_name: raw.title,
+          status: raw.status,
+          status_authority: "external",
+          valid_to: null,
+          provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
+          due_at: raw.dueAt ?? null,
+          created_by_user_id: fact.created_by_user_id,
+          source_fact_id: fact.id,
+          metadata_json: null,
+          updated_at: now,
+        })
+        .execute();
+    }
+    await insertSubEntityEvidence(db, subEntityId, "fact", fact.id);
+    for (const fileId of raw.evidence.fileIds) {
+      await insertSubEntityEvidence(db, subEntityId, "file", fileId);
+    }
+    for (const entityId of raw.evidence.entityIds) {
+      await insertSubEntityEvidence(db, subEntityId, "entity", entityId);
+    }
+  }
+}
+
+async function insertSubEntityEvidence(
+  db: Kysely<CommitmentBackfillDb>,
+  subEntityId: string,
+  kind: string,
+  refId: string,
+): Promise<void> {
+  await db
+    .insertInto("sub_entity_evidence")
+    .values({ sub_entity_id: subEntityId, kind, ref_id: refId })
+    .onConflict((oc) => oc.columns(["sub_entity_id", "kind", "ref_id"]).doNothing())
+    .execute();
+}
+
+function readCommitmentRaw(raw: string | null): CommitmentRaw | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) return null;
+    if (typeof parsed.title !== "string" || parsed.title.trim().length === 0) return null;
+    const status = typeof parsed.status === "string" && parsed.status.length > 0 ? parsed.status : "open";
+    const evidence = readEvidence(parsed.evidence);
+    if (!evidence) return null;
+    return {
+      parentEntityId: readOptionalString(parsed.parentEntityId),
+      title: parsed.title.trim(),
+      status,
+      dueAt: readOptionalString(parsed.dueAt),
+      evidence,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readEvidence(value: unknown): CommitmentRaw["evidence"] | null {
+  if (!isRecord(value)) return null;
+  if (!Array.isArray(value.fileIds) || !value.fileIds.every((id) => typeof id === "string")) return null;
+  if (!Array.isArray(value.entityIds) || !value.entityIds.every((id) => typeof id === "string")) return null;
+  return { fileIds: value.fileIds, entityIds: value.entityIds };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 116;
+const EXPECTED_MIGRATION_COUNT = 119;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -149,6 +149,83 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[113]).toBe("118-whatsapp-window-keepalives");
     expect(names[114]).toBe("119-agent-outputs-source-scope");
     expect(names[115]).toBe("120-agent-output-period-key");
+    expect(names[116]).toBe("121-tasks");
+    expect(names[117]).toBe("122-tasks-owner");
+    expect(names[118]).toBe("123-sub-entities");
+  });
+
+  it("creates the sub-entities table and current-row partial unique index", async () => {
+    const columns = await sql<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>`
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'sub_entities'
+    `.execute(db);
+    expect(columns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ column_name: "parent_entity_id", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "parent_scope_key", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "kind", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "normalized_name", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "source_fact_id", data_type: "text", is_nullable: "YES" }),
+      ]),
+    );
+
+    const indexes = await sql<{ indexname: string; indexdef: string }>`
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'sub_entities'
+    `.execute(db);
+    const currentIndex = indexes.rows.find((row) => row.indexname === "idx_sub_entities_current_scope_kind_name");
+    expect(currentIndex?.indexdef).toContain("UNIQUE INDEX");
+    expect(currentIndex?.indexdef).toContain("parent_scope_key");
+    expect(currentIndex?.indexdef).toContain("kind");
+    expect(currentIndex?.indexdef).toContain("normalized_name");
+    expect(currentIndex?.indexdef).toContain("WHERE (valid_to IS NULL)");
+
+    const foreignKeys = await sql<{
+      column_name: string;
+      foreign_table_name: string;
+      foreign_column_name: string;
+      delete_rule: string;
+    }>`
+      SELECT kcu.column_name, ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name
+       AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name
+       AND rc.constraint_schema = tc.table_schema
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'sub_entities'
+        AND tc.constraint_type = 'FOREIGN KEY'
+    `.execute(db);
+    expect(foreignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column_name: "parent_entity_id",
+          foreign_table_name: "entities",
+          foreign_column_name: "id",
+          delete_rule: "SET NULL",
+        }),
+        expect.objectContaining({
+          column_name: "created_by_user_id",
+          foreign_table_name: "users",
+          foreign_column_name: "id",
+        }),
+      ]),
+    );
+    expect(foreignKeys.rows.some((row) => row.column_name === "source_fact_id")).toBe(false);
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 116;
+const EXPECTED_MIGRATION_COUNT = 119;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -172,6 +172,59 @@ describe("runMigrations — full sequence", () => {
     expect(names[113]).toBe("118-whatsapp-window-keepalives");
     expect(names[114]).toBe("119-agent-outputs-source-scope");
     expect(names[115]).toBe("120-agent-output-period-key");
+    expect(names[116]).toBe("121-tasks");
+    expect(names[117]).toBe("122-tasks-owner");
+    expect(names[118]).toBe("123-sub-entities");
+  });
+
+  it("creates the sub-entities table and current-row partial unique index", async () => {
+    await runMigrations(db, { quiet: true });
+
+    const columns = await sql<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>`PRAGMA table_info(sub_entities)`.execute(db);
+    expect(columns.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "parent_entity_id", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "parent_scope_key", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "kind", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "normalized_name", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "status_authority", type: "TEXT", notnull: 1, dflt_value: "'local'" }),
+        expect.objectContaining({ name: "source_fact_id", type: "TEXT", notnull: 0 }),
+      ]),
+    );
+
+    const indexes = await sql<{
+      name: string;
+      unique: number;
+      partial: number;
+    }>`PRAGMA index_list(sub_entities)`.execute(db);
+    expect(indexes.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "idx_sub_entities_current_scope_kind_name",
+          unique: 1,
+          partial: 1,
+        }),
+      ]),
+    );
+
+    const foreignKeys = await sql<{
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>`PRAGMA foreign_key_list(sub_entities)`.execute(db);
+    expect(foreignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ table: "entities", from: "parent_entity_id", to: "id", on_delete: "SET NULL" }),
+        expect.objectContaining({ table: "users", from: "created_by_user_id", to: "id" }),
+      ]),
+    );
+    expect(foreignKeys.rows.some((row) => row.from === "source_fact_id")).toBe(false);
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {

--- a/packages/server/src/db/repositories/commitments.integration.test.ts
+++ b/packages/server/src/db/repositories/commitments.integration.test.ts
@@ -1,8 +1,10 @@
 import { type Kysely, sql } from "kysely";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { getSharedPgDb } from "../../test-utils";
+import { materializeUnmaterializedFacts } from "../../entities/materialize";
+import { createTestLogger, createTestPgDb, getSharedPgDb } from "../../test-utils";
 import type { DB } from "../schema";
 import { markCommitmentDone, measureCommitmentStomp, upsertCommitmentFact } from "./commitments";
+import { createEntityRepository } from "./entities";
 import { createIndexedFileFactRepository } from "./indexed-file-facts";
 
 const USER_ID = "commitment-pg-user";
@@ -45,6 +47,96 @@ describe("commitment stomp measurement postgres", () => {
 
     expect(result).toEqual({ overwritten: 2, tombstoned: 2, survived: 0, reconcileSkipped: false });
   });
+});
+
+describe("commitment sub-entities postgres", () => {
+  it("preserves local status across re-materialization with the partial unique index", async () => {
+    const freshDb = await createTestPgDb();
+    try {
+      await seedBase(freshDb);
+      const project = await seedProject(freshDb, { id: "commitment-pg-project", name: "Commitment PG Project" });
+
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-1",
+        source: "linear",
+        commitmentId: "pg-survives",
+        parentEntityId: project.id,
+        title: "Send the PG follow-up",
+        status: "open",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await expect(markCommitmentDone(freshDb, "pg-survives")).resolves.toBe(true);
+
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-2",
+        source: "linear",
+        commitmentId: "pg-survives",
+        parentEntityId: project.id,
+        title: "Send the PG follow-up",
+        status: "open",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await createIndexedFileFactRepository(freshDb).reconcileStaleFacts(
+        { kind: "connector", connectorConfigId: CONNECTOR_ID, syncRunId: "sync-2" },
+        null,
+      );
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+
+      const rows = await freshDb
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("kind", "=", "commitment")
+        .where("normalized_name", "=", "send the pg follow-up")
+        .where("valid_to", "is", null)
+        .execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ status: "done", status_authority: "local", parent_scope_key: project.id });
+
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-3",
+        source: "linear",
+        commitmentId: "pg-external",
+        parentEntityId: project.id,
+        title: "Track external status",
+        status: "open",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await upsertCommitmentFact(freshDb, {
+        experimentalFlag: true,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        lastSeenSyncRunId: "sync-4",
+        source: "linear",
+        commitmentId: "pg-external",
+        parentEntityId: project.id,
+        title: "Track external status",
+        status: "dropped",
+        evidence: { fileIds: [], entityIds: [project.id] },
+      });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      const external = await freshDb
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("kind", "=", "commitment")
+        .where("normalized_name", "=", "track external status")
+        .where("valid_to", "is", null)
+        .executeTakeFirstOrThrow();
+      expect(external).toMatchObject({ status: "dropped", status_authority: "external" });
+    } finally {
+      await freshDb.destroy();
+    }
+  }, 30000);
 });
 
 async function seedBase(db: Kysely<DB>): Promise<void> {
@@ -91,4 +183,27 @@ async function seedOtherFact(db: Kysely<DB>, id: string): Promise<void> {
     subjectSourceId: id,
     raw: { sourceType: "project", sourcePath: id },
   });
+}
+
+async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) {
+  const repo = createEntityRepository(db);
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await repo.upsertSourceRef({ entityId: input.id, source: "linear", sourceId: `${input.id}-source` });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
 }

--- a/packages/server/src/db/repositories/commitments.test.ts
+++ b/packages/server/src/db/repositories/commitments.test.ts
@@ -1,24 +1,18 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { emitFactsForSyncedItem } from "../../connectors/sync-facts";
-import type { Connector, SyncedItem } from "../../connectors/types";
-import {
-  buildMaterializeDeps,
-  materializeFromFact,
-  materializeUnmaterializedFacts,
-  shouldMarkMaterialized,
-} from "../../entities/materialize";
+import { buildMaterializeDeps, materializeFromFact, materializeUnmaterializedFacts } from "../../entities/materialize";
 import { createTestDb, createTestLogger } from "../../test-utils";
 import type { DB } from "../schema";
 import { listOpenCommitments, markCommitmentDone, upsertCommitmentFact } from "./commitments";
 import { createEntityRepository } from "./entities";
 import { createIndexedFileFactRepository } from "./indexed-file-facts";
+import { createSubEntityRepository } from "./sub-entities";
 import { TEST_ACCOUNT_ENTITY_ID } from "./tasks";
 
 const USER_ID = "commitment-user";
 const CONNECTOR_ID = "commitment-config";
 
-describe("commitment facts", () => {
+describe("commitment sub-entities", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
@@ -29,66 +23,48 @@ describe("commitment facts", () => {
     await db.destroy();
   });
 
-  it("materializes with parent and due date while flag-gating emission and materialization counters", async () => {
+  it("keeps local commitment status across re-sync while external rows track source status", async () => {
     await seedBase(db);
     const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
     await seedProject(db, { id: TEST_ACCOUNT_ENTITY_ID, name: "Test Account" });
-    const connector = { type: "linear" } as Connector;
-    const item = commitmentItem(project.id);
 
-    await emitFactsForSyncedItem({
-      db,
-      factRepo: createIndexedFileFactRepository(db),
-      connector,
-      connectorType: "linear",
-      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-off" },
-      item,
-      indexedFileId: "commitment-file-1",
+    await upsertCommitmentFact(db, {
       experimentalFlag: false,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-off",
+      source: "linear",
+      commitmentId: "flag-off",
+      parentRef: { source: "linear", sourceId: `${project.id}-source` },
+      title: "Flag-off commitment",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
     });
-    let count = await db
-      .selectFrom("indexed_file_facts")
-      .select((eb) => eb.fn.countAll<number>().as("count"))
-      .where("fact_type", "=", "commitment")
-      .executeTakeFirstOrThrow();
-    expect(Number(count.count)).toBe(0);
+    expect(await countRows(db, "indexed_file_facts", "commitment")).toBe(0);
+    expect(await countRows(db, "sub_entities", "commitment")).toBe(0);
 
-    await emitFactsForSyncedItem({
-      db,
-      factRepo: createIndexedFileFactRepository(db),
-      connector,
-      connectorType: "linear",
-      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-on" },
-      item,
-      indexedFileId: "commitment-file-1",
+    await upsertCommitmentFact(db, {
       experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-1",
+      source: "linear",
+      commitmentId: "commitment-1",
+      parentRef: { source: "linear", sourceId: `${project.id}-source` },
+      title: "Send the follow-up",
+      status: "open",
+      dueAt: "2026-07-01T00:00:00.000Z",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
     });
     const fact = await db
       .selectFrom("indexed_file_facts")
       .selectAll()
-      .where("fact_type", "=", "commitment")
+      .where("subject_source_id", "=", "commitment-1")
       .executeTakeFirstOrThrow();
-    const depsOff = await buildMaterializeDeps(db, { experimentalFlag: false });
-    const offResult = await materializeFromFact(depsOff, fact);
+    const offResult = await materializeFromFact(await buildMaterializeDeps(db, { experimentalFlag: false }), fact);
     expect(offResult).toEqual({ kind: "skipped", reason: "experimental_off" });
-    expect(shouldMarkMaterialized(offResult)).toBe(true);
+    expect(await countRows(db, "sub_entities", "commitment")).toBe(0);
 
     const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
-    const materializedFact = await db
-      .selectFrom("indexed_file_facts")
-      .selectAll()
-      .where("fact_type", "=", "commitment")
-      .executeTakeFirstOrThrow();
-    const raw = JSON.parse(materializedFact.raw ?? "{}");
-    expect(raw).toMatchObject({
-      commitmentId: "commitment-1",
-      parentEntityId: project.id,
-      parent_entity_id: project.id,
-      dueAt: "2026-07-01T00:00:00.000Z",
-      status: "open",
-    });
-    expect(raw.parentEntityId).not.toBe(TEST_ACCOUNT_ENTITY_ID);
-    expect(materializedFact.materialized_at).not.toBeNull();
     expect(summary).toMatchObject({
       factsRead: 1,
       entitiesCreated: 0,
@@ -101,35 +77,158 @@ describe("commitment facts", () => {
       deferred: 0,
       deferredBelowThreshold: 0,
     });
-    count = await db
-      .selectFrom("tasks")
-      .select((eb) => eb.fn.countAll<number>().as("count"))
-      .executeTakeFirstOrThrow();
-    expect(Number(count.count)).toBe(0);
-  });
-
-  it("mark-done persists within a run and removes the row from open commitments", async () => {
-    await seedBase(db);
-    const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
-    await upsertCommitmentFact(db, {
-      experimentalFlag: true,
-      indexedFileId: "commitment-file-1",
-      connectorConfigId: CONNECTOR_ID,
-      createdByUserId: USER_ID,
-      lastSeenSyncRunId: "sync-1",
-      source: "linear",
-      commitmentId: "commitment-1",
-      parentEntityId: project.id,
-      title: "Send the follow-up",
-      dueAt: "2026-07-01T00:00:00.000Z",
-      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    let row = await currentCommitmentRow(db, "Send the follow-up");
+    expect(row).toMatchObject({
+      parent_entity_id: project.id,
+      parent_scope_key: project.id,
+      kind: "commitment",
+      normalized_name: "send the follow-up",
+      display_name: "Send the follow-up",
+      status: "open",
+      status_authority: "external",
+      due_at: "2026-07-01T00:00:00.000Z",
+      created_by_user_id: USER_ID,
     });
+    expect(row?.valid_to).toBeNull();
+    const rawAfterMaterialize = JSON.parse(
+      (await db.selectFrom("indexed_file_facts").select("raw").where("id", "=", fact.id).executeTakeFirstOrThrow())
+        .raw ?? "{}",
+    );
+    expect(rawAfterMaterialize).toMatchObject({ status: "open" });
+    expect(rawAfterMaterialize.parent_entity_id).toBeUndefined();
+    expect(rawAfterMaterialize.parentEntityId).toBeUndefined();
 
     await expect(listOpenCommitments(db, { parentEntityId: project.id })).resolves.toHaveLength(1);
     await expect(markCommitmentDone(db, "commitment-1")).resolves.toBe(true);
     await expect(listOpenCommitments(db, { parentEntityId: project.id })).resolves.toHaveLength(0);
-    const fact = await db.selectFrom("indexed_file_facts").selectAll().executeTakeFirstOrThrow();
-    expect(JSON.parse(fact.raw ?? "{}").status).toBe("done");
+    row = await currentCommitmentRow(db, "Send the follow-up");
+    expect(row).toMatchObject({ status: "done", status_authority: "local" });
+
+    await upsertCommitmentFact(db, {
+      experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-2",
+      source: "linear",
+      commitmentId: "commitment-1",
+      parentRef: { source: "linear", sourceId: `${project.id}-source` },
+      title: "Send the follow-up",
+      status: "open",
+      dueAt: "2026-07-01T00:00:00.000Z",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    });
+    await createIndexedFileFactRepository(db).reconcileStaleFacts(
+      { kind: "connector", connectorConfigId: CONNECTOR_ID, syncRunId: "sync-2" },
+      null,
+    );
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    row = await currentCommitmentRow(db, "Send the follow-up");
+    expect(row).toMatchObject({ status: "done", status_authority: "local", valid_to: null });
+    const rawAfterDone = JSON.parse(
+      (
+        await db
+          .selectFrom("indexed_file_facts")
+          .select("raw")
+          .where("subject_source_id", "=", "commitment-1")
+          .executeTakeFirstOrThrow()
+      ).raw ?? "{}",
+    );
+    expect(rawAfterDone.status).toBe("open");
+
+    await upsertCommitmentFact(db, {
+      experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-3",
+      source: "linear",
+      commitmentId: "commitment-2",
+      parentEntityId: project.id,
+      title: "Update the rollout note",
+      status: "open",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await upsertCommitmentFact(db, {
+      experimentalFlag: true,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-4",
+      source: "linear",
+      commitmentId: "commitment-2",
+      parentEntityId: project.id,
+      title: "Update the rollout note",
+      status: "dropped",
+      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    expect(await currentCommitmentRow(db, "Update the rollout note")).toMatchObject({
+      status: "dropped",
+      status_authority: "external",
+    });
+  });
+
+  it("deduplicates commitment sub-entities within parent scope and global scope", async () => {
+    await seedBase(db);
+    const projectA = await seedProject(db, { id: "project-a", name: "Project A" });
+    const projectB = await seedProject(db, { id: "project-b", name: "Project B" });
+
+    await seedCommitmentFact(db, "commitment-a1", projectA.id, "Send Update");
+    await seedCommitmentFact(db, "commitment-a2", projectA.id, " send   update ");
+    await seedCommitmentFact(db, "commitment-b1", projectB.id, "Send Update");
+    await seedCommitmentFact(db, "commitment-global-1", null, "Send Update");
+    await seedCommitmentFact(db, "commitment-global-2", null, "send update");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const rows = await db
+      .selectFrom("sub_entities")
+      .selectAll()
+      .where("kind", "=", "commitment")
+      .orderBy("parent_scope_key", "asc")
+      .execute();
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.parent_scope_key).sort()).toEqual(["global", projectA.id, projectB.id].sort());
+    expect(rows.every((row) => row.normalized_name === "send update")).toBe(true);
+
+    const projectARow = rows.find((row) => row.parent_entity_id === projectA.id);
+    expect(projectARow).toBeDefined();
+    const evidence = await db
+      .selectFrom("sub_entity_evidence")
+      .select(["kind", "ref_id"])
+      .where("sub_entity_id", "=", projectARow?.id ?? "")
+      .where("kind", "=", "fact")
+      .execute();
+    expect(evidence).toHaveLength(2);
+  });
+
+  it("keeps commitment sub-entities off entity and search indexes", async () => {
+    await seedBase(db);
+    const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
+    await seedCommitmentFact(db, "commitment-1", project.id, "Send the follow-up");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const subEntities = await createSubEntityRepository(db).listOpenSubEntities({
+      parentEntityId: project.id,
+      kind: "commitment",
+    });
+    expect(subEntities).toHaveLength(1);
+    expect(subEntities[0]).toMatchObject({
+      kind: "commitment",
+      display_name: "Send the follow-up",
+      parent_entity_id: project.id,
+    });
+
+    await expect(
+      db.selectFrom("entities").selectAll().where("name", "=", "Send the follow-up").execute(),
+    ).resolves.toHaveLength(0);
+    await expect(createEntityRepository(db).searchEntities("Send the follow-up")).resolves.toHaveLength(0);
+    await expect(
+      db.selectFrom("indexed_files").selectAll().where("id", "=", subEntities[0].id).execute(),
+    ).resolves.toHaveLength(0);
+    await expect(
+      db.selectFrom("document_chunks").selectAll().where("id", "=", subEntities[0].id).execute(),
+    ).resolves.toHaveLength(0);
   });
 });
 
@@ -203,27 +302,43 @@ async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) 
   return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
 }
 
-function commitmentItem(projectId: string): SyncedItem {
-  return {
-    providerFileId: "commitment-file-1",
-    providerUrl: null,
-    fileName: "Commitment file",
-    fileType: "issue",
-    contentCategory: "structured",
-    content: "Commitment file",
-    sourcePath: null,
-    contentHash: "hash-1",
-    sourceCreatedAt: null,
-    sourceUpdatedAt: null,
-    commitments: [
-      {
-        commitmentId: "commitment-1",
-        parentRef: { source: "linear", sourceId: `${projectId}-source` },
-        title: "Send the follow-up",
-        status: "open",
-        dueAt: "2026-07-01T00:00:00.000Z",
-        evidence: { fileIds: ["commitment-file-1"], entityIds: [projectId, TEST_ACCOUNT_ENTITY_ID] },
-      },
-    ],
-  };
+async function seedCommitmentFact(
+  db: Kysely<DB>,
+  commitmentId: string,
+  parentEntityId: string | null,
+  title: string,
+): Promise<void> {
+  await upsertCommitmentFact(db, {
+    experimentalFlag: true,
+    indexedFileId: "commitment-file-1",
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    lastSeenSyncRunId: "sync-1",
+    source: "linear",
+    commitmentId,
+    parentEntityId: parentEntityId ?? undefined,
+    title,
+    status: "open",
+    evidence: { fileIds: ["commitment-file-1"], entityIds: parentEntityId ? [parentEntityId] : [] },
+  });
+}
+
+async function currentCommitmentRow(db: Kysely<DB>, displayName: string) {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "commitment")
+    .where("display_name", "=", displayName)
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+}
+
+async function countRows(db: Kysely<DB>, table: "indexed_file_facts" | "sub_entities", kind: string): Promise<number> {
+  const column = table === "indexed_file_facts" ? "fact_type" : "kind";
+  const row = await db
+    .selectFrom(table)
+    .select((eb) => eb.fn.countAll<number>().as("count"))
+    .where(column, "=", kind)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
 }

--- a/packages/server/src/db/repositories/commitments.ts
+++ b/packages/server/src/db/repositories/commitments.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
 import type { CommitmentSeed, IndexedFileFactRaw } from "../../connectors/types";
 import type { DB, IndexedFileFactsTable } from "../schema";
 import {
@@ -6,6 +7,7 @@ import {
   type IndexedFileFactType,
   createIndexedFileFactRepository,
 } from "./indexed-file-facts";
+import { type SubEntityRow, createSubEntityRepository } from "./sub-entities";
 
 export type CommitmentStatus = "open" | "done" | "dropped";
 
@@ -88,37 +90,34 @@ export async function markCommitmentDone(db: Kysely<DB>, commitmentId: string): 
   if (!fact) return false;
   const raw = readCommitmentRaw(fact.raw);
   if (!raw) return false;
-  await db
-    .updateTable("indexed_file_facts")
-    .set({ raw: JSON.stringify({ ...raw, status: "done" }), updated_at: new Date().toISOString() })
-    .where("id", "=", fact.id)
-    .execute();
-  return true;
+  const repo = createSubEntityRepository(db);
+  const subEntityId = await findCommitmentSubEntityIdByFact(db, fact.id);
+  if (subEntityId) return repo.markSubEntityStatus(subEntityId, "done");
+  const fallback = await findCommitmentSubEntityByScopeAndName(db, readParentEntityId(raw), raw.title);
+  if (!fallback) return false;
+  return repo.markSubEntityStatus(fallback.id, "done");
 }
 
 export async function listOpenCommitments(
   db: Kysely<DB>,
   opts: { parentEntityId?: string | null } = {},
 ): Promise<OpenCommitment[]> {
-  const rows = await db
-    .selectFrom("indexed_file_facts")
-    .selectAll()
-    .where("fact_type", "=", "commitment")
-    .where("deleted_at", "is", null)
-    .execute();
+  const rows = await createSubEntityRepository(db).listOpenSubEntities({
+    parentEntityId: opts.parentEntityId,
+    kind: "commitment",
+  });
   const out: OpenCommitment[] = [];
   for (const row of rows) {
-    const raw = readCommitmentRaw(row.raw);
-    if (!raw || raw.status === "done" || raw.status === "dropped") continue;
-    const parentEntityId = readParentEntityId(raw);
-    if (opts.parentEntityId && parentEntityId !== opts.parentEntityId) continue;
+    const fact = await findSubEntityCommitmentFact(db, row.id);
+    const raw = readCommitmentRaw(fact?.raw ?? null);
+    if (!fact || !raw) continue;
     out.push({
-      factId: row.id,
+      factId: fact.id,
       commitmentId: raw.commitmentId,
-      parentEntityId,
+      parentEntityId: row.parent_entity_id,
       title: raw.title,
       status: "open",
-      dueAt: raw.dueAt ?? null,
+      dueAt: row.due_at,
       evidence: raw.evidence,
       raw,
     });
@@ -247,6 +246,47 @@ async function findActiveCommitmentFact(db: Kysely<DB>, commitmentId: string) {
     .where("fact_type", "=", "commitment")
     .where("subject_source_id", "=", commitmentId)
     .where("deleted_at", "is", null)
+    .executeTakeFirst();
+}
+
+async function findCommitmentSubEntityIdByFact(db: Kysely<DB>, factId: string): Promise<string | null> {
+  const row = await db
+    .selectFrom("sub_entity_evidence")
+    .innerJoin("sub_entities", "sub_entities.id", "sub_entity_evidence.sub_entity_id")
+    .select("sub_entities.id")
+    .where("sub_entity_evidence.kind", "=", "fact")
+    .where("sub_entity_evidence.ref_id", "=", factId)
+    .where("sub_entities.kind", "=", "commitment")
+    .where("sub_entities.valid_to", "is", null)
+    .executeTakeFirst();
+  return row?.id ?? null;
+}
+
+async function findCommitmentSubEntityByScopeAndName(
+  db: Kysely<DB>,
+  parentEntityId: string | null,
+  title: string,
+): Promise<SubEntityRow | undefined> {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("parent_scope_key", "=", parentEntityId ?? "global")
+    .where("kind", "=", "commitment")
+    .where("normalized_name", "=", normalizeName(title))
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+}
+
+async function findSubEntityCommitmentFact(db: Kysely<DB>, subEntityId: string) {
+  return db
+    .selectFrom("sub_entity_evidence")
+    .innerJoin("indexed_file_facts", "indexed_file_facts.id", "sub_entity_evidence.ref_id")
+    .selectAll("indexed_file_facts")
+    .where("sub_entity_evidence.sub_entity_id", "=", subEntityId)
+    .where("sub_entity_evidence.kind", "=", "fact")
+    .where("indexed_file_facts.fact_type", "=", "commitment")
+    .where("indexed_file_facts.deleted_at", "is", null)
+    .orderBy("indexed_file_facts.updated_at", "desc")
     .executeTakeFirst();
 }
 

--- a/packages/server/src/db/repositories/sub-entities.ts
+++ b/packages/server/src/db/repositories/sub-entities.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely, Selectable } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+import type { DB, SubEntitiesTable } from "../schema";
+
+export type SubEntityStatus = "open" | "done" | "dropped" | string;
+export type SubEntityStatusAuthority = "external" | "local";
+
+export interface UpsertSubEntityInput {
+  parentEntityId?: string | null;
+  kind: string;
+  displayName: string;
+  status: SubEntityStatus;
+  provenance: string;
+  dueAt?: string | null;
+  ownerUserId?: string | null;
+  sourceFactId?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface ListOpenSubEntitiesOptions {
+  parentEntityId?: string | null;
+  kind: string;
+}
+
+export type SubEntityRow = Selectable<SubEntitiesTable>;
+
+const GLOBAL_PARENT_SCOPE_KEY = "global";
+const TERMINAL_STATUSES = ["done", "dropped"];
+
+export function createSubEntityRepository(db: Kysely<DB>) {
+  return {
+    async upsertSubEntity(input: UpsertSubEntityInput): Promise<{ subEntityId: string; created: boolean }> {
+      try {
+        return await upsertInTransaction(db, input);
+      } catch (err) {
+        if (!isUniqueConstraintError(err)) throw err;
+        return upsertInTransaction(db, input);
+      }
+    },
+
+    async markSubEntityStatus(subEntityId: string, status: SubEntityStatus): Promise<boolean> {
+      const result = await db
+        .updateTable("sub_entities")
+        .set({ status, status_authority: "local", updated_at: new Date().toISOString() })
+        .where("id", "=", subEntityId)
+        .where("valid_to", "is", null)
+        .executeTakeFirst();
+      return Number(result.numUpdatedRows ?? 0) > 0;
+    },
+
+    async listOpenSubEntities(opts: ListOpenSubEntitiesOptions): Promise<SubEntityRow[]> {
+      let query = db
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("valid_to", "is", null)
+        .where("kind", "=", opts.kind)
+        .where("status", "not in", TERMINAL_STATUSES)
+        .orderBy("updated_at", "desc");
+      if (opts.parentEntityId !== undefined) {
+        query =
+          opts.parentEntityId === null
+            ? query.where("parent_entity_id", "is", null)
+            : query.where("parent_entity_id", "=", opts.parentEntityId);
+      }
+      return query.execute();
+    },
+
+    async upsertSubEntityEvidence(subEntityId: string, kind: string, refId: string): Promise<void> {
+      await db
+        .insertInto("sub_entity_evidence")
+        .values({ sub_entity_id: subEntityId, kind, ref_id: refId })
+        .onConflict((oc) => oc.columns(["sub_entity_id", "kind", "ref_id"]).doNothing())
+        .execute();
+    },
+  };
+}
+
+async function upsertInTransaction(
+  db: Kysely<DB>,
+  input: UpsertSubEntityInput,
+): Promise<{ subEntityId: string; created: boolean }> {
+  return db.transaction().execute(async (trx) => {
+    const parentScopeKey = input.parentEntityId ?? GLOBAL_PARENT_SCOPE_KEY;
+    const normalized = normalizeName(input.displayName);
+    const existing = await selectCurrent(trx, parentScopeKey, input.kind, normalized);
+    const now = new Date().toISOString();
+    if (!existing) {
+      const id = randomUUID();
+      await trx
+        .insertInto("sub_entities")
+        .values({
+          id,
+          parent_entity_id: input.parentEntityId ?? null,
+          parent_scope_key: parentScopeKey,
+          kind: input.kind,
+          normalized_name: normalized,
+          display_name: input.displayName,
+          status: input.status,
+          status_authority: "external",
+          valid_to: null,
+          provenance: input.provenance,
+          due_at: input.dueAt ?? null,
+          created_by_user_id: input.ownerUserId ?? null,
+          source_fact_id: input.sourceFactId ?? null,
+          metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
+          updated_at: now,
+        })
+        .execute();
+      return { subEntityId: id, created: true };
+    }
+
+    await updateExisting(trx, existing, input, now);
+    return { subEntityId: existing.id, created: false };
+  });
+}
+
+async function selectCurrent(
+  db: Kysely<DB>,
+  parentScopeKey: string,
+  kind: string,
+  normalizedName: string,
+): Promise<SubEntityRow | undefined> {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("parent_scope_key", "=", parentScopeKey)
+    .where("kind", "=", kind)
+    .where("normalized_name", "=", normalizedName)
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+}
+
+async function updateExisting(
+  db: Kysely<DB>,
+  existing: SubEntityRow,
+  input: UpsertSubEntityInput,
+  now: string,
+): Promise<void> {
+  await db
+    .updateTable("sub_entities")
+    .set({
+      display_name: input.displayName,
+      status: existing.status_authority === "local" ? existing.status : input.status,
+      due_at: input.dueAt ?? null,
+      source_fact_id: input.sourceFactId ?? null,
+      metadata_json: input.metadata ? JSON.stringify(input.metadata) : existing.metadata_json,
+      updated_at: now,
+    })
+    .where("id", "=", existing.id)
+    .execute();
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = "code" in error ? String(error.code) : "";
+  if (code === "23505" || code === "SQLITE_CONSTRAINT_UNIQUE") return true;
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return message.includes("unique constraint") || message.includes("duplicate key");
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -954,6 +954,32 @@ export interface TaskEvidenceTable {
   ref_id: string;
 }
 
+export interface SubEntitiesTable {
+  id: string;
+  parent_entity_id: string | null;
+  parent_scope_key: string;
+  kind: string;
+  normalized_name: string;
+  display_name: string;
+  status: string;
+  status_authority: Generated<string>;
+  valid_from: Generated<string>;
+  valid_to: string | null;
+  provenance: string;
+  due_at: string | null;
+  created_by_user_id: string | null;
+  source_fact_id: string | null;
+  metadata_json: string | null;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
+export interface SubEntityEvidenceTable {
+  sub_entity_id: string;
+  kind: string;
+  ref_id: string;
+}
+
 export interface DB {
   users: UsersTable;
   channels: ChannelsTable;
@@ -1021,6 +1047,8 @@ export interface DB {
   indexed_file_facts: IndexedFileFactsTable;
   tasks: TasksTable;
   task_evidence: TaskEvidenceTable;
+  sub_entities: SubEntitiesTable;
+  sub_entity_evidence: SubEntityEvidenceTable;
   entity_domains: EntityDomainsTable;
   entity_project_bindings: EntityProjectBindingsTable;
   entity_project_member_overrides: EntityProjectMemberOverridesTable;

--- a/packages/server/src/entities/materialize-commitment.ts
+++ b/packages/server/src/entities/materialize-commitment.ts
@@ -1,3 +1,4 @@
+import { createSubEntityRepository } from "../db/repositories/sub-entities";
 import { TEST_ACCOUNT_ENTITY_ID } from "../db/repositories/tasks";
 import { readJsonObject } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
@@ -12,19 +13,24 @@ export async function materializeCommitment(
   if (!commitment) return { kind: "skipped", reason: "invalid_commitment" };
 
   const parent = resolveParent(deps, commitment);
-  await deps.db
-    .updateTable("indexed_file_facts")
-    .set({
-      raw: JSON.stringify({
-        ...raw,
-        status: commitment.status,
-        parentEntityId: parent?.id ?? null,
-        parent_entity_id: parent?.id ?? null,
-      }),
-      updated_at: new Date().toISOString(),
-    })
-    .where("id", "=", fact.id)
-    .execute();
+  const repo = createSubEntityRepository(deps.db);
+  const result = await repo.upsertSubEntity({
+    parentEntityId: parent?.id ?? null,
+    kind: "commitment",
+    displayName: commitment.title,
+    status: commitment.status,
+    provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
+    dueAt: commitment.dueAt ?? null,
+    ownerUserId: deps.resolveOwner(fact),
+    sourceFactId: fact.id,
+  });
+  await repo.upsertSubEntityEvidence(result.subEntityId, "fact", fact.id);
+  for (const fileId of commitment.evidence.fileIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "file", fileId);
+  }
+  for (const entityId of commitment.evidence.entityIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "entity", entityId);
+  }
   return { kind: "commitment_materialized" };
 }
 
@@ -64,13 +70,16 @@ interface CommitmentInput {
   commitmentId: string;
   parentRef?: { source: string; sourceId: string };
   parentEntityId?: string;
+  title: string;
   status: "open" | "done" | "dropped";
-  evidence: { entityIds: string[] };
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
 }
 
 function readCommitment(raw: Record<string, unknown>): CommitmentInput | null {
   if (
     typeof raw.commitmentId !== "string" ||
+    typeof raw.title !== "string" ||
     (raw.status !== "open" && raw.status !== "done" && raw.status !== "dropped") ||
     !isEvidence(raw.evidence)
   ) {
@@ -80,8 +89,10 @@ function readCommitment(raw: Record<string, unknown>): CommitmentInput | null {
     commitmentId: raw.commitmentId,
     parentRef: readParentRef(raw.parentRef),
     parentEntityId: readOptionalString(raw.parentEntityId),
+    title: raw.title,
     status: raw.status,
-    evidence: { entityIds: raw.evidence.entityIds },
+    dueAt: readOptionalString(raw.dueAt),
+    evidence: { fileIds: raw.evidence.fileIds, entityIds: raw.evidence.entityIds },
   };
 }
 
@@ -92,10 +103,15 @@ function readParentRef(value: unknown): { source: string; sourceId: string } | u
   return { source: record.source, sourceId: record.sourceId };
 }
 
-function isEvidence(value: unknown): value is { entityIds: string[] } {
+function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: string[] } {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
-  return Array.isArray(record.entityIds) && record.entityIds.every((id) => typeof id === "string");
+  return (
+    Array.isArray(record.fileIds) &&
+    record.fileIds.every((id) => typeof id === "string") &&
+    Array.isArray(record.entityIds) &&
+    record.entityIds.every((id) => typeof id === "string")
+  );
 }
 
 function readOptionalString(value: unknown): string | undefined {


### PR DESCRIPTION
Stacked context-graph slice 10/27.

Base: `feat/context-graph-09-llm-task-gate`
Head: `feat/context-graph-10-commitment-sub-entities`

Adds commitment status sub-entities that survive re-sync.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`