### PR TITLE
feat: qualify connector container names

### DIFF
--- a/packages/server/src/connectors/clickup-hierarchy-mapping.test.ts
+++ b/packages/server/src/connectors/clickup-hierarchy-mapping.test.ts
@@ -130,10 +130,14 @@ describe("ClickUp hierarchy mapping", () => {
     );
 
     expect(canvas.seeds.filter((seed) => seed.sourceType === "team")).toEqual([
-      expect.objectContaining({ sourceId: "space-marketing", name: "Marketing" }),
+      expect.objectContaining({ sourceId: "space-marketing", name: "Marketing", aliases: undefined }),
     ]);
     expect(canvas.seeds.filter((seed) => seed.sourceType === "project")).toEqual([
-      expect.objectContaining({ sourceId: "folder-content", name: "Content Engine" }),
+      expect.objectContaining({
+        sourceId: "folder-content",
+        name: "Marketing Content Engine",
+        aliases: ["Content Engine"],
+      }),
     ]);
     expect(canvas.seeds.map((seed) => seed.sourceId)).not.toEqual(
       expect.arrayContaining(["list-blog", "list-video", "list-web"]),
@@ -297,7 +301,11 @@ describe("ClickUp hierarchy mapping", () => {
       expect.arrayContaining(["space-project-list", "list-sprint-project"]),
     );
     expect(items[0]?.task?.cycle).toBeUndefined();
-    expect(items[0]?.task?.project).toEqual({ name: "Sprint 9", source: "clickup", sourceId: "list-sprint-project" });
+    expect(items[0]?.task?.project).toEqual({
+      name: "Project List Space Sprint 9",
+      source: "clickup",
+      sourceId: "list-sprint-project",
+    });
   });
 
   it("keeps sprint tasks parented to the nearest mapped project and drops sprint cycles with no project ancestor", async () => {

--- a/packages/server/src/connectors/clickup-project-seeding.test.ts
+++ b/packages/server/src/connectors/clickup-project-seeding.test.ts
@@ -192,6 +192,7 @@ async function syncRecordedClickUpPayload(db: Kysely<DB>, syncRunId: string): Pr
       factContext,
       item,
       indexedFileId: itemResult.indexedFileId,
+      experimentalFlag: true,
     });
   }
 
@@ -214,20 +215,30 @@ describe("ClickUp project entity seeding", () => {
   it("seeds folder-with-lists and folderless-list projects and links folderless tasks to the list project", async () => {
     await syncRecordedClickUpPayload(db, "sync-run-1");
 
-    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
 
     expect(summary.entitiesCreated).toBe(2);
     const projects = await db
       .selectFrom("entities")
       .innerJoin("entity_source_refs", "entity_source_refs.entity_id", "entities.id")
-      .select(["entities.id", "entities.name", "entity_source_refs.source_id"])
+      .select(["entities.id", "entities.name", "entities.aliases", "entity_source_refs.source_id"])
       .where("entities.source_type", "=", "project")
       .where("entity_source_refs.source", "=", "clickup")
       .orderBy("entity_source_refs.source_id")
       .execute();
     expect(projects).toEqual([
-      { id: expect.any(String), name: "Atlas Launch", source_id: "cu-folder-1" },
-      { id: expect.any(String), name: "Customer Rollout", source_id: "cu-list-flat-1" },
+      {
+        id: expect.any(String),
+        name: "Delivery Atlas Launch",
+        aliases: '["Atlas Launch"]',
+        source_id: "cu-folder-1",
+      },
+      {
+        id: expect.any(String),
+        name: "Delivery Customer Rollout",
+        aliases: '["Customer Rollout"]',
+        source_id: "cu-list-flat-1",
+      },
     ]);
     const legacyFolders = await db
       .selectFrom("entities")
@@ -250,6 +261,12 @@ describe("ClickUp project entity seeding", () => {
       .where("source", "=", "clickup_parent_entity")
       .executeTakeFirstOrThrow();
     expect(flatProjectMention.context_snippet).toBe("In list: Customer Rollout");
+    const flatTaskRow = await db
+      .selectFrom("tasks")
+      .select(["parent_name"])
+      .where("source_task_id", "=", "cu-task-flat-1")
+      .executeTakeFirstOrThrow();
+    expect(flatTaskRow.parent_name).toBe("Delivery Customer Rollout");
   });
 
   it("re-syncs the same ClickUp tree without duplicate project entities or entity churn", async () => {
@@ -258,7 +275,13 @@ describe("ClickUp project entity seeding", () => {
     const firstProjects = await db
       .selectFrom("entities")
       .innerJoin("entity_source_refs", "entity_source_refs.entity_id", "entities.id")
-      .select(["entities.id", "entities.updated_at", "entity_source_refs.source_id"])
+      .select([
+        "entities.id",
+        "entities.name",
+        "entities.aliases",
+        "entities.updated_at",
+        "entity_source_refs.source_id",
+      ])
       .where("entities.source_type", "=", "project")
       .where("entity_source_refs.source", "=", "clickup")
       .orderBy("entity_source_refs.source_id")
@@ -271,7 +294,13 @@ describe("ClickUp project entity seeding", () => {
     const secondProjects = await db
       .selectFrom("entities")
       .innerJoin("entity_source_refs", "entity_source_refs.entity_id", "entities.id")
-      .select(["entities.id", "entities.updated_at", "entity_source_refs.source_id"])
+      .select([
+        "entities.id",
+        "entities.name",
+        "entities.aliases",
+        "entities.updated_at",
+        "entity_source_refs.source_id",
+      ])
       .where("entities.source_type", "=", "project")
       .where("entity_source_refs.source", "=", "clickup")
       .orderBy("entity_source_refs.source_id")

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -14,6 +14,7 @@
  */
 import { createHash } from "node:crypto";
 import pino, { type Logger } from "pino";
+import { qualifyContainerName } from "./container-name";
 import {
   type HierarchyMapping,
   type HierarchyNode,
@@ -425,7 +426,7 @@ function taskToSyncedItem(
   const mappedProject = hierarchyMapping
     ? nearestMappedAncestor(rawHierarchyNodes, hierarchyMapping, ["project"])
     : undefined;
-  const taskProject = hierarchyMapping
+  const rawTaskProject = hierarchyMapping
     ? mappedProject
       ? { name: mappedProject.name, source: "clickup", sourceId: mappedProject.id }
       : undefined
@@ -434,6 +435,9 @@ function taskToSyncedItem(
       : listProjectParent
         ? { name: listProjectParent.name, source: "clickup", sourceId: listProjectParent.id }
         : undefined;
+  const taskProject = rawTaskProject
+    ? { ...rawTaskProject, name: qualifyContainerName(rawTaskProject.name, spaceName) }
+    : undefined;
   const primaryAssignee = task.assignees.find((assignee) => assignee.username);
   const syncedTask: NonNullable<SyncedItem["task"]> = {
     sourceTaskId: task.id,
@@ -485,11 +489,13 @@ function clickupProjectSeed(params: {
   spaceName: string;
   spaceId: string;
 }): EntitySeed {
+  const name = qualifyContainerName(params.node.name, params.spaceName);
   return {
-    name: params.node.name,
+    name,
     sourceType: "project",
     source: "clickup",
     sourceId: params.node.id,
+    aliases: name === params.node.name ? undefined : [params.node.name],
     metadata: {
       workspaceName: params.workspaceName,
       workspaceId: params.workspaceId,
@@ -511,11 +517,16 @@ function clickupHierarchySeed(params: {
   parentPath?: string[];
 }): EntitySeed {
   const path = [...(params.parentPath ?? []), params.node.name].join(" / ");
+  const name =
+    params.sourceType === "project"
+      ? qualifyContainerName(params.node.name, params.spaceName ?? null)
+      : params.node.name;
   return {
-    name: params.node.name,
+    name,
     sourceType: params.sourceType,
     source: "clickup",
     sourceId: params.node.id,
+    aliases: name === params.node.name ? undefined : [params.node.name],
     metadata: {
       levelKey: params.levelKey,
       workspaceName: params.workspaceName,

--- a/packages/server/src/connectors/container-name.test.ts
+++ b/packages/server/src/connectors/container-name.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { qualifyContainerName } from "./container-name";
+
+describe("qualifyContainerName", () => {
+  it("qualifies with a determinate scope and keeps already-contained names unchanged", () => {
+    expect(qualifyContainerName("Platform", "Sketch")).toBe("Sketch Platform");
+    expect(qualifyContainerName("Sketch OSS", "Sketch")).toBe("Sketch OSS");
+    expect(qualifyContainerName("Sketch, OSS", "sketch")).toBe("Sketch, OSS");
+  });
+
+  it("leaves names unchanged without a qualifier", () => {
+    expect(qualifyContainerName("Platform", null)).toBe("Platform");
+    expect(qualifyContainerName("Platform", " ")).toBe("Platform");
+  });
+});

--- a/packages/server/src/connectors/container-name.test.ts
+++ b/packages/server/src/connectors/container-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { qualifyContainerName } from "./container-name";
+import { deriveQualifiedSeedName, qualifyContainerName } from "./container-name";
 
 describe("qualifyContainerName", () => {
   it("qualifies with a determinate scope and keeps already-contained names unchanged", () => {
@@ -11,5 +11,43 @@ describe("qualifyContainerName", () => {
   it("leaves names unchanged without a qualifier", () => {
     expect(qualifyContainerName("Platform", null)).toBe("Platform");
     expect(qualifyContainerName("Platform", " ")).toBe("Platform");
+  });
+});
+
+describe("deriveQualifiedSeedName", () => {
+  it("qualifies a legacy bare fact from its raw metadata (durable replay)", () => {
+    expect(
+      deriveQualifiedSeedName({
+        source: "linear",
+        subjectName: "Platform",
+        raw: { name: "Platform", metadata: { teams: ["Sketch"] } },
+      }),
+    ).toEqual({ name: "Sketch Platform", aliases: ["Platform"] });
+
+    expect(
+      deriveQualifiedSeedName({
+        source: "clickup",
+        subjectName: "Content Engine",
+        raw: { name: "Content Engine", metadata: { spaceName: "Marketing" } },
+      }),
+    ).toEqual({ name: "Marketing Content Engine", aliases: ["Content Engine"] });
+  });
+
+  it("is idempotent on an already-qualified fact and leaves multi-team seeds bare", () => {
+    expect(
+      deriveQualifiedSeedName({
+        source: "linear",
+        subjectName: "Sketch Platform",
+        raw: { name: "Sketch Platform", aliases: ["Platform"], metadata: { teams: ["Sketch"] } },
+      }),
+    ).toEqual({ name: "Sketch Platform", aliases: ["Platform"] });
+
+    expect(
+      deriveQualifiedSeedName({
+        source: "linear",
+        subjectName: "Platform",
+        raw: { name: "Platform", metadata: { teams: ["Sketch", "Canvas"] } },
+      }),
+    ).toEqual({ name: "Platform", aliases: [] });
   });
 });

--- a/packages/server/src/connectors/container-name.ts
+++ b/packages/server/src/connectors/container-name.ts
@@ -11,3 +11,60 @@ export function qualifyContainerName(leaf: string, qualifier: string | null): st
 
   return `${trimmedQualifier} ${trimmedLeaf}`;
 }
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readNestedRecord(value: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const nested = value[key];
+  return nested && typeof nested === "object" && !Array.isArray(nested) ? (nested as Record<string, unknown>) : null;
+}
+
+function rawAliases(raw: Record<string, unknown>): string[] {
+  const aliases = raw.aliases;
+  if (!Array.isArray(aliases)) return [];
+  return aliases.filter((alias): alias is string => typeof alias === "string" && alias.trim().length > 0);
+}
+
+function unionAlias(aliases: string[], alias: string): string[] {
+  const trimmed = alias.trim();
+  if (!trimmed || aliases.some((existing) => existing.toLowerCase() === trimmed.toLowerCase())) return aliases;
+  return [...aliases, trimmed];
+}
+
+/**
+ * The scope qualifier carried in a structural seed's raw metadata: the single
+ * Linear team or the ClickUp space. Mirrors the connector emit logic so that
+ * replaying a pre-qualification fact (bare `subject_name`, no `aliases`)
+ * recovers the same qualified name the live sync would now produce.
+ */
+export function readSeedQualifier(source: string, raw: Record<string, unknown>): string | null {
+  const metadata = readNestedRecord(raw, "metadata");
+  if (!metadata) return null;
+  if (source === "linear") {
+    const teams = metadata.teams;
+    if (!Array.isArray(teams) || teams.length !== 1) return null;
+    return readString(teams[0]);
+  }
+  if (source === "clickup") return readString(metadata.spaceName);
+  return null;
+}
+
+/**
+ * Durable, replay-safe qualification for a container seed. Derives the
+ * qualified name from the fact's raw metadata rather than trusting a possibly
+ * bare `subject_name`, and is idempotent on an already-qualified fact (the
+ * token guard in `qualifyContainerName` prevents double-qualification).
+ */
+export function deriveQualifiedSeedName(params: {
+  source: string;
+  subjectName: string;
+  raw: Record<string, unknown>;
+}): { name: string; aliases: string[] } {
+  const metadataAliases = rawAliases(params.raw);
+  const leaf = readString(params.raw.name) ?? params.subjectName;
+  const qualified = qualifyContainerName(leaf, readSeedQualifier(params.source, params.raw));
+  const aliases = qualified === leaf ? metadataAliases : unionAlias(metadataAliases, leaf);
+  return { name: qualified, aliases };
+}

--- a/packages/server/src/connectors/container-name.ts
+++ b/packages/server/src/connectors/container-name.ts
@@ -1,0 +1,13 @@
+import { tokenizeName } from "../entities/name-tokenize";
+
+export function qualifyContainerName(leaf: string, qualifier: string | null): string {
+  const trimmedLeaf = leaf.trim();
+  const trimmedQualifier = qualifier?.trim();
+  if (!trimmedLeaf || !trimmedQualifier) return leaf;
+
+  const leafTokens = new Set(tokenizeName(trimmedLeaf));
+  const qualifierTokens = tokenizeName(trimmedQualifier);
+  if (qualifierTokens.length > 0 && qualifierTokens.every((token) => leafTokens.has(token))) return leaf;
+
+  return `${trimmedQualifier} ${trimmedLeaf}`;
+}

--- a/packages/server/src/connectors/linear-project-seeding.test.ts
+++ b/packages/server/src/connectors/linear-project-seeding.test.ts
@@ -184,6 +184,7 @@ async function syncRecordedLinearPayload(db: Kysely<DB>, syncRunId: string): Pro
       factContext,
       item,
       indexedFileId: itemResult.indexedFileId,
+      experimentalFlag: true,
     });
   }
 
@@ -211,12 +212,13 @@ describe("Linear project entity seeding", () => {
   it("materializes one Linear project seed with a bare project source ref", async () => {
     await syncRecordedLinearPayload(db, "sync-run-1");
 
-    const summary = await materializeUnmaterializedFacts(db, createTestLogger());
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
 
     expect(summary.entitiesCreated).toBe(1);
     const projects = await db.selectFrom("entities").selectAll().where("source_type", "=", "project").execute();
     expect(projects).toHaveLength(1);
-    expect(projects[0].name).toBe("Atlas Launch");
+    expect(projects[0].name).toBe("Platform Atlas Launch");
+    expect(JSON.parse(projects[0].aliases ?? "[]")).toEqual(["Atlas Launch"]);
     const projectRef = await db
       .selectFrom("entity_source_refs")
       .selectAll()
@@ -236,6 +238,99 @@ describe("Linear project entity seeding", () => {
       .where("id", "=", teamRef.entity_id)
       .executeTakeFirstOrThrow();
     expect(team.source_type).toBe("team");
+    const task = await db
+      .selectFrom("tasks")
+      .select(["parent_name"])
+      .where("source_task_id", "=", "lin-issue-tagged-1")
+      .executeTakeFirstOrThrow();
+    expect(task.parent_name).toBe("Platform Atlas Launch");
+  });
+
+  it("qualifies Linear project seeds only when one team provides scope", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        graphqlResponse({ data: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } }),
+      )
+      .mockResolvedValueOnce(
+        graphqlResponse({ data: { teams: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } }),
+      )
+      .mockResolvedValueOnce(
+        graphqlResponse({
+          data: {
+            projects: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  id: "lin-proj-platform",
+                  name: "Platform",
+                  description: null,
+                  url: "https://linear.example/project/platform",
+                  state: "started",
+                  lead: null,
+                  startDate: null,
+                  targetDate: null,
+                  teams: { nodes: [{ name: "Sketch", key: "SK" }] },
+                  createdAt: "2026-06-01T00:00:00.000Z",
+                  updatedAt: "2026-06-10T00:00:00.000Z",
+                },
+                {
+                  id: "lin-proj-oss",
+                  name: "Sketch OSS",
+                  description: null,
+                  url: "https://linear.example/project/oss",
+                  state: "started",
+                  lead: null,
+                  startDate: null,
+                  targetDate: null,
+                  teams: { nodes: [{ name: "Sketch", key: "SK" }] },
+                  createdAt: "2026-06-01T00:00:00.000Z",
+                  updatedAt: "2026-06-10T00:00:00.000Z",
+                },
+                {
+                  id: "lin-proj-shared",
+                  name: "Shared",
+                  description: null,
+                  url: "https://linear.example/project/shared",
+                  state: "started",
+                  lead: null,
+                  startDate: null,
+                  targetDate: null,
+                  teams: {
+                    nodes: [
+                      { name: "Sketch", key: "SK" },
+                      { name: "Canvas", key: "CV" },
+                    ],
+                  },
+                  createdAt: "2026-06-01T00:00:00.000Z",
+                  updatedAt: "2026-06-10T00:00:00.000Z",
+                },
+              ],
+            },
+          },
+        }),
+      );
+
+    const seeds: EntitySeed[] = [];
+    const items = [];
+    for await (const item of createLinearConnector().sync({
+      connectorConfigId: CONNECTOR_ID,
+      credentials: { type: "api_key", api_key: "linear-token" },
+      scopeConfig: {},
+      cursor: null,
+      logger: createTestLogger(),
+      onEntitySeed: async (seed) => {
+        seeds.push(seed);
+      },
+    })) {
+      items.push(item);
+    }
+
+    expect(items).toHaveLength(3);
+    expect(seeds.map((seed) => ({ name: seed.name, aliases: seed.aliases }))).toEqual([
+      { name: "Sketch Platform", aliases: ["Platform"] },
+      { name: "Sketch OSS", aliases: undefined },
+      { name: "Shared", aliases: undefined },
+    ]);
   });
 
   it("links the seeded Linear project entity to its own project document", async () => {
@@ -355,6 +450,8 @@ describe("Linear project entity seeding", () => {
     const projects = await db.selectFrom("entities").selectAll().where("source_type", "=", "project").execute();
     expect(projects).toHaveLength(1);
     expect(projects[0].id).toBe(firstProject.id);
+    expect(projects[0].name).toBe("Platform Atlas Launch");
+    expect(JSON.parse(projects[0].aliases ?? "[]")).toEqual(["Atlas Launch"]);
     expect(projects[0].updated_at).toBe(firstProject.updated_at);
     const reviews = await db.selectFrom("entity_review_queue").selectAll().execute();
     expect(reviews).toHaveLength(0);

--- a/packages/server/src/connectors/linear.ts
+++ b/packages/server/src/connectors/linear.ts
@@ -15,6 +15,7 @@
  */
 import { createHash } from "node:crypto";
 import pino, { type Logger } from "pino";
+import { qualifyContainerName } from "./container-name";
 import type { Connector, ConnectorCredentials, EntitySeedCallback, OAuthCredentials, SyncedItem } from "./types";
 
 const LINEAR_API = "https://api.linear.app/graphql";
@@ -239,7 +240,13 @@ function issueToSyncedItem(issue: LinearIssue): SyncedItem {
       statusRaw: issue.state?.name,
       priority: issue.priorityLabel || PRIORITY_LABELS[issue.priority] || undefined,
       dueAt: issue.dueDate ?? undefined,
-      project: issue.project ? { name: issue.project.name, source: "linear", sourceId: issue.project.id } : undefined,
+      project: issue.project
+        ? {
+            name: qualifyContainerName(issue.project.name, issue.team?.name ?? null),
+            source: "linear",
+            sourceId: issue.project.id,
+          }
+        : undefined,
       assignee: issue.assignee
         ? {
             name: issue.assignee.displayName,
@@ -473,16 +480,19 @@ query TeamMembers($teamId: String!, $first: Int!, $after: String) {
  * entities inherit org-wide visibility until Linear connector hardening lands.
  */
 async function emitLinearProjectSeed(project: LinearProject, onEntitySeed: EntitySeedCallback): Promise<void> {
+  const teams = project.teams.nodes.map((team) => team.name);
+  const name = qualifyContainerName(project.name, teams.length === 1 ? teams[0] : null);
   await onEntitySeed({
-    name: project.name,
+    name,
     sourceType: "project",
     source: "linear",
     sourceId: project.id,
     sourceUrl: project.url,
+    aliases: name === project.name ? undefined : [project.name],
     metadata: {
       state: project.state,
       lead: project.lead?.displayName ?? null,
-      teams: project.teams.nodes.map((team) => team.name),
+      teams,
       startDate: project.startDate,
       targetDate: project.targetDate,
     },

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -199,6 +199,7 @@ export interface EntitySeed {
   source: string;
   sourceId: string;
   sourceUrl?: string;
+  aliases?: string[];
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -128,6 +128,7 @@ import * as m125 from "./migrations/125-milestone-series-and-value-signature";
 import * as m126 from "./migrations/126-work-cycles";
 import * as m127 from "./migrations/127-work-cycles-connector";
 import * as m128 from "./migrations/128-work-cycles-connector-key";
+import * as m129 from "./migrations/129-container-name-qualification";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -260,6 +261,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "126-work-cycles": m126,
           "127-work-cycles-connector": m127,
           "128-work-cycles-connector-key": m128,
+          "129-container-name-qualification": m129,
         };
       },
     },

--- a/packages/server/src/db/migrations/129-container-name-qualification.integration.test.ts
+++ b/packages/server/src/db/migrations/129-container-name-qualification.integration.test.ts
@@ -1,0 +1,251 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { up as qualifyContainerNames } from "./115-container-name-qualification";
+
+const NOW = "2026-06-23T00:00:00.000Z";
+
+async function insertProjectFixture(
+  db: Kysely<DB>,
+  input: {
+    id: string;
+    name: string;
+    source: "linear" | "clickup";
+    sourceId: string;
+    rawName: string;
+    metadata: Record<string, unknown>;
+    aliases?: string | null;
+    mergedIntoEntityId?: string | null;
+  },
+): Promise<void> {
+  await db
+    .insertInto("entities")
+    .values({
+      id: input.id,
+      name: input.name,
+      source_type: "project",
+      subtype: null,
+      aliases: input.aliases ?? null,
+      metadata: JSON.stringify(input.metadata),
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: NOW,
+      updated_at: NOW,
+      merged_into_entity_id: input.mergedIntoEntityId ?? null,
+    })
+    .execute();
+  await db
+    .insertInto("entity_source_refs")
+    .values({
+      id: `${input.id}-ref`,
+      entity_id: input.id,
+      source: input.source,
+      source_id: input.sourceId,
+      source_url: null,
+      last_seen_at: NOW,
+    })
+    .execute();
+  await db
+    .insertInto("indexed_file_facts")
+    .values({
+      id: `${input.id}-fact`,
+      indexed_file_id: null,
+      connector_config_id: null,
+      created_by_user_id: null,
+      source: input.source,
+      fact_type: "structural_seed",
+      relation: "seeded",
+      subject_name: input.rawName,
+      subject_source: input.source,
+      subject_source_id: input.sourceId,
+      context_snippet: null,
+      raw: JSON.stringify({
+        name: input.rawName,
+        sourceType: "project",
+        source: input.source,
+        sourceId: input.sourceId,
+        metadata: input.metadata,
+      }),
+      fact_key: `${input.source}:${input.sourceId}:seeded`,
+      last_seen_sync_run_id: null,
+      deleted_at: null,
+      content_hash: null,
+      materialized_at: null,
+      created_at: NOW,
+      updated_at: NOW,
+    })
+    .execute();
+}
+
+describe("115-container-name-qualification", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestPgDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("qualifies untouched project entities without rewriting facts", async () => {
+    await insertProjectFixture(db, {
+      id: "untouched-linear",
+      name: "Analytics",
+      source: "linear",
+      sourceId: "lin-analytics",
+      rawName: "Analytics",
+      metadata: { teams: ["Sketch"] },
+    });
+    await insertProjectFixture(db, {
+      id: "edited-clickup",
+      name: "Edited Rollout",
+      source: "clickup",
+      sourceId: "cu-rollout",
+      rawName: "Rollout",
+      metadata: { spaceName: "Delivery" },
+    });
+    await db
+      .insertInto("entities")
+      .values({
+        id: "some-survivor",
+        name: "Sketch Archive",
+        source_type: "project",
+        subtype: null,
+        aliases: null,
+        metadata: null,
+        source_ref_id: null,
+        status: "confirmed",
+        hotness: 0,
+        created_at: NOW,
+        updated_at: NOW,
+      })
+      .execute();
+    await insertProjectFixture(db, {
+      id: "merged-linear",
+      name: "Archive",
+      source: "linear",
+      sourceId: "lin-archive",
+      rawName: "Archive",
+      metadata: { teams: ["Sketch"] },
+      mergedIntoEntityId: "some-survivor",
+    });
+
+    await qualifyContainerNames(db as unknown as Kysely<unknown>);
+    await qualifyContainerNames(db as unknown as Kysely<unknown>);
+
+    const untouched = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("id", "=", "untouched-linear")
+      .executeTakeFirstOrThrow();
+    expect(untouched.name).toBe("Sketch Analytics");
+    expect(JSON.parse(untouched.aliases ?? "[]")).toEqual(["Analytics"]);
+
+    const untouchedFact = await db
+      .selectFrom("indexed_file_facts")
+      .select(["subject_name", "raw"])
+      .where("id", "=", "untouched-linear-fact")
+      .executeTakeFirstOrThrow();
+    expect(untouchedFact.subject_name).toBe("Analytics");
+    expect(JSON.parse(untouchedFact.raw ?? "{}")).toMatchObject({ name: "Analytics" });
+
+    const edited = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("id", "=", "edited-clickup")
+      .executeTakeFirstOrThrow();
+    expect(edited.name).toBe("Edited Rollout");
+    expect(edited.aliases).toBeNull();
+    const editedFact = await db
+      .selectFrom("indexed_file_facts")
+      .select(["subject_name", "raw"])
+      .where("id", "=", "edited-clickup-fact")
+      .executeTakeFirstOrThrow();
+    expect(editedFact.subject_name).toBe("Rollout");
+    expect(JSON.parse(editedFact.raw ?? "{}")).toMatchObject({ name: "Rollout" });
+
+    const merged = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("id", "=", "merged-linear")
+      .executeTakeFirstOrThrow();
+    expect(merged.name).toBe("Archive");
+    expect(merged.aliases).toBeNull();
+  });
+
+  it("requalifies pending project queue rows, is idempotent, and leaves facts untouched", async () => {
+    await insertProjectFixture(db, {
+      id: "queue-linear-entity",
+      name: "Already Edited",
+      source: "linear",
+      sourceId: "lin-platform",
+      rawName: "Platform",
+      metadata: { teams: ["Sketch"] },
+    });
+    await db
+      .insertInto("entity_review_queue")
+      .values({
+        id: "queue-platform",
+        proposed_name: "Platform",
+        normalized_name: "platform",
+        entity_type: "project",
+        proposed_email: null,
+        candidate_entity_id: null,
+        candidate_score: null,
+        candidate_reason: null,
+        candidate_generated_at: NOW,
+        first_seen_at: NOW,
+        last_seen_at: NOW,
+        occurrence_count: 1,
+        status: "pending",
+        triggered_by_user_id: "user-1",
+        review_started_at: null,
+        review_started_by: null,
+        backfill_cursor: null,
+        resolved_by: null,
+        resolved_at: null,
+        resolved_entity_id: null,
+        seed_source: "linear",
+        seed_source_id: "lin-platform",
+        seed_aliases: null,
+      })
+      .execute();
+
+    const factBefore = await db
+      .selectFrom("indexed_file_facts")
+      .select(["fact_key"])
+      .where("id", "=", "queue-linear-entity-fact")
+      .executeTakeFirstOrThrow();
+    const factCountBefore = await db
+      .selectFrom("indexed_file_facts")
+      .select((eb) => eb.fn.countAll<string>().as("count"))
+      .executeTakeFirstOrThrow();
+
+    await qualifyContainerNames(db as unknown as Kysely<unknown>);
+    await qualifyContainerNames(db as unknown as Kysely<unknown>);
+
+    const queueRow = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", "queue-platform")
+      .executeTakeFirstOrThrow();
+    expect(queueRow.proposed_name).toBe("Sketch Platform");
+    expect(queueRow.normalized_name).toBe("sketch platform");
+    expect(queueRow.seed_aliases).toBe(JSON.stringify(["Platform"]));
+
+    const factAfter = await db
+      .selectFrom("indexed_file_facts")
+      .select(["fact_key"])
+      .where("id", "=", "queue-linear-entity-fact")
+      .executeTakeFirstOrThrow();
+    const factCountAfter = await db
+      .selectFrom("indexed_file_facts")
+      .select((eb) => eb.fn.countAll<string>().as("count"))
+      .executeTakeFirstOrThrow();
+    expect(factAfter.fact_key).toBe(factBefore.fact_key);
+    expect(factCountAfter.count).toBe(factCountBefore.count);
+  });
+});

--- a/packages/server/src/db/migrations/129-container-name-qualification.integration.test.ts
+++ b/packages/server/src/db/migrations/129-container-name-qualification.integration.test.ts
@@ -2,7 +2,7 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestPgDb } from "../../test-utils";
 import type { DB } from "../schema";
-import { up as qualifyContainerNames } from "./126-container-name-qualification";
+import { up as qualifyContainerNames } from "./129-container-name-qualification";
 
 const NOW = "2026-06-23T00:00:00.000Z";
 
@@ -79,7 +79,7 @@ async function insertProjectFixture(
     .execute();
 }
 
-describe("126-container-name-qualification", () => {
+describe("129-container-name-qualification", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {

--- a/packages/server/src/db/migrations/129-container-name-qualification.integration.test.ts
+++ b/packages/server/src/db/migrations/129-container-name-qualification.integration.test.ts
@@ -2,7 +2,7 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestPgDb } from "../../test-utils";
 import type { DB } from "../schema";
-import { up as qualifyContainerNames } from "./115-container-name-qualification";
+import { up as qualifyContainerNames } from "./126-container-name-qualification";
 
 const NOW = "2026-06-23T00:00:00.000Z";
 
@@ -79,7 +79,7 @@ async function insertProjectFixture(
     .execute();
 }
 
-describe("115-container-name-qualification", () => {
+describe("126-container-name-qualification", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {

--- a/packages/server/src/db/migrations/129-container-name-qualification.ts
+++ b/packages/server/src/db/migrations/129-container-name-qualification.ts
@@ -130,11 +130,11 @@ async function addSeedAliasesColumn(db: Kysely<unknown>): Promise<void> {
   await db.schema.alterTable("entity_review_queue").addColumn("seed_aliases", "text").execute();
 }
 
-async function normalizedQueueName(
+async function isNormalizedNameTaken(
   db: Kysely<MigrationDb>,
   row: QueueCandidateRow,
   normalizedName: string,
-): Promise<string> {
+): Promise<boolean> {
   const colliding = await db
     .selectFrom("entity_review_queue")
     .select(["id"])
@@ -142,8 +142,24 @@ async function normalizedQueueName(
     .where("entity_type", "=", row.entity_type)
     .where("id", "!=", row.id)
     .executeTakeFirst();
-  if (!colliding) return normalizedName;
-  return `${normalizedName}:${row.seed_source}:${row.seed_source_id}`;
+  return Boolean(colliding);
+}
+
+/**
+ * Returns a collision-free `normalized_name` honoring the unique
+ * `(normalized_name, entity_type)` index, or null if even the seed-handle
+ * fallback is already taken (caller skips the row rather than failing the
+ * migration).
+ */
+async function normalizedQueueName(
+  db: Kysely<MigrationDb>,
+  row: QueueCandidateRow,
+  normalizedName: string,
+): Promise<string | null> {
+  if (!(await isNormalizedNameTaken(db, row, normalizedName))) return normalizedName;
+  const fallback = `${normalizedName}:${row.seed_source}:${row.seed_source_id}`;
+  if (!(await isNormalizedNameTaken(db, row, fallback))) return fallback;
+  return null;
 }
 
 async function findSeedFact(
@@ -185,6 +201,7 @@ async function backfillQueueContainerNames(db: Kysely<MigrationDb>): Promise<voi
     if (qualifiedName === bareLeaf) continue;
 
     const normalizedName = await normalizedQueueName(db, row, normalizeEntityMatchName(row.entity_type, qualifiedName));
+    if (normalizedName === null) continue;
     await db
       .updateTable("entity_review_queue")
       .set({

--- a/packages/server/src/db/migrations/129-container-name-qualification.ts
+++ b/packages/server/src/db/migrations/129-container-name-qualification.ts
@@ -1,0 +1,260 @@
+import { type Kysely, sql } from "kysely";
+import { qualifyContainerName } from "../../connectors/container-name";
+import { normalizeEntityMatchName } from "../../entities/materialize-deps";
+
+interface SeedFactRow {
+  subject_name: string | null;
+  raw: string | null;
+  source: string;
+  subject_source: string | null;
+  subject_source_id: string | null;
+}
+
+interface EntityCandidateRow extends SeedFactRow {
+  entity_id: string;
+  entity_name: string;
+  entity_aliases: string | null;
+}
+
+interface QueueCandidateRow {
+  id: string;
+  proposed_name: string;
+  normalized_name: string;
+  entity_type: string;
+  seed_source: string | null;
+  seed_source_id: string | null;
+}
+
+interface MigrationDb {
+  entities: {
+    id: string;
+    name: string;
+    source_type: string;
+    aliases: string | null;
+    updated_at: string;
+    deleted_at: string | null;
+    merged_into_entity_id: string | null;
+  };
+  entity_source_refs: {
+    id: string;
+    entity_id: string;
+    source: string;
+    source_id: string;
+  };
+  indexed_file_facts: {
+    id: string;
+    source: string;
+    fact_type: string;
+    subject_name: string | null;
+    subject_source: string | null;
+    subject_source_id: string | null;
+    raw: string | null;
+    deleted_at: string | null;
+  };
+  entity_review_queue: {
+    id: string;
+    proposed_name: string;
+    normalized_name: string;
+    entity_type: string;
+    status: string;
+    seed_source: string | null;
+    seed_source_id: string | null;
+    seed_aliases: string | null;
+  };
+}
+
+async function hasColumn(db: Kysely<unknown>, tableName: string, columnName: string): Promise<boolean> {
+  const tables = await db.introspection.getTables();
+  return tables.some((table) => table.name === tableName && table.columns.some((column) => column.name === columnName));
+}
+
+function parseJsonObject(value: string | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseStringArray(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function readNestedRecord(value: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const nested = value[key];
+  return nested && typeof nested === "object" && !Array.isArray(nested) ? (nested as Record<string, unknown>) : null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readBareLeaf(raw: Record<string, unknown> | null, subjectName: string | null): string | null {
+  const aliases = raw?.aliases;
+  if (Array.isArray(aliases)) {
+    const alias = aliases.find((item): item is string => typeof item === "string" && item.trim().length > 0);
+    if (alias) return alias;
+  }
+  return readString(raw?.name) ?? readString(subjectName);
+}
+
+function readQualifier(source: string, raw: Record<string, unknown> | null): string | null {
+  const metadata = raw ? readNestedRecord(raw, "metadata") : null;
+  if (source === "linear") {
+    const teams = metadata?.teams;
+    if (!Array.isArray(teams) || teams.length !== 1) return null;
+    return readString(teams[0]);
+  }
+  if (source === "clickup") return readString(metadata?.spaceName);
+  return null;
+}
+
+function unionAlias(aliases: string[], alias: string): string[] {
+  const trimmed = alias.trim();
+  if (!trimmed) return aliases;
+  if (aliases.some((existing) => existing.toLowerCase() === trimmed.toLowerCase())) return aliases;
+  return [...aliases, trimmed];
+}
+
+async function addSeedAliasesColumn(db: Kysely<unknown>): Promise<void> {
+  if (await hasColumn(db, "entity_review_queue", "seed_aliases")) return;
+  await db.schema.alterTable("entity_review_queue").addColumn("seed_aliases", "text").execute();
+}
+
+async function normalizedQueueName(
+  db: Kysely<MigrationDb>,
+  row: QueueCandidateRow,
+  normalizedName: string,
+): Promise<string> {
+  const colliding = await db
+    .selectFrom("entity_review_queue")
+    .select(["id"])
+    .where("normalized_name", "=", normalizedName)
+    .where("entity_type", "=", row.entity_type)
+    .where("id", "!=", row.id)
+    .executeTakeFirst();
+  if (!colliding) return normalizedName;
+  return `${normalizedName}:${row.seed_source}:${row.seed_source_id}`;
+}
+
+async function findSeedFact(
+  db: Kysely<MigrationDb>,
+  source: string,
+  sourceId: string,
+): Promise<SeedFactRow | undefined> {
+  return db
+    .selectFrom("indexed_file_facts")
+    .select(["source", "subject_source", "subject_source_id", "subject_name", "raw"])
+    .where("fact_type", "=", "structural_seed")
+    .where("deleted_at", "is", null)
+    .where("subject_source", "=", source)
+    .where("subject_source_id", "=", sourceId)
+    .executeTakeFirst();
+}
+
+async function backfillQueueContainerNames(db: Kysely<MigrationDb>): Promise<void> {
+  const rows = await db
+    .selectFrom("entity_review_queue")
+    .select(["id", "proposed_name", "normalized_name", "entity_type", "seed_source", "seed_source_id"])
+    .where("entity_type", "=", "project")
+    .where("status", "=", "pending")
+    .where("seed_source", "in", ["linear", "clickup"])
+    .where("seed_source_id", "is not", null)
+    .execute();
+
+  for (const row of rows as QueueCandidateRow[]) {
+    if (!row.seed_source || !row.seed_source_id) continue;
+    const fact = await findSeedFact(db, row.seed_source, row.seed_source_id);
+    if (!fact) continue;
+
+    const raw = parseJsonObject(fact.raw);
+    const bareLeaf = readBareLeaf(raw, fact.subject_name);
+    const qualifier = readQualifier(row.seed_source, raw);
+    if (!bareLeaf || !qualifier || row.proposed_name !== bareLeaf) continue;
+
+    const qualifiedName = qualifyContainerName(bareLeaf, qualifier);
+    if (qualifiedName === bareLeaf) continue;
+
+    const normalizedName = await normalizedQueueName(db, row, normalizeEntityMatchName(row.entity_type, qualifiedName));
+    await db
+      .updateTable("entity_review_queue")
+      .set({
+        proposed_name: qualifiedName,
+        normalized_name: normalizedName,
+        seed_aliases: JSON.stringify([bareLeaf]),
+      })
+      .where("id", "=", row.id)
+      .where("proposed_name", "=", bareLeaf)
+      .execute();
+  }
+}
+
+async function backfillEntityContainerNames(db: Kysely<MigrationDb>): Promise<void> {
+  const rows = await db
+    .selectFrom("entities")
+    .innerJoin("entity_source_refs", "entity_source_refs.entity_id", "entities.id")
+    .innerJoin("indexed_file_facts", (join) =>
+      join
+        .onRef("indexed_file_facts.subject_source", "=", "entity_source_refs.source")
+        .onRef("indexed_file_facts.subject_source_id", "=", "entity_source_refs.source_id"),
+    )
+    .select([
+      "entities.id as entity_id",
+      "entities.name as entity_name",
+      "entities.aliases as entity_aliases",
+      "indexed_file_facts.subject_name as subject_name",
+      "indexed_file_facts.raw as raw",
+      "entity_source_refs.source as source",
+      "indexed_file_facts.subject_source as subject_source",
+      "indexed_file_facts.subject_source_id as subject_source_id",
+    ])
+    .where("entities.source_type", "=", "project")
+    .where("entities.deleted_at", "is", null)
+    .where("entities.merged_into_entity_id", "is", null)
+    .where("entity_source_refs.source", "in", ["linear", "clickup"])
+    .where("indexed_file_facts.fact_type", "=", "structural_seed")
+    .where("indexed_file_facts.deleted_at", "is", null)
+    .execute();
+
+  for (const row of rows as EntityCandidateRow[]) {
+    const raw = parseJsonObject(row.raw);
+    const bareLeaf = readBareLeaf(raw, row.subject_name);
+    const qualifier = readQualifier(row.source, raw);
+    if (!bareLeaf || !qualifier || row.entity_name !== bareLeaf) continue;
+
+    const qualifiedName = qualifyContainerName(bareLeaf, qualifier);
+    if (qualifiedName === bareLeaf) continue;
+
+    const entityAliases = unionAlias(parseStringArray(row.entity_aliases), bareLeaf);
+    await db
+      .updateTable("entities")
+      .set({
+        name: qualifiedName,
+        aliases: JSON.stringify(entityAliases),
+        updated_at: sql`CURRENT_TIMESTAMP`,
+      })
+      .where("id", "=", row.entity_id)
+      .where("name", "=", bareLeaf)
+      .execute();
+  }
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await addSeedAliasesColumn(db);
+  await backfillQueueContainerNames(db as Kysely<MigrationDb>);
+  await backfillEntityContainerNames(db as Kysely<MigrationDb>);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  if (!(await hasColumn(db, "entity_review_queue", "seed_aliases"))) return;
+  await db.schema.alterTable("entity_review_queue").dropColumn("seed_aliases").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 124;
+const EXPECTED_MIGRATION_COUNT = 125;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -157,6 +157,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[121]).toBe("126-work-cycles");
     expect(names[122]).toBe("127-work-cycles-connector");
     expect(names[123]).toBe("128-work-cycles-connector-key");
+    expect(names[124]).toBe("129-container-name-qualification");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 124;
+const EXPECTED_MIGRATION_COUNT = 125;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -180,6 +180,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[121]).toBe("126-work-cycles");
     expect(names[122]).toBe("127-work-cycles-connector");
     expect(names[123]).toBe("128-work-cycles-connector-key");
+    expect(names[124]).toBe("129-container-name-qualification");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/repositories/entity-review.test.ts
+++ b/packages/server/src/db/repositories/entity-review.test.ts
@@ -43,6 +43,7 @@ describe("entity review seed rows", () => {
 
     expect(renamed.row.id).toBe(first.row.id);
     expect(renamed.row.proposed_name).toBe("Ruler");
+    expect(renamed.row.normalized_name).toBe("ruler");
     expect(renamed.row.occurrence_count).toBe(first.row.occurrence_count + 1);
 
     const colliding = await repo.upsertSeedReviewRow({
@@ -56,7 +57,21 @@ describe("entity review seed rows", () => {
     });
 
     expect(colliding.row.id).not.toBe(first.row.id);
-    expect(colliding.row.normalized_name).toBe("sketch:linear:P2");
+    expect(colliding.row.normalized_name).toBe("sketch");
+
+    const renamedBack = await repo.upsertSeedReviewRow({
+      proposedName: "Sketch",
+      normalizedName: normalizeName("Sketch"),
+      entityType: "project",
+      seedSource: "linear",
+      seedSourceId: "P1",
+      candidateEntityId: null,
+      triggeredByUserId: USER_ID,
+    });
+
+    expect(renamedBack.row.id).toBe(first.row.id);
+    expect(renamedBack.row.proposed_name).toBe("Sketch");
+    expect(renamedBack.row.normalized_name).toBe("sketch:linear:P1");
 
     const rows = await db.selectFrom("entity_review_queue").selectAll().orderBy("id", "asc").execute();
     expect(rows).toHaveLength(2);

--- a/packages/server/src/db/repositories/entity-review.test.ts
+++ b/packages/server/src/db/repositories/entity-review.test.ts
@@ -107,4 +107,53 @@ describe("entity review seed rows", () => {
     const rows = await db.selectFrom("entity_review_queue").selectAll().execute();
     expect(rows).toHaveLength(1);
   });
+
+  it("keeps normalized_name unchanged when both base and fallback handles collide", async () => {
+    const target = await repo.upsertSeedReviewRow({
+      proposedName: "Alpha",
+      normalizedName: normalizeName("Alpha"),
+      entityType: "project",
+      seedSource: "linear",
+      seedSourceId: "P1",
+      candidateEntityId: null,
+      triggeredByUserId: USER_ID,
+    });
+
+    await repo.upsertSeedReviewRow({
+      proposedName: "Sketch",
+      normalizedName: normalizeName("Sketch"),
+      entityType: "project",
+      seedSource: "linear",
+      seedSourceId: "P2",
+      candidateEntityId: null,
+      triggeredByUserId: USER_ID,
+    });
+
+    await repo.upsertSeedReviewRow({
+      proposedName: "Occupies Fallback",
+      normalizedName: `${normalizeName("Sketch")}:linear:P1`,
+      entityType: "project",
+      seedSource: "linear",
+      seedSourceId: "P3",
+      candidateEntityId: null,
+      triggeredByUserId: USER_ID,
+    });
+
+    const renamed = await repo.upsertSeedReviewRow({
+      proposedName: "Sketch",
+      normalizedName: normalizeName("Sketch"),
+      entityType: "project",
+      seedSource: "linear",
+      seedSourceId: "P1",
+      candidateEntityId: null,
+      triggeredByUserId: USER_ID,
+    });
+
+    expect(renamed.row.id).toBe(target.row.id);
+    expect(renamed.row.proposed_name).toBe("Sketch");
+    expect(renamed.row.normalized_name).toBe("alpha");
+
+    const rows = await db.selectFrom("entity_review_queue").selectAll().execute();
+    expect(rows).toHaveLength(3);
+  });
 });

--- a/packages/server/src/db/repositories/entity-review.ts
+++ b/packages/server/src/db/repositories/entity-review.ts
@@ -77,6 +77,7 @@ export interface UpsertSeedReviewRowInput {
   candidateEntityId: string | null;
   triggeredByUserId: string;
   metadata?: Record<string, unknown>;
+  seedAliases?: string[];
 }
 
 export interface UpsertEvidenceInput {
@@ -175,6 +176,7 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
         triggered_by_user_id: input.triggeredByUserId,
         seed_source: input.seedSource,
         seed_source_id: input.seedSourceId,
+        seed_aliases: input.seedAliases && input.seedAliases.length > 0 ? JSON.stringify(input.seedAliases) : null,
       })
       .execute();
 
@@ -299,16 +301,28 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
 
       const now = new Date().toISOString();
       if (existing) {
+        const normalizedNameCollision = await db
+          .selectFrom("entity_review_queue")
+          .select(["id"])
+          .where("normalized_name", "=", input.normalizedName)
+          .where("entity_type", "=", input.entityType)
+          .where("id", "!=", existing.id)
+          .executeTakeFirst();
+        const normalizedName = normalizedNameCollision
+          ? `${input.normalizedName}:${input.seedSource}:${input.seedSourceId}`
+          : input.normalizedName;
         await db
           .updateTable("entity_review_queue")
           .set({
             proposed_name: input.proposedName,
+            normalized_name: normalizedName,
             candidate_entity_id: input.candidateEntityId,
             candidate_score: null,
             candidate_reason: null,
             candidate_generated_at: now,
             last_seen_at: now,
             occurrence_count: existing.occurrence_count + 1,
+            seed_aliases: input.seedAliases && input.seedAliases.length > 0 ? JSON.stringify(input.seedAliases) : null,
           })
           .where("id", "=", existing.id)
           .execute();

--- a/packages/server/src/db/repositories/entity-review.ts
+++ b/packages/server/src/db/repositories/entity-review.ts
@@ -301,21 +301,27 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
 
       const now = new Date().toISOString();
       if (existing) {
-        const normalizedNameCollision = await db
-          .selectFrom("entity_review_queue")
-          .select(["id"])
-          .where("normalized_name", "=", input.normalizedName)
-          .where("entity_type", "=", input.entityType)
-          .where("id", "!=", existing.id)
-          .executeTakeFirst();
-        const normalizedName = normalizedNameCollision
-          ? `${input.normalizedName}:${input.seedSource}:${input.seedSourceId}`
-          : input.normalizedName;
+        const isTaken = async (candidate: string): Promise<boolean> => {
+          const collision = await db
+            .selectFrom("entity_review_queue")
+            .select(["id"])
+            .where("normalized_name", "=", candidate)
+            .where("entity_type", "=", input.entityType)
+            .where("id", "!=", existing.id)
+            .executeTakeFirst();
+          return Boolean(collision);
+        };
+        const fallback = `${input.normalizedName}:${input.seedSource}:${input.seedSourceId}`;
+        const normalizedName = !(await isTaken(input.normalizedName))
+          ? input.normalizedName
+          : !(await isTaken(fallback))
+            ? fallback
+            : undefined;
         await db
           .updateTable("entity_review_queue")
           .set({
             proposed_name: input.proposedName,
-            normalized_name: normalizedName,
+            ...(normalizedName !== undefined ? { normalized_name: normalizedName } : {}),
             candidate_entity_id: input.candidateEntityId,
             candidate_score: null,
             candidate_reason: null,

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -873,6 +873,7 @@ export interface EntityReviewQueueTable {
   resolved_entity_id: string | null;
   seed_source: string | null;
   seed_source_id: string | null;
+  seed_aliases: string | null;
 }
 
 export interface EntityReviewEvidenceTable {

--- a/packages/server/src/entities/materialize-birth-gate.test.ts
+++ b/packages/server/src/entities/materialize-birth-gate.test.ts
@@ -83,7 +83,7 @@ async function upsertLlmMention(db: Kysely<DB>, fileId: string, name: string, ty
 
 async function upsertStructuralSeed(
   db: Kysely<DB>,
-  input: { fileId: string; sourceType: string; name: string; sourceId: string; source?: string },
+  input: { fileId: string; sourceType: string; name: string; sourceId: string; source?: string; aliases?: string[] },
 ): Promise<void> {
   const source = input.source ?? "linear";
   const repo = createIndexedFileFactRepository(db);
@@ -98,7 +98,11 @@ async function upsertStructuralSeed(
     subjectSource: source,
     subjectSourceId: input.sourceId,
     raw: {
+      name: input.name,
       sourceType: input.sourceType,
+      source: source,
+      sourceId: input.sourceId,
+      aliases: input.aliases,
       providerFileId: input.sourceId,
       sourcePath: `${source}/${input.sourceId}`,
     },
@@ -179,9 +183,10 @@ describe("A1 birth gate", () => {
     await upsertStructuralSeed(db, {
       fileId: "file-2",
       sourceType: "team",
-      name: "Platform Team",
+      name: "Sketch Platform",
       sourceId: "team-1",
       source: "linear",
+      aliases: ["Platform"],
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
       birthGateTypes: A1_BIRTH_GATE_TYPES,
@@ -195,7 +200,20 @@ describe("A1 birth gate", () => {
       entity_type: "team",
       seed_source: "linear",
       seed_source_id: "team-1",
+      seed_aliases: '["Platform"]',
     });
+    if (!row.candidate_generated_at) throw new Error("missing candidate_generated_at");
+
+    const result = await confirmReview({ db, userId: USER_ID }, row.id, {
+      candidateGeneratedAt: row.candidate_generated_at,
+    });
+    const team = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("id", "=", result.targetEntityId)
+      .executeTakeFirstOrThrow();
+    expect(team.name).toBe("Sketch Platform");
+    expect(JSON.parse(team.aliases ?? "[]")).toEqual(expect.arrayContaining(["Platform"]));
   });
 
   it("links exact product matches under the gate and flag-off product mentions still auto-create", async () => {

--- a/packages/server/src/entities/materialize-project.ts
+++ b/packages/server/src/entities/materialize-project.ts
@@ -57,7 +57,29 @@ export async function materializeProjectSeed(
   }
 
   const entity = result.entity as unknown as EntityRow;
-  registerEntity(deps.index, entity);
-  deps.index.bySourceRef.set(`${subjectSource}:${subjectSourceId}`, entity);
-  return { kind: result.kind === "created" ? "entity_created" : "entity_linked", entity, mentionWritten: false };
+  const refreshed = await applySeedAliases(deps, entity, extractSeedAliases(raw));
+  deps.index.bySourceRef.set(`${subjectSource}:${subjectSourceId}`, refreshed);
+  return {
+    kind: result.kind === "created" ? "entity_created" : "entity_linked",
+    entity: refreshed,
+    mentionWritten: false,
+  };
+}
+
+function extractSeedAliases(raw: Record<string, unknown>): string[] {
+  const aliases = raw.aliases;
+  if (!Array.isArray(aliases)) return [];
+  return aliases.filter((alias): alias is string => typeof alias === "string" && alias.trim().length > 0);
+}
+
+async function applySeedAliases(deps: MaterializeDeps, entity: EntityRow, aliases: string[]): Promise<EntityRow> {
+  let refreshed = entity;
+  for (const alias of aliases) {
+    await deps.entityRepo.appendAlias(refreshed.id, alias);
+  }
+  if (aliases.length > 0) {
+    refreshed = ((await deps.entityRepo.getEntity(refreshed.id)) ?? refreshed) as unknown as EntityRow;
+  }
+  registerEntity(deps.index, refreshed);
+  return refreshed;
 }

--- a/packages/server/src/entities/materialize-spine-candidate.ts
+++ b/packages/server/src/entities/materialize-spine-candidate.ts
@@ -1,3 +1,4 @@
+import { deriveQualifiedSeedName } from "../connectors/container-name";
 import { normalizeEntityMatchName, registerEntity } from "./materialize-deps";
 import { createMentionFromFact } from "./materialize-mentions";
 import { buildSeedProvenanceNote, isProjectCandidateSeed } from "./materialize-structural-gate";
@@ -81,7 +82,11 @@ export async function materializeSpineCandidate(
     const owner = deps.resolveOwner(fact);
     if (!owner) return { kind: "skipped_missing_owner", reason: "missing_fact_owner" };
 
-    const subjectName = fact.subject_name as string;
+    const { name: subjectName, aliases: seedAliases } = deriveQualifiedSeedName({
+      source: args.subjectSource,
+      subjectName: fact.subject_name as string,
+      raw: args.raw,
+    });
     const { row, skipEvidence } = await deps.reviewRepo.upsertSeedReviewRow({
       proposedName: subjectName,
       normalizedName: normalizeEntityMatchName(spineType, subjectName),
@@ -91,7 +96,7 @@ export async function materializeSpineCandidate(
       candidateEntityId: null,
       triggeredByUserId: owner,
       metadata: args.metadata,
-      seedAliases: extractSeedAliases(args.raw),
+      seedAliases,
     });
 
     if (skipEvidence) {
@@ -109,15 +114,20 @@ export async function materializeSpineCandidate(
     return { kind: "queued", reviewId: row.id };
   }
 
+  const { name: qualifiedName, aliases: qualifiedAliases } = deriveQualifiedSeedName({
+    source: args.subjectSource,
+    subjectName: fact.subject_name as string,
+    raw: args.raw,
+  });
   const entity = await upsertEntityFromSeed(deps, {
-    name: fact.subject_name as string,
+    name: qualifiedName,
     sourceType: spineType,
     source: args.subjectSource,
     sourceId: args.subjectSourceId,
     sourceUrl: args.sourceUrl,
     sourceRefId: fact.indexed_file_id ?? undefined,
     metadata: args.metadata,
-    aliases: extractSeedAliases(args.raw),
+    aliases: qualifiedAliases,
   });
   deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
   return { kind: "structural", entity };

--- a/packages/server/src/entities/materialize-spine-candidate.ts
+++ b/packages/server/src/entities/materialize-spine-candidate.ts
@@ -26,7 +26,7 @@ export async function materializeSpineCandidate(
 ): Promise<MaterializeResult> {
   const spineType = canonicalSpineTypeForStructuralSource(args.sourceType);
   if (!spineType) {
-    const entity = (await deps.entityRepo.upsertEntityFromTool({
+    const entity = await upsertEntityFromSeed(deps, {
       name: fact.subject_name as string,
       sourceType: args.sourceType,
       source: args.subjectSource,
@@ -34,15 +34,15 @@ export async function materializeSpineCandidate(
       sourceUrl: args.sourceUrl,
       sourceRefId: fact.indexed_file_id ?? undefined,
       metadata: args.metadata,
-    })) as unknown as EntityRow;
-    registerEntity(deps.index, entity);
+      aliases: extractSeedAliases(args.raw),
+    });
     deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
     return { kind: "structural", entity };
   }
 
   const existing = await deps.entityRepo.getEntityBySourceRef(args.subjectSource, args.subjectSourceId);
   if (existing && existing.source_type === spineType) {
-    const entity = existing as unknown as EntityRow;
+    const entity = await applySeedAliases(deps, existing as unknown as EntityRow, extractSeedAliases(args.raw));
     if (fact.indexed_file_id) {
       await createMentionFromFact(deps, {
         entityId: entity.id,
@@ -58,7 +58,11 @@ export async function materializeSpineCandidate(
   }
 
   if (spineType === "project" && existing && isProjectCandidateSeed(existing.source_type)) {
-    const entity = await promoteLegacyProjectContainer(deps, existing as unknown as EntityRow, fact, args.metadata);
+    const entity = await applySeedAliases(
+      deps,
+      await promoteLegacyProjectContainer(deps, existing as unknown as EntityRow, fact, args.metadata),
+      extractSeedAliases(args.raw),
+    );
     if (fact.indexed_file_id) {
       await createMentionFromFact(deps, {
         entityId: entity.id,
@@ -87,6 +91,7 @@ export async function materializeSpineCandidate(
       candidateEntityId: null,
       triggeredByUserId: owner,
       metadata: args.metadata,
+      seedAliases: extractSeedAliases(args.raw),
     });
 
     if (skipEvidence) {
@@ -104,7 +109,7 @@ export async function materializeSpineCandidate(
     return { kind: "queued", reviewId: row.id };
   }
 
-  const entity = (await deps.entityRepo.upsertEntityFromTool({
+  const entity = await upsertEntityFromSeed(deps, {
     name: fact.subject_name as string,
     sourceType: spineType,
     source: args.subjectSource,
@@ -112,10 +117,53 @@ export async function materializeSpineCandidate(
     sourceUrl: args.sourceUrl,
     sourceRefId: fact.indexed_file_id ?? undefined,
     metadata: args.metadata,
-  })) as unknown as EntityRow;
-  registerEntity(deps.index, entity);
+    aliases: extractSeedAliases(args.raw),
+  });
   deps.index.bySourceRef.set(`${args.subjectSource}:${args.subjectSourceId}`, entity);
   return { kind: "structural", entity };
+}
+
+function extractSeedAliases(raw: Record<string, unknown>): string[] {
+  const aliases = raw.aliases;
+  if (!Array.isArray(aliases)) return [];
+  return aliases.filter((alias): alias is string => typeof alias === "string" && alias.trim().length > 0);
+}
+
+async function upsertEntityFromSeed(
+  deps: MaterializeDeps,
+  input: {
+    name: string;
+    sourceType: string;
+    source: string;
+    sourceId: string;
+    sourceUrl?: string;
+    sourceRefId?: string;
+    metadata?: Record<string, unknown>;
+    aliases: string[];
+  },
+): Promise<EntityRow> {
+  const entity = (await deps.entityRepo.upsertEntityFromTool({
+    name: input.name,
+    sourceType: input.sourceType,
+    source: input.source,
+    sourceId: input.sourceId,
+    sourceUrl: input.sourceUrl,
+    sourceRefId: input.sourceRefId,
+    metadata: input.metadata,
+  })) as unknown as EntityRow;
+  return applySeedAliases(deps, entity, input.aliases);
+}
+
+async function applySeedAliases(deps: MaterializeDeps, entity: EntityRow, aliases: string[]): Promise<EntityRow> {
+  let refreshed = entity;
+  for (const alias of aliases) {
+    await deps.entityRepo.appendAlias(refreshed.id, alias);
+  }
+  if (aliases.length > 0) {
+    refreshed = ((await deps.entityRepo.getEntity(refreshed.id)) ?? refreshed) as unknown as EntityRow;
+  }
+  registerEntity(deps.index, refreshed);
+  return refreshed;
 }
 
 async function promoteLegacyProjectContainer(

--- a/packages/server/src/entities/name-dedup.ts
+++ b/packages/server/src/entities/name-dedup.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { stripDomainSuffix, tokenizeName } from "./name-tokenize";
 
 export type CandidateValueKind = "name" | "alias";
 
@@ -52,12 +53,7 @@ export function normalizeStrict(name: string): string {
  * (`Sanaa` vs an unrelated `Sanaa`). The caller treats `""` as "no key".
  */
 export function normalizeTokenSet(name: string): string {
-  const tokens = stripDomainSuffix(name)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim()
-    .split(" ")
-    .filter(Boolean);
+  const tokens = tokenizeName(name);
   if (tokens.length < 2) return "";
   return tokens.sort().join(" ");
 }
@@ -310,8 +306,4 @@ function canCreateBlake2b64(): boolean {
   } catch {
     return false;
   }
-}
-
-function stripDomainSuffix(value: string): string {
-  return value.trim().replace(/\.(com|org|net|io|ai|co|in|dev|app)\b\.?$/i, "");
 }

--- a/packages/server/src/entities/name-tokenize.ts
+++ b/packages/server/src/entities/name-tokenize.ts
@@ -1,0 +1,12 @@
+export function tokenizeName(name: string): string[] {
+  return stripDomainSuffix(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+}
+
+export function stripDomainSuffix(value: string): string {
+  return value.trim().replace(/\.(com|org|net|io|ai|co|in|dev|app)\b\.?$/i, "");
+}

--- a/packages/server/src/entities/resolve.ts
+++ b/packages/server/src/entities/resolve.ts
@@ -424,6 +424,17 @@ async function autoResolutionShortCircuit(ctx: ResolveTxnCtx, target: Entity, pr
   return aliases.some((a) => normalizeName(a) === normalized);
 }
 
+function parseSeedAliases(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((alias): alias is string => typeof alias === "string" && alias.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Find stale entities to merge during Confirm. Stale = same source_type,
  * canonical name matches the proposed name, no email, distinct from target.
@@ -747,6 +758,9 @@ export async function confirmReview(ctx: ResolveCtx, reviewId: string, opts: Con
         source: row.seed_source,
         sourceId: row.seed_source_id,
       });
+    }
+    for (const alias of parseSeedAliases(row.seed_aliases)) {
+      await trxCtx.entityRepo.appendAlias(target.id, alias);
     }
 
     // Evidence cap (chunking deferred).


### PR DESCRIPTION
Stacked context-graph slice 16/27.

Base: `feat/context-graph-15-connector-hierarchy-fireflies`
Head: `feat/context-graph-16-connector-name-qualification`

Adds durable connector container-name qualification and migration coverage.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`