### PR TITLE
feat: add decision sub-entities

### DIFF
--- a/packages/server/src/connectors/sync-facts.ts
+++ b/packages/server/src/connectors/sync-facts.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from "kysely";
 import { upsertCommitmentFact } from "../db/repositories/commitments";
+import { upsertDecisionFactsForFile } from "../db/repositories/decisions";
 import { type createIndexedFileFactRepository, upsertLlmTaskFact } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
 import { normalizeRelationType } from "../entities/graph";
@@ -237,6 +238,20 @@ export async function emitFactsForSyncedItem({
         contextSnippet: item.sourcePath,
       });
     }
+  }
+
+  if (item.decisions && db) {
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag,
+      indexedFileId,
+      connectorConfigId: factContext.connectorConfigId,
+      createdByUserId: factContext.createdByUserId,
+      lastSeenSyncRunId: factContext.lastSeenSyncRunId,
+      contentHash: item.contentHash,
+      source: connectorType,
+      decisions: item.decisions,
+      contextSnippet: item.sourcePath,
+    });
   }
 
   if (experimentalFlag && db && item.contentCategory === "document" && item.content) {

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -130,6 +130,7 @@ export interface SyncedItem {
     assignee?: { name: string; email?: string; source?: string; sourceId?: string };
   };
   commitments?: CommitmentSeed[];
+  decisions?: DecisionSeed[];
   /**
    * People meaningfully attached to this item (meeting speakers, doc authors).
    * Sync seeds person entities from entries where `name` is present or can be
@@ -214,6 +215,19 @@ export interface CommitmentSeed {
   evidence: { fileIds: string[]; entityIds: string[] };
 }
 
+export interface DecisionSeed {
+  decisionId?: string;
+  topic: string;
+  statement: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  decidedBy?: string;
+  decidedAt?: string;
+  rationale?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  promptVersion?: string;
+}
+
 export interface LlmTaskCandidate {
   title: string;
   owner?: { name?: string; email?: string };
@@ -252,6 +266,7 @@ export type IndexedFileFactRaw =
       task: NonNullable<SyncedItem["task"]>;
     }
   | CommitmentSeed
+  | DecisionSeed
   | LlmTaskFactRaw
   | { providerFileId: string; contactPoint: ContactPointSeed }
   | { sourceType: string; sourceUrl?: string; sourcePath?: string; metadata?: Record<string, unknown> }

--- a/packages/server/src/db/repositories/decisions.integration.test.ts
+++ b/packages/server/src/db/repositories/decisions.integration.test.ts
@@ -1,0 +1,317 @@
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+import { materializeUnmaterializedFacts } from "../../entities/materialize";
+import { createTestLogger, createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { upsertDecisionFact, upsertDecisionFactsForFile } from "./decisions";
+import { createEntityRepository } from "./entities";
+import { createSubEntityRepository } from "./sub-entities";
+import { TEST_ACCOUNT_ENTITY_ID } from "./tasks";
+
+const USER_ID = "decision-pg-user";
+const CONNECTOR_ID = "decision-pg-config";
+
+describe("decision sub-entity supersession postgres", () => {
+  let db: Kysely<DB> | undefined;
+
+  afterEach(async () => {
+    await db?.destroy();
+    db = undefined;
+  });
+
+  it("supersedes changed decisions and keeps normalized statement replays idempotent", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedProject(db, { id: "decision-project-forward", name: "Decision Project Forward" });
+    await seedProject(db, { id: TEST_ACCOUNT_ENTITY_ID, name: "Test Account" });
+    await seedFile(db, "decision-file-forward", "2026-06-22T09:00:00.000Z");
+
+    await expect(
+      upsertDecisionFact(db, {
+        experimentalFlag: false,
+        indexedFileId: "decision-file-forward",
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        source: "linear",
+        topic: "Pricing Tier",
+        statement: "Use price A",
+        parentEntityId: project.id,
+        decidedAt: "2026-06-22T09:00:00.000Z",
+        evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
+      }),
+    ).resolves.toEqual({ emitted: false });
+    expect(await countDecisionRows(db)).toBe(0);
+
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-forward",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      decisions: [
+        {
+          topic: "Pricing Tier",
+          statement: "Use price A",
+          parentEntityId: project.id,
+          decidedAt: "2026-06-22T09:00:00.000Z",
+          evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
+        },
+      ],
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-forward",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      decisions: [
+        {
+          topic: "Pricing Tier",
+          statement: "Use price B",
+          parentEntityId: project.id,
+          decidedAt: "2026-06-22T11:00:00.000Z",
+          evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id] },
+        },
+      ],
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    let rows = await decisionRows(db, project.id, "pricing tier");
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.display_name === "Use price A")).toMatchObject({
+      status: "superseded",
+      valid_from: "2026-06-22T09:00:00.000Z",
+      valid_to: "2026-06-22T11:00:00.000Z",
+    });
+    expect(rows.find((row) => row.display_name === "Use price B")).toMatchObject({
+      status: "active",
+      valid_from: "2026-06-22T11:00:00.000Z",
+      valid_to: null,
+    });
+
+    await upsertDecisionFactsForFile(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-forward",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      decisions: [
+        {
+          topic: "Pricing Tier",
+          statement: " use   PRICE b ",
+          parentEntityId: project.id,
+          decidedAt: "2026-06-22T11:00:00.000Z",
+          evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id] },
+        },
+      ],
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    rows = await decisionRows(db, project.id, "pricing tier");
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((row) => row.valid_to === null)).toHaveLength(1);
+  }, 30000);
+
+  it("places out-of-order decisions into the same-day temporal interval", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedProject(db, { id: "decision-project-order", name: "Decision Project Order" });
+    await seedFile(db, "decision-file-order", "2026-06-22T10:00:00.000Z");
+
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-order",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Launch Date",
+      statement: "Launch at noon",
+      parentEntityId: project.id,
+      decidedAt: "2026-06-22T12:00:00.000Z",
+      evidence: { fileIds: ["decision-file-order"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-order",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Launch Date",
+      statement: "Launch in the morning",
+      parentEntityId: project.id,
+      decidedAt: "2026-06-22T10:00:00.000Z",
+      evidence: { fileIds: ["decision-file-order"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const asOf = await createSubEntityRepository(db).getSubEntitiesAsOf({
+      parentEntityId: project.id,
+      kind: "decision",
+      at: "2026-06-22T10:30:00.000Z",
+    });
+    const current = await createSubEntityRepository(db).listCurrentByKind({
+      parentEntityId: project.id,
+      kind: "decision",
+    });
+    const rows = await decisionRows(db, project.id, "launch date");
+
+    expect(asOf.map((row) => row.display_name)).toEqual(["Launch in the morning"]);
+    expect(current.map((row) => row.display_name)).toEqual(["Launch at noon"]);
+    expect(rows.find((row) => row.display_name === "Launch in the morning")).toMatchObject({
+      status: "superseded",
+      valid_from: "2026-06-22T10:00:00.000Z",
+      valid_to: "2026-06-22T12:00:00.000Z",
+    });
+    expect(rows.find((row) => row.display_name === "Launch at noon")).toMatchObject({
+      status: "active",
+      valid_from: "2026-06-22T12:00:00.000Z",
+      valid_to: null,
+    });
+  }, 30000);
+
+  it("deduplicates decisions within a parent while keeping parent scopes separate", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const projectA = await seedProject(db, { id: "decision-project-a", name: "Decision Project A" });
+    const projectB = await seedProject(db, { id: "decision-project-b", name: "Decision Project B" });
+    await seedFile(db, "decision-file-a1", "2026-06-22T09:00:00.000Z");
+    await seedFile(db, "decision-file-a2", "2026-06-22T09:05:00.000Z");
+    await seedFile(db, "decision-file-b1", "2026-06-22T09:10:00.000Z");
+
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-a1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Support Model",
+      statement: "Use staffed support",
+      parentEntityId: projectA.id,
+      decidedAt: "2026-06-22T09:00:00.000Z",
+      evidence: { fileIds: ["decision-file-a1"], entityIds: [projectA.id] },
+    });
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-a2",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: " support   model ",
+      statement: "use STAFFED support",
+      parentEntityId: projectA.id,
+      decidedAt: "2026-06-22T09:05:00.000Z",
+      evidence: { fileIds: ["decision-file-a2"], entityIds: [projectA.id] },
+    });
+    await upsertDecisionFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "decision-file-b1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      topic: "Support Model",
+      statement: "Use staffed support",
+      parentEntityId: projectB.id,
+      decidedAt: "2026-06-22T09:10:00.000Z",
+      evidence: { fileIds: ["decision-file-b1"], entityIds: [projectB.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const projectARows = await decisionRows(db, projectA.id, "support model");
+    const projectBRows = await decisionRows(db, projectB.id, "support model");
+    expect(projectARows).toHaveLength(1);
+    expect(projectBRows).toHaveLength(1);
+    expect(projectARows[0].parent_scope_key).toBe(projectA.id);
+    expect(projectBRows[0].parent_scope_key).toBe(projectB.id);
+    expect(projectARows[0].valid_to).toBeNull();
+    expect(projectBRows[0].valid_to).toBeNull();
+  }, 30000);
+});
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: USER_ID, name: "Decision PG User", email: "decision-pg-user@example.com" })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) {
+  const repo = createEntityRepository(db);
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await repo.upsertSourceRef({ entityId: input.id, source: "linear", sourceId: `${input.id}-source` });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
+}
+
+async function seedFile(db: Kysely<DB>, id: string, sourceTime: string): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      provider_url: null,
+      file_name: id,
+      file_type: "issue",
+      content_category: "structured",
+      content: "Decision file",
+      source: "linear",
+      source_path: null,
+      content_hash: `${id}-hash`,
+      source_created_at: sourceTime,
+      source_updated_at: sourceTime,
+      synced_at: sourceTime,
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function decisionRows(db: Kysely<DB>, parentEntityId: string, normalizedName: string) {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "decision")
+    .where("parent_entity_id", "=", parentEntityId)
+    .where("normalized_name", "=", normalizedName)
+    .orderBy("valid_from", "asc")
+    .execute();
+}
+
+async function countDecisionRows(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("sub_entities")
+    .select((eb) => eb.fn.countAll<number>().as("count"))
+    .where("kind", "=", "decision")
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}

--- a/packages/server/src/db/repositories/decisions.ts
+++ b/packages/server/src/db/repositories/decisions.ts
@@ -1,0 +1,268 @@
+import { createHash } from "node:crypto";
+import type { Kysely } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+import type { DecisionSeed } from "../../connectors/types";
+import type { DB, IndexedFileFactsTable } from "../schema";
+import { buildIndexedFileFactKey, createIndexedFileFactRepository } from "./indexed-file-facts";
+import { type SubEntityRow, createSubEntityRepository } from "./sub-entities";
+
+const DECISION_ID_SEPARATOR = "\u001f";
+
+export interface DecisionFactRaw extends DecisionSeed {
+  decisionId: string;
+}
+
+export interface UpsertDecisionFactInput {
+  experimentalFlag?: boolean;
+  indexedFileId: string;
+  connectorConfigId: string;
+  createdByUserId?: string | null;
+  lastSeenSyncRunId?: string | null;
+  contentHash?: string | null;
+  source: string;
+  decisionId?: string;
+  topic: string;
+  statement: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  decidedBy?: string;
+  decidedAt?: string;
+  rationale?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  promptVersion?: string;
+  contextSnippet?: string | null;
+}
+
+export interface UpsertDecisionFactsForFileInput {
+  experimentalFlag?: boolean;
+  indexedFileId: string;
+  connectorConfigId: string;
+  createdByUserId?: string | null;
+  lastSeenSyncRunId?: string | null;
+  contentHash?: string | null;
+  source: string;
+  decisions: DecisionSeed[];
+  contextSnippet?: string | null;
+}
+
+export interface CurrentDecision {
+  factId: string;
+  decisionId: string;
+  parentEntityId: string;
+  topic: string;
+  statement: string;
+  decidedBy: string | null;
+  decidedAt: string | null;
+  rationale: string | null;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  raw: DecisionFactRaw;
+  row: SubEntityRow;
+}
+
+export async function upsertDecisionFact(
+  db: Kysely<DB>,
+  input: UpsertDecisionFactInput,
+): Promise<{ emitted: boolean; factKey?: string; decisionId?: string }> {
+  const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
+  const source = requireNonEmpty(input.source, "source");
+  const decisionId = requireNonEmpty(
+    input.decisionId ?? buildDecisionId(input.indexedFileId, input.topic, input.statement),
+    "decisionId",
+  );
+  if (!input.experimentalFlag) return { emitted: false };
+
+  const raw: DecisionFactRaw = {
+    decisionId,
+    topic: input.topic,
+    statement: input.statement,
+    parentRef: input.parentRef,
+    parentEntityId: input.parentEntityId,
+    decidedBy: input.decidedBy,
+    decidedAt: input.decidedAt,
+    rationale: input.rationale,
+    evidence: input.evidence,
+    promptVersion: input.promptVersion,
+  };
+  const factInput = {
+    indexedFileId: input.indexedFileId,
+    connectorConfigId,
+    createdByUserId: input.createdByUserId ?? null,
+    lastSeenSyncRunId: input.lastSeenSyncRunId ?? null,
+    contentHash: input.contentHash ?? null,
+    source,
+    factType: "decision" as const,
+    relation: "mentioned" as const,
+    subjectName: input.statement,
+    subjectSource: source,
+    subjectSourceId: decisionId,
+    contextSnippet: input.contextSnippet ?? null,
+    raw,
+  };
+  await createIndexedFileFactRepository(db).upsertFact(factInput);
+  return { emitted: true, factKey: buildIndexedFileFactKey(factInput), decisionId };
+}
+
+export async function upsertDecisionFactsForFile(
+  db: Kysely<DB>,
+  input: UpsertDecisionFactsForFileInput,
+): Promise<{ emitted: boolean; factKeys: Set<string> }> {
+  requireNonEmpty(input.connectorConfigId, "connectorConfigId");
+  requireNonEmpty(input.source, "source");
+  const emittedKeys = new Set<string>();
+  if (!input.experimentalFlag) return { emitted: false, factKeys: emittedKeys };
+
+  for (const decision of input.decisions) {
+    const result = await upsertDecisionFact(db, {
+      experimentalFlag: input.experimentalFlag,
+      indexedFileId: input.indexedFileId,
+      connectorConfigId: input.connectorConfigId,
+      createdByUserId: input.createdByUserId,
+      lastSeenSyncRunId: input.lastSeenSyncRunId,
+      contentHash: input.contentHash,
+      source: input.source,
+      decisionId: decision.decisionId,
+      topic: decision.topic,
+      statement: decision.statement,
+      parentRef: decision.parentRef,
+      parentEntityId: decision.parentEntityId,
+      decidedBy: decision.decidedBy,
+      decidedAt: decision.decidedAt,
+      rationale: decision.rationale,
+      evidence: decision.evidence,
+      promptVersion: decision.promptVersion,
+      contextSnippet: input.contextSnippet,
+    });
+    if (result.factKey) emittedKeys.add(result.factKey);
+  }
+  await createIndexedFileFactRepository(db).reconcileStaleFacts(
+    { kind: "file", indexedFileId: input.indexedFileId, source: input.source, factType: "decision" },
+    emittedKeys,
+  );
+  return { emitted: true, factKeys: emittedKeys };
+}
+
+export function buildDecisionId(indexedFileId: string, topic: string, statement: string): string {
+  return createHash("sha256")
+    .update([indexedFileId, normalizeName(topic), normalizeName(statement)].join(DECISION_ID_SEPARATOR))
+    .digest("hex");
+}
+
+export async function listCurrentDecisions(
+  db: Kysely<DB>,
+  opts: { experimentalFlag?: boolean; parentEntityId: string },
+): Promise<CurrentDecision[]> {
+  if (!opts.experimentalFlag) return [];
+  const rows = await createSubEntityRepository(db).listCurrentByKind({
+    parentEntityId: opts.parentEntityId,
+    kind: "decision",
+  });
+  return hydrateDecisionRows(db, rows);
+}
+
+export async function getDecisionsAsOf(
+  db: Kysely<DB>,
+  opts: { experimentalFlag?: boolean; parentEntityId: string; at: string },
+): Promise<CurrentDecision[]> {
+  if (!opts.experimentalFlag) return [];
+  const rows = await createSubEntityRepository(db).getSubEntitiesAsOf({
+    parentEntityId: opts.parentEntityId,
+    kind: "decision",
+    at: opts.at,
+  });
+  return hydrateDecisionRows(db, rows);
+}
+
+async function hydrateDecisionRows(db: Kysely<DB>, rows: SubEntityRow[]): Promise<CurrentDecision[]> {
+  const out: CurrentDecision[] = [];
+  for (const row of rows) {
+    const fact = row.source_fact_id ? await findDecisionFact(db, row.source_fact_id) : undefined;
+    const raw = readDecisionRaw(fact?.raw ?? null);
+    if (!fact || !raw || !row.parent_entity_id) continue;
+    out.push({
+      factId: fact.id,
+      decisionId: raw.decisionId,
+      parentEntityId: row.parent_entity_id,
+      topic: raw.topic,
+      statement: row.display_name,
+      decidedBy: raw.decidedBy ?? null,
+      decidedAt: raw.decidedAt ?? null,
+      rationale: raw.rationale ?? null,
+      evidence: raw.evidence,
+      raw,
+      row,
+    });
+  }
+  return out;
+}
+
+async function findDecisionFact(
+  db: Kysely<DB>,
+  factId: string,
+): Promise<Pick<IndexedFileFactsTable, "id" | "raw"> | undefined> {
+  return db
+    .selectFrom("indexed_file_facts")
+    .select(["id", "raw"])
+    .where("id", "=", factId)
+    .where("fact_type", "=", "decision")
+    .executeTakeFirst();
+}
+
+function readDecisionRaw(raw: string | null): DecisionFactRaw | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  if (
+    typeof record.decisionId !== "string" ||
+    typeof record.topic !== "string" ||
+    typeof record.statement !== "string" ||
+    !isEvidence(record.evidence)
+  ) {
+    return null;
+  }
+  return {
+    decisionId: record.decisionId,
+    topic: record.topic,
+    statement: record.statement,
+    parentRef: readParentRef(record.parentRef),
+    parentEntityId: readOptionalString(record.parentEntityId),
+    decidedBy: readOptionalString(record.decidedBy),
+    decidedAt: readOptionalString(record.decidedAt),
+    rationale: readOptionalString(record.rationale),
+    evidence: { fileIds: record.evidence.fileIds, entityIds: record.evidence.entityIds },
+    promptVersion: readOptionalString(record.promptVersion),
+  };
+}
+
+function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.fileIds) &&
+    record.fileIds.every((id) => typeof id === "string") &&
+    Array.isArray(record.entityIds) &&
+    record.entityIds.every((id) => typeof id === "string")
+  );
+}
+
+function readParentRef(value: unknown): { source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || typeof record.sourceId !== "string") return undefined;
+  return { source: record.source, sourceId: record.sourceId };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function requireNonEmpty(value: string | null | undefined, name: string): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) throw new Error(`decision ${name} is required`);
+  return trimmed;
+}

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -13,6 +13,7 @@ export type IndexedFileFactType =
   | "structural_seed"
   | "structural_task"
   | "commitment"
+  | "decision"
   | "llm_task"
   | "person_seed"
   | "llm_extracted"
@@ -144,6 +145,13 @@ export function buildIndexedFileFactKey(input: UpsertIndexedFileFactInput): stri
       .update([input.connectorConfigId ?? "", input.factType, input.source, commitmentId].join("|"))
       .digest("hex");
   }
+  if (input.factType === "decision") {
+    const raw = input.raw as Record<string, unknown> | undefined;
+    const decisionId = typeof raw?.decisionId === "string" ? raw.decisionId.trim().toLowerCase() : "";
+    return createHash("sha256")
+      .update([input.connectorConfigId ?? "", input.factType, input.source, decisionId].join("|"))
+      .digest("hex");
+  }
   if (input.factType === "llm_task") {
     const raw = input.raw as Record<string, unknown> | undefined;
     const candidateId = typeof raw?.candidateId === "string" ? raw.candidateId.trim().toLowerCase() : "";
@@ -209,6 +217,9 @@ function hasString(value: Record<string, unknown>, key: string): boolean {
 }
 
 function validateRaw(input: UpsertIndexedFileFactInput): string | null {
+  if (!input.raw && input.factType === "decision") {
+    throw new Error("decision facts require raw decision data");
+  }
   if (!input.raw) return null;
   if (!isRecord(input.raw)) {
     throw new Error("indexed_file_facts.raw must be an object");
@@ -289,6 +300,39 @@ function validateRaw(input: UpsertIndexedFileFactInput): string | null {
     const parentRef = raw.parentRef as Record<string, unknown> | undefined;
     if (parentRef && (!hasString(parentRef, "source") || !hasString(parentRef, "sourceId"))) {
       throw new Error("commitment parentRef requires source and sourceId");
+    }
+  } else if (input.factType === "decision") {
+    if (
+      !input.connectorConfigId?.trim() ||
+      !input.source.trim() ||
+      !hasString(raw, "decisionId") ||
+      !hasString(raw, "topic") ||
+      !hasString(raw, "statement") ||
+      !isRecord(raw.evidence)
+    ) {
+      throw new Error("decision facts require connectorConfigId, source, decisionId, topic, statement, and evidence");
+    }
+    const evidence = raw.evidence as Record<string, unknown>;
+    if (!Array.isArray(evidence.fileIds) || !Array.isArray(evidence.entityIds)) {
+      throw new Error("decision evidence requires fileIds and entityIds arrays");
+    }
+    if (
+      !evidence.fileIds.every((id) => typeof id === "string") ||
+      !evidence.entityIds.every((id) => typeof id === "string")
+    ) {
+      throw new Error("decision evidence ids must be strings");
+    }
+    if (raw.parentRef !== undefined && !isRecord(raw.parentRef)) {
+      throw new Error("decision parentRef must be an object");
+    }
+    const parentRef = raw.parentRef as Record<string, unknown> | undefined;
+    if (parentRef && (!hasString(parentRef, "source") || !hasString(parentRef, "sourceId"))) {
+      throw new Error("decision parentRef requires source and sourceId");
+    }
+    for (const key of ["parentEntityId", "decidedBy", "decidedAt", "rationale", "promptVersion"]) {
+      if (raw[key] !== undefined && typeof raw[key] !== "string") {
+        throw new Error(`decision ${key} must be a string`);
+      }
     }
   } else if (input.factType === "llm_task") {
     if (

--- a/packages/server/src/db/repositories/sub-entities.ts
+++ b/packages/server/src/db/repositories/sub-entities.ts
@@ -9,6 +9,7 @@ export type SubEntityStatusAuthority = "external" | "local";
 export interface UpsertSubEntityInput {
   parentEntityId?: string | null;
   kind: string;
+  dedupName?: string | null;
   displayName: string;
   status: SubEntityStatus;
   provenance: string;
@@ -23,10 +24,33 @@ export interface ListOpenSubEntitiesOptions {
   kind: string;
 }
 
+export interface SupersedeSubEntityInput {
+  parentEntityId: string;
+  kind: string;
+  dedupName: string;
+  displayName: string;
+  provenance: string;
+  metadata?: Record<string, unknown> | null;
+  sourceFactId?: string | null;
+  effectiveAt: string;
+}
+
+export interface ListCurrentByKindOptions {
+  parentEntityId: string;
+  kind: string;
+}
+
+export interface GetSubEntitiesAsOfOptions {
+  parentEntityId: string;
+  kind: string;
+  at: string;
+}
+
 export type SubEntityRow = Selectable<SubEntitiesTable>;
 
-const GLOBAL_PARENT_SCOPE_KEY = "global";
+export const GLOBAL_PARENT_SCOPE_KEY = "global";
 const TERMINAL_STATUSES = ["done", "dropped"];
+const MAX_SUPERSESSION_ATTEMPTS = 3;
 
 export function createSubEntityRepository(db: Kysely<DB>) {
   return {
@@ -47,6 +71,45 @@ export function createSubEntityRepository(db: Kysely<DB>) {
         .where("valid_to", "is", null)
         .executeTakeFirst();
       return Number(result.numUpdatedRows ?? 0) > 0;
+    },
+
+    async supersedeSubEntity(
+      input: SupersedeSubEntityInput,
+    ): Promise<{ subEntityId: string; created: boolean; superseded: boolean }> {
+      let lastError: unknown;
+      for (let attempt = 0; attempt < MAX_SUPERSESSION_ATTEMPTS; attempt++) {
+        try {
+          return await supersedeInTransaction(db, input);
+        } catch (err) {
+          if (!isUniqueConstraintError(err) && !(err instanceof SupersessionRetryError)) throw err;
+          lastError = err;
+        }
+      }
+      throw lastError;
+    },
+
+    async listCurrentByKind(opts: ListCurrentByKindOptions): Promise<SubEntityRow[]> {
+      return db
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("parent_entity_id", "=", opts.parentEntityId)
+        .where("kind", "=", opts.kind)
+        .where("valid_to", "is", null)
+        .orderBy("updated_at", "desc")
+        .execute();
+    },
+
+    async getSubEntitiesAsOf(opts: GetSubEntitiesAsOfOptions): Promise<SubEntityRow[]> {
+      const at = new Date(opts.at).toISOString();
+      return db
+        .selectFrom("sub_entities")
+        .selectAll()
+        .where("parent_entity_id", "=", opts.parentEntityId)
+        .where("kind", "=", opts.kind)
+        .where("valid_from", "<=", at)
+        .where((eb) => eb.or([eb("valid_to", "is", null), eb("valid_to", ">", at)]))
+        .orderBy("valid_from", "desc")
+        .execute();
     },
 
     async listOpenSubEntities(opts: ListOpenSubEntitiesOptions): Promise<SubEntityRow[]> {
@@ -82,7 +145,7 @@ async function upsertInTransaction(
 ): Promise<{ subEntityId: string; created: boolean }> {
   return db.transaction().execute(async (trx) => {
     const parentScopeKey = input.parentEntityId ?? GLOBAL_PARENT_SCOPE_KEY;
-    const normalized = normalizeName(input.displayName);
+    const normalized = normalizeName(input.dedupName ?? input.displayName);
     const existing = await selectCurrent(trx, parentScopeKey, input.kind, normalized);
     const now = new Date().toISOString();
     if (!existing) {
@@ -113,6 +176,96 @@ async function upsertInTransaction(
     await updateExisting(trx, existing, input, now);
     return { subEntityId: existing.id, created: false };
   });
+}
+
+async function supersedeInTransaction(
+  db: Kysely<DB>,
+  input: SupersedeSubEntityInput,
+): Promise<{ subEntityId: string; created: boolean; superseded: boolean }> {
+  return db.transaction().execute(async (trx) => {
+    const parentScopeKey = input.parentEntityId;
+    const normalized = normalizeName(input.dedupName);
+    const displayNormalized = normalizeName(input.displayName);
+    const effectiveAt = new Date(input.effectiveAt).toISOString();
+    const now = new Date().toISOString();
+    const rows = await trx
+      .selectFrom("sub_entities")
+      .selectAll()
+      .where("parent_scope_key", "=", parentScopeKey)
+      .where("kind", "=", input.kind)
+      .where("normalized_name", "=", normalized)
+      .orderBy("valid_from", "asc")
+      .execute();
+    const existingAtTime = rows.find(
+      (row) => row.valid_from === effectiveAt && normalizeName(row.display_name) === displayNormalized,
+    );
+    if (existingAtTime) {
+      await refreshSupersededRow(trx, existingAtTime.id, input, now);
+      return { subEntityId: existingAtTime.id, created: false, superseded: false };
+    }
+
+    const predecessor = [...rows].reverse().find((row) => row.valid_from <= effectiveAt);
+    const successor = rows.find((row) => row.valid_from > effectiveAt);
+    if (predecessor && normalizeName(predecessor.display_name) === displayNormalized) {
+      return { subEntityId: predecessor.id, created: false, superseded: false };
+    }
+
+    if (predecessor && (predecessor.valid_to === null || predecessor.valid_to > effectiveAt)) {
+      const update = trx
+        .updateTable("sub_entities")
+        .set({ valid_to: effectiveAt, status: "superseded", updated_at: now })
+        .where("id", "=", predecessor.id);
+      const result =
+        predecessor.valid_to === null
+          ? await update.where("valid_to", "is", null).executeTakeFirst()
+          : await update.where("valid_to", "=", predecessor.valid_to).executeTakeFirst();
+      if (Number(result.numUpdatedRows ?? 0) !== 1) throw new SupersessionRetryError();
+    }
+
+    const id = randomUUID();
+    const validTo = successor?.valid_from ?? null;
+    await trx
+      .insertInto("sub_entities")
+      .values({
+        id,
+        parent_entity_id: input.parentEntityId,
+        parent_scope_key: parentScopeKey,
+        kind: input.kind,
+        normalized_name: normalized,
+        display_name: input.displayName,
+        status: validTo === null ? "active" : "superseded",
+        status_authority: "external",
+        valid_from: effectiveAt,
+        valid_to: validTo,
+        provenance: input.provenance,
+        due_at: null,
+        created_by_user_id: null,
+        source_fact_id: input.sourceFactId ?? null,
+        metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
+        updated_at: now,
+      })
+      .execute();
+    return { subEntityId: id, created: true, superseded: Boolean(predecessor) };
+  });
+}
+
+async function refreshSupersededRow(
+  db: Kysely<DB>,
+  subEntityId: string,
+  input: SupersedeSubEntityInput,
+  now: string,
+): Promise<void> {
+  await db
+    .updateTable("sub_entities")
+    .set({
+      display_name: input.displayName,
+      provenance: input.provenance,
+      source_fact_id: input.sourceFactId ?? null,
+      metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
+      updated_at: now,
+    })
+    .where("id", "=", subEntityId)
+    .execute();
 }
 
 async function selectCurrent(
@@ -151,10 +304,12 @@ async function updateExisting(
     .execute();
 }
 
-function isUniqueConstraintError(error: unknown): boolean {
+export function isUniqueConstraintError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const code = "code" in error ? String(error.code) : "";
   if (code === "23505" || code === "SQLITE_CONSTRAINT_UNIQUE") return true;
   const message = error instanceof Error ? error.message.toLowerCase() : "";
   return message.includes("unique constraint") || message.includes("duplicate key");
 }
+
+class SupersessionRetryError extends Error {}

--- a/packages/server/src/entities/materialize-commitment.ts
+++ b/packages/server/src/entities/materialize-commitment.ts
@@ -34,16 +34,22 @@ export async function materializeCommitment(
   return { kind: "commitment_materialized" };
 }
 
-function resolveParent(deps: MaterializeDeps, commitment: CommitmentInput): EntityRow | null {
-  if (commitment.parentRef) {
-    const byRef = deps.index.bySourceRef.get(`${commitment.parentRef.source}:${commitment.parentRef.sourceId}`);
+export interface SubEntityParentInput {
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  evidence: { entityIds: string[] };
+}
+
+export function resolveParent(deps: MaterializeDeps, input: SubEntityParentInput): EntityRow | null {
+  if (input.parentRef) {
+    const byRef = deps.index.bySourceRef.get(`${input.parentRef.source}:${input.parentRef.sourceId}`);
     if (isAllowedParent(byRef)) return byRef;
   }
-  if (commitment.parentEntityId) {
-    const byId = findEntityById(deps, commitment.parentEntityId);
+  if (input.parentEntityId) {
+    const byId = findEntityById(deps, input.parentEntityId);
     if (isAllowedParent(byId)) return byId;
   }
-  for (const entityId of commitment.evidence.entityIds) {
+  for (const entityId of input.evidence.entityIds) {
     const byId = findEntityById(deps, entityId);
     if (isAllowedParent(byId)) return byId;
   }
@@ -66,10 +72,8 @@ function isAllowedParent(entity: EntityRow | undefined): entity is EntityRow {
   );
 }
 
-interface CommitmentInput {
+interface CommitmentInput extends SubEntityParentInput {
   commitmentId: string;
-  parentRef?: { source: string; sourceId: string };
-  parentEntityId?: string;
   title: string;
   status: "open" | "done" | "dropped";
   dueAt?: string;

--- a/packages/server/src/entities/materialize-decision.ts
+++ b/packages/server/src/entities/materialize-decision.ts
@@ -1,0 +1,108 @@
+import { createSubEntityRepository } from "../db/repositories/sub-entities";
+import { resolveParent } from "./materialize-commitment";
+import { readJsonObject } from "./materialize-json";
+import type { IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+
+export async function materializeDecision(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
+  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
+  const raw = readJsonObject(fact.raw);
+  const decision = readDecision(raw);
+  if (!decision) return { kind: "skipped", reason: "invalid_decision" };
+
+  const parent = resolveParent(deps, decision);
+  if (!parent) return { kind: "skipped", reason: "missing_decision_parent" };
+  const effectiveAt = await resolveEffectiveAt(deps, fact, decision);
+  if (!effectiveAt) return { kind: "skipped", reason: "missing_decision_effective_time" };
+
+  const repo = createSubEntityRepository(deps.db);
+  const result = await repo.supersedeSubEntity({
+    parentEntityId: parent.id,
+    kind: "decision",
+    dedupName: decision.topic,
+    displayName: decision.statement,
+    provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
+    metadata: {
+      decidedBy: decision.decidedBy,
+      decidedAt: decision.decidedAt,
+      rationale: decision.rationale,
+    },
+    sourceFactId: fact.id,
+    effectiveAt,
+  });
+  await repo.upsertSubEntityEvidence(result.subEntityId, "fact", fact.id);
+  for (const fileId of decision.evidence.fileIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "file", fileId);
+  }
+  for (const entityId of decision.evidence.entityIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "entity", entityId);
+  }
+  return { kind: "decision_materialized" };
+}
+
+async function resolveEffectiveAt(
+  deps: MaterializeDeps,
+  fact: IndexedFileFactRow,
+  decision: DecisionInput,
+): Promise<string | null> {
+  const sourceTimes = fact.indexed_file_id ? await deps.getIndexedFileSourceTime(fact.indexed_file_id) : null;
+  const value =
+    decision.decidedAt ?? sourceTimes?.source_updated_at ?? sourceTimes?.source_created_at ?? sourceTimes?.synced_at;
+  if (!value) return null;
+  return new Date(value).toISOString();
+}
+
+interface DecisionInput {
+  decisionId: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  topic: string;
+  statement: string;
+  decidedBy?: string;
+  decidedAt?: string;
+  rationale?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+}
+
+function readDecision(raw: Record<string, unknown>): DecisionInput | null {
+  if (
+    typeof raw.decisionId !== "string" ||
+    typeof raw.topic !== "string" ||
+    typeof raw.statement !== "string" ||
+    !isEvidence(raw.evidence)
+  ) {
+    return null;
+  }
+  return {
+    decisionId: raw.decisionId,
+    parentRef: readParentRef(raw.parentRef),
+    parentEntityId: readOptionalString(raw.parentEntityId),
+    topic: raw.topic,
+    statement: raw.statement,
+    decidedBy: readOptionalString(raw.decidedBy),
+    decidedAt: readOptionalString(raw.decidedAt),
+    rationale: readOptionalString(raw.rationale),
+    evidence: { fileIds: raw.evidence.fileIds, entityIds: raw.evidence.entityIds },
+  };
+}
+
+function readParentRef(value: unknown): { source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || typeof record.sourceId !== "string") return undefined;
+  return { source: record.source, sourceId: record.sourceId };
+}
+
+function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.fileIds) &&
+    record.fileIds.every((id) => typeof id === "string") &&
+    Array.isArray(record.entityIds) &&
+    record.entityIds.every((id) => typeof id === "string")
+  );
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -369,6 +369,13 @@ export async function buildMaterializeDeps(
     experimentalFlag,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),
     onEntityResolved: (entity: Entity) => refreshResolvedEntityIndex(db, index, entity),
+    getIndexedFileSourceTime: (indexedFileId: string) =>
+      db
+        .selectFrom("indexed_files")
+        .select(["source_created_at", "source_updated_at", "synced_at"])
+        .where("id", "=", indexedFileId)
+        .executeTakeFirst()
+        .then((row) => row ?? null),
     resolveOwner: (fact: IndexedFileFactRow) => {
       if (fact.created_by_user_id) return fact.created_by_user_id;
       const indexedFileId = fact.indexed_file_id;

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -5,6 +5,7 @@ import type { DB } from "../db/schema";
 import { yieldToEventLoop } from "../lib/event-loop";
 import { materializeCommitment } from "./materialize-commitment";
 import { materializeContactPointFact } from "./materialize-contact-points";
+import { materializeDecision } from "./materialize-decision";
 import { buildMaterializeDeps } from "./materialize-deps";
 import { readJsonObject } from "./materialize-json";
 import { materializeLlmExtractedFact } from "./materialize-llm-mentions";
@@ -38,6 +39,7 @@ const FACT_REPLAY_ORDER = [
   "llm_relation",
   "structural_task",
   "commitment",
+  "decision",
   "llm_task",
 ] as const;
 
@@ -81,6 +83,9 @@ export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFi
   if (fact.fact_type === "commitment") {
     return materializeCommitment(deps, fact);
   }
+  if (fact.fact_type === "decision") {
+    return materializeDecision(deps, fact);
+  }
   if (fact.fact_type === "llm_task") {
     return materializeLlmTask(deps, fact);
   }
@@ -118,6 +123,10 @@ function accumulate(summary: ReplayFactsSummary, result: MaterializeResult): voi
     return;
   }
   if (result.kind === "commitment_materialized") {
+    if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
+    return;
+  }
+  if (result.kind === "decision_materialized") {
     if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
     return;
   }
@@ -256,7 +265,12 @@ async function materializeUnmaterializedFactsInner(
           .set({ materialized_at: new Date().toISOString() })
           .where("id", "=", fact.id)
           .execute();
-        if (result.kind !== "task_materialized" && result.kind !== "commitment_materialized") summary.materialized++;
+        if (
+          result.kind !== "task_materialized" &&
+          result.kind !== "commitment_materialized" &&
+          result.kind !== "decision_materialized"
+        )
+          summary.materialized++;
       } else {
         summary.deferred++;
       }
@@ -282,6 +296,7 @@ export function shouldMarkMaterialized(result: MaterializeResult): boolean {
     result.kind === "relationship_materialized" ||
     result.kind === "task_materialized" ||
     result.kind === "commitment_materialized" ||
+    result.kind === "decision_materialized" ||
     result.kind === "structural"
   ) {
     return true;

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -51,6 +51,11 @@ export interface MaterializeDeps {
   readEmail: (entity: Entity) => string | null;
   onEntityResolved: (entity: Entity) => void | Promise<void>;
   resolveOwner: (fact: IndexedFileFactRow) => string | null;
+  getIndexedFileSourceTime: (indexedFileId: string) => Promise<{
+    source_created_at: string | null;
+    source_updated_at: string | null;
+    synced_at: string;
+  } | null>;
   llmPromotionThreshold: number;
   countActiveLlmFilesForName: (normalizedName: string, mentionType: MentionType) => Promise<number>;
   llmTaskCorroborationThreshold: number;
@@ -73,6 +78,7 @@ export type MaterializeResult =
     }
   | { kind: "task_materialized"; taskId: string; created: boolean }
   | { kind: "commitment_materialized" }
+  | { kind: "decision_materialized" }
   | { kind: "structural"; entity: EntityRow }
   | { kind: "skipped_missing_owner"; reason: string }
   | { kind: "deferred_below_threshold"; reason: string }


### PR DESCRIPTION
Stacked context-graph slice 11/27.

Base: `feat/context-graph-10-commitment-sub-entities`
Head: `feat/context-graph-11-decision-sub-entities`

Adds append-only decision sub-entities.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`