### PR TITLE
feat: add connector hierarchy and Fireflies improvements

### DIFF
--- a/packages/server/src/api/connectors-hierarchy-scope.test.ts
+++ b/packages/server/src/api/connectors-hierarchy-scope.test.ts
@@ -1,0 +1,115 @@
+/**
+ * PR-2a coverage for the connector hierarchy mapping: the PATCH /:id/scope merge
+ * (a partial scope update must preserve sibling keys it does not touch) and the
+ * flag-gated exposure of a connector's declared `hierarchyLevels` on the GET routes.
+ */
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hashPassword } from "../auth/password";
+import { createConnectorRepository } from "../db/repositories/connectors";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+
+const logger = createTestLogger();
+const ADMIN_EMAIL = "admin@test.com";
+const PASSWORD = "testpassword123";
+
+async function seedAdmin(db: Kysely<DB>): Promise<string> {
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  await settings.create();
+  const hash = await hashPassword(PASSWORD);
+  const admin = await users.create({
+    name: "admin",
+    email: ADMIN_EMAIL,
+    emailVerified: true,
+    passwordHash: hash,
+    authRole: "admin",
+  });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+  return admin.id;
+}
+
+async function login(app: ReturnType<typeof createApp>): Promise<string> {
+  const res = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: PASSWORD }),
+  });
+  return res.headers.get("set-cookie") ?? "";
+}
+
+async function insertClickUp(db: Kysely<DB>, createdBy: string): Promise<string> {
+  const cfg = await createConnectorRepository(db).createConfig({
+    connectorType: "clickup",
+    authType: "api_key",
+    credentials: JSON.stringify({ type: "api_key", api_key: "stub" }),
+    createdBy,
+  });
+  return cfg.id;
+}
+
+describe("Connectors API — hierarchy mapping scope", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    // Keep the background re-sync triggered by PATCH /scope offline.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 401 }));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    try {
+      await db.destroy();
+    } catch {}
+  });
+
+  it("merges scope_config so a partial update preserves sibling keys", async () => {
+    const app = createApp(db, createTestConfig(), { logger });
+    const adminId = await seedAdmin(db);
+    const cookie = await login(app);
+    const id = await insertClickUp(db, adminId);
+
+    await app.request(`/api/connectors/${id}/scope`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({ scopeConfig: { workspaces: ["ws-1"] } }),
+    });
+    await app.request(`/api/connectors/${id}/scope`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({ scopeConfig: { hierarchyMapping: { space: "team", folder: "project" } } }),
+    });
+
+    const stored = JSON.parse((await createConnectorRepository(db).findConfigById(id))?.scope_config ?? "{}");
+    expect(stored.workspaces).toEqual(["ws-1"]);
+    expect(stored.hierarchyMapping).toEqual({ space: "team", folder: "project" });
+  });
+
+  it("exposes hierarchyLevels on GET only when EXPERIMENTAL_FLAG is on", async () => {
+    const adminId = await seedAdmin(db);
+
+    const onApp = createApp(db, { ...createTestConfig(), EXPERIMENTAL_FLAG: true }, { logger });
+    const onCookie = await login(onApp);
+    const id = await insertClickUp(db, adminId);
+    const onRes = await onApp.request(`/api/connectors/${id}`, { headers: { Cookie: onCookie } });
+    const onBody = await onRes.json();
+    expect(Array.isArray(onBody.connector.hierarchyLevels)).toBe(true);
+    expect(onBody.connector.hierarchyLevels.map((l: { key: string }) => l.key)).toEqual([
+      "workspace",
+      "space",
+      "folder",
+      "list",
+    ]);
+
+    const offApp = createApp(db, { ...createTestConfig(), EXPERIMENTAL_FLAG: false }, { logger });
+    const offCookie = await login(offApp);
+    const offRes = await offApp.request(`/api/connectors/${id}`, { headers: { Cookie: offCookie } });
+    const offBody = await offRes.json();
+    expect(offBody.connector.hierarchyLevels).toBeUndefined();
+  });
+});

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -532,6 +532,7 @@ export function connectorRoutes(
           fileCount,
           perUserAuth: meta.perUserAuth,
           requiresOAuthClientSetup: meta.requiresOAuthClientSetup,
+          hierarchyLevels: appConfig?.EXPERIMENTAL_FLAG ? (meta.hierarchyLevels ?? null) : undefined,
           ...permissionFields(permissions),
         };
       }),
@@ -1799,6 +1800,7 @@ export function connectorRoutes(
         fileCount,
         perUserAuth: meta.perUserAuth,
         requiresOAuthClientSetup: meta.requiresOAuthClientSetup,
+        hierarchyLevels: appConfig?.EXPERIMENTAL_FLAG ? (meta.hierarchyLevels ?? null) : undefined,
         ...permissionFields(permissions),
       },
     });
@@ -2177,9 +2179,16 @@ export function connectorRoutes(
       return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
     }
 
-    // Update scope and clear sync cursor to force a full re-sync
+    // Merge into the existing scope_config and clear the sync cursor to force a full re-sync.
+    // hierarchyMapping and the workspace/space selections are sibling keys edited by separate
+    // flows, so a partial update must preserve the keys it does not touch rather than replace.
+    const existingScope =
+      config.scope_config && typeof config.scope_config === "string"
+        ? (JSON.parse(config.scope_config) as Record<string, unknown>)
+        : {};
+    const mergedScope = { ...existingScope, ...parsed.data.scopeConfig };
     await connectorRepo.updateConfig(config.id, {
-      scopeConfig: JSON.stringify(parsed.data.scopeConfig),
+      scopeConfig: JSON.stringify(mergedScope),
       syncCursor: null,
       errorMessage: null,
     });

--- a/packages/server/src/connectors/clickup-hierarchy-mapping.test.ts
+++ b/packages/server/src/connectors/clickup-hierarchy-mapping.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClickUpConnector } from "./clickup";
+import { emitFactsForSyncedItem } from "./sync-facts";
+import type { EntitySeed, SyncedItem } from "./types";
+
+interface ClickUpFixture {
+  team: { id: string; name: string; members: Array<{ user: { id: number; username: string; email?: string } }> };
+  spaces: Array<{ id: string; name: string; private?: boolean; features?: { sprints?: { enabled?: boolean } } }>;
+  foldersBySpace: Record<string, Array<{ id: string; name: string }>>;
+  listsByFolder: Record<
+    string,
+    Array<{ id: string; name: string; task_count?: number; start_date?: string; due_date?: string }>
+  >;
+  folderlessListsBySpace: Record<
+    string,
+    Array<{ id: string; name: string; task_count?: number; start_date?: string; due_date?: string }>
+  >;
+  tasksByList?: Record<string, unknown[]>;
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function clickupTask(input: {
+  id: string;
+  name: string;
+  spaceId: string;
+  list: { id: string; name: string };
+  folder?: { id: string; name: string };
+}) {
+  return {
+    id: input.id,
+    name: input.name,
+    description: "",
+    status: { status: "open", type: "open" },
+    priority: null,
+    assignees: [],
+    tags: [],
+    date_created: "1780000000000",
+    date_updated: "1780000001000",
+    url: `https://app.clickup.com/t/${input.id}`,
+    parent: null,
+    list: input.list,
+    folder: input.folder,
+    space: { id: input.spaceId },
+    custom_fields: [],
+  };
+}
+
+function mockClickUpFetch(fixture: ClickUpFixture): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const path = new URL(String(input)).pathname;
+
+    if (path === "/api/v2/team") return jsonResponse({ teams: [fixture.team] });
+    if (path === `/api/v2/team/${fixture.team.id}/space`) return jsonResponse({ spaces: fixture.spaces });
+    if (path === `/api/v3/workspaces/${fixture.team.id}/docs`) return jsonResponse({ docs: [] });
+
+    for (const space of fixture.spaces) {
+      if (path === `/api/v2/space/${space.id}/folder`) {
+        return jsonResponse({ folders: fixture.foldersBySpace[space.id] ?? [] });
+      }
+      if (path === `/api/v2/space/${space.id}/list`) {
+        return jsonResponse({ lists: fixture.folderlessListsBySpace[space.id] ?? [] });
+      }
+    }
+
+    for (const [folderId, lists] of Object.entries(fixture.listsByFolder)) {
+      if (path === `/api/v2/folder/${folderId}/list`) return jsonResponse({ lists });
+    }
+
+    for (const [listId, tasks] of Object.entries(fixture.tasksByList ?? {})) {
+      if (path === `/api/v2/list/${listId}/task`) return jsonResponse({ tasks });
+    }
+
+    return new Response(JSON.stringify({ error: `unexpected path ${path}` }), { status: 404 });
+  });
+}
+
+async function collectClickUpSync(
+  fixture: ClickUpFixture,
+  hierarchyMapping?: Record<string, string>,
+): Promise<{ seeds: EntitySeed[]; items: SyncedItem[] }> {
+  mockClickUpFetch(fixture);
+  const connector = createClickUpConnector();
+  const seeds: EntitySeed[] = [];
+  const items: SyncedItem[] = [];
+
+  for await (const item of connector.sync({
+    credentials: { type: "api_key", api_key: "clickup-token" },
+    scopeConfig: hierarchyMapping ? { hierarchyMapping } : {},
+    cursor: null,
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+    experimentalFlag: true,
+    onEntitySeed: async (seed) => {
+      seeds.push(seed);
+    },
+  })) {
+    items.push(item);
+  }
+
+  return { seeds, items };
+}
+
+describe("ClickUp hierarchy mapping", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the mapping to seed Canvas-X-style and getEpik-style hierarchies", async () => {
+    const canvas = await collectClickUpSync(
+      {
+        team: { id: "workspace-canvas", name: "Canvas X", members: [] },
+        spaces: [{ id: "space-marketing", name: "Marketing" }],
+        foldersBySpace: { "space-marketing": [{ id: "folder-content", name: "Content Engine" }] },
+        listsByFolder: {
+          "folder-content": [
+            { id: "list-blog", name: "Blog Calendar" },
+            { id: "list-video", name: "Video | Autopilot" },
+            { id: "list-web", name: "Website management" },
+          ],
+        },
+        folderlessListsBySpace: { "space-marketing": [] },
+        tasksByList: { "list-blog": [], "list-video": [], "list-web": [] },
+      },
+      { space: "team", folder: "project", list: "ignore" },
+    );
+
+    expect(canvas.seeds.filter((seed) => seed.sourceType === "team")).toEqual([
+      expect.objectContaining({ sourceId: "space-marketing", name: "Marketing" }),
+    ]);
+    expect(canvas.seeds.filter((seed) => seed.sourceType === "project")).toEqual([
+      expect.objectContaining({ sourceId: "folder-content", name: "Content Engine" }),
+    ]);
+    expect(canvas.seeds.map((seed) => seed.sourceId)).not.toEqual(
+      expect.arrayContaining(["list-blog", "list-video", "list-web"]),
+    );
+
+    const getEpik = await collectClickUpSync(
+      {
+        team: { id: "workspace-getepik", name: "getEpik", members: [] },
+        spaces: [{ id: "space-eng", name: "Engineering" }],
+        foldersBySpace: { "space-eng": [] },
+        listsByFolder: {},
+        folderlessListsBySpace: { "space-eng": [{ id: "list-default", name: "List" }] },
+        tasksByList: { "list-default": [] },
+      },
+      { space: "project", list: "ignore" },
+    );
+
+    expect(getEpik.seeds.filter((seed) => seed.sourceType === "project")).toEqual([
+      expect.objectContaining({ sourceId: "space-eng", name: "Engineering" }),
+    ]);
+    expect(getEpik.seeds.map((seed) => seed.sourceId)).not.toContain("list-default");
+  });
+
+  it("points task project and parent facts at the nearest mapped project instead of an ignored folder", async () => {
+    const folder = { id: "folder-delivery", name: "Delivery Folder" };
+    const list = { id: "list-build", name: "Build" };
+    const { items } = await collectClickUpSync(
+      {
+        team: { id: "workspace-acme", name: "Acme", members: [] },
+        spaces: [{ id: "space-product", name: "Product" }],
+        foldersBySpace: { "space-product": [folder] },
+        listsByFolder: { "folder-delivery": [list] },
+        folderlessListsBySpace: { "space-product": [] },
+        tasksByList: {
+          "list-build": [
+            clickupTask({
+              id: "task-build",
+              name: "Build mapped task",
+              spaceId: "space-product",
+              list,
+              folder,
+            }),
+          ],
+        },
+      },
+      { space: "project", folder: "ignore", list: "ignore" },
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.task?.project).toEqual({ name: "Product", source: "clickup", sourceId: "space-product" });
+    expect(items[0]?.parentEntities).toEqual([
+      { source: "clickup", sourceId: "space-product", contextSnippet: "In space: Product" },
+    ]);
+
+    const emittedFacts: Array<Record<string, unknown>> = [];
+    await emitFactsForSyncedItem({
+      factRepo: {
+        upsertFact: async (fact: Record<string, unknown>) => {
+          emittedFacts.push(fact);
+        },
+      } as never,
+      connector: createClickUpConnector(),
+      connectorType: "clickup",
+      factContext: {
+        connectorConfigId: "connector-clickup",
+        createdByUserId: "user-clickup",
+        lastSeenSyncRunId: "sync-run",
+      },
+      item: items[0] as SyncedItem,
+      indexedFileId: "indexed-task",
+      experimentalFlag: true,
+    });
+
+    expect(emittedFacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          factType: "parent_entity",
+          subjectSourceId: "space-product",
+          raw: expect.objectContaining({
+            parent: { source: "clickup", sourceId: "space-product", contextSnippet: "In space: Product" },
+          }),
+        }),
+        expect.objectContaining({
+          factType: "structural_task",
+          raw: expect.objectContaining({
+            task: expect.objectContaining({
+              project: { name: "Product", source: "clickup", sourceId: "space-product" },
+            }),
+          }),
+        }),
+      ]),
+    );
+    expect(emittedFacts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ subjectSourceId: "folder-delivery" })]),
+    );
+  });
+
+  it("keeps default hierarchy seeding while preserving legacy sprint cycle detection when no mapping is stored", async () => {
+    const list = {
+      id: "list-sprint-default",
+      name: "Sprint 8",
+      start_date: "1747094400000",
+      due_date: "1748217600000",
+    };
+    const { seeds, items } = await collectClickUpSync({
+      team: { id: "workspace-default", name: "Default Workspace", members: [] },
+      spaces: [{ id: "space-default", name: "Default Space", features: { sprints: { enabled: true } } }],
+      foldersBySpace: { "space-default": [] },
+      listsByFolder: {},
+      folderlessListsBySpace: { "space-default": [list] },
+      tasksByList: {
+        "list-sprint-default": [
+          clickupTask({
+            id: "task-default-sprint",
+            name: "Default sprint task",
+            spaceId: "space-default",
+            list,
+          }),
+        ],
+      },
+    });
+
+    expect(seeds).toEqual([expect.objectContaining({ sourceType: "project", sourceId: "space-default" })]);
+    expect(items[0]?.task?.project).toEqual({ name: "Default Space", source: "clickup", sourceId: "space-default" });
+    expect(items[0]?.task?.cycle).toMatchObject({
+      externalRef: "list-sprint-default",
+      scopeRef: { source: "clickup", sourceId: "space-default" },
+      isSprint: true,
+    });
+  });
+
+  it("treats a stored list project mapping as authoritative over sprint-like names", async () => {
+    const list = {
+      id: "list-sprint-project",
+      name: "Sprint 9",
+      start_date: "1747094400000",
+      due_date: "1748217600000",
+    };
+    const { seeds, items } = await collectClickUpSync(
+      {
+        team: { id: "workspace-project-list", name: "Project List Workspace", members: [] },
+        spaces: [{ id: "space-project-list", name: "Project List Space", features: { sprints: { enabled: true } } }],
+        foldersBySpace: { "space-project-list": [] },
+        listsByFolder: {},
+        folderlessListsBySpace: { "space-project-list": [list] },
+        tasksByList: {
+          "list-sprint-project": [
+            clickupTask({
+              id: "task-project-list",
+              name: "Project list task",
+              spaceId: "space-project-list",
+              list,
+            }),
+          ],
+        },
+      },
+      { space: "project", list: "project" },
+    );
+
+    expect(seeds.map((seed) => seed.sourceId)).toEqual(
+      expect.arrayContaining(["space-project-list", "list-sprint-project"]),
+    );
+    expect(items[0]?.task?.cycle).toBeUndefined();
+    expect(items[0]?.task?.project).toEqual({ name: "Sprint 9", source: "clickup", sourceId: "list-sprint-project" });
+  });
+
+  it("keeps sprint tasks parented to the nearest mapped project and drops sprint cycles with no project ancestor", async () => {
+    const sprintList = {
+      id: "list-dated-iteration",
+      name: "Iteration 10",
+      start_date: "1747094400000",
+      due_date: "1748217600000",
+    };
+    const withProject = await collectClickUpSync(
+      {
+        team: { id: "workspace-sprint", name: "Sprint Workspace", members: [] },
+        spaces: [{ id: "space-sprint", name: "Sprint Space", features: { sprints: { enabled: false } } }],
+        foldersBySpace: { "space-sprint": [{ id: "folder-ignored", name: "Ignored Folder" }] },
+        listsByFolder: { "folder-ignored": [sprintList] },
+        folderlessListsBySpace: { "space-sprint": [] },
+        tasksByList: {
+          "list-dated-iteration": [
+            clickupTask({
+              id: "task-sprint-parent",
+              name: "Sprint parent task",
+              spaceId: "space-sprint",
+              folder: { id: "folder-ignored", name: "Ignored Folder" },
+              list: sprintList,
+            }),
+          ],
+        },
+      },
+      { space: "project", folder: "ignore", list: "sprint" },
+    );
+
+    expect(withProject.items[0]?.task?.project).toEqual({
+      name: "Sprint Space",
+      source: "clickup",
+      sourceId: "space-sprint",
+    });
+    expect(withProject.items[0]?.task?.cycle).toMatchObject({
+      externalRef: "list-dated-iteration",
+      scopeRef: { source: "clickup", sourceId: "space-sprint" },
+      isSprint: true,
+    });
+
+    const withoutProject = await collectClickUpSync(
+      {
+        team: { id: "workspace-no-project", name: "No Project Workspace", members: [] },
+        spaces: [{ id: "space-no-project", name: "No Project Space", features: { sprints: { enabled: false } } }],
+        foldersBySpace: { "space-no-project": [] },
+        listsByFolder: {},
+        folderlessListsBySpace: { "space-no-project": [sprintList] },
+        tasksByList: {
+          "list-dated-iteration": [
+            clickupTask({
+              id: "task-no-project",
+              name: "No project task",
+              spaceId: "space-no-project",
+              list: sprintList,
+            }),
+          ],
+        },
+      },
+      { workspace: "team", space: "ignore", list: "sprint" },
+    );
+
+    expect(withoutProject.items[0]?.task?.project).toBeUndefined();
+    expect(withoutProject.items[0]?.task?.cycle).toBeUndefined();
+  });
+});

--- a/packages/server/src/connectors/clickup.test.ts
+++ b/packages/server/src/connectors/clickup.test.ts
@@ -5,7 +5,13 @@
  * do not produce an infinite loop.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type ClickUpList, type ClickUpSpace, createClickUpConnector, detectSprintCycle } from "./clickup";
+import {
+  type ClickUpList,
+  type ClickUpSpace,
+  createClickUpConnector,
+  detectSprintCycle,
+  resolveListCycle,
+} from "./clickup";
 
 const sprintsEnabledSpace: ClickUpSpace = {
   id: "space-design",
@@ -65,6 +71,112 @@ describe("detectSprintCycle", () => {
     ]) {
       expect(detectSprintCycle(list, sprintsEnabledSpace)).toBeNull();
     }
+  });
+});
+
+describe("resolveListCycle", () => {
+  it("keeps legacy sprint detection for flag-off and computed-default states", () => {
+    expect(
+      resolveListCycle({
+        list: sprintList,
+        space: sprintsEnabledSpace,
+        workspaceName: "Workspace",
+        workspaceId: "workspace",
+        storedMapping: { space: "project", list: "ignore" },
+        experimentalFlag: false,
+      }),
+    ).toMatchObject({ externalRef: sprintList.id, scopeRef: { source: "clickup", sourceId: sprintsEnabledSpace.id } });
+
+    for (const storedMapping of [undefined, {}, { nope: "project" }, { list: "bogus" }]) {
+      expect(
+        resolveListCycle({
+          list: sprintList,
+          space: sprintsEnabledSpace,
+          workspaceName: "Workspace",
+          workspaceId: "workspace",
+          storedMapping,
+          experimentalFlag: true,
+        }),
+      ).toMatchObject({ externalRef: sprintList.id });
+    }
+  });
+
+  it("lets a stored list mapping suppress the heuristic or create dates-only sprint cycles", () => {
+    expect(
+      resolveListCycle({
+        list: sprintList,
+        space: sprintsEnabledSpace,
+        workspaceName: "Workspace",
+        workspaceId: "workspace",
+        storedMapping: { space: "project", list: "project" },
+        experimentalFlag: true,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveListCycle({
+        list: { ...sprintList, name: "Iteration 5" },
+        space: { ...sprintsEnabledSpace, features: { sprints: { enabled: false } } },
+        workspaceName: "Workspace",
+        workspaceId: "workspace",
+        storedMapping: { space: "project", list: "sprint" },
+        experimentalFlag: true,
+      }),
+    ).toMatchObject({
+      externalRef: sprintList.id,
+      name: "Iteration 5",
+      scopeRef: { source: "clickup", sourceId: sprintsEnabledSpace.id },
+      isSprint: true,
+    });
+  });
+
+  it("requires dates and a nearest mapped project ancestor for stored sprint lists", () => {
+    expect(
+      resolveListCycle({
+        list: { ...sprintList, start_date: null },
+        space: sprintsEnabledSpace,
+        workspaceName: "Workspace",
+        workspaceId: "workspace",
+        storedMapping: { space: "project", list: "sprint" },
+        experimentalFlag: true,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveListCycle({
+        list: sprintList,
+        space: sprintsEnabledSpace,
+        workspaceName: "Workspace",
+        workspaceId: "workspace",
+        storedMapping: { workspace: "team", space: "ignore", list: "sprint" },
+        experimentalFlag: true,
+        logger: { warn: vi.fn() },
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveListCycle({
+        list: sprintList,
+        space: sprintsEnabledSpace,
+        folder: { id: "folder-design", name: "Design" },
+        workspaceName: "Workspace",
+        workspaceId: "workspace",
+        storedMapping: { space: "project", folder: "ignore", list: "sprint" },
+        experimentalFlag: true,
+      }),
+    ).toMatchObject({ scopeRef: { source: "clickup", sourceId: sprintsEnabledSpace.id } });
+
+    expect(
+      resolveListCycle({
+        list: sprintList,
+        space: sprintsEnabledSpace,
+        folder: { id: "folder-design", name: "Design" },
+        workspaceName: "Workspace",
+        workspaceId: "workspace",
+        storedMapping: { folder: "project", list: "sprint" },
+        experimentalFlag: true,
+      }),
+    ).toMatchObject({ scopeRef: { source: "clickup", sourceId: "folder-design" } });
   });
 });
 

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -14,11 +14,21 @@
  */
 import { createHash } from "node:crypto";
 import pino, { type Logger } from "pino";
+import {
+  type HierarchyMapping,
+  type HierarchyNode,
+  computeStructureAwareDefault,
+  mappedAncestors,
+  nearestMappedAncestor,
+  resolveHierarchyMapping,
+} from "./hierarchy-mapping";
 import type {
   Connector,
   ConnectorCredentials,
   EntitySeed,
   EntitySeedCallback,
+  HierarchyLevelDeclaration,
+  HierarchyTarget,
   OAuthCredentials,
   PersonEntitySeedCallback,
   SyncedItem,
@@ -101,6 +111,16 @@ function getAccessToken(credentials: ConnectorCredentials): string {
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
+
+const CLICKUP_HIERARCHY_LEVELS: HierarchyLevelDeclaration[] = [
+  { key: "workspace", label: "Workspace", allowedTargets: ["team", "ignore"], default: "ignore" },
+  { key: "space", label: "Space", allowedTargets: ["team", "project", "ignore"], default: "ignore" },
+  { key: "folder", label: "Folder", allowedTargets: ["project", "ignore"], default: "ignore" },
+  { key: "list", label: "List", allowedTargets: ["project", "sprint", "ignore"], default: "ignore" },
+];
+
+const HIERARCHY_TARGETS = new Set<HierarchyTarget>(["team", "project", "sprint", "ignore"]);
+const CLICKUP_HIERARCHY_LEVEL_KEYS = new Set(CLICKUP_HIERARCHY_LEVELS.map((level) => level.key));
 
 async function clickupRequest(path: string, token: string, logger: Logger, attempt = 1): Promise<unknown> {
   const url = `${CLICKUP_API}${path}`;
@@ -254,6 +274,92 @@ function isPositiveDigitString(value: string | null | undefined): value is strin
   return Number.isFinite(numericValue) && numericValue > 0;
 }
 
+function hasListDates(list: ClickUpList): boolean {
+  return isPositiveDigitString(list.start_date) && isPositiveDigitString(list.due_date);
+}
+
+function hasStoredHierarchyMapping(stored: unknown): boolean {
+  if (!stored || typeof stored !== "object" || Array.isArray(stored)) return false;
+  return Object.entries(stored).some(
+    ([levelKey, target]) =>
+      CLICKUP_HIERARCHY_LEVEL_KEYS.has(levelKey) && HIERARCHY_TARGETS.has(target as HierarchyTarget),
+  );
+}
+
+function clickupHierarchyNodes(params: {
+  workspaceName: string;
+  workspaceId: string;
+  spaceName: string;
+  spaceId: string;
+  folder?: { id: string; name: string };
+  list?: ClickUpList;
+}): HierarchyNode[] {
+  return [
+    { levelKey: "workspace", id: params.workspaceId, name: params.workspaceName },
+    { levelKey: "space", id: params.spaceId, name: params.spaceName },
+    ...(params.folder ? [{ levelKey: "folder", id: params.folder.id, name: params.folder.name }] : []),
+    ...(params.list
+      ? [{ levelKey: "list", id: params.list.id, name: params.list.name, hasDates: hasListDates(params.list) }]
+      : []),
+  ];
+}
+
+export function resolveListCycle(params: {
+  list: ClickUpList;
+  space: ClickUpSpace;
+  folder?: { id: string; name: string };
+  workspaceName: string;
+  workspaceId: string;
+  storedMapping: unknown;
+  experimentalFlag: boolean;
+  logger?: Pick<Logger, "warn">;
+}): SyncedTaskCycle | null {
+  if (!params.experimentalFlag || !hasStoredHierarchyMapping(params.storedMapping)) {
+    return detectSprintCycle(params.list, params.space, params.folder);
+  }
+
+  const mapping = resolveHierarchyMapping(CLICKUP_HIERARCHY_LEVELS, params.storedMapping, {
+    levelContexts: [{ key: "list", hasDates: hasListDates(params.list) }],
+    logger: params.logger,
+  });
+  if (mapping.list !== "sprint") return null;
+
+  const startsAt = parseClickUpTimestamp(params.list.start_date);
+  const endsAt = parseClickUpTimestamp(params.list.due_date);
+  if (!startsAt || !endsAt) return null;
+
+  const projectAncestor = nearestMappedAncestor(
+    clickupHierarchyNodes({
+      workspaceName: params.workspaceName,
+      workspaceId: params.workspaceId,
+      spaceName: params.space.name,
+      spaceId: params.space.id,
+      folder: params.folder,
+    }),
+    mapping,
+    ["project"],
+  );
+  if (!projectAncestor) {
+    params.logger?.warn(
+      { listId: params.list.id, listName: params.list.name },
+      "Ignoring mapped sprint list without project ancestor",
+    );
+    return null;
+  }
+
+  const sequenceMatch = /\bsprint\s*#?\s*(\d+)/i.exec(params.list.name);
+  return {
+    source: "clickup",
+    externalRef: params.list.id,
+    name: params.list.name,
+    scopeRef: { source: "clickup", sourceId: projectAncestor.id },
+    startsAt,
+    endsAt,
+    sequence: sequenceMatch ? Number(sequenceMatch[1]) : undefined,
+    isSprint: true,
+  };
+}
+
 function taskToSyncedItem(
   task: ClickUpTask,
   workspaceName: string,
@@ -265,6 +371,7 @@ function taskToSyncedItem(
   listProjectParent: { id: string; name: string } | undefined,
   accessScope?: SyncedItem["accessScope"],
   cycle?: SyncedTaskCycle,
+  hierarchyMapping?: HierarchyMapping,
 ): SyncedItem {
   const hasDescription = task.description && task.description.trim().length > 0;
 
@@ -287,22 +394,42 @@ function taskToSyncedItem(
   // Full hierarchical path: Workspace / Space / Folder / List
   const sourcePath = [workspaceName, spaceName, folderName, task.list.name].filter(Boolean).join(" / ");
 
-  const parentEntities: SyncedItem["parentEntities"] = [
-    { source: "clickup", sourceId: workspaceId, contextSnippet: `In workspace: ${workspaceName}` },
-    { source: "clickup", sourceId: spaceId, contextSnippet: `In space: ${spaceName}` },
-  ];
-  if (folderId && folderName) {
+  const rawHierarchyNodes = clickupHierarchyNodes({
+    workspaceName,
+    workspaceId,
+    spaceName,
+    spaceId,
+    folder: folderId && folderName ? { id: folderId, name: folderName } : undefined,
+    list: { id: task.list.id, name: task.list.name },
+  });
+  const parentEntities: SyncedItem["parentEntities"] = hierarchyMapping
+    ? mappedAncestors(rawHierarchyNodes, hierarchyMapping).map((node) => ({
+        source: "clickup",
+        sourceId: node.id,
+        contextSnippet: `In ${node.levelKey}: ${node.name}`,
+      }))
+    : [
+        { source: "clickup", sourceId: workspaceId, contextSnippet: `In workspace: ${workspaceName}` },
+        { source: "clickup", sourceId: spaceId, contextSnippet: `In space: ${spaceName}` },
+      ];
+  if (!hierarchyMapping && folderId && folderName) {
     parentEntities.push({ source: "clickup", sourceId: folderId, contextSnippet: `In folder: ${folderName}` });
   }
-  if (listProjectParent) {
+  if (!hierarchyMapping && listProjectParent) {
     parentEntities.push({
       source: "clickup",
       sourceId: listProjectParent.id,
       contextSnippet: `In list: ${listProjectParent.name}`,
     });
   }
-  const taskProject =
-    folderId && folderName
+  const mappedProject = hierarchyMapping
+    ? nearestMappedAncestor(rawHierarchyNodes, hierarchyMapping, ["project"])
+    : undefined;
+  const taskProject = hierarchyMapping
+    ? mappedProject
+      ? { name: mappedProject.name, source: "clickup", sourceId: mappedProject.id }
+      : undefined
+    : folderId && folderName
       ? { name: folderName, source: "clickup", sourceId: folderId }
       : listProjectParent
         ? { name: listProjectParent.name, source: "clickup", sourceId: listProjectParent.id }
@@ -371,6 +498,60 @@ function clickupProjectSeed(params: {
       path: `${params.workspaceName} / ${params.spaceName} / ${params.node.name}`,
     },
   };
+}
+
+function clickupHierarchySeed(params: {
+  node: { id: string; name: string };
+  sourceType: "team" | "project";
+  levelKey: string;
+  workspaceName: string;
+  workspaceId: string;
+  spaceName?: string;
+  spaceId?: string;
+  parentPath?: string[];
+}): EntitySeed {
+  const path = [...(params.parentPath ?? []), params.node.name].join(" / ");
+  return {
+    name: params.node.name,
+    sourceType: params.sourceType,
+    source: "clickup",
+    sourceId: params.node.id,
+    metadata: {
+      levelKey: params.levelKey,
+      workspaceName: params.workspaceName,
+      workspaceId: params.workspaceId,
+      spaceName: params.spaceName,
+      spaceId: params.spaceId,
+      path,
+    },
+  };
+}
+
+async function maybeSeedMappedClickUpNode(params: {
+  onEntitySeed?: EntitySeedCallback;
+  mapping: HierarchyMapping;
+  levelKey: string;
+  node: { id: string; name: string };
+  workspaceName: string;
+  workspaceId: string;
+  spaceName?: string;
+  spaceId?: string;
+  parentPath?: string[];
+}): Promise<void> {
+  const target = params.mapping[params.levelKey];
+  if (target !== "team" && target !== "project") return;
+  await params.onEntitySeed?.(
+    clickupHierarchySeed({
+      node: params.node,
+      sourceType: target,
+      levelKey: params.levelKey,
+      workspaceName: params.workspaceName,
+      workspaceId: params.workspaceId,
+      spaceName: params.spaceName,
+      spaceId: params.spaceId,
+      parentPath: params.parentPath,
+    }),
+  );
 }
 
 /** Flatten nested doc pages into a single ordered list. */
@@ -453,6 +634,7 @@ export function createClickUpConnector(): Connector {
     type: "clickup",
     perUserAuth: false,
     requiresOAuthClientSetup: false,
+    hierarchyLevels: CLICKUP_HIERARCHY_LEVELS,
 
     assigneeSourceRefKey(name: string) {
       return `clickup:assignee:${name}`;
@@ -463,10 +645,12 @@ export function createClickUpConnector(): Connector {
       await clickupRequest("/user", token, pino({ level: "silent" }));
     },
 
-    async *sync({ credentials, scopeConfig, cursor, logger, onEntitySeed, onPersonSeed }) {
+    async *sync({ credentials, scopeConfig, cursor, logger, onEntitySeed, onPersonSeed, experimentalFlag = false }) {
       const token = getAccessToken(credentials);
       const allowedWorkspaces = (scopeConfig.workspaces as string[] | undefined) ?? [];
       const allowedSpaces = (scopeConfig.spaces as string[] | undefined) ?? [];
+      const storedHierarchyMapping = scopeConfig.hierarchyMapping;
+      const hasStoredMapping = hasStoredHierarchyMapping(storedHierarchyMapping);
       const seenAssignees = new Map<string, { username: string; email?: string }>();
 
       // Incremental: convert cursor to Unix ms for date_updated_gt filter
@@ -491,8 +675,28 @@ export function createClickUpConnector(): Connector {
           "Workspace members resolved",
         );
 
+        const workspaceMapping = experimentalFlag
+          ? resolveHierarchyMapping(
+              CLICKUP_HIERARCHY_LEVELS,
+              hasStoredMapping ? storedHierarchyMapping : computeStructureAwareDefault(CLICKUP_HIERARCHY_LEVELS),
+              { logger },
+            )
+          : undefined;
+
+        if (experimentalFlag && workspaceMapping) {
+          await maybeSeedMappedClickUpNode({
+            onEntitySeed,
+            mapping: workspaceMapping,
+            levelKey: "workspace",
+            node: { id: team.id, name: workspaceName },
+            workspaceName,
+            workspaceId: team.id,
+            parentPath: [],
+          });
+        }
+
         // Seed workspace as top-level entity
-        if (onEntitySeed) {
+        if (!experimentalFlag && onEntitySeed) {
           await onEntitySeed({
             name: workspaceName,
             sourceType: "clickup_workspace",
@@ -535,7 +739,7 @@ export function createClickUpConnector(): Connector {
           }
 
           // Seed space as entity with workspace context
-          if (onEntitySeed) {
+          if (!experimentalFlag && onEntitySeed) {
             await onEntitySeed({
               name: space.name,
               sourceType: "clickup_space",
@@ -571,11 +775,49 @@ export function createClickUpConnector(): Connector {
           const foldersRes = (await clickupRequest(`/space/${space.id}/folder`, token, logger)) as {
             folders: ClickUpFolder[];
           };
+
+          // Folderless lists are fetched up-front only on the experimental path, where the
+          // structure-aware default mapping needs to know whether the space has any. When the
+          // flag is off they are fetched after the folder loop (the original order) so a failure
+          // there cannot block folder-list tasks that have already been traversed.
+          let hierarchyMapping: HierarchyMapping | undefined;
+          let folderlessLists: ClickUpList[] = [];
+          if (experimentalFlag) {
+            const folderlessListsRes = (await clickupRequest(`/space/${space.id}/list`, token, logger)) as {
+              lists: ClickUpList[];
+            };
+            folderlessLists = folderlessListsRes.lists;
+            hierarchyMapping = resolveHierarchyMapping(
+              CLICKUP_HIERARCHY_LEVELS,
+              hasStoredMapping
+                ? storedHierarchyMapping
+                : computeStructureAwareDefault(CLICKUP_HIERARCHY_LEVELS, {
+                    hasFolders: foldersRes.folders.length > 0,
+                    hasFolderlessLists: folderlessLists.length > 0,
+                  }),
+              { logger },
+            );
+            if (hierarchyMapping) {
+              await maybeSeedMappedClickUpNode({
+                onEntitySeed,
+                mapping: hierarchyMapping,
+                levelKey: "space",
+                node: space,
+                workspaceName,
+                workspaceId: team.id,
+                spaceName: space.name,
+                spaceId: space.id,
+                parentPath: [workspaceName],
+              });
+            }
+          }
+
           for (const folder of foldersRes.folders) {
             const listsRes = (await clickupRequest(`/folder/${folder.id}/list`, token, logger)) as {
               lists: ClickUpList[];
             };
-            if (onEntitySeed && listsRes.lists.length > 0) {
+            const lists = listsRes.lists;
+            if (!experimentalFlag && onEntitySeed && lists.length > 0) {
               await onEntitySeed(
                 clickupProjectSeed({
                   node: folder,
@@ -586,8 +828,43 @@ export function createClickUpConnector(): Connector {
                 }),
               );
             }
-            for (const list of listsRes.lists) {
-              const cycle = detectSprintCycle(list, space, { id: folder.id, name: folder.name });
+            if (experimentalFlag && hierarchyMapping) {
+              await maybeSeedMappedClickUpNode({
+                onEntitySeed,
+                mapping: hierarchyMapping,
+                levelKey: "folder",
+                node: folder,
+                workspaceName,
+                workspaceId: team.id,
+                spaceName: space.name,
+                spaceId: space.id,
+                parentPath: [workspaceName, space.name],
+              });
+            }
+            for (const list of lists) {
+              if (experimentalFlag && hierarchyMapping) {
+                await maybeSeedMappedClickUpNode({
+                  onEntitySeed,
+                  mapping: hierarchyMapping,
+                  levelKey: "list",
+                  node: list,
+                  workspaceName,
+                  workspaceId: team.id,
+                  spaceName: space.name,
+                  spaceId: space.id,
+                  parentPath: [workspaceName, space.name, folder.name],
+                });
+              }
+              const cycle = resolveListCycle({
+                list,
+                space,
+                folder: { id: folder.id, name: folder.name },
+                workspaceName,
+                workspaceId: team.id,
+                storedMapping: storedHierarchyMapping,
+                experimentalFlag,
+                logger,
+              });
               yield* fetchTasksFromList(
                 list.id,
                 workspaceName,
@@ -603,15 +880,19 @@ export function createClickUpConnector(): Connector {
                 seenAssignees,
                 sinceMs,
                 cycle ?? undefined,
+                hierarchyMapping,
               );
             }
           }
 
-          const folderlessListsRes = (await clickupRequest(`/space/${space.id}/list`, token, logger)) as {
-            lists: ClickUpList[];
-          };
-          for (const list of folderlessListsRes.lists) {
-            if (onEntitySeed) {
+          if (!experimentalFlag) {
+            const folderlessListsRes = (await clickupRequest(`/space/${space.id}/list`, token, logger)) as {
+              lists: ClickUpList[];
+            };
+            folderlessLists = folderlessListsRes.lists;
+          }
+          for (const list of folderlessLists) {
+            if (!experimentalFlag && onEntitySeed) {
               await onEntitySeed(
                 clickupProjectSeed({
                   node: list,
@@ -622,7 +903,28 @@ export function createClickUpConnector(): Connector {
                 }),
               );
             }
-            const cycle = detectSprintCycle(list, space, undefined);
+            if (experimentalFlag && hierarchyMapping) {
+              await maybeSeedMappedClickUpNode({
+                onEntitySeed,
+                mapping: hierarchyMapping,
+                levelKey: "list",
+                node: list,
+                workspaceName,
+                workspaceId: team.id,
+                spaceName: space.name,
+                spaceId: space.id,
+                parentPath: [workspaceName, space.name],
+              });
+            }
+            const cycle = resolveListCycle({
+              list,
+              space,
+              workspaceName,
+              workspaceId: team.id,
+              storedMapping: storedHierarchyMapping,
+              experimentalFlag,
+              logger,
+            });
             yield* fetchTasksFromList(
               list.id,
               workspaceName,
@@ -638,6 +940,7 @@ export function createClickUpConnector(): Connector {
               seenAssignees,
               sinceMs,
               cycle ?? undefined,
+              hierarchyMapping,
             );
           }
         }
@@ -702,6 +1005,7 @@ async function* fetchTasksFromList(
   seenAssignees?: Map<string, { username: string; email?: string }>,
   sinceMs?: number,
   cycle?: SyncedTaskCycle,
+  hierarchyMapping?: HierarchyMapping,
 ): AsyncGenerator<SyncedItem> {
   try {
     let url = `/list/${listId}/task?include_subtasks=true&subtasks=true&include_closed=true`;
@@ -730,6 +1034,7 @@ async function* fetchTasksFromList(
         listProjectParent,
         accessScope,
         cycle,
+        hierarchyMapping,
       );
     }
   } catch (err) {

--- a/packages/server/src/connectors/fireflies.isolated.test.ts
+++ b/packages/server/src/connectors/fireflies.isolated.test.ts
@@ -1,11 +1,13 @@
 /**
- * Tests for the Fireflies connector's cursor lag.
+ * Tests for the Fireflies connector's incremental overlap window.
  *
  * Fireflies' GraphQL `fromDate` filters by meeting start time, not by
- * transcript availability. Fireflies takes ~15–45 min to post-process a
- * recording into a queryable transcript. If `getCursor` returned `now`,
- * any transcript whose meeting predates the cursor at the moment
- * Fireflies makes it listable would be silently dropped forever.
+ * transcript availability. A transcript can be finalized days after its
+ * meeting (delayed processing or a manual upload of an old recording); it
+ * then carries an OLD meeting `date`. If incremental sync started exactly at
+ * the stored cursor, such a transcript would sit below the high-watermark and
+ * be filtered out forever. `sync` instead looks back an overlap window before
+ * the cursor and relies on content-hash dedup to make the re-scan cheap.
  */
 import pino from "pino";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -118,8 +120,8 @@ async function runFirefliesOnce(
   }
 }
 
-describe("Fireflies getCursor lag", () => {
-  it("returns a timestamp exactly 2h behind the current time", async () => {
+describe("Fireflies getCursor", () => {
+  it("stores the true high-watermark (now), leaving the recent-window re-scan to sync's overlap", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-27T12:00:00.000Z"));
 
@@ -133,7 +135,7 @@ describe("Fireflies getCursor lag", () => {
         logger: silentLogger,
       });
 
-      expect(cursor).toBe("2026-04-27T10:00:00.000Z");
+      expect(cursor).toBe("2026-04-27T12:00:00.000Z");
     } finally {
       vi.useRealTimers();
     }
@@ -142,8 +144,11 @@ describe("Fireflies getCursor lag", () => {
 
 describe("Fireflies sync includes late-arriving transcripts", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
+  /** Captures the `fromDate` the connector asked the API to filter on. */
+  let requestedFromDate: string | undefined;
 
   beforeEach(() => {
+    requestedFromDate = undefined;
     fetchSpy = vi.spyOn(globalThis, "fetch");
   });
 
@@ -151,13 +156,13 @@ describe("Fireflies sync includes late-arriving transcripts", () => {
     vi.restoreAllMocks();
   });
 
-  it("yields a transcript whose meeting date is 30 min before now when cursor is 2h in the past", async () => {
-    const now = Date.now();
-    const meetingDate = now - 30 * 60 * 1000; // 30 min ago
-    const cursor = new Date(now - 2 * 60 * 60 * 1000).toISOString();
-
-    // Page 1: one transcript; page 2: empty list ends pagination.
-    // Interleaved with summary lookups per transcript.
+  /**
+   * Mock that mimics Fireflies' SERVER-SIDE `fromDate` filtering: a transcript
+   * is only listable when its meeting `date` is at or after the requested
+   * `fromDate`. This is what makes the test meaningful — a connector that
+   * started exactly at the cursor would never see the late transcript.
+   */
+  function mockFirefliesFilteringByFromDate(transcripts: Array<{ id: string; date: number }>): void {
     fetchSpy.mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
       const body = JSON.parse((init as RequestInit).body as string) as {
         query: string;
@@ -165,26 +170,24 @@ describe("Fireflies sync includes late-arriving transcripts", () => {
       };
 
       if (body.query.includes("transcripts(")) {
-        // List query
         if ((body.variables.skip as number) === 0) {
-          return new Response(
-            JSON.stringify({
-              data: {
-                transcripts: [
-                  {
-                    id: "t1",
-                    title: "Late transcript",
-                    date: meetingDate,
-                    duration: 600,
-                    organizer_email: "a@example.com",
-                    participants: ["a@example.com", "b@example.com"],
-                    transcript_url: "https://fireflies.example/t1",
-                  },
-                ],
-              },
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          );
+          requestedFromDate = body.variables.fromDate as string | undefined;
+          const fromMs = requestedFromDate ? Date.parse(requestedFromDate) : Number.NEGATIVE_INFINITY;
+          const visible = transcripts
+            .filter((t) => t.date >= fromMs)
+            .map((t) => ({
+              id: t.id,
+              title: `Meeting ${t.id}`,
+              date: t.date,
+              duration: 600,
+              organizer_email: "a@example.com",
+              participants: ["a@example.com"],
+              transcript_url: `https://fireflies.example/${t.id}`,
+            }));
+          return new Response(JSON.stringify({ data: { transcripts: visible } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
         }
         return new Response(JSON.stringify({ data: { transcripts: [] } }), {
           status: 200,
@@ -193,21 +196,10 @@ describe("Fireflies sync includes late-arriving transcripts", () => {
       }
 
       if (body.query.includes("transcript(id:")) {
-        return new Response(
-          JSON.stringify({
-            data: {
-              transcript: {
-                summary: {
-                  overview: "Overview",
-                  shorthand_bullet: ["Point"],
-                  action_items: ["Action"],
-                  keywords: ["kw"],
-                },
-              },
-            },
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ data: { transcript: { summary: { overview: "o" }, speakers: [] } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       return new Response(JSON.stringify({ data: {} }), {
@@ -215,20 +207,47 @@ describe("Fireflies sync includes late-arriving transcripts", () => {
         headers: { "Content-Type": "application/json" },
       });
     });
+  }
 
+  async function collectSync(cursor: string, scopeConfig: Record<string, unknown> = {}): Promise<string[]> {
     const connector = createFirefliesConnector({ minRequestIntervalMs: 0 });
-    const items: Array<{ providerFileId: string }> = [];
+    const ids: string[] = [];
     for await (const item of connector.sync({
       credentials: { type: "api_key", api_key: "test" },
-      scopeConfig: {},
+      scopeConfig,
       cursor,
       logger: silentLogger,
     })) {
-      items.push(item);
+      ids.push(item.providerFileId);
     }
+    return ids;
+  }
 
-    expect(items).toHaveLength(1);
-    expect(items[0].providerFileId).toBe("t1");
+  it("recovers a transcript finalized days after its meeting date (below the cursor high-watermark)", async () => {
+    const cursor = "2026-06-23T00:00:00.000Z";
+    // Meeting was 5 days before the cursor — a tight `fromDate=cursor` filter
+    // would skip it. The 7-day overlap pulls it back in.
+    const meetingDate = Date.parse("2026-06-18T00:00:00.000Z");
+    mockFirefliesFilteringByFromDate([{ id: "t-late", date: meetingDate }]);
+
+    const ids = await collectSync(cursor);
+
+    expect(ids).toEqual(["t-late"]);
+    expect(requestedFromDate).toBe("2026-06-16T00:00:00.000Z");
+  }, 20_000);
+
+  it("respects a per-connector scopeConfig.incrementalOverlapDays override", async () => {
+    const cursor = "2026-06-23T00:00:00.000Z";
+    // 10 days back: missed by the default 7-day window, caught by a 14-day override.
+    const meetingDate = Date.parse("2026-06-13T00:00:00.000Z");
+    mockFirefliesFilteringByFromDate([{ id: "t-old", date: meetingDate }]);
+
+    const missed = await collectSync(cursor);
+    expect(missed).toEqual([]);
+
+    const recovered = await collectSync(cursor, { incrementalOverlapDays: 14 });
+    expect(recovered).toEqual(["t-old"]);
+    expect(requestedFromDate).toBe("2026-06-09T00:00:00.000Z");
   }, 20_000);
 });
 

--- a/packages/server/src/connectors/fireflies.ts
+++ b/packages/server/src/connectors/fireflies.ts
@@ -30,16 +30,50 @@ const RETRY_BASE_MS = 1000;
 const REQUEST_TIMEOUT_MS = 30_000;
 
 /**
- * Fireflies post-processes recordings into queryable transcripts for
- * ~15–45 min after a meeting ends. During that window the transcript
- * is invisible to the API. If we advance the cursor to `now`, a
- * transcript whose meeting `date` predates the cursor when it finally
- * becomes listable is filtered out by Fireflies' `fromDate` forever.
+ * Fireflies' GraphQL `fromDate` filters transcripts by meeting start time
+ * (`date`), NOT by when a transcript becomes listable. Two gaps follow:
  *
- * Lag the cursor by 2h so the next sync always re-queries the recent
- * window. Content-hash dedup makes re-fetches cheap.
+ *  1. Post-processing lag — a recording is queryable only ~15–45 min after
+ *     the meeting ends.
+ *  2. Late finalization — a transcript can be finalized or uploaded days
+ *     after the meeting (delayed processing, or a manual upload of an old
+ *     recording). It then carries an OLD meeting `date`, so once the stored
+ *     cursor's high-watermark has advanced past that date, the next
+ *     incremental sync's `fromDate` filters it out forever — it only
+ *     reappears on a full re-pull (cursor reset).
+ *
+ * Fix: on every incremental sync, look back {@link DEFAULT_INCREMENTAL_OVERLAP_MS}
+ * before the stored cursor instead of starting exactly at it. Content-hash
+ * dedup (`processSyncedItem` returns `kind: "unchanged"`) makes re-seeing an
+ * untouched transcript a cheap no-op, so a generous overlap is safe.
+ *
+ * The window is tunable per connector via `scopeConfig.incrementalOverlapDays`.
+ * Transcripts finalized later than the overlap window still need a cursor
+ * reset to recover.
  */
-const FIREFLIES_PROCESSING_LAG_MS = 2 * 60 * 60 * 1000;
+const DEFAULT_INCREMENTAL_OVERLAP_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Compute the `fromDate` to send for an incremental sync: the stored cursor
+ * shifted back by `overlapMs`. Returns `undefined` for a full sync (no cursor)
+ * so the API returns everything. A malformed cursor falls back to itself
+ * rather than silently widening to all-time.
+ */
+function incrementalFromDate(cursor: string | null, overlapMs: number): string | undefined {
+  if (!cursor) return undefined;
+  const ts = Date.parse(cursor);
+  if (Number.isNaN(ts)) return cursor;
+  return new Date(ts - overlapMs).toISOString();
+}
+
+/** Resolve the incremental overlap window, honoring a per-connector override. */
+function resolveOverlapMs(scopeConfig: Record<string, unknown> | undefined): number {
+  const days = scopeConfig?.incrementalOverlapDays;
+  if (typeof days === "number" && Number.isFinite(days) && days >= 0) {
+    return days * 24 * 60 * 60 * 1000;
+  }
+  return DEFAULT_INCREMENTAL_OVERLAP_MS;
+}
 
 interface FirefliesSpeaker {
   id: number;
@@ -464,7 +498,7 @@ async function fetchContactsMap(
 
 async function* syncTranscripts(
   apiKey: string,
-  sinceTimestamp: string | null,
+  fromDate: string | undefined,
   ownerEmail: string | null,
   resolveNameToEmail: NameResolver | undefined,
   logger: Logger,
@@ -475,13 +509,9 @@ async function* syncTranscripts(
 
   const { byEmail: contacts, byName: contactsByName } = await fetchContactsMap(apiKey, logger, firefliesRequest);
   logger.debug(
-    { contactsCount: contacts.size, contactsByNameCount: contactsByName.size, ownerEmail },
+    { contactsCount: contacts.size, contactsByNameCount: contactsByName.size, ownerEmail, fromDate },
     "Fireflies contacts directory loaded",
   );
-
-  // Pass fromDate to the API so it only returns transcripts newer than our cursor.
-  // Without this, a failed sync retries from the old cursor and re-fetches everything.
-  const fromDate = sinceTimestamp ?? undefined;
 
   let hasMore = true;
   while (hasMore) {
@@ -554,13 +584,17 @@ export function createFirefliesConnector(options: FirefliesConnectorOptions = {}
       await firefliesRequest(USER_QUERY, {}, apiKey, pino({ level: "silent" }));
     },
 
-    async *sync({ credentials, cursor, ownerEmail, resolveNameToEmail, logger }) {
+    async *sync({ credentials, cursor, scopeConfig, ownerEmail, resolveNameToEmail, logger }) {
       const apiKey = getApiKey(credentials);
-      yield* syncTranscripts(apiKey, cursor, ownerEmail ?? null, resolveNameToEmail, logger, firefliesRequest);
+      const fromDate = incrementalFromDate(cursor, resolveOverlapMs(scopeConfig));
+      yield* syncTranscripts(apiKey, fromDate, ownerEmail ?? null, resolveNameToEmail, logger, firefliesRequest);
     },
 
     async getCursor() {
-      return new Date(Date.now() - FIREFLIES_PROCESSING_LAG_MS).toISOString();
+      // Store the true high-watermark; the read-time overlap in `sync` re-scans
+      // the recent window to recover late-finalized transcripts (see
+      // DEFAULT_INCREMENTAL_OVERLAP_MS).
+      return new Date(Date.now()).toISOString();
     },
   };
 }

--- a/packages/server/src/connectors/hierarchy-mapping.test.ts
+++ b/packages/server/src/connectors/hierarchy-mapping.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveHierarchyMapping } from "./hierarchy-mapping";
+import type { HierarchyLevelDeclaration } from "./types";
+
+const TEST_LEVELS: HierarchyLevelDeclaration[] = [
+  { key: "workspace", label: "Workspace", allowedTargets: ["team", "project", "ignore"], default: "ignore" },
+  { key: "space", label: "Space", allowedTargets: ["team", "project", "ignore"], default: "ignore" },
+  { key: "folder", label: "Folder", allowedTargets: ["team", "project", "ignore"], default: "ignore" },
+  { key: "list", label: "List", allowedTargets: ["project", "sprint", "ignore"], default: "ignore" },
+];
+
+describe("resolveHierarchyMapping", () => {
+  it("normalizes duplicate teams and project-above-team chains deterministically", () => {
+    const logger = { warn: vi.fn() };
+
+    const mapping = resolveHierarchyMapping(
+      TEST_LEVELS,
+      {
+        workspace: "project",
+        space: "team",
+        folder: "team",
+        list: "project",
+      },
+      { logger },
+    );
+
+    expect(mapping).toEqual({
+      workspace: "project",
+      space: "ignore",
+      folder: "ignore",
+      list: "project",
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "space", reason: "chain_order" }),
+      "Normalized connector hierarchy mapping",
+    );
+  });
+
+  it("falls sprint mappings on undated lists back to ignore and logs the normalization", () => {
+    const logger = { warn: vi.fn() };
+
+    const mapping = resolveHierarchyMapping(TEST_LEVELS, { list: "sprint" }, { logger });
+
+    expect(mapping.list).toBe("ignore");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "list", reason: "sprint_requires_dates", normalizedTarget: "ignore" }),
+      "Normalized connector hierarchy mapping",
+    );
+  });
+});

--- a/packages/server/src/connectors/hierarchy-mapping.ts
+++ b/packages/server/src/connectors/hierarchy-mapping.ts
@@ -1,0 +1,165 @@
+import type { Logger } from "pino";
+import type { HierarchyLevelDeclaration, HierarchyTarget } from "./types";
+
+export type HierarchyMapping = Record<string, HierarchyTarget>;
+
+export interface HierarchyNode {
+  levelKey: string;
+  id: string;
+  name: string;
+  hasDates?: boolean;
+}
+
+interface HierarchyLevelContext {
+  key: string;
+  hasDates?: boolean;
+}
+
+interface StructureAwareDefaultInput {
+  hasFolders?: boolean;
+  hasFolderlessLists?: boolean;
+}
+
+const REAL_TARGETS = new Set<HierarchyTarget>(["team", "project", "sprint"]);
+const CHAIN_INDEX: Record<Exclude<HierarchyTarget, "ignore">, number> = {
+  team: 0,
+  project: 1,
+  sprint: 2,
+};
+
+function isHierarchyTarget(value: unknown): value is HierarchyTarget {
+  return value === "team" || value === "project" || value === "sprint" || value === "ignore";
+}
+
+function levelHasDates(level: HierarchyLevelDeclaration, context?: HierarchyLevelContext): boolean {
+  return context?.key === level.key && context.hasDates === true;
+}
+
+function logNormalization(logger: Pick<Logger, "warn"> | undefined, details: Record<string, unknown>): void {
+  logger?.warn(details, "Normalized connector hierarchy mapping");
+}
+
+/**
+ * Normalization order is: coerce unknown/disallowed targets to the level default, demote undated sprint levels,
+ * keep the first team only, then walk top-down and demote any real target that would move backward in
+ * `team -> project -> sprint`.
+ */
+export function resolveHierarchyMapping(
+  levels: HierarchyLevelDeclaration[],
+  stored: unknown,
+  opts: { levelContexts?: HierarchyLevelContext[]; logger?: Pick<Logger, "warn"> } = {},
+): HierarchyMapping {
+  const storedRecord =
+    stored && typeof stored === "object" && !Array.isArray(stored) ? (stored as Record<string, unknown>) : {};
+  const levelContexts = opts.levelContexts ?? [];
+  const mapping: HierarchyMapping = {};
+
+  for (const level of levels) {
+    const rawTarget = storedRecord[level.key];
+    const coercedTarget =
+      isHierarchyTarget(rawTarget) && level.allowedTargets.includes(rawTarget) ? rawTarget : level.default;
+    mapping[level.key] = coercedTarget;
+
+    if (rawTarget !== undefined && rawTarget !== coercedTarget) {
+      logNormalization(opts.logger, {
+        level: level.key,
+        requestedTarget: rawTarget,
+        normalizedTarget: coercedTarget,
+        reason: "target_not_allowed",
+      });
+    }
+  }
+
+  for (const level of levels) {
+    if (mapping[level.key] !== "sprint") continue;
+    const context = levelContexts.find((candidate) => candidate.key === level.key);
+    if (!levelHasDates(level, context)) {
+      mapping[level.key] = "ignore";
+      logNormalization(opts.logger, {
+        level: level.key,
+        requestedTarget: "sprint",
+        normalizedTarget: "ignore",
+        reason: "sprint_requires_dates",
+      });
+    }
+  }
+
+  let teamSeen = false;
+  for (const level of levels) {
+    if (mapping[level.key] !== "team") continue;
+    if (teamSeen) {
+      mapping[level.key] = "ignore";
+      logNormalization(opts.logger, {
+        level: level.key,
+        requestedTarget: "team",
+        normalizedTarget: "ignore",
+        reason: "duplicate_team",
+      });
+      continue;
+    }
+    teamSeen = true;
+  }
+
+  let deepestChainIndex = -1;
+  for (const level of levels) {
+    const target = mapping[level.key];
+    if (target === "ignore") continue;
+    const chainIndex = CHAIN_INDEX[target];
+    if (chainIndex < deepestChainIndex) {
+      mapping[level.key] = "ignore";
+      logNormalization(opts.logger, {
+        level: level.key,
+        requestedTarget: target,
+        normalizedTarget: "ignore",
+        reason: "chain_order",
+      });
+      continue;
+    }
+    deepestChainIndex = chainIndex;
+  }
+
+  return mapping;
+}
+
+export function computeStructureAwareDefault(
+  levels: HierarchyLevelDeclaration[],
+  structure: StructureAwareDefaultInput = {},
+): HierarchyMapping {
+  const mapping = Object.fromEntries(levels.map((level) => [level.key, level.default])) as HierarchyMapping;
+
+  if ("workspace" in mapping) mapping.workspace = "ignore";
+  if ("space" in mapping) mapping.space = structure.hasFolders ? "ignore" : "project";
+  if ("folder" in mapping) mapping.folder = structure.hasFolders ? "project" : "ignore";
+  if ("list" in mapping) mapping.list = "ignore";
+
+  if (!structure.hasFolders && !structure.hasFolderlessLists && "space" in mapping) {
+    mapping.space = "ignore";
+  }
+
+  return mapping;
+}
+
+export function nearestMappedAncestor(
+  nodes: HierarchyNode[],
+  mapping: HierarchyMapping,
+  targets: HierarchyTarget[] = ["team", "project", "sprint"],
+): (HierarchyNode & { target: HierarchyTarget }) | undefined {
+  const allowedTargets = new Set(targets);
+  for (let index = nodes.length - 1; index >= 0; index--) {
+    const node = nodes[index];
+    const target = mapping[node.levelKey] ?? "ignore";
+    if (REAL_TARGETS.has(target) && allowedTargets.has(target)) {
+      return { ...node, target };
+    }
+  }
+  return undefined;
+}
+
+export function mappedAncestors(
+  nodes: HierarchyNode[],
+  mapping: HierarchyMapping,
+): Array<HierarchyNode & { target: HierarchyTarget }> {
+  return nodes
+    .map((node) => ({ ...node, target: mapping[node.levelKey] ?? "ignore" }))
+    .filter((node) => node.target === "team" || node.target === "project");
+}

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -256,6 +256,7 @@ export async function runConnectorSync(
       logger: syncLogger,
       ownerEmail,
       resolveNameToEmail,
+      experimentalFlag: appConfig?.EXPERIMENTAL_FLAG ?? false,
       onEntitySeed: async (seed) => {
         await factRepo.upsertFact({
           ...factContext,

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -27,6 +27,15 @@ export type SyncStatus = "pending" | "active" | "syncing" | "paused" | "error" |
 
 export type ContentCategory = "document" | "structured";
 
+export type HierarchyTarget = "team" | "project" | "sprint" | "ignore";
+
+export interface HierarchyLevelDeclaration {
+  key: string;
+  label: string;
+  allowedTargets: HierarchyTarget[];
+  default: HierarchyTarget;
+}
+
 /**
  * Decrypted credentials stored per connector.
  * Shape varies by provider + auth type.
@@ -412,6 +421,8 @@ export interface Connector {
    */
   readonly promotableFileTypes?: string[];
 
+  readonly hierarchyLevels?: HierarchyLevelDeclaration[];
+
   /**
    * Whether this connector's people are email correspondents rather than meeting
    * attendees / document authors. When true, `attendees` and `authorEmail` seed
@@ -452,6 +463,7 @@ export interface Connector {
      * Optional — connectors that don't need it leave it unset.
      */
     resolveNameToEmail?: NameResolver;
+    experimentalFlag?: boolean;
     onEntitySeed?: EntitySeedCallback;
     onPersonSeed?: PersonEntitySeedCallback;
     onEmailSuppressed?: (record: SuppressedEmailRecord) => Promise<void>;

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -127,6 +127,7 @@ import * as m124 from "./migrations/124-tasks-assignee-name";
 import * as m125 from "./migrations/125-milestone-series-and-value-signature";
 import * as m126 from "./migrations/126-work-cycles";
 import * as m127 from "./migrations/127-work-cycles-connector";
+import * as m128 from "./migrations/128-work-cycles-connector-key";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -258,6 +259,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "125-milestone-series-and-value-signature": m125,
           "126-work-cycles": m126,
           "127-work-cycles-connector": m127,
+          "128-work-cycles-connector-key": m128,
         };
       },
     },

--- a/packages/server/src/db/migrations/128-work-cycles-connector-key.ts
+++ b/packages/server/src/db/migrations/128-work-cycles-connector-key.ts
@@ -1,0 +1,21 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_work_cycles_source_ref").ifExists().execute();
+  await db.schema
+    .createIndex("idx_work_cycles_connector_source_ref")
+    .unique()
+    .on("work_cycles")
+    .columns(["connector_config_id", "source", "external_ref"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_work_cycles_connector_source_ref").ifExists().execute();
+  await db.schema
+    .createIndex("idx_work_cycles_source_ref")
+    .unique()
+    .on("work_cycles")
+    .columns(["source", "external_ref"])
+    .execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 123;
+const EXPECTED_MIGRATION_COUNT = 124;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -156,6 +156,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[120]).toBe("125-milestone-series-and-value-signature");
     expect(names[121]).toBe("126-work-cycles");
     expect(names[122]).toBe("127-work-cycles-connector");
+    expect(names[123]).toBe("128-work-cycles-connector-key");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 123;
+const EXPECTED_MIGRATION_COUNT = 124;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -179,6 +179,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[120]).toBe("125-milestone-series-and-value-signature");
     expect(names[121]).toBe("126-work-cycles");
     expect(names[122]).toBe("127-work-cycles-connector");
+    expect(names[123]).toBe("128-work-cycles-connector-key");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/repositories/work-cycles.integration.test.ts
+++ b/packages/server/src/db/repositories/work-cycles.integration.test.ts
@@ -125,14 +125,17 @@ describe("work cycle sink postgres", () => {
 
   it("preserves carryover history and rejects a duplicate open membership", async () => {
     db = await createTestPgDb();
+    await seedBase(db);
     const task = await seedTask(db, { sourceTaskId: "carryover-task", title: "Carry over", status: "open" });
     const cycleA = await upsertWorkCycle(db, {
+      connectorConfigId: CONNECTOR_ID,
       source: "linear",
       externalRef: "sprint-a",
       name: "Sprint 1",
       lastSeenSyncRunId: "sync-1",
     });
     const cycleB = await upsertWorkCycle(db, {
+      connectorConfigId: CONNECTOR_ID,
       source: "linear",
       externalRef: "sprint-b",
       name: "Sprint 2",
@@ -258,6 +261,58 @@ describe("work cycle sink postgres", () => {
       total: 4,
     });
   }, 30000);
+
+  it("keeps work cycle identity scoped to connector config", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    await seedConnector(db, "work-cycle-pg-config-b");
+
+    const cycleA = await upsertWorkCycle(db, {
+      connectorConfigId: CONNECTOR_ID,
+      source: "clickup",
+      externalRef: "shared-list-id",
+      name: "Sprint Shared A",
+      lastSeenSyncRunId: "sync-old",
+    });
+    const cycleB = await upsertWorkCycle(db, {
+      connectorConfigId: "work-cycle-pg-config-b",
+      source: "clickup",
+      externalRef: "shared-list-id",
+      name: "Sprint Shared B",
+      lastSeenSyncRunId: "sync-old",
+    });
+
+    expect(cycleA.cycleId).not.toBe(cycleB.cycleId);
+    await expect(
+      db.selectFrom("work_cycles").selectAll().where("external_ref", "=", "shared-list-id").execute(),
+    ).resolves.toHaveLength(2);
+
+    await expect(
+      reconcileWorkCycles(db, {
+        connectorConfigId: CONNECTOR_ID,
+        syncRunId: "sync-new",
+        at: "2026-06-15T00:00:00.000Z",
+      }),
+    ).resolves.toBe(1);
+
+    await expect(loadCycleState(db, cycleA.cycleId)).resolves.toEqual({
+      state: "closed",
+      deleted_at: "2026-06-15T00:00:00.000Z",
+    });
+    await expect(loadCycleState(db, cycleB.cycleId)).resolves.toEqual({ state: "active", deleted_at: null });
+
+    await expect(
+      reconcileWorkCycles(db, {
+        connectorConfigId: "work-cycle-pg-config-b",
+        syncRunId: "sync-new",
+        at: "2026-06-16T00:00:00.000Z",
+      }),
+    ).resolves.toBe(1);
+    await expect(loadCycleState(db, cycleB.cycleId)).resolves.toEqual({
+      state: "closed",
+      deleted_at: "2026-06-16T00:00:00.000Z",
+    });
+  }, 30000);
 });
 
 async function seedBase(db: Kysely<DB>): Promise<void> {
@@ -265,10 +320,14 @@ async function seedBase(db: Kysely<DB>): Promise<void> {
     .insertInto("users")
     .values({ id: USER_ID, name: "Work Cycle PG User", email: "work-cycle-pg-user@example.com" })
     .execute();
+  await seedConnector(db, CONNECTOR_ID);
+}
+
+async function seedConnector(db: Kysely<DB>, id: string): Promise<void> {
   await db
     .insertInto("connector_configs")
     .values({
-      id: CONNECTOR_ID,
+      id,
       connector_type: "linear",
       auth_type: "api_key",
       credentials: "{}",
@@ -409,4 +468,8 @@ async function openMembershipCount(db: Kysely<DB>, sourceTaskId: string): Promis
     .where("task_cycle_memberships.removed_at", "is", null)
     .executeTakeFirstOrThrow();
   return Number(row.count);
+}
+
+async function loadCycleState(db: Kysely<DB>, id: string): Promise<{ state: string; deleted_at: string | null }> {
+  return db.selectFrom("work_cycles").select(["state", "deleted_at"]).where("id", "=", id).executeTakeFirstOrThrow();
 }

--- a/packages/server/src/db/repositories/work-cycles.ts
+++ b/packages/server/src/db/repositories/work-cycles.ts
@@ -8,7 +8,7 @@ export type WorkCycleState = "planned" | "active" | "closed";
 
 export interface UpsertWorkCycleInput {
   scopeEntityId?: string | null;
-  connectorConfigId?: string | null;
+  connectorConfigId: string;
   source: string;
   externalRef: string;
   name: string;
@@ -52,16 +52,18 @@ export async function upsertWorkCycle(
   db: Kysely<DB>,
   input: UpsertWorkCycleInput,
 ): Promise<{ cycleId: string; created: boolean }> {
+  if (!input.connectorConfigId) throw new Error("Work cycle upsert requires connectorConfigId");
   const existing = await db
     .selectFrom("work_cycles")
     .selectAll()
+    .where("connector_config_id", "=", input.connectorConfigId)
     .where("source", "=", input.source)
     .where("external_ref", "=", input.externalRef)
     .executeTakeFirst();
   const now = new Date().toISOString();
   const values = {
     scope_entity_id: input.scopeEntityId ?? null,
-    connector_config_id: input.connectorConfigId ?? null,
+    connector_config_id: input.connectorConfigId,
     name: input.name,
     sequence: input.sequence ?? null,
     starts_at: input.startsAt ?? null,
@@ -82,7 +84,7 @@ export async function upsertWorkCycle(
       state: input.state ?? "active",
     })
     .onConflict((oc) =>
-      oc.columns(["source", "external_ref"]).doUpdateSet({
+      oc.columns(["connector_config_id", "source", "external_ref"]).doUpdateSet({
         ...values,
       }),
     )
@@ -91,6 +93,7 @@ export async function upsertWorkCycle(
   const row = await db
     .selectFrom("work_cycles")
     .select("id")
+    .where("connector_config_id", "=", input.connectorConfigId)
     .where("source", "=", input.source)
     .where("external_ref", "=", input.externalRef)
     .executeTakeFirstOrThrow();

--- a/packages/server/src/entities/materialize-task.ts
+++ b/packages/server/src/entities/materialize-task.ts
@@ -55,6 +55,7 @@ export async function materializeStructuralTask(
   if (deps.experimentalFlag) {
     const now = new Date().toISOString();
     if (task.cycle?.isSprint) {
+      if (!fact.connector_config_id) throw new Error("Work cycle materialization requires connector_config_id");
       const scopeEntityId = resolveCycleScope(deps, task.cycle.scopeRef)?.id ?? null;
       const cycle = await upsertWorkCycle(deps.db, {
         scopeEntityId,

--- a/packages/web/src/components/hierarchy-mapping-panel.test.ts
+++ b/packages/web/src/components/hierarchy-mapping-panel.test.ts
@@ -1,0 +1,38 @@
+import type { HierarchyLevel } from "@/lib/api";
+/**
+ * Coherence rules for the hierarchy mapping picker: at most one team, a project may
+ * not sit above a team, and a sprint requires a project above it. Tested directly on the pure selectability predicate the
+ * picker uses to disable invalid options (the server re-normalizes authoritatively).
+ */
+import { describe, expect, it } from "vitest";
+import { isTargetSelectable } from "./hierarchy-mapping-panel";
+
+const LEVELS: HierarchyLevel[] = [
+  { key: "workspace", label: "Workspace", allowedTargets: ["team", "ignore"], default: "ignore" },
+  { key: "space", label: "Space", allowedTargets: ["team", "project", "ignore"], default: "ignore" },
+  { key: "folder", label: "Folder", allowedTargets: ["project", "ignore"], default: "ignore" },
+  { key: "list", label: "List", allowedTargets: ["project", "sprint", "ignore"], default: "ignore" },
+];
+
+describe("isTargetSelectable", () => {
+  it("forbids a second team when another level is already a team", () => {
+    expect(isTargetSelectable(LEVELS, { workspace: "team" }, 1, "team")).toBe(false);
+    expect(isTargetSelectable(LEVELS, { space: "team" }, 0, "team")).toBe(false);
+  });
+
+  it("forbids a project above a team (deeper level is a team)", () => {
+    expect(isTargetSelectable(LEVELS, { space: "team" }, 0, "project")).toBe(false);
+  });
+
+  it("allows a coherent chain — a project under a team, and ignore anywhere", () => {
+    expect(isTargetSelectable(LEVELS, { space: "team" }, 2, "project")).toBe(true);
+    expect(isTargetSelectable(LEVELS, { workspace: "team", space: "team" }, 3, "ignore")).toBe(true);
+  });
+
+  it("requires a project above a sprint", () => {
+    expect(isTargetSelectable(LEVELS, { space: "project" }, 3, "sprint")).toBe(true);
+    expect(isTargetSelectable(LEVELS, { workspace: "team", space: "ignore", folder: "ignore" }, 3, "sprint")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/web/src/components/hierarchy-mapping-panel.tsx
+++ b/packages/web/src/components/hierarchy-mapping-panel.tsx
@@ -1,0 +1,147 @@
+/**
+ * Per-connection hierarchy mapping picker (experimental). Lets the user choose what
+ * each tracker level (e.g. ClickUp Workspace/Space/Folder/List) becomes in Sketch:
+ * team, project, sprint, or ignore. The server re-normalizes and re-seeds on save,
+ * so this picker is best-effort UX over an authoritative resolver.
+ */
+import type { HierarchyLevel, HierarchyTarget } from "@/lib/api";
+import { api } from "@/lib/api";
+import { Button } from "@sketch/ui/components/button";
+import { Label } from "@sketch/ui/components/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@sketch/ui/components/select";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+const TARGET_LABELS: Record<HierarchyTarget, string> = {
+  team: "Team",
+  project: "Project",
+  sprint: "Sprint",
+  ignore: "Ignore",
+};
+
+const OFFERED_TARGETS: HierarchyTarget[] = ["team", "project", "sprint", "ignore"];
+
+type Mapping = Record<string, HierarchyTarget>;
+
+function effectiveTarget(level: HierarchyLevel, stored: Mapping): HierarchyTarget {
+  const value = stored[level.key];
+  return value && OFFERED_TARGETS.includes(value) ? value : level.default;
+}
+
+/**
+ * A target is selectable for a level only if it keeps the mapping coherent given the
+ * other levels' current choices: at most one team, no project above a team, and no sprint without a project above it.
+ */
+export function isTargetSelectable(
+  levels: HierarchyLevel[],
+  mapping: Mapping,
+  levelIndex: number,
+  target: HierarchyTarget,
+): boolean {
+  if (target === "ignore") return true;
+  if (target === "team") {
+    const anotherTeam = levels.some((l, i) => i !== levelIndex && mapping[l.key] === "team");
+    const shallowerProject = levels.some((l, i) => i < levelIndex && mapping[l.key] === "project");
+    return !anotherTeam && !shallowerProject;
+  }
+  if (target === "project") {
+    const deeperTeam = levels.some((l, i) => i > levelIndex && mapping[l.key] === "team");
+    return !deeperTeam;
+  }
+  if (target === "sprint") {
+    return levels.some((l, i) => i < levelIndex && mapping[l.key] === "project");
+  }
+  return true;
+}
+
+export function HierarchyMappingPanel({
+  connectorId,
+  levels,
+  scopeConfig,
+}: {
+  connectorId: string;
+  levels: HierarchyLevel[];
+  scopeConfig: Record<string, unknown>;
+}) {
+  const queryClient = useQueryClient();
+  const stored = useMemo<Mapping>(() => {
+    const raw = scopeConfig.hierarchyMapping;
+    return raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Mapping) : {};
+  }, [scopeConfig]);
+
+  const baseline = useMemo<Mapping>(() => {
+    const result: Mapping = {};
+    for (const level of levels) result[level.key] = effectiveTarget(level, stored);
+    return result;
+  }, [levels, stored]);
+
+  const [mapping, setMapping] = useState<Mapping>(baseline);
+
+  const dirty = levels.some((level) => mapping[level.key] !== baseline[level.key]);
+
+  const mutation = useMutation({
+    mutationFn: () => api.integrations.updateScope(connectorId, { ...scopeConfig, hierarchyMapping: mapping }),
+    onSuccess: () => {
+      toast.success("Hierarchy mapping updated — re-syncing.");
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Hierarchy</Label>
+        <p className="text-[11px] text-muted-foreground">
+          Choose what each level becomes in Sketch. A team owns people and cadence; a project is a unit of work; a
+          sprint is a dated cycle that needs a project above it; ignore skips that level.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {levels.map((level, index) => {
+          const value = mapping[level.key];
+          return (
+            <div key={level.key} className="flex items-center justify-between gap-3">
+              <Label htmlFor={`hierarchy-${level.key}`} className="text-xs font-medium text-foreground">
+                {level.label}
+              </Label>
+              <Select
+                value={value}
+                onValueChange={(next) => setMapping((prev) => ({ ...prev, [level.key]: next as HierarchyTarget }))}
+              >
+                <SelectTrigger id={`hierarchy-${level.key}`} className="h-8 w-40 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {level.allowedTargets
+                    .filter((target) => OFFERED_TARGETS.includes(target))
+                    .map((target) => (
+                      <SelectItem
+                        key={target}
+                        value={target}
+                        disabled={!isTargetSelectable(levels, mapping, index, target)}
+                        className="text-xs"
+                      >
+                        {TARGET_LABELS[target]}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+          );
+        })}
+      </div>
+
+      <Button
+        size="sm"
+        className="h-7 text-xs"
+        onClick={() => mutation.mutate()}
+        disabled={!dirty || mutation.isPending}
+      >
+        {mutation.isPending ? "Saving…" : "Save & re-sync"}
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -749,12 +749,22 @@ export type BrowseResult =
   | { type: "nested"; groups: BrowseNestedGroup[] }
   | { type: "tree"; items: BrowseTreeItem[]; groups?: BrowseNestedGroup[] };
 
+export type HierarchyTarget = "team" | "project" | "sprint" | "ignore";
+
+export interface HierarchyLevel {
+  key: string;
+  label: string;
+  allowedTargets: HierarchyTarget[];
+  default: HierarchyTarget;
+}
+
 export interface ConnectorConfig {
   id: string;
   connectorType: string;
   authType: string;
   credentialSource?: "local" | "canvas";
   scopeConfig: Record<string, unknown>;
+  hierarchyLevels?: HierarchyLevel[] | null;
 
   syncStatus: "active" | "syncing" | "error" | "paused" | "pending" | "disabled";
   lastSyncedAt: string | null;

--- a/packages/web/src/routes/files/manage-connector-dialog.tsx
+++ b/packages/web/src/routes/files/manage-connector-dialog.tsx
@@ -8,8 +8,9 @@ import { IntegrationIcon } from "@/components/connect-integration-dialog";
  *
  * Authz: edit controls render from server-provided connector capability fields.
  */
+import { HierarchyMappingPanel } from "@/components/hierarchy-mapping-panel";
 import { GenericScopeEditor } from "@/components/scope-picker";
-import type { ConnectorConfig } from "@/lib/api";
+import type { ConnectorConfig, HierarchyLevel } from "@/lib/api";
 import { api } from "@/lib/api";
 import type { IntegrationDefinition } from "@/lib/integrations";
 import {
@@ -217,6 +218,7 @@ export function ManageConnectorDialog({
               connectorId={connector.id}
               connectorType={connector.connectorType}
               scopeConfig={connector.scopeConfig}
+              hierarchyLevels={connector.hierarchyLevels}
               scopeConfigKey={definition.scopeConfigKey}
               scopeLabel={definition.scopeLabel}
               scopeEntries={scopeEntries}
@@ -424,6 +426,7 @@ function ScopeEditorDispatch({
   connectorId,
   connectorType,
   scopeConfig,
+  hierarchyLevels,
   scopeConfigKey,
   scopeLabel,
   scopeEntries,
@@ -433,46 +436,66 @@ function ScopeEditorDispatch({
   connectorId: string;
   connectorType: string;
   scopeConfig: Record<string, unknown>;
+  hierarchyLevels?: HierarchyLevel[] | null;
   scopeConfigKey?: string;
   scopeLabel: string;
   scopeEntries: [string, unknown][];
   onBrowsingChange?: (browsing: boolean) => void;
 }) {
+  const { data: setupStatus } = useQuery({ queryKey: ["setup", "status"], queryFn: () => api.setup.status() });
+  const experimentalEnabled = setupStatus?.experimentalFlag === true;
+  const showHierarchy = experimentalEnabled && Array.isArray(hierarchyLevels) && hierarchyLevels.length > 0;
+
   if (connectorType === "gmail") {
     return <EmailScopeEditor connectorId={connectorId} scopeConfig={scopeConfig} />;
   }
 
+  const hierarchySection = showHierarchy ? (
+    <HierarchyMappingPanel
+      key={connectorId}
+      connectorId={connectorId}
+      levels={hierarchyLevels}
+      scopeConfig={scopeConfig}
+    />
+  ) : null;
+
   if (scopeType === "none") {
     return (
-      <div>
-        <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-          Sync scope — {scopeLabel}
-        </p>
-        <div className="mt-1.5">
-          {scopeEntries.length > 0 ? (
-            <div className="flex flex-wrap gap-1.5">
-              {scopeEntries.map(([key, value]) => (
-                <Badge key={key} variant="secondary" className="text-[10px]">
-                  {Array.isArray(value) ? value.join(", ") : String(value)}
-                </Badge>
-              ))}
-            </div>
-          ) : (
-            <p className="text-xs text-muted-foreground">All accessible {scopeLabel} are being synced.</p>
-          )}
+      <div className="space-y-4">
+        {hierarchySection}
+        <div>
+          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Sync scope — {scopeLabel}
+          </p>
+          <div className="mt-1.5">
+            {scopeEntries.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {scopeEntries.map(([key, value]) => (
+                  <Badge key={key} variant="secondary" className="text-[10px]">
+                    {Array.isArray(value) ? value.join(", ") : String(value)}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">All accessible {scopeLabel} are being synced.</p>
+            )}
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <GenericScopeEditor
-      connectorId={connectorId}
-      scopeConfig={scopeConfig}
-      scopeConfigKey={scopeConfigKey}
-      noun={scopeLabel}
-      onBrowsingChange={onBrowsingChange}
-    />
+    <div className="space-y-4">
+      {hierarchySection}
+      <GenericScopeEditor
+        connectorId={connectorId}
+        scopeConfig={scopeConfig}
+        scopeConfigKey={scopeConfigKey}
+        noun={scopeLabel}
+        onBrowsingChange={onBrowsingChange}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
Stacked context-graph slice 15/27.

Base: `feat/context-graph-14-work-cycles-sprints`
Head: `feat/context-graph-15-connector-hierarchy-fireflies`

Adds connector hierarchy handling and Fireflies overlap improvements.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`