### PR TITLE
feat: add feature and milestone structures

### DIFF
--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -225,6 +225,17 @@ export interface FeatureFactRaw {
   evidence: { fileIds: string[]; entityIds: string[] };
 }
 
+export interface MilestoneFactRaw {
+  milestoneId: string;
+  milestoneName: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  status: "planned" | "hit" | "missed";
+  dueAt: string;
+  observedAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+}
+
 export interface DecisionSeed {
   decisionId?: string;
   topic: string;
@@ -279,6 +290,7 @@ export type IndexedFileFactRaw =
     }
   | CommitmentSeed
   | FeatureFactRaw
+  | MilestoneFactRaw
   | DecisionSeed
   | LlmTaskFactRaw
   | { providerFileId: string; contactPoint: ContactPointSeed }

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -215,6 +215,16 @@ export interface CommitmentSeed {
   evidence: { fileIds: string[]; entityIds: string[] };
 }
 
+export interface FeatureFactRaw {
+  featureId: string;
+  featureName: string;
+  parentProductRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  status: "proposed" | "building" | "shipped" | "deprecated";
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+}
+
 export interface DecisionSeed {
   decisionId?: string;
   topic: string;
@@ -268,6 +278,7 @@ export type IndexedFileFactRaw =
       task: NonNullable<SyncedItem["task"]>;
     }
   | CommitmentSeed
+  | FeatureFactRaw
   | DecisionSeed
   | LlmTaskFactRaw
   | { providerFileId: string; contactPoint: ContactPointSeed }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -124,6 +124,7 @@ import * as m121 from "./migrations/121-tasks";
 import * as m122 from "./migrations/122-tasks-owner";
 import * as m123 from "./migrations/123-sub-entities";
 import * as m124 from "./migrations/124-tasks-assignee-name";
+import * as m125 from "./migrations/125-milestone-series-and-value-signature";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -252,6 +253,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "122-tasks-owner": m122,
           "123-sub-entities": m123,
           "124-tasks-assignee-name": m124,
+          "125-milestone-series-and-value-signature": m125,
         };
       },
     },

--- a/packages/server/src/db/migrations/125-milestone-series-and-value-signature.ts
+++ b/packages/server/src/db/migrations/125-milestone-series-and-value-signature.ts
@@ -1,0 +1,63 @@
+import type { Kysely } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+import { seriesKeyFor } from "../../entities/sub-entity-signatures";
+import { yieldToEventLoop } from "../../lib/event-loop";
+
+interface SubEntityBackfillRow {
+  id: string;
+  parent_scope_key: string;
+  kind: string;
+  normalized_name: string;
+  display_name: string;
+}
+
+interface MigrationDb {
+  sub_entities: {
+    id: string;
+    parent_scope_key: string;
+    kind: string;
+    normalized_name: string;
+    display_name: string;
+    value_signature: string | null;
+    series_key: string | null;
+  };
+  tasks: {
+    id: string;
+    milestone_series_key: string | null;
+  };
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("sub_entities").addColumn("value_signature", "text").execute();
+  await db.schema.alterTable("sub_entities").addColumn("series_key", "text").execute();
+  await db.schema.alterTable("tasks").addColumn("milestone_series_key", "text").execute();
+
+  const typedDb = db as Kysely<MigrationDb>;
+  const rows = await typedDb
+    .selectFrom("sub_entities")
+    .select(["id", "parent_scope_key", "kind", "normalized_name", "display_name"])
+    .execute();
+
+  for (const row of rows as SubEntityBackfillRow[]) {
+    await typedDb
+      .updateTable("sub_entities")
+      .set({
+        value_signature: normalizeName(row.display_name),
+        series_key: seriesKeyFor(row.parent_scope_key, row.kind, row.normalized_name),
+      })
+      .where("id", "=", row.id)
+      .execute();
+    await yieldToEventLoop();
+  }
+
+  await db.schema.createIndex("idx_sub_entities_series_key").on("sub_entities").column("series_key").execute();
+  await db.schema.createIndex("idx_tasks_milestone_series_key").on("tasks").column("milestone_series_key").execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_tasks_milestone_series_key").ifExists().execute();
+  await db.schema.dropIndex("idx_sub_entities_series_key").ifExists().execute();
+  await db.schema.alterTable("tasks").dropColumn("milestone_series_key").execute();
+  await db.schema.alterTable("sub_entities").dropColumn("series_key").execute();
+  await db.schema.alterTable("sub_entities").dropColumn("value_signature").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 120;
+const EXPECTED_MIGRATION_COUNT = 121;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -153,6 +153,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[117]).toBe("122-tasks-owner");
     expect(names[118]).toBe("123-sub-entities");
     expect(names[119]).toBe("124-tasks-assignee-name");
+    expect(names[120]).toBe("125-milestone-series-and-value-signature");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 120;
+const EXPECTED_MIGRATION_COUNT = 121;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -176,6 +176,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[117]).toBe("122-tasks-owner");
     expect(names[118]).toBe("123-sub-entities");
     expect(names[119]).toBe("124-tasks-assignee-name");
+    expect(names[120]).toBe("125-milestone-series-and-value-signature");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/repositories/decisions.integration.test.ts
+++ b/packages/server/src/db/repositories/decisions.integration.test.ts
@@ -85,6 +85,7 @@ describe("decision sub-entity supersession postgres", () => {
       valid_from: "2026-06-22T09:00:00.000Z",
       valid_to: "2026-06-22T11:00:00.000Z",
     });
+    expect(rows.find((row) => row.display_name === "Use price A")?.status).toBe("superseded");
     expect(rows.find((row) => row.display_name === "Use price B")).toMatchObject({
       status: "active",
       valid_from: "2026-06-22T11:00:00.000Z",

--- a/packages/server/src/db/repositories/features.integration.test.ts
+++ b/packages/server/src/db/repositories/features.integration.test.ts
@@ -1,0 +1,329 @@
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+import type { IndexedFileFactRaw } from "../../connectors/types";
+import { buildMaterializeDeps, materializeFromFact, materializeUnmaterializedFacts } from "../../entities/materialize";
+import { resolveParent } from "../../entities/materialize-commitment";
+import { createTestLogger, createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createEntityRepository } from "./entities";
+import { upsertFeatureFact } from "./features";
+import { createIndexedFileFactRepository } from "./indexed-file-facts";
+import { createSubEntityRepository } from "./sub-entities";
+
+const USER_ID = "feature-pg-user";
+const CONNECTOR_ID = "feature-pg-config";
+
+describe("feature sub-entities postgres", () => {
+  let db: Kysely<DB> | undefined;
+
+  afterEach(async () => {
+    await db?.destroy();
+    db = undefined;
+  });
+
+  it("materializes features under an existing product by product ref and product entity id", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const product = await seedEntity(db, { id: "feature-product-ref", name: "Feature Product", type: "product" });
+
+    await upsertFeatureFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "feature-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-1",
+      source: "linear",
+      featureId: "feature-ref",
+      featureName: "Inline comments",
+      parentProductRef: { source: "linear", sourceId: `${product.id}-source` },
+      status: "building",
+      dueAt: "2026-07-01T00:00:00.000Z",
+      evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
+    });
+    await upsertFeatureFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "feature-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-1",
+      source: "linear",
+      featureId: "feature-id",
+      featureName: "Bulk archive",
+      parentEntityId: product.id,
+      status: "building",
+      evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
+    });
+
+    const beforeProducts = await countEntitiesByType(db, "product");
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    await expect(featureRow(db, "inline comments")).resolves.toMatchObject({
+      kind: "feature",
+      parent_entity_id: product.id,
+      parent_scope_key: product.id,
+      normalized_name: "inline comments",
+      status: "building",
+      valid_to: null,
+      due_at: "2026-07-01T00:00:00.000Z",
+    });
+    await expect(featureRow(db, "bulk archive")).resolves.toMatchObject({
+      kind: "feature",
+      parent_entity_id: product.id,
+      parent_scope_key: product.id,
+      normalized_name: "bulk archive",
+      status: "building",
+      valid_to: null,
+    });
+    await expect(countEntitiesByType(db, "product")).resolves.toBe(beforeProducts);
+    await expect(
+      db.selectFrom("entities").selectAll().where("name", "=", "Inline comments").execute(),
+    ).resolves.toEqual([]);
+    await expect(db.selectFrom("entities").selectAll().where("name", "=", "Bulk archive").execute()).resolves.toEqual(
+      [],
+    );
+    await expect(
+      db.selectFrom("entity_mentions").selectAll().where("entity_id", "=", product.id).execute(),
+    ).resolves.toEqual([]);
+  }, 30000);
+
+  it("preserves local feature status across re-sync", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const product = await seedEntity(db, {
+      id: "feature-product-status",
+      name: "Feature Product Status",
+      type: "product",
+    });
+
+    await upsertFeatureFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "feature-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-1",
+      source: "linear",
+      featureId: "feature-status",
+      featureName: "Usage dashboards",
+      parentEntityId: product.id,
+      status: "building",
+      evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const row = await featureRow(db, "usage dashboards");
+    await expect(createSubEntityRepository(db).markSubEntityStatus(row.id, "shipped")).resolves.toBe(true);
+
+    await upsertFeatureFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "feature-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      lastSeenSyncRunId: "sync-2",
+      source: "linear",
+      featureId: "feature-status",
+      featureName: "Usage dashboards",
+      parentEntityId: product.id,
+      status: "deprecated",
+      evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    await expect(featureRow(db, "usage dashboards")).resolves.toMatchObject({
+      status: "shipped",
+      status_authority: "local",
+      valid_to: null,
+    });
+  }, 30000);
+
+  it("skips non-product parents and feature materialization when the flag is off", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedEntity(db, { id: "feature-project-parent", name: "Feature Project", type: "project" });
+    const product = await seedEntity(db, { id: "feature-product-off", name: "Feature Product Off", type: "product" });
+
+    await upsertFeatureFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "feature-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      featureId: "feature-project-only",
+      featureName: "Project-only feature",
+      parentEntityId: project.id,
+      status: "proposed",
+      evidence: { fileIds: ["feature-file-1"], entityIds: [project.id] },
+    });
+    const projectFact = await db
+      .selectFrom("indexed_file_facts")
+      .selectAll()
+      .where("subject_source_id", "=", "feature-project-only")
+      .executeTakeFirstOrThrow();
+    await expect(
+      materializeFromFact(await buildMaterializeDeps(db, { experimentalFlag: true }), projectFact),
+    ).resolves.toEqual({ kind: "skipped", reason: "missing_feature_parent" });
+    await expect(countFeatureRows(db)).resolves.toBe(0);
+
+    await expect(
+      upsertFeatureFact(db, {
+        experimentalFlag: false,
+        indexedFileId: "feature-file-1",
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        source: "linear",
+        featureId: "feature-emit-off",
+        featureName: "Flag-off feature",
+        parentEntityId: product.id,
+        status: "building",
+        evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
+      }),
+    ).resolves.toEqual({ emitted: false });
+
+    await upsertFeatureFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "feature-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      featureId: "feature-materialize-off",
+      featureName: "Materialize-off feature",
+      parentEntityId: product.id,
+      status: "building",
+      evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
+    });
+    const flagOffFact = await db
+      .selectFrom("indexed_file_facts")
+      .selectAll()
+      .where("subject_source_id", "=", "feature-materialize-off")
+      .executeTakeFirstOrThrow();
+    await expect(
+      materializeFromFact(await buildMaterializeDeps(db, { experimentalFlag: false }), flagOffFact),
+    ).resolves.toEqual({ kind: "skipped", reason: "experimental_off" });
+    await expect(countFeatureRows(db)).resolves.toBe(0);
+  }, 30000);
+
+  it("keeps the shared parent resolver scoped by explicit allowed types", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedEntity(db, { id: "resolver-project", name: "Resolver Project", type: "project" });
+    const person = await seedEntity(db, { id: "resolver-person", name: "Resolver Person", type: "person" });
+    const product = await seedEntity(db, { id: "resolver-product", name: "Resolver Product", type: "product" });
+    const team = await seedEntity(db, { id: "resolver-team", name: "Resolver Team", type: "team" });
+    const deps = await buildMaterializeDeps(db, { experimentalFlag: true });
+
+    expect(resolveParent(deps, resolverInput(project.id), ["project", "person"])?.id).toBe(project.id);
+    expect(resolveParent(deps, resolverInput(person.id), ["project", "person"])?.id).toBe(person.id);
+    expect(resolveParent(deps, resolverInput(product.id), ["project", "person"])).toBeNull();
+    expect(resolveParent(deps, resolverInput(team.id), ["project", "person"])).toBeNull();
+    expect(resolveParent(deps, resolverInput(product.id), ["product"])?.id).toBe(product.id);
+    expect(resolveParent(deps, resolverInput(project.id), ["product"])).toBeNull();
+  }, 30000);
+
+  it("rejects feature facts with invalid statuses", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    await expect(
+      createIndexedFileFactRepository(db).upsertFact({
+        indexedFileId: "feature-file-1",
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        source: "linear",
+        factType: "feature",
+        relation: "mentioned",
+        subjectName: "Invalid feature",
+        subjectSource: "linear",
+        subjectSourceId: "invalid-feature",
+        raw: {
+          featureId: "invalid-feature",
+          featureName: "Invalid feature",
+          status: "paused",
+          evidence: { fileIds: [], entityIds: [] },
+        } as unknown as IndexedFileFactRaw,
+      }),
+    ).rejects.toThrow("feature status must be proposed, building, shipped, or deprecated");
+  }, 30000);
+});
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: USER_ID, name: "Feature PG User", email: "feature-pg-user@example.com" })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: "feature-file-1",
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: "feature-file-1",
+      provider_url: null,
+      file_name: "Feature file",
+      file_type: "issue",
+      content_category: "structured",
+      content: "Feature file",
+      source: "linear",
+      source_path: null,
+      content_hash: "feature-file-1-hash",
+      source_created_at: new Date().toISOString(),
+      source_updated_at: new Date().toISOString(),
+      synced_at: new Date().toISOString(),
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function seedEntity(db: Kysely<DB>, input: { id: string; name: string; type: string }) {
+  const repo = createEntityRepository(db);
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: input.type,
+      subtype: input.type === "person" ? "external" : null,
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await repo.upsertSourceRef({ entityId: input.id, source: "linear", sourceId: `${input.id}-source` });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
+}
+
+function resolverInput(entityId: string) {
+  return { parentEntityId: entityId, evidence: { entityIds: [entityId] } };
+}
+
+async function featureRow(db: Kysely<DB>, normalizedName: string) {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "feature")
+    .where("normalized_name", "=", normalizedName)
+    .where("valid_to", "is", null)
+    .executeTakeFirstOrThrow();
+}
+
+async function countFeatureRows(db: Kysely<DB>): Promise<number> {
+  const rows = await db.selectFrom("sub_entities").select("id").where("kind", "=", "feature").execute();
+  return rows.length;
+}
+
+async function countEntitiesByType(db: Kysely<DB>, type: string): Promise<number> {
+  const rows = await db.selectFrom("entities").select("id").where("source_type", "=", type).execute();
+  return rows.length;
+}

--- a/packages/server/src/db/repositories/features.ts
+++ b/packages/server/src/db/repositories/features.ts
@@ -1,0 +1,66 @@
+import type { Kysely } from "kysely";
+import type { FeatureFactRaw } from "../../connectors/types";
+import type { DB } from "../schema";
+import { createIndexedFileFactRepository } from "./indexed-file-facts";
+
+export type FeatureStatus = "proposed" | "building" | "shipped" | "deprecated";
+
+export interface UpsertFeatureFactInput {
+  experimentalFlag?: boolean;
+  indexedFileId?: string | null;
+  connectorConfigId: string;
+  createdByUserId?: string | null;
+  lastSeenSyncRunId?: string | null;
+  contentHash?: string | null;
+  source: string;
+  featureId: string;
+  featureName: string;
+  parentProductRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  status: FeatureStatus;
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  contextSnippet?: string | null;
+}
+
+export async function upsertFeatureFact(db: Kysely<DB>, input: UpsertFeatureFactInput): Promise<{ emitted: boolean }> {
+  const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
+  const source = requireNonEmpty(input.source, "source");
+  const featureId = requireNonEmpty(input.featureId, "featureId");
+  if (!input.experimentalFlag) return { emitted: false };
+
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: input.indexedFileId ?? null,
+    connectorConfigId,
+    createdByUserId: input.createdByUserId ?? null,
+    lastSeenSyncRunId: input.lastSeenSyncRunId ?? null,
+    contentHash: input.contentHash ?? null,
+    source,
+    factType: "feature",
+    relation: "mentioned",
+    subjectName: input.featureName,
+    subjectSource: source,
+    subjectSourceId: featureId,
+    contextSnippet: input.contextSnippet ?? null,
+    raw: buildFeatureRaw(input, featureId),
+  });
+  return { emitted: true };
+}
+
+function buildFeatureRaw(input: UpsertFeatureFactInput, featureId: string): FeatureFactRaw {
+  return {
+    featureId,
+    featureName: input.featureName,
+    parentProductRef: input.parentProductRef,
+    parentEntityId: input.parentEntityId,
+    status: input.status,
+    dueAt: input.dueAt,
+    evidence: input.evidence,
+  };
+}
+
+function requireNonEmpty(value: string | null | undefined, name: string): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) throw new Error(`feature ${name} is required`);
+  return trimmed;
+}

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -13,6 +13,7 @@ export type IndexedFileFactType =
   | "structural_seed"
   | "structural_task"
   | "commitment"
+  | "feature"
   | "decision"
   | "llm_task"
   | "person_seed"
@@ -143,6 +144,13 @@ export function buildIndexedFileFactKey(input: UpsertIndexedFileFactInput): stri
     const commitmentId = typeof raw?.commitmentId === "string" ? raw.commitmentId.trim().toLowerCase() : "";
     return createHash("sha256")
       .update([input.connectorConfigId ?? "", input.factType, input.source, commitmentId].join("|"))
+      .digest("hex");
+  }
+  if (input.factType === "feature") {
+    const raw = input.raw as Record<string, unknown> | undefined;
+    const featureId = typeof raw?.featureId === "string" ? raw.featureId.trim().toLowerCase() : "";
+    return createHash("sha256")
+      .update([input.connectorConfigId ?? "", input.factType, input.source, featureId].join("|"))
       .digest("hex");
   }
   if (input.factType === "decision") {
@@ -300,6 +308,45 @@ function validateRaw(input: UpsertIndexedFileFactInput): string | null {
     const parentRef = raw.parentRef as Record<string, unknown> | undefined;
     if (parentRef && (!hasString(parentRef, "source") || !hasString(parentRef, "sourceId"))) {
       throw new Error("commitment parentRef requires source and sourceId");
+    }
+  } else if (input.factType === "feature") {
+    if (
+      !hasString(raw, "featureId") ||
+      !hasString(raw, "featureName") ||
+      !hasString(raw, "status") ||
+      !isRecord(raw.evidence)
+    ) {
+      throw new Error("feature facts require featureId, featureName, status, and evidence");
+    }
+    if (
+      raw.status !== "proposed" &&
+      raw.status !== "building" &&
+      raw.status !== "shipped" &&
+      raw.status !== "deprecated"
+    ) {
+      throw new Error("feature status must be proposed, building, shipped, or deprecated");
+    }
+    const evidence = raw.evidence as Record<string, unknown>;
+    if (!Array.isArray(evidence.fileIds) || !Array.isArray(evidence.entityIds)) {
+      throw new Error("feature evidence requires fileIds and entityIds arrays");
+    }
+    if (
+      !evidence.fileIds.every((id) => typeof id === "string") ||
+      !evidence.entityIds.every((id) => typeof id === "string")
+    ) {
+      throw new Error("feature evidence ids must be strings");
+    }
+    if (raw.parentProductRef !== undefined && !isRecord(raw.parentProductRef)) {
+      throw new Error("feature parentProductRef must be an object");
+    }
+    const parentProductRef = raw.parentProductRef as Record<string, unknown> | undefined;
+    if (parentProductRef && (!hasString(parentProductRef, "source") || !hasString(parentProductRef, "sourceId"))) {
+      throw new Error("feature parentProductRef requires source and sourceId");
+    }
+    for (const key of ["parentEntityId", "dueAt"]) {
+      if (raw[key] !== undefined && typeof raw[key] !== "string") {
+        throw new Error(`feature ${key} must be a string`);
+      }
     }
   } else if (input.factType === "decision") {
     if (

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -14,6 +14,7 @@ export type IndexedFileFactType =
   | "structural_task"
   | "commitment"
   | "feature"
+  | "milestone"
   | "decision"
   | "llm_task"
   | "person_seed"
@@ -151,6 +152,13 @@ export function buildIndexedFileFactKey(input: UpsertIndexedFileFactInput): stri
     const featureId = typeof raw?.featureId === "string" ? raw.featureId.trim().toLowerCase() : "";
     return createHash("sha256")
       .update([input.connectorConfigId ?? "", input.factType, input.source, featureId].join("|"))
+      .digest("hex");
+  }
+  if (input.factType === "milestone") {
+    const raw = input.raw as Record<string, unknown> | undefined;
+    const milestoneId = typeof raw?.milestoneId === "string" ? raw.milestoneId.trim().toLowerCase() : "";
+    return createHash("sha256")
+      .update([input.connectorConfigId ?? "", input.factType, input.source, milestoneId].join("|"))
       .digest("hex");
   }
   if (input.factType === "decision") {
@@ -346,6 +354,48 @@ function validateRaw(input: UpsertIndexedFileFactInput): string | null {
     for (const key of ["parentEntityId", "dueAt"]) {
       if (raw[key] !== undefined && typeof raw[key] !== "string") {
         throw new Error(`feature ${key} must be a string`);
+      }
+    }
+  } else if (input.factType === "milestone") {
+    if (
+      !input.connectorConfigId?.trim() ||
+      !input.source.trim() ||
+      !hasString(raw, "milestoneId") ||
+      !hasString(raw, "milestoneName") ||
+      !hasString(raw, "status") ||
+      !hasString(raw, "dueAt") ||
+      !isRecord(raw.evidence)
+    ) {
+      throw new Error(
+        "milestone facts require connectorConfigId, source, milestoneId, milestoneName, status, dueAt, and evidence",
+      );
+    }
+    if (raw.status !== "planned" && raw.status !== "hit" && raw.status !== "missed") {
+      throw new Error("milestone status must be planned, hit, or missed");
+    }
+    if (Number.isNaN(Date.parse(String(raw.dueAt)))) {
+      throw new Error("milestone dueAt must be an ISO date");
+    }
+    const evidence = raw.evidence as Record<string, unknown>;
+    if (!Array.isArray(evidence.fileIds) || !Array.isArray(evidence.entityIds)) {
+      throw new Error("milestone evidence requires fileIds and entityIds arrays");
+    }
+    if (
+      !evidence.fileIds.every((id) => typeof id === "string") ||
+      !evidence.entityIds.every((id) => typeof id === "string")
+    ) {
+      throw new Error("milestone evidence ids must be strings");
+    }
+    if (raw.parentRef !== undefined && !isRecord(raw.parentRef)) {
+      throw new Error("milestone parentRef must be an object");
+    }
+    const parentRef = raw.parentRef as Record<string, unknown> | undefined;
+    if (parentRef && (!hasString(parentRef, "source") || !hasString(parentRef, "sourceId"))) {
+      throw new Error("milestone parentRef requires source and sourceId");
+    }
+    for (const key of ["parentEntityId", "observedAt"]) {
+      if (raw[key] !== undefined && typeof raw[key] !== "string") {
+        throw new Error(`milestone ${key} must be a string`);
       }
     }
   } else if (input.factType === "decision") {

--- a/packages/server/src/db/repositories/milestones.integration.test.ts
+++ b/packages/server/src/db/repositories/milestones.integration.test.ts
@@ -1,0 +1,309 @@
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+import { materializeUnmaterializedFacts } from "../../entities/materialize";
+import { createTestLogger, createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createEntityRepository } from "./entities";
+import { resolveCurrentMilestoneForTask, upsertMilestoneFact } from "./milestones";
+import { createSubEntityRepository } from "./sub-entities";
+import { createTaskRepository } from "./tasks";
+
+const USER_ID = "milestone-pg-user";
+const CONNECTOR_ID = "milestone-pg-config";
+
+describe("milestone sub-entity supersession postgres", () => {
+  let db: Kysely<DB> | undefined;
+
+  afterEach(async () => {
+    await db?.destroy();
+    db = undefined;
+  });
+
+  it("supersedes a slipped due date while preserving milestone history", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedProject(db, { id: "milestone-project-slip", name: "Milestone Project Slip" });
+    await seedFile(db, "milestone-file-slip-1", "2026-06-01T09:00:00.000Z");
+    await seedFile(db, "milestone-file-slip-2", "2026-06-15T09:00:00.000Z");
+
+    await upsertMilestoneFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "milestone-file-slip-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      milestoneId: "milestone-slip",
+      milestoneName: "Public beta",
+      parentEntityId: project.id,
+      status: "planned",
+      dueAt: "2026-06-30",
+      observedAt: "2026-06-01T09:00:00.000Z",
+      evidence: { fileIds: ["milestone-file-slip-1"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    await upsertMilestoneFact(db, {
+      experimentalFlag: true,
+      indexedFileId: "milestone-file-slip-2",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      milestoneId: "milestone-slip",
+      milestoneName: "Public beta",
+      parentEntityId: project.id,
+      status: "planned",
+      dueAt: "2026-09-30",
+      observedAt: "2026-06-15T09:00:00.000Z",
+      evidence: { fileIds: ["milestone-file-slip-2"], entityIds: [project.id] },
+    });
+    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+
+    const rows = await milestoneRows(db, project.id, "public beta");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      display_name: "Public beta",
+      status: "planned",
+      due_at: "2026-06-30",
+      valid_from: "2026-06-01T09:00:00.000Z",
+      valid_to: "2026-06-15T09:00:00.000Z",
+    });
+    expect(rows[1]).toMatchObject({
+      display_name: "Public beta",
+      status: "planned",
+      due_at: "2026-09-30",
+      valid_from: "2026-06-15T09:00:00.000Z",
+      valid_to: null,
+    });
+
+    const current = await createSubEntityRepository(db).listCurrentByKind({
+      parentEntityId: project.id,
+      kind: "milestone",
+    });
+    expect(current.map((row) => row.id)).toEqual([rows[1].id]);
+
+    const asOf = await createSubEntityRepository(db).getSubEntitiesAsOf({
+      parentEntityId: project.id,
+      kind: "milestone",
+      at: "2026-06-10T09:00:00.000Z",
+    });
+    expect(asOf.map((row) => row.id)).toEqual([rows[0].id]);
+  }, 30000);
+
+  it("orders status transitions, reopened intervals, and backdated slips deterministically", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedProject(db, { id: "milestone-project-order", name: "Milestone Project Order" });
+    await seedFile(db, "milestone-file-order-1", "2026-06-15T09:00:00.000Z");
+    await seedFile(db, "milestone-file-order-2", "2026-07-15T09:00:00.000Z");
+    await seedFile(db, "milestone-file-order-3", "2026-07-01T09:00:00.000Z");
+
+    await emitMilestone(db, project.id, {
+      fileId: "milestone-file-order-1",
+      status: "planned",
+      dueAt: "2026-09-30",
+      observedAt: "2026-06-15T09:00:00.000Z",
+    });
+    await emitMilestone(db, project.id, {
+      fileId: "milestone-file-order-2",
+      status: "hit",
+      dueAt: "2026-09-30",
+      observedAt: "2026-07-15T09:00:00.000Z",
+    });
+    await emitMilestone(db, project.id, {
+      fileId: "milestone-file-order-3",
+      status: "planned",
+      dueAt: "2026-12-31",
+      observedAt: "2026-07-01T09:00:00.000Z",
+    });
+
+    const rows = await milestoneRows(db, project.id, "ga launch");
+    expect(
+      rows.map((row) => ({ status: row.status, dueAt: row.due_at, from: row.valid_from, to: row.valid_to })),
+    ).toEqual([
+      {
+        status: "planned",
+        dueAt: "2026-09-30",
+        from: "2026-06-15T09:00:00.000Z",
+        to: "2026-07-01T09:00:00.000Z",
+      },
+      {
+        status: "planned",
+        dueAt: "2026-12-31",
+        from: "2026-07-01T09:00:00.000Z",
+        to: "2026-07-15T09:00:00.000Z",
+      },
+      {
+        status: "hit",
+        dueAt: "2026-09-30",
+        from: "2026-07-15T09:00:00.000Z",
+        to: null,
+      },
+    ]);
+    expect(rows.find((row) => row.valid_to === null)).toMatchObject({ status: "hit", due_at: "2026-09-30" });
+  }, 30000);
+
+  it("resolves a task milestone series link to the current interval across a slip", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const project = await seedProject(db, { id: "milestone-project-task", name: "Milestone Project Task" });
+    await seedFile(db, "milestone-file-task-1", "2026-06-01T09:00:00.000Z");
+    await seedFile(db, "milestone-file-task-2", "2026-06-15T09:00:00.000Z");
+
+    await emitMilestone(db, project.id, {
+      fileId: "milestone-file-task-1",
+      status: "planned",
+      dueAt: "2026-06-30",
+      observedAt: "2026-06-01T09:00:00.000Z",
+    });
+    const first = await currentMilestone(db, project.id, "ga launch");
+    expect(first.series_key).toBeTruthy();
+
+    const taskResult = await createTaskRepository(db).upsertTask({
+      parentEntityId: project.id,
+      parentSourceRef: null,
+      parentName: project.name,
+      source: "linear",
+      externalRef: null,
+      title: "Ship the release notes",
+      status: "open",
+      statusRaw: "Open",
+      statusAuthority: "external",
+      assigneeEntityId: null,
+      priority: null,
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "milestone-task-1",
+      createdByUserId: USER_ID,
+    });
+    await db
+      .updateTable("tasks")
+      .set({ milestone_series_key: first.series_key })
+      .where("id", "=", taskResult.taskId)
+      .execute();
+
+    await emitMilestone(db, project.id, {
+      fileId: "milestone-file-task-2",
+      status: "planned",
+      dueAt: "2026-09-30",
+      observedAt: "2026-06-15T09:00:00.000Z",
+    });
+
+    const rows = await milestoneRows(db, project.id, "ga launch");
+    expect(new Set(rows.map((row) => row.series_key))).toEqual(new Set([first.series_key]));
+    const resolved = await resolveCurrentMilestoneForTask(db, taskResult.taskId);
+    expect(resolved).toMatchObject({
+      id: rows[1].id,
+      due_at: "2026-09-30",
+      valid_to: null,
+    });
+  }, 30000);
+});
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: USER_ID, name: "Milestone PG User", email: "milestone-pg-user@example.com" })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedProject(db: Kysely<DB>, input: { id: string; name: string }) {
+  const repo = createEntityRepository(db);
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await repo.upsertSourceRef({ entityId: input.id, source: "linear", sourceId: `${input.id}-source` });
+  return db.selectFrom("entities").selectAll().where("id", "=", input.id).executeTakeFirstOrThrow();
+}
+
+async function seedFile(db: Kysely<DB>, id: string, sourceTime: string): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      provider_url: null,
+      file_name: id,
+      file_type: "issue",
+      content_category: "structured",
+      content: "Milestone file",
+      source: "linear",
+      source_path: null,
+      content_hash: `${id}-hash`,
+      source_created_at: sourceTime,
+      source_updated_at: sourceTime,
+      synced_at: sourceTime,
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function emitMilestone(
+  db: Kysely<DB>,
+  projectId: string,
+  input: { fileId: string; status: "planned" | "hit" | "missed"; dueAt: string; observedAt: string },
+): Promise<void> {
+  await upsertMilestoneFact(db, {
+    experimentalFlag: true,
+    indexedFileId: input.fileId,
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    source: "linear",
+    milestoneId: "milestone-ga",
+    milestoneName: "GA Launch",
+    parentEntityId: projectId,
+    status: input.status,
+    dueAt: input.dueAt,
+    observedAt: input.observedAt,
+    evidence: { fileIds: [input.fileId], entityIds: [projectId] },
+  });
+  await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+}
+
+async function milestoneRows(db: Kysely<DB>, parentEntityId: string, normalizedName: string) {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "milestone")
+    .where("parent_entity_id", "=", parentEntityId)
+    .where("normalized_name", "=", normalizedName)
+    .orderBy("valid_from", "asc")
+    .execute();
+}
+
+async function currentMilestone(db: Kysely<DB>, parentEntityId: string, normalizedName: string) {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "milestone")
+    .where("parent_entity_id", "=", parentEntityId)
+    .where("normalized_name", "=", normalizedName)
+    .where("valid_to", "is", null)
+    .executeTakeFirstOrThrow();
+}

--- a/packages/server/src/db/repositories/milestones.ts
+++ b/packages/server/src/db/repositories/milestones.ts
@@ -1,0 +1,96 @@
+import type { Kysely } from "kysely";
+import type { MilestoneFactRaw } from "../../connectors/types";
+import type { DB } from "../schema";
+import { createIndexedFileFactRepository } from "./indexed-file-facts";
+import { type SubEntityRow, createSubEntityRepository } from "./sub-entities";
+
+export type MilestoneStatus = "planned" | "hit" | "missed";
+
+export interface UpsertMilestoneFactInput {
+  experimentalFlag?: boolean;
+  indexedFileId?: string | null;
+  connectorConfigId: string;
+  createdByUserId?: string | null;
+  lastSeenSyncRunId?: string | null;
+  contentHash?: string | null;
+  source: string;
+  milestoneId: string;
+  milestoneName: string;
+  parentRef?: { source: string; sourceId: string };
+  parentEntityId?: string;
+  status: MilestoneStatus;
+  dueAt: string;
+  observedAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+  contextSnippet?: string | null;
+}
+
+export async function upsertMilestoneFact(
+  db: Kysely<DB>,
+  input: UpsertMilestoneFactInput,
+): Promise<{ emitted: boolean }> {
+  const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
+  const source = requireNonEmpty(input.source, "source");
+  const milestoneId = requireNonEmpty(input.milestoneId, "milestoneId");
+  if (!input.experimentalFlag) return { emitted: false };
+
+  await createIndexedFileFactRepository(db).upsertFact({
+    indexedFileId: input.indexedFileId ?? null,
+    connectorConfigId,
+    createdByUserId: input.createdByUserId ?? null,
+    lastSeenSyncRunId: input.lastSeenSyncRunId ?? null,
+    contentHash: input.contentHash ?? null,
+    source,
+    factType: "milestone",
+    relation: "mentioned",
+    subjectName: input.milestoneName,
+    subjectSource: source,
+    subjectSourceId: milestoneId,
+    contextSnippet: input.contextSnippet ?? null,
+    raw: buildMilestoneRaw(input, milestoneId),
+  });
+  return { emitted: true };
+}
+
+export async function listCurrentMilestones(
+  db: Kysely<DB>,
+  opts: { experimentalFlag?: boolean; parentEntityId: string },
+): Promise<SubEntityRow[]> {
+  if (!opts.experimentalFlag) return [];
+  return createSubEntityRepository(db).listCurrentByKind({
+    parentEntityId: opts.parentEntityId,
+    kind: "milestone",
+  });
+}
+
+export async function resolveCurrentMilestoneForTask(db: Kysely<DB>, taskId: string): Promise<SubEntityRow | null> {
+  const task = await db.selectFrom("tasks").select("milestone_series_key").where("id", "=", taskId).executeTakeFirst();
+  if (!task?.milestone_series_key) return null;
+  return (
+    (await db
+      .selectFrom("sub_entities")
+      .selectAll()
+      .where("series_key", "=", task.milestone_series_key)
+      .where("valid_to", "is", null)
+      .executeTakeFirst()) ?? null
+  );
+}
+
+function buildMilestoneRaw(input: UpsertMilestoneFactInput, milestoneId: string): MilestoneFactRaw {
+  return {
+    milestoneId,
+    milestoneName: input.milestoneName,
+    parentRef: input.parentRef,
+    parentEntityId: input.parentEntityId,
+    status: input.status,
+    dueAt: input.dueAt,
+    observedAt: input.observedAt,
+    evidence: input.evidence,
+  };
+}
+
+function requireNonEmpty(value: string | null | undefined, name: string): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) throw new Error(`milestone ${name} is required`);
+  return trimmed;
+}

--- a/packages/server/src/db/repositories/sub-entities.ts
+++ b/packages/server/src/db/repositories/sub-entities.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Kysely, Selectable } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
+import { defaultValueSignature, seriesKeyFor } from "../../entities/sub-entity-signatures";
 import type { DB, SubEntitiesTable } from "../schema";
 
 export type SubEntityStatus = "open" | "done" | "dropped" | string;
@@ -29,6 +30,9 @@ export interface SupersedeSubEntityInput {
   kind: string;
   dedupName: string;
   displayName: string;
+  status?: string;
+  dueAt?: string | null;
+  valueSignature?: string;
   provenance: string;
   metadata?: Record<string, unknown> | null;
   sourceFactId?: string | null;
@@ -146,6 +150,7 @@ async function upsertInTransaction(
   return db.transaction().execute(async (trx) => {
     const parentScopeKey = input.parentEntityId ?? GLOBAL_PARENT_SCOPE_KEY;
     const normalized = normalizeName(input.dedupName ?? input.displayName);
+    const valueSignature = defaultValueSignature(input.displayName);
     const existing = await selectCurrent(trx, parentScopeKey, input.kind, normalized);
     const now = new Date().toISOString();
     if (!existing) {
@@ -164,6 +169,8 @@ async function upsertInTransaction(
           valid_to: null,
           provenance: input.provenance,
           due_at: input.dueAt ?? null,
+          value_signature: valueSignature,
+          series_key: seriesKeyFor(parentScopeKey, input.kind, normalized),
           created_by_user_id: input.ownerUserId ?? null,
           source_fact_id: input.sourceFactId ?? null,
           metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
@@ -185,7 +192,8 @@ async function supersedeInTransaction(
   return db.transaction().execute(async (trx) => {
     const parentScopeKey = input.parentEntityId;
     const normalized = normalizeName(input.dedupName);
-    const displayNormalized = normalizeName(input.displayName);
+    const incomingSig = input.valueSignature ?? defaultValueSignature(input.displayName);
+    const hasDomainStatus = input.status !== undefined;
     const effectiveAt = new Date(input.effectiveAt).toISOString();
     const now = new Date().toISOString();
     const rows = await trx
@@ -196,9 +204,7 @@ async function supersedeInTransaction(
       .where("normalized_name", "=", normalized)
       .orderBy("valid_from", "asc")
       .execute();
-    const existingAtTime = rows.find(
-      (row) => row.valid_from === effectiveAt && normalizeName(row.display_name) === displayNormalized,
-    );
+    const existingAtTime = rows.find((row) => row.valid_from === effectiveAt && row.value_signature === incomingSig);
     if (existingAtTime) {
       await refreshSupersededRow(trx, existingAtTime.id, input, now);
       return { subEntityId: existingAtTime.id, created: false, superseded: false };
@@ -206,15 +212,15 @@ async function supersedeInTransaction(
 
     const predecessor = [...rows].reverse().find((row) => row.valid_from <= effectiveAt);
     const successor = rows.find((row) => row.valid_from > effectiveAt);
-    if (predecessor && normalizeName(predecessor.display_name) === displayNormalized) {
+    if (predecessor && predecessor.value_signature === incomingSig) {
       return { subEntityId: predecessor.id, created: false, superseded: false };
     }
 
     if (predecessor && (predecessor.valid_to === null || predecessor.valid_to > effectiveAt)) {
-      const update = trx
-        .updateTable("sub_entities")
-        .set({ valid_to: effectiveAt, status: "superseded", updated_at: now })
-        .where("id", "=", predecessor.id);
+      const closeValues = hasDomainStatus
+        ? { valid_to: effectiveAt, updated_at: now }
+        : { valid_to: effectiveAt, status: "superseded", updated_at: now };
+      const update = trx.updateTable("sub_entities").set(closeValues).where("id", "=", predecessor.id);
       const result =
         predecessor.valid_to === null
           ? await update.where("valid_to", "is", null).executeTakeFirst()
@@ -233,12 +239,14 @@ async function supersedeInTransaction(
         kind: input.kind,
         normalized_name: normalized,
         display_name: input.displayName,
-        status: validTo === null ? "active" : "superseded",
+        status: input.status ?? (validTo === null ? "active" : "superseded"),
         status_authority: "external",
         valid_from: effectiveAt,
         valid_to: validTo,
         provenance: input.provenance,
-        due_at: null,
+        due_at: input.dueAt ?? null,
+        value_signature: incomingSig,
+        series_key: seriesKeyFor(parentScopeKey, input.kind, normalized),
         created_by_user_id: null,
         source_fact_id: input.sourceFactId ?? null,
         metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
@@ -255,17 +263,17 @@ async function refreshSupersededRow(
   input: SupersedeSubEntityInput,
   now: string,
 ): Promise<void> {
-  await db
-    .updateTable("sub_entities")
-    .set({
-      display_name: input.displayName,
-      provenance: input.provenance,
-      source_fact_id: input.sourceFactId ?? null,
-      metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
-      updated_at: now,
-    })
-    .where("id", "=", subEntityId)
-    .execute();
+  const values = {
+    display_name: input.displayName,
+    provenance: input.provenance,
+    due_at: input.dueAt ?? null,
+    value_signature: input.valueSignature ?? defaultValueSignature(input.displayName),
+    source_fact_id: input.sourceFactId ?? null,
+    metadata_json: input.metadata ? JSON.stringify(input.metadata) : null,
+    updated_at: now,
+    ...(input.status !== undefined ? { status: input.status } : {}),
+  };
+  await db.updateTable("sub_entities").set(values).where("id", "=", subEntityId).execute();
 }
 
 async function selectCurrent(

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -945,6 +945,7 @@ export interface TasksTable {
   completed_at: string | null;
   valid_from: string | null;
   valid_to: string | null;
+  milestone_series_key: string | null;
   created_at: Generated<string>;
   updated_at: Generated<string>;
 }
@@ -968,6 +969,8 @@ export interface SubEntitiesTable {
   valid_to: string | null;
   provenance: string;
   due_at: string | null;
+  value_signature: string | null;
+  series_key: string | null;
   created_by_user_id: string | null;
   source_fact_id: string | null;
   metadata_json: string | null;

--- a/packages/server/src/entities/materialize-commitment.ts
+++ b/packages/server/src/entities/materialize-commitment.ts
@@ -2,6 +2,7 @@ import { createSubEntityRepository } from "../db/repositories/sub-entities";
 import { TEST_ACCOUNT_ENTITY_ID } from "../db/repositories/tasks";
 import { readJsonObject } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+import type { ProposeEntityType } from "./propose";
 
 export async function materializeCommitment(
   deps: MaterializeDeps,
@@ -12,7 +13,7 @@ export async function materializeCommitment(
   const commitment = readCommitment(raw);
   if (!commitment) return { kind: "skipped", reason: "invalid_commitment" };
 
-  const parent = resolveParent(deps, commitment);
+  const parent = resolveParent(deps, commitment, ["project", "person"]);
   const repo = createSubEntityRepository(deps.db);
   const result = await repo.upsertSubEntity({
     parentEntityId: parent?.id ?? null,
@@ -40,36 +41,40 @@ export interface SubEntityParentInput {
   evidence: { entityIds: string[] };
 }
 
-export function resolveParent(deps: MaterializeDeps, input: SubEntityParentInput): EntityRow | null {
+export function resolveParent(
+  deps: MaterializeDeps,
+  input: SubEntityParentInput,
+  allowedTypes: readonly string[],
+): EntityRow | null {
   if (input.parentRef) {
     const byRef = deps.index.bySourceRef.get(`${input.parentRef.source}:${input.parentRef.sourceId}`);
-    if (isAllowedParent(byRef)) return byRef;
+    if (isAllowedParent(byRef, allowedTypes)) return byRef;
   }
   if (input.parentEntityId) {
-    const byId = findEntityById(deps, input.parentEntityId);
-    if (isAllowedParent(byId)) return byId;
+    const byId = findEntityById(deps, input.parentEntityId, allowedTypes);
+    if (isAllowedParent(byId, allowedTypes)) return byId;
   }
   for (const entityId of input.evidence.entityIds) {
-    const byId = findEntityById(deps, entityId);
-    if (isAllowedParent(byId)) return byId;
+    const byId = findEntityById(deps, entityId, allowedTypes);
+    if (isAllowedParent(byId, allowedTypes)) return byId;
   }
   return null;
 }
 
-function findEntityById(deps: MaterializeDeps, entityId: string): EntityRow | undefined {
-  for (const type of ["project", "person"] as const) {
-    const found = deps.index.entitiesByType.get(type)?.find((entity) => entity.id === entityId);
+export function findEntityById(
+  deps: MaterializeDeps,
+  entityId: string,
+  allowedTypes: readonly string[],
+): EntityRow | undefined {
+  for (const type of allowedTypes) {
+    const found = deps.index.entitiesByType.get(type as ProposeEntityType)?.find((entity) => entity.id === entityId);
     if (found) return found;
   }
   return undefined;
 }
 
-function isAllowedParent(entity: EntityRow | undefined): entity is EntityRow {
-  return Boolean(
-    entity &&
-      entity.id !== TEST_ACCOUNT_ENTITY_ID &&
-      (entity.source_type === "project" || entity.source_type === "person"),
-  );
+export function isAllowedParent(entity: EntityRow | undefined, allowedTypes: readonly string[]): entity is EntityRow {
+  return Boolean(entity && entity.id !== TEST_ACCOUNT_ENTITY_ID && allowedTypes.includes(entity.source_type));
 }
 
 interface CommitmentInput extends SubEntityParentInput {

--- a/packages/server/src/entities/materialize-decision.ts
+++ b/packages/server/src/entities/materialize-decision.ts
@@ -9,7 +9,7 @@ export async function materializeDecision(deps: MaterializeDeps, fact: IndexedFi
   const decision = readDecision(raw);
   if (!decision) return { kind: "skipped", reason: "invalid_decision" };
 
-  const parent = resolveParent(deps, decision);
+  const parent = resolveParent(deps, decision, ["project", "person"]);
   if (!parent) return { kind: "skipped", reason: "missing_decision_parent" };
   const effectiveAt = await resolveEffectiveAt(deps, fact, decision);
   if (!effectiveAt) return { kind: "skipped", reason: "missing_decision_effective_time" };

--- a/packages/server/src/entities/materialize-effective-time.ts
+++ b/packages/server/src/entities/materialize-effective-time.ts
@@ -1,0 +1,13 @@
+import type { IndexedFileFactRow, MaterializeDeps } from "./materialize-types";
+
+export async function resolveEffectiveAt(
+  deps: MaterializeDeps,
+  fact: IndexedFileFactRow,
+  explicitTime?: string,
+): Promise<string | null> {
+  const sourceTimes = fact.indexed_file_id ? await deps.getIndexedFileSourceTime(fact.indexed_file_id) : null;
+  const value =
+    explicitTime ?? sourceTimes?.source_updated_at ?? sourceTimes?.source_created_at ?? sourceTimes?.synced_at;
+  if (!value) return null;
+  return new Date(value).toISOString();
+}

--- a/packages/server/src/entities/materialize-feature.ts
+++ b/packages/server/src/entities/materialize-feature.ts
@@ -1,0 +1,88 @@
+import { createSubEntityRepository } from "../db/repositories/sub-entities";
+import { type SubEntityParentInput, resolveParent } from "./materialize-commitment";
+import { readJsonObject } from "./materialize-json";
+import type { IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+
+export async function materializeFeature(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
+  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
+  const raw = readJsonObject(fact.raw);
+  const feature = readFeature(raw);
+  if (!feature) return { kind: "skipped", reason: "invalid_feature" };
+
+  const parent = resolveParent(deps, feature, ["product"]);
+  if (!parent) return { kind: "skipped", reason: "missing_feature_parent" };
+
+  const repo = createSubEntityRepository(deps.db);
+  const result = await repo.upsertSubEntity({
+    parentEntityId: parent.id,
+    kind: "feature",
+    dedupName: feature.featureName,
+    displayName: feature.featureName,
+    status: feature.status,
+    provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
+    dueAt: feature.dueAt ?? null,
+    ownerUserId: deps.resolveOwner(fact),
+    sourceFactId: fact.id,
+  });
+  await repo.upsertSubEntityEvidence(result.subEntityId, "fact", fact.id);
+  for (const fileId of feature.evidence.fileIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "file", fileId);
+  }
+  for (const entityId of feature.evidence.entityIds) {
+    await repo.upsertSubEntityEvidence(result.subEntityId, "entity", entityId);
+  }
+  return { kind: "feature_materialized" };
+}
+
+interface FeatureInput extends SubEntityParentInput {
+  featureId: string;
+  featureName: string;
+  status: "proposed" | "building" | "shipped" | "deprecated";
+  dueAt?: string;
+  evidence: { fileIds: string[]; entityIds: string[] };
+}
+
+function readFeature(raw: Record<string, unknown>): FeatureInput | null {
+  if (
+    typeof raw.featureId !== "string" ||
+    typeof raw.featureName !== "string" ||
+    (raw.status !== "proposed" &&
+      raw.status !== "building" &&
+      raw.status !== "shipped" &&
+      raw.status !== "deprecated") ||
+    !isEvidence(raw.evidence)
+  ) {
+    return null;
+  }
+  return {
+    featureId: raw.featureId,
+    featureName: raw.featureName,
+    parentRef: readParentProductRef(raw.parentProductRef),
+    parentEntityId: readOptionalString(raw.parentEntityId),
+    status: raw.status,
+    dueAt: readOptionalString(raw.dueAt),
+    evidence: { fileIds: raw.evidence.fileIds, entityIds: raw.evidence.entityIds },
+  };
+}
+
+function readParentProductRef(value: unknown): { source: string; sourceId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || typeof record.sourceId !== "string") return undefined;
+  return { source: record.source, sourceId: record.sourceId };
+}
+
+function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.fileIds) &&
+    record.fileIds.every((id) => typeof id === "string") &&
+    Array.isArray(record.entityIds) &&
+    record.entityIds.every((id) => typeof id === "string")
+  );
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/server/src/entities/materialize-milestone.ts
+++ b/packages/server/src/entities/materialize-milestone.ts
@@ -1,75 +1,74 @@
 import { createSubEntityRepository } from "../db/repositories/sub-entities";
-import { resolveParent } from "./materialize-commitment";
+import { type SubEntityParentInput, resolveParent } from "./materialize-commitment";
 import { resolveEffectiveAt } from "./materialize-effective-time";
 import { readJsonObject } from "./materialize-json";
 import type { IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+import { valueSignatureForParts } from "./sub-entity-signatures";
 
-export async function materializeDecision(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
+export async function materializeMilestone(
+  deps: MaterializeDeps,
+  fact: IndexedFileFactRow,
+): Promise<MaterializeResult> {
   if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readJsonObject(fact.raw);
-  const decision = readDecision(raw);
-  if (!decision) return { kind: "skipped", reason: "invalid_decision" };
+  const milestone = readMilestone(raw);
+  if (!milestone) return { kind: "skipped", reason: "invalid_milestone" };
 
-  const parent = resolveParent(deps, decision, ["project", "person"]);
-  if (!parent) return { kind: "skipped", reason: "missing_decision_parent" };
-  const effectiveAt = await resolveEffectiveAt(deps, fact, decision.decidedAt);
-  if (!effectiveAt) return { kind: "skipped", reason: "missing_decision_effective_time" };
+  const parent = resolveParent(deps, milestone, ["project"]);
+  if (!parent) return { kind: "skipped", reason: "missing_milestone_parent" };
+  const effectiveAt = await resolveEffectiveAt(deps, fact, milestone.observedAt);
+  if (!effectiveAt) return { kind: "skipped", reason: "missing_milestone_effective_time" };
 
   const repo = createSubEntityRepository(deps.db);
   const result = await repo.supersedeSubEntity({
     parentEntityId: parent.id,
-    kind: "decision",
-    dedupName: decision.topic,
-    displayName: decision.statement,
+    kind: "milestone",
+    dedupName: milestone.milestoneName,
+    displayName: milestone.milestoneName,
+    status: milestone.status,
+    dueAt: milestone.dueAt,
+    valueSignature: valueSignatureForParts([milestone.status, milestone.dueAt]),
     provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
-    metadata: {
-      decidedBy: decision.decidedBy,
-      decidedAt: decision.decidedAt,
-      rationale: decision.rationale,
-    },
     sourceFactId: fact.id,
     effectiveAt,
   });
   await repo.upsertSubEntityEvidence(result.subEntityId, "fact", fact.id);
-  for (const fileId of decision.evidence.fileIds) {
+  for (const fileId of milestone.evidence.fileIds) {
     await repo.upsertSubEntityEvidence(result.subEntityId, "file", fileId);
   }
-  for (const entityId of decision.evidence.entityIds) {
+  for (const entityId of milestone.evidence.entityIds) {
     await repo.upsertSubEntityEvidence(result.subEntityId, "entity", entityId);
   }
-  return { kind: "decision_materialized" };
+  return { kind: "milestone_materialized" };
 }
 
-interface DecisionInput {
-  decisionId: string;
-  parentRef?: { source: string; sourceId: string };
-  parentEntityId?: string;
-  topic: string;
-  statement: string;
-  decidedBy?: string;
-  decidedAt?: string;
-  rationale?: string;
+interface MilestoneInput extends SubEntityParentInput {
+  milestoneId: string;
+  milestoneName: string;
+  status: "planned" | "hit" | "missed";
+  dueAt: string;
+  observedAt?: string;
   evidence: { fileIds: string[]; entityIds: string[] };
 }
 
-function readDecision(raw: Record<string, unknown>): DecisionInput | null {
+function readMilestone(raw: Record<string, unknown>): MilestoneInput | null {
   if (
-    typeof raw.decisionId !== "string" ||
-    typeof raw.topic !== "string" ||
-    typeof raw.statement !== "string" ||
+    typeof raw.milestoneId !== "string" ||
+    typeof raw.milestoneName !== "string" ||
+    (raw.status !== "planned" && raw.status !== "hit" && raw.status !== "missed") ||
+    typeof raw.dueAt !== "string" ||
     !isEvidence(raw.evidence)
   ) {
     return null;
   }
   return {
-    decisionId: raw.decisionId,
+    milestoneId: raw.milestoneId,
+    milestoneName: raw.milestoneName,
     parentRef: readParentRef(raw.parentRef),
     parentEntityId: readOptionalString(raw.parentEntityId),
-    topic: raw.topic,
-    statement: raw.statement,
-    decidedBy: readOptionalString(raw.decidedBy),
-    decidedAt: readOptionalString(raw.decidedAt),
-    rationale: readOptionalString(raw.rationale),
+    status: raw.status,
+    dueAt: raw.dueAt,
+    observedAt: readOptionalString(raw.observedAt),
     evidence: { fileIds: raw.evidence.fileIds, entityIds: raw.evidence.entityIds },
   };
 }

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -11,6 +11,7 @@ import { materializeFeature } from "./materialize-feature";
 import { readJsonObject } from "./materialize-json";
 import { materializeLlmExtractedFact } from "./materialize-llm-mentions";
 import { materializeLlmTask } from "./materialize-llm-task";
+import { materializeMilestone } from "./materialize-milestone";
 import { materializePersonFact, materializePersonSeed } from "./materialize-person";
 import { materializeProjectSeed } from "./materialize-project";
 import { materializeCrmRelationFact, materializeLlmRelationFact } from "./materialize-relations";
@@ -42,6 +43,7 @@ const FACT_REPLAY_ORDER = [
   "commitment",
   "feature",
   "decision",
+  "milestone",
   "llm_task",
 ] as const;
 
@@ -91,6 +93,9 @@ export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFi
   if (fact.fact_type === "decision") {
     return materializeDecision(deps, fact);
   }
+  if (fact.fact_type === "milestone") {
+    return materializeMilestone(deps, fact);
+  }
   if (fact.fact_type === "llm_task") {
     return materializeLlmTask(deps, fact);
   }
@@ -136,6 +141,10 @@ function accumulate(summary: ReplayFactsSummary, result: MaterializeResult): voi
     return;
   }
   if (result.kind === "decision_materialized") {
+    if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
+    return;
+  }
+  if (result.kind === "milestone_materialized") {
     if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
     return;
   }
@@ -278,7 +287,8 @@ async function materializeUnmaterializedFactsInner(
           result.kind !== "task_materialized" &&
           result.kind !== "commitment_materialized" &&
           result.kind !== "feature_materialized" &&
-          result.kind !== "decision_materialized"
+          result.kind !== "decision_materialized" &&
+          result.kind !== "milestone_materialized"
         )
           summary.materialized++;
       } else {
@@ -308,6 +318,7 @@ export function shouldMarkMaterialized(result: MaterializeResult): boolean {
     result.kind === "commitment_materialized" ||
     result.kind === "feature_materialized" ||
     result.kind === "decision_materialized" ||
+    result.kind === "milestone_materialized" ||
     result.kind === "structural"
   ) {
     return true;

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -7,6 +7,7 @@ import { materializeCommitment } from "./materialize-commitment";
 import { materializeContactPointFact } from "./materialize-contact-points";
 import { materializeDecision } from "./materialize-decision";
 import { buildMaterializeDeps } from "./materialize-deps";
+import { materializeFeature } from "./materialize-feature";
 import { readJsonObject } from "./materialize-json";
 import { materializeLlmExtractedFact } from "./materialize-llm-mentions";
 import { materializeLlmTask } from "./materialize-llm-task";
@@ -39,6 +40,7 @@ const FACT_REPLAY_ORDER = [
   "llm_relation",
   "structural_task",
   "commitment",
+  "feature",
   "decision",
   "llm_task",
 ] as const;
@@ -83,6 +85,9 @@ export async function materializeFromFact(deps: MaterializeDeps, fact: IndexedFi
   if (fact.fact_type === "commitment") {
     return materializeCommitment(deps, fact);
   }
+  if (fact.fact_type === "feature") {
+    return materializeFeature(deps, fact);
+  }
   if (fact.fact_type === "decision") {
     return materializeDecision(deps, fact);
   }
@@ -123,6 +128,10 @@ function accumulate(summary: ReplayFactsSummary, result: MaterializeResult): voi
     return;
   }
   if (result.kind === "commitment_materialized") {
+    if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
+    return;
+  }
+  if (result.kind === "feature_materialized") {
     if ("materialized" in summary) (summary as MaterializeFactsSummary).materialized++;
     return;
   }
@@ -268,6 +277,7 @@ async function materializeUnmaterializedFactsInner(
         if (
           result.kind !== "task_materialized" &&
           result.kind !== "commitment_materialized" &&
+          result.kind !== "feature_materialized" &&
           result.kind !== "decision_materialized"
         )
           summary.materialized++;
@@ -296,6 +306,7 @@ export function shouldMarkMaterialized(result: MaterializeResult): boolean {
     result.kind === "relationship_materialized" ||
     result.kind === "task_materialized" ||
     result.kind === "commitment_materialized" ||
+    result.kind === "feature_materialized" ||
     result.kind === "decision_materialized" ||
     result.kind === "structural"
   ) {

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -78,6 +78,7 @@ export type MaterializeResult =
     }
   | { kind: "task_materialized"; taskId: string; created: boolean }
   | { kind: "commitment_materialized" }
+  | { kind: "feature_materialized" }
   | { kind: "decision_materialized" }
   | { kind: "structural"; entity: EntityRow }
   | { kind: "skipped_missing_owner"; reason: string }

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -80,6 +80,7 @@ export type MaterializeResult =
   | { kind: "commitment_materialized" }
   | { kind: "feature_materialized" }
   | { kind: "decision_materialized" }
+  | { kind: "milestone_materialized" }
   | { kind: "structural"; entity: EntityRow }
   | { kind: "skipped_missing_owner"; reason: string }
   | { kind: "deferred_below_threshold"; reason: string }

--- a/packages/server/src/entities/sub-entity-signatures.ts
+++ b/packages/server/src/entities/sub-entity-signatures.ts
@@ -1,0 +1,18 @@
+import { createHash } from "node:crypto";
+import { normalizeName } from "../connectors/name-normalize";
+
+export const SUB_ENTITY_SIGNATURE_DELIM = "\x1f";
+
+export function seriesKeyFor(parentScopeKey: string, kind: string, normalizedName: string): string {
+  return createHash("sha256")
+    .update([parentScopeKey, kind, normalizedName].join(SUB_ENTITY_SIGNATURE_DELIM))
+    .digest("hex");
+}
+
+export function defaultValueSignature(displayName: string): string {
+  return normalizeName(displayName);
+}
+
+export function valueSignatureForParts(parts: readonly string[]): string {
+  return createHash("sha256").update(parts.join(SUB_ENTITY_SIGNATURE_DELIM)).digest("hex");
+}


### PR DESCRIPTION
Stacked context-graph slice 13/27.

Base: `feat/context-graph-12-task-assignees-llm-pipeline`
Head: `feat/context-graph-13-features-milestones`

Adds feature and milestone structural handling.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`