### PR TITLE
feat: add provenance tier and product gates

### DIFF
--- a/packages/server/src/api/entities/profile-routes.ts
+++ b/packages/server/src/api/entities/profile-routes.ts
@@ -289,6 +289,7 @@ export function createEntityProfileRoutes(db: Kysely<DB>, _deps: EntityRoutesDep
       subtype: body.subtype,
       aliases: body.aliases,
       status: "confirmed",
+      provenanceTier: "declared",
     });
 
     return c.json({

--- a/packages/server/src/api/settings.test.ts
+++ b/packages/server/src/api/settings.test.ts
@@ -295,32 +295,48 @@ describe("Settings API — security", () => {
   });
 
   describe("PUT /api/settings/identity — org context", () => {
-    it("round-trips orgContext.description and survives a malformed stored blob", async () => {
+    it("round-trips disambiguation guidance and handles empty or malformed org context", async () => {
       const app = createApp(db, config, { logger });
       const adminCookie = await loginAdmin(app);
 
-      // Roundtrip: PUT then GET returns the saved value.
       const putRes = await app.request("/api/settings/identity", {
         method: "PUT",
         headers: { "Content-Type": "application/json", Cookie: adminCookie },
         body: JSON.stringify({
           orgName: "Canvas Labs",
-          orgContext: { description: "AI services company. Sketch is one of our products." },
+          orgContext: {
+            description: "AI services company. Sketch is one of our products.",
+            disambiguationGuidance: "A dataset or a UI tab is not a product.",
+          },
         }),
       });
       expect(putRes.status).toBe(200);
       const putBody = (await putRes.json()) as {
         orgName: string;
-        orgContext: { description?: string } | null;
+        orgContext: { description?: string; disambiguationGuidance?: string } | null;
       };
       expect(putBody.orgName).toBe("Canvas Labs");
       expect(putBody.orgContext?.description).toBe("AI services company. Sketch is one of our products.");
+      expect(putBody.orgContext?.disambiguationGuidance).toBe("A dataset or a UI tab is not a product.");
 
       const getRes = await app.request("/api/settings/identity", { headers: { Cookie: adminCookie } });
-      const getBody = (await getRes.json()) as { orgContext: { description?: string } | null };
+      const getBody = (await getRes.json()) as {
+        orgContext: { description?: string; disambiguationGuidance?: string } | null;
+      };
       expect(getBody.orgContext?.description).toBe("AI services company. Sketch is one of our products.");
+      expect(getBody.orgContext?.disambiguationGuidance).toBe("A dataset or a UI tab is not a product.");
 
-      // Resilience: bad JSON in the column returns orgContext: null, not 500.
+      const emptyRes = await app.request("/api/settings/identity", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Cookie: adminCookie },
+        body: JSON.stringify({
+          orgContext: { description: " ", disambiguationGuidance: " " },
+        }),
+      });
+      expect(emptyRes.status).toBe(200);
+      const emptyBody = (await emptyRes.json()) as { orgContext: unknown };
+      expect(emptyBody.orgContext).toBeNull();
+
       await db.updateTable("settings").set({ org_context: "{not valid json" }).where("id", "=", "default").execute();
       const afterCorruption = await app.request("/api/settings/identity", { headers: { Cookie: adminCookie } });
       expect(afterCorruption.status).toBe(200);

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -10,7 +10,7 @@ import {
   createEnrichmentGenerator,
   resolveOpenRouterEnrichmentConfig,
 } from "../connectors/enrichment-providers";
-import { type createSettingsRepository, parseOrgContext } from "../db/repositories/settings";
+import { type createSettingsRepository, parseOrgContext, serializeOrgContext } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 
 const searchConfigSchema = z.object({
@@ -26,6 +26,7 @@ const identityUpdateSchema = z.object({
     .object({
       description: z.string().trim().max(2000).optional(),
       industry: z.string().trim().max(80).optional(),
+      disambiguationGuidance: z.string().trim().max(2000).optional(),
     })
     .optional(),
 });
@@ -79,12 +80,7 @@ export function settingsRoutes(
     const updates: Parameters<typeof settings.update>[0] = {};
     if (parsed.data.orgName !== undefined) updates.orgName = parsed.data.orgName;
     if (parsed.data.orgContext !== undefined) {
-      const description = parsed.data.orgContext.description ?? "";
-      const industry = parsed.data.orgContext.industry ?? "";
-      const next: Record<string, string> = {};
-      if (description.length > 0) next.description = description;
-      if (industry.length > 0) next.industry = industry;
-      updates.orgContext = Object.keys(next).length > 0 ? JSON.stringify(next) : null;
+      updates.orgContext = serializeOrgContext(parsed.data.orgContext);
     }
 
     if (Object.keys(updates).length === 0) {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -105,6 +105,9 @@ export async function createServer(config: Config, options?: CreateServerOptions
     birthGateTypes: config.EXPERIMENTAL_FLAG
       ? new Set<ProposeEntityType>(["project", "product", "team"])
       : new Set<ProposeEntityType>(),
+    birthGateLiveTypes: config.EXPERIMENTAL_FLAG
+      ? new Set<ProposeEntityType>(["product"])
+      : new Set<ProposeEntityType>(),
     birthGateDryRun: config.BIRTH_GATE_DRY_RUN,
     experimentalFlag: config.EXPERIMENTAL_FLAG,
   });

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -18,6 +18,7 @@ import type { Logger } from "pino";
 import { isPg } from "../db/dialect";
 import { createEntityRepository, whereLiveEntity } from "../db/repositories/entities";
 import { PERSON_PARTICIPANT_FACT_TYPES } from "../db/repositories/indexed-file-facts";
+import { parseOrgContext } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
@@ -383,7 +384,7 @@ export interface EnrichmentDeps {
   /** If set, only enrich these specific file IDs (ignoring pending status). */
   fileIds?: string[];
   /** Org context for enrichment prompts. Populated at start of enrichment run. */
-  orgContext?: { orgName?: string; description?: string; industry?: string } | null;
+  orgContext?: { orgName?: string; description?: string; industry?: string; disambiguationGuidance?: string } | null;
   /**
    * Org-wide baseline of confirmed entities used as a
    * fallback when a file has no resolvable anchors. The per-file scoped list
@@ -449,11 +450,12 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
       .where("id", "=", "default")
       .executeTakeFirst();
     if (settings?.org_context) {
-      const parsed = JSON.parse(settings.org_context) as Record<string, string>;
+      const parsed = parseOrgContext(settings.org_context);
       deps.orgContext = {
         orgName: settings.org_name ?? undefined,
-        description: parsed.description,
-        industry: parsed.industry,
+        description: parsed?.description,
+        industry: parsed?.industry,
+        disambiguationGuidance: parsed?.disambiguationGuidance,
       };
     }
   } catch {

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -21,6 +21,7 @@ import { PERSON_PARTICIPANT_FACT_TYPES } from "../db/repositories/indexed-file-f
 import type { DB } from "../db/schema";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
+import { PRODUCT_MATCH_TARGET_PROVENANCE_TIERS } from "../entities/provenance";
 import { yieldToEventLoop } from "../lib/event-loop";
 import type { Chunk } from "./chunking";
 import { chunkText } from "./chunking";
@@ -336,6 +337,12 @@ export async function loadBaselineKnownEntities(
     .select(["id", "name", "source_type", "aliases", "metadata", "hotness"])
     .where("source_type", "in", ["product", "team"])
     .where("status", "=", "confirmed")
+    .where((eb) =>
+      eb.or([
+        eb("source_type", "!=", "product"),
+        eb("provenance_tier", "in", [...PRODUCT_MATCH_TARGET_PROVENANCE_TIERS]),
+      ]),
+    )
     .where(whereLiveEntity())
     .execute();
   const projectEntities = opts.experimentalFlag

--- a/packages/server/src/connectors/entity-linking.ts
+++ b/packages/server/src/connectors/entity-linking.ts
@@ -67,6 +67,9 @@ export function formatEntitiesForPrompt(entities: Entity[]): string {
  * 1. Exact name match in entities
  * 2. Fuzzy match (Jaro-Winkler >= 0.85) — auto-merge with alias
  * 3. No match — create tentative person entity
+ *
+ * Dormant legacy path retained for compatibility; new extraction flows should
+ * use propose/materialize helpers and pass provenance explicitly.
  */
 export async function resolveNewPerson(db: Kysely<DB>, name: string): Promise<Entity> {
   const entityRepo = createEntityRepository(db);
@@ -96,5 +99,6 @@ export async function resolveNewPerson(db: Kysely<DB>, name: string): Promise<En
     sourceType: "person",
     subtype: "external",
     status: "tentative",
+    provenanceTier: "inferred",
   });
 }

--- a/packages/server/src/connectors/file-scope-context.test.ts
+++ b/packages/server/src/connectors/file-scope-context.test.ts
@@ -79,7 +79,14 @@ async function seedFile(db: Kysely<DB>, id: string, sourceUpdatedAt: string | nu
 
 async function seedEntity(
   db: Kysely<DB>,
-  args: { id: string; name: string; sourceType: string; hotness?: number; metadata?: Record<string, unknown> },
+  args: {
+    id: string;
+    name: string;
+    sourceType: string;
+    hotness?: number;
+    metadata?: Record<string, unknown>;
+    provenanceTier?: string;
+  },
 ): Promise<void> {
   const now = new Date().toISOString();
   await db
@@ -93,6 +100,7 @@ async function seedEntity(
       metadata: args.metadata ? JSON.stringify(args.metadata) : null,
       source_ref_id: null,
       status: "confirmed",
+      provenance_tier: args.provenanceTier ?? "inferred",
       hotness: args.hotness ?? 0,
       created_at: now,
       updated_at: now,
@@ -425,6 +433,39 @@ describe("file-scope-context", () => {
     });
   });
 
+  it("loadBaselineKnownEntities excludes inferred products while preserving declared products and teams", async () => {
+    await seedEntity(db, {
+      id: "baseline-product-inferred",
+      name: "Inferred Product",
+      sourceType: "product",
+      provenanceTier: "inferred",
+    });
+    await seedEntity(db, {
+      id: "baseline-product-declared",
+      name: "Declared Product",
+      sourceType: "product",
+      provenanceTier: "declared",
+    });
+    await seedEntity(db, {
+      id: "baseline-product-confirmed",
+      name: "Confirmed Product",
+      sourceType: "product",
+      provenanceTier: "human_confirmed",
+    });
+    await seedEntity(db, {
+      id: "baseline-team-inferred",
+      name: "Inferred Team",
+      sourceType: "team",
+      provenanceTier: "inferred",
+    });
+
+    const baseline = await loadBaselineKnownEntities(db);
+    const names = baseline.map((entry) => entry.name);
+
+    expect(names).not.toContain("Inferred Product");
+    expect(names).toEqual(expect.arrayContaining(["Declared Product", "Confirmed Product", "Inferred Team"]));
+  });
+
   it("uses person anchors when company anchoring fails and skips ambiguous participant emails", async () => {
     const now = Date.UTC(2026, 4, 26);
     const recentDate = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
@@ -522,7 +563,13 @@ describe("file-scope-context", () => {
     await seedFile(db, promptFile, recentDate);
     await seedFile(db, coMentionFile, recentDate);
     await seedEntity(db, { id: "ent-parity-company", name: "Parity Co", sourceType: "company", hotness: 10 });
-    await seedEntity(db, { id: "ent-parity-product", name: "Parity Product", sourceType: "product", hotness: 10 });
+    await seedEntity(db, {
+      id: "ent-parity-product",
+      name: "Parity Product",
+      sourceType: "product",
+      hotness: 10,
+      provenanceTier: "declared",
+    });
     await seedDomain(db, { entityId: "ent-parity-company", domain: "parity.example", kind: "corporate" });
     await seedAttendeeFact(db, { fileId: promptFile, name: "Parity Person", email: "person@parity.example" });
     await seedMention(db, { entityId: "ent-parity-company", fileId: coMentionFile });

--- a/packages/server/src/connectors/smart-enrichment.test.ts
+++ b/packages/server/src/connectors/smart-enrichment.test.ts
@@ -1206,7 +1206,10 @@ describe("extractEntities prompt — v6 entity type removal", () => {
 });
 
 describe("extractEntities prompt — v7 quality rules", () => {
-  async function capturePrompt(): Promise<string> {
+  async function capturePrompt(
+    orgContext?: Parameters<typeof extractEntities>[2],
+    knownEntities?: Parameters<typeof extractEntities>[3],
+  ): Promise<string> {
     let captured = "";
     const generator = {
       generate: async () => "",
@@ -1216,18 +1219,23 @@ describe("extractEntities prompt — v7 quality rules", () => {
       },
     } as GeminiGenerator;
 
-    await extractEntities(generator, {
-      id: "f-v7",
-      fileName: "transcript.txt",
-      content: "body",
-      contentCategory: "document",
-      source: "fireflies",
-      sourcePath: "/",
-      contentHash: null,
-      connectorConfigId: "conn-v7",
-      sourceCreatedAt: null,
-      sourceUpdatedAt: null,
-    });
+    await extractEntities(
+      generator,
+      {
+        id: "f-v7",
+        fileName: "transcript.txt",
+        content: "body",
+        contentCategory: "document",
+        source: "fireflies",
+        sourcePath: "/",
+        contentHash: null,
+        connectorConfigId: "conn-v7",
+        sourceCreatedAt: null,
+        sourceUpdatedAt: null,
+      },
+      orgContext,
+      knownEntities,
+    );
     return captured;
   }
 
@@ -1259,33 +1267,39 @@ describe("extractEntities prompt — v7 quality rules", () => {
   });
 
   it("renders the org description into the extraction prompt when provided", async () => {
-    let captured = "";
-    const generator = {
-      generate: async () => "",
-      generateJSON: async <T>(prompt: string) => {
-        captured = prompt;
-        return { mentions: [], relations: [] } as T;
-      },
-    } as GeminiGenerator;
-
-    await extractEntities(
-      generator,
-      {
-        id: "f-orgctx",
-        fileName: "transcript.txt",
-        content: "body",
-        contentCategory: "document",
-        source: "fireflies",
-        sourcePath: "/",
-        contentHash: null,
-        connectorConfigId: "conn-orgctx",
-        sourceCreatedAt: null,
-        sourceUpdatedAt: null,
-      },
-      { orgName: "Canvas Labs", description: "AI services company. Sketch is one of our products." },
-    );
+    const captured = await capturePrompt({
+      orgName: "Canvas Labs",
+      description: "AI services company. Sketch is one of our products.",
+    });
 
     expect(captured).toContain("Organization: Canvas Labs");
     expect(captured).toContain("AI services company. Sketch is one of our products.");
+  });
+
+  it("includes product disambiguation guidance when org context provides it", async () => {
+    const captured = await capturePrompt({
+      orgName: "Canvas Labs",
+      description: "AI services company.",
+      disambiguationGuidance: "A dataset or UI tab is not a product.",
+    });
+
+    expect(captured).toContain("Product/disambiguation guidance");
+    expect(captured).toContain("A dataset or UI tab is not a product.");
+  });
+
+  it("does not hardcode Sketch as a product example and points products at injected known products", async () => {
+    const captured = await capturePrompt(undefined, [
+      { name: "Known Product", type: "product", description: "Declared product" },
+    ]);
+    const productLine = captured.split("\n").find((line) => line.startsWith("- **Products**"));
+
+    expect(productLine).toBeDefined();
+    expect(captured).not.toContain("Sketch");
+    expect(productLine).not.toContain("Sketch");
+    expect(productLine).not.toContain("Canvas AI");
+    expect(productLine).not.toContain("Meetup by Habuild");
+    expect(productLine).toContain("injected known-products list");
+    expect(captured).toContain("Known entities likely to appear in this file");
+    expect(captured).toContain("Known Product (product)");
   });
 });

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -576,6 +576,7 @@ export async function handleCandidates(
             triggeredByUserId: owner?.created_by ?? "system",
             aliases: mention.variations,
             metadata: { origin: "ai" },
+            provenanceTier: "inferred",
           },
         );
 

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -138,12 +138,19 @@ interface MatchedEntity {
   learnedFacts: LearnedFactStored[];
 }
 
+interface ExtractionOrgContext {
+  orgName?: string;
+  description?: string;
+  industry?: string;
+  disambiguationGuidance?: string;
+}
+
 interface SmartEnrichmentDeps {
   db: Kysely<DB>;
   logger: Logger;
   generator: GeminiGenerator;
   embeddingProvider: EmbeddingProvider | null;
-  orgContext?: { orgName?: string; description?: string; industry?: string } | null;
+  orgContext?: ExtractionOrgContext | null;
   /** Known product/team entities to include in extraction prompt for better matching. */
   knownEntities?: Array<{
     name: string;
@@ -261,7 +268,7 @@ async function withFreshFileWriteLock<T>(
 export async function extractEntities(
   generator: GeminiGenerator,
   file: FileContext,
-  orgContext?: { orgName?: string; description?: string; industry?: string } | null,
+  orgContext?: ExtractionOrgContext | null,
   knownEntities?: Array<{
     name: string;
     type: string;
@@ -278,6 +285,9 @@ export async function extractEntities(
 
   const orgSection = orgContext?.description
     ? `\nOrganization: ${orgContext.orgName ?? "Unknown"}. ${orgContext.description}${orgContext.industry ? ` (Industry: ${orgContext.industry})` : ""}\n`
+    : "";
+  const disambiguationSection = orgContext?.disambiguationGuidance
+    ? `\nProduct/disambiguation guidance:\n${orgContext.disambiguationGuidance}\n`
     : "";
 
   const renderKnown = (e: {
@@ -300,7 +310,7 @@ export async function extractEntities(
 
   const knownSection =
     knownEntities && knownEntities.length > 0
-      ? `\nKnown entities likely to appear in this file — match these to mentions instead of creating duplicates, and prefer them as relationship endpoints:\n${knownEntities.map(renderKnown).join("\n")}\n`
+      ? `\nKnown entities likely to appear in this file — match these to mentions instead of creating duplicates, and prefer them as relationship endpoints. Product entries here are the injected known-products list; map product mentions to those entries instead of inventing new product names:\n${knownEntities.map(renderKnown).join("\n")}\n`
       : "";
 
   const participantSection = participantBlock && participantBlock.length > 0 ? participantBlock : "";
@@ -325,7 +335,7 @@ export async function extractEntities(
     'Use "engagement_for" for a PROJECT delivered for a client company; use "engaged_with" for a PERSON working with a company.';
 
   const prompt = `You are analyzing a document to identify meaningful business entities mentioned in it.
-${orgSection}${knownSection}${participantSection}${threadSection}
+${orgSection}${disambiguationSection}${knownSection}${participantSection}${threadSection}
 File: ${file.fileName}
 Source: ${file.source}${file.sourcePath ? ` / ${file.sourcePath}` : ""}
 Type: ${file.contentCategory}
@@ -333,7 +343,7 @@ Type: ${file.contentCategory}
 Extract entities that a business team would want to track and reference across documents. Focus on:
 - **People**: named individuals (employees, clients, contacts)
 - **Companies**: external businesses, clients, partners, vendors
-- **Products**: named products or services your org builds or uses (e.g., "Canvas AI", "Sketch", "Meetup by Habuild")
+- **Products**: named products or services your org builds or uses. When product entries appear in the Known entities section, treat that injected known-products list as the source of truth instead of inventing product names.
 - **Projects**: named umbrella engagements or programs with their own scope and timeline (e.g., "OW Tourism Dashboard", "Paid Member Migration Phase 2", "K8S Migration"). A project is the umbrella, NOT a single ticket, pull request, or one feature of a product.
 ${toolFocusLine}
 
@@ -351,7 +361,7 @@ DO NOT extract:
 - Meeting titles or calendar event names — anything containing "<>", "Standup", "Sync", "Weekly", "Daily", or "1:1". These are calendar event names, not projects. Extract the companies and people referenced by the meeting instead.
 - Document, note, or artifact titles as projects (e.g. names ending in "note", "chart", "doc", "spec", "deck"). These are filenames, not engagements.
 - Issue or ticket identifiers and keys — "SKE-123", "ECR-01", "ABC-1234", or a bare "#192". These are individual work items, not projects; extract the project or product they belong to instead, never the ticket key (even when the key is followed by a title, e.g. "SKE-120: Provenance columns").
-- Pull requests, commits, or branches — "PR #192", "Sketch PR #45", commit SHAs, branch names. These are code artifacts, not engagements.
+- Pull requests, commits, or branches — "PR #192", commit SHAs, branch names. These are code artifacts, not engagements.
 - A single feature, tab, screen, or module of a product as a project — "Files", "Workflows", "Analytics", "Push Notifications", "Outlook Integration". These are parts of a product, not umbrella engagements with their own scope.
 - Generic feature descriptions or internal component names as products (e.g. "responder functionality", "conversational model", "X service", "X module", "X pipeline"). Products must be a branded, proper-noun name your org or a client publicly markets — not the internal name of a component you are building.
 - Meeting section titles, status notes, activity descriptions, metrics, generic verbs, or generic technical nouns

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -563,6 +563,7 @@ export async function handleCandidates(
             lookup: materializeDeps.lookup,
             logger: materializeDeps.logger,
             birthGateTypes: materializeDeps.birthGateTypes,
+            birthGateLiveTypes: materializeDeps.birthGateLiveTypes,
             birthGateDryRun: materializeDeps.birthGateDryRun,
             readEmail: materializeDeps.readEmail,
           },

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -74,6 +74,7 @@ export async function seedTeamDirectoryEntities(db: Kysely<DB>, logger: Logger):
         subtype: "internal",
         source: "team",
         sourceId: user.id,
+        provenanceTier: "structural",
       });
       // Direct seed path: no file evidence available, so the helper can
       // only write a works_at edge when a corporate domain is already

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -129,6 +129,7 @@ import * as m126 from "./migrations/126-work-cycles";
 import * as m127 from "./migrations/127-work-cycles-connector";
 import * as m128 from "./migrations/128-work-cycles-connector-key";
 import * as m129 from "./migrations/129-container-name-qualification";
+import * as m130 from "./migrations/130-entity-provenance-tier";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -262,6 +263,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "127-work-cycles-connector": m127,
           "128-work-cycles-connector-key": m128,
           "129-container-name-qualification": m129,
+          "130-entity-provenance-tier": m130,
         };
       },
     },

--- a/packages/server/src/db/migrations/130-entity-provenance-tier.integration.test.ts
+++ b/packages/server/src/db/migrations/130-entity-provenance-tier.integration.test.ts
@@ -1,0 +1,122 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { up as backfillProvenanceTier } from "./116-entity-provenance-tier";
+
+const NOW = "2026-06-26T00:00:00.000Z";
+
+async function insertEntity(db: Kysely<DB>, id: string, name: string): Promise<void> {
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: "project",
+      subtype: null,
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: NOW,
+      updated_at: NOW,
+    })
+    .execute();
+}
+
+describe("116-entity-provenance-tier", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestPgDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("backfills structural, human-confirmed, and inferred entity tiers", async () => {
+    await insertEntity(db, "structural-entity", "Structural Project");
+    await insertEntity(db, "confirmed-entity", "Confirmed Project");
+    await insertEntity(db, "llm-entity", "LLM Project");
+    await db
+      .insertInto("entity_source_refs")
+      .values({
+        id: "structural-ref",
+        entity_id: "structural-entity",
+        source: "linear",
+        source_id: "linear-project-1",
+        source_url: null,
+        last_seen_at: NOW,
+      })
+      .execute();
+    await db
+      .insertInto("indexed_file_facts")
+      .values({
+        id: "structural-fact",
+        indexed_file_id: null,
+        connector_config_id: null,
+        created_by_user_id: null,
+        source: "linear",
+        fact_type: "structural_seed",
+        relation: "seeded",
+        subject_name: "Structural Project",
+        subject_source: "linear",
+        subject_source_id: "linear-project-1",
+        subject_email: null,
+        context_snippet: null,
+        raw: "{}",
+        fact_key: "linear:linear-project-1:seeded",
+        last_seen_sync_run_id: null,
+        deleted_at: null,
+        content_hash: null,
+        materialized_at: null,
+        created_at: NOW,
+        updated_at: NOW,
+      })
+      .execute();
+    await db
+      .insertInto("entity_review_queue")
+      .values({
+        id: "confirmed-review",
+        proposed_name: "Confirmed Project",
+        normalized_name: "confirmed project",
+        entity_type: "project",
+        proposed_email: null,
+        candidate_entity_id: null,
+        candidate_score: null,
+        candidate_reason: null,
+        candidate_generated_at: NOW,
+        first_seen_at: NOW,
+        last_seen_at: NOW,
+        occurrence_count: 1,
+        status: "confirmed",
+        triggered_by_user_id: "user-1",
+        review_started_at: null,
+        review_started_by: null,
+        backfill_cursor: null,
+        resolved_by: "user-1",
+        resolved_at: NOW,
+        resolved_entity_id: "confirmed-entity",
+        seed_source: null,
+        seed_source_id: null,
+        seed_aliases: null,
+      })
+      .execute();
+
+    await backfillProvenanceTier(db as unknown as Kysely<unknown>);
+
+    const rows = await db
+      .selectFrom("entities")
+      .select(["id", "provenance_tier"])
+      .where("id", "in", ["structural-entity", "confirmed-entity", "llm-entity"])
+      .orderBy("id", "asc")
+      .execute();
+    expect(rows).toEqual([
+      { id: "confirmed-entity", provenance_tier: "human_confirmed" },
+      { id: "llm-entity", provenance_tier: "inferred" },
+      { id: "structural-entity", provenance_tier: "structural" },
+    ]);
+  });
+});

--- a/packages/server/src/db/migrations/130-entity-provenance-tier.integration.test.ts
+++ b/packages/server/src/db/migrations/130-entity-provenance-tier.integration.test.ts
@@ -2,7 +2,7 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestPgDb } from "../../test-utils";
 import type { DB } from "../schema";
-import { up as backfillProvenanceTier } from "./116-entity-provenance-tier";
+import { up as backfillProvenanceTier } from "./127-entity-provenance-tier";
 
 const NOW = "2026-06-26T00:00:00.000Z";
 
@@ -25,7 +25,7 @@ async function insertEntity(db: Kysely<DB>, id: string, name: string): Promise<v
     .execute();
 }
 
-describe("116-entity-provenance-tier", () => {
+describe("127-entity-provenance-tier", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {

--- a/packages/server/src/db/migrations/130-entity-provenance-tier.integration.test.ts
+++ b/packages/server/src/db/migrations/130-entity-provenance-tier.integration.test.ts
@@ -2,7 +2,7 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestPgDb } from "../../test-utils";
 import type { DB } from "../schema";
-import { up as backfillProvenanceTier } from "./127-entity-provenance-tier";
+import { up as backfillProvenanceTier } from "./130-entity-provenance-tier";
 
 const NOW = "2026-06-26T00:00:00.000Z";
 
@@ -25,7 +25,7 @@ async function insertEntity(db: Kysely<DB>, id: string, name: string): Promise<v
     .execute();
 }
 
-describe("127-entity-provenance-tier", () => {
+describe("130-entity-provenance-tier", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {

--- a/packages/server/src/db/migrations/130-entity-provenance-tier.ts
+++ b/packages/server/src/db/migrations/130-entity-provenance-tier.ts
@@ -1,0 +1,156 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+interface MigrationDb {
+  entities: {
+    id: string;
+    metadata: string | null;
+    provenance_tier: string;
+  };
+  entity_source_refs: {
+    entity_id: string;
+    source: string;
+    source_id: string;
+  };
+  indexed_file_facts: {
+    id: string;
+    source: string;
+    fact_type: string;
+    subject_source: string | null;
+    subject_source_id: string | null;
+    deleted_at: string | null;
+  };
+  entity_review_queue: {
+    status: string;
+    resolved_entity_id: string | null;
+  };
+}
+
+async function hasColumn(db: Kysely<unknown>, tableName: string, columnName: string): Promise<boolean> {
+  const tables = await db.introspection.getTables();
+  return tables.some((table) => table.name === tableName && table.columns.some((column) => column.name === columnName));
+}
+
+async function updateTier(db: Kysely<MigrationDb>, ids: string[], tier: string): Promise<void> {
+  if (ids.length === 0) return;
+  await db.updateTable("entities").set({ provenance_tier: tier }).where("id", "in", ids).execute();
+}
+
+function parseMetadata(value: string | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function positiveManualMarker(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase().replace(/[-\s]/g, "_");
+  return normalized === "manual" || normalized === "human" || normalized === "user" || normalized === "non_ai";
+}
+
+/**
+ * Historical manual creation was not represented by a stable source column.
+ * This deliberately requires an explicit metadata marker such as
+ * `origin: "manual"` or `createdBy: "user"` and no source refs; ambiguous
+ * no-ref rows stay inferred.
+ */
+function isDeclaredHistoricalEntity(metadata: string | null): boolean {
+  const parsed = parseMetadata(metadata);
+  if (!parsed) return false;
+  return (
+    positiveManualMarker(parsed.origin) ||
+    positiveManualMarker(parsed.source) ||
+    positiveManualMarker(parsed.createdBy) ||
+    positiveManualMarker(parsed.created_by) ||
+    positiveManualMarker(parsed.creationSource) ||
+    positiveManualMarker(parsed.manual)
+  );
+}
+
+async function backfillStructural(db: Kysely<MigrationDb>): Promise<void> {
+  const rows = await db
+    .selectFrom("entity_source_refs as refs")
+    .leftJoin("indexed_file_facts as facts", (join) =>
+      join
+        .onRef("facts.subject_source", "=", "refs.source")
+        .onRef("facts.subject_source_id", "=", "refs.source_id")
+        .on("facts.fact_type", "=", "structural_seed")
+        .on(sql<boolean>`facts.deleted_at IS NULL`),
+    )
+    .select("refs.entity_id")
+    .distinct()
+    .where((eb) => eb.or([eb("refs.source", "=", "team"), eb("facts.id", "is not", null)]))
+    .execute();
+  await updateTier(
+    db,
+    rows.map((row) => row.entity_id),
+    "structural",
+  );
+}
+
+/**
+ * `entity_review_queue.status = "confirmed"` is the approved terminal state;
+ * rejected rows also carry `resolved_entity_id` for idempotency but are not
+ * approval evidence for historical backfill.
+ */
+async function backfillHumanConfirmed(db: Kysely<MigrationDb>): Promise<void> {
+  const rows = await db
+    .selectFrom("entity_review_queue")
+    .select("resolved_entity_id")
+    .distinct()
+    .where("status", "=", "confirmed")
+    .where("resolved_entity_id", "is not", null)
+    .execute();
+  await updateTier(
+    db,
+    rows.map((row) => row.resolved_entity_id).filter((id): id is string => typeof id === "string"),
+    "human_confirmed",
+  );
+}
+
+async function backfillDeclared(db: Kysely<MigrationDb>): Promise<void> {
+  const rows = await db
+    .selectFrom("entities")
+    .select(["id", "metadata"])
+    .where((eb) =>
+      eb.not(
+        eb.exists(
+          eb
+            .selectFrom("entity_source_refs")
+            .select("entity_source_refs.entity_id")
+            .whereRef("entity_source_refs.entity_id", "=", "entities.id"),
+        ),
+      ),
+    )
+    .execute();
+  await updateTier(
+    db,
+    rows.filter((row) => isDeclaredHistoricalEntity(row.metadata)).map((row) => row.id),
+    "declared",
+  );
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (!(await hasColumn(db, "entities", "provenance_tier"))) {
+    await db.schema
+      .alterTable("entities")
+      .addColumn("provenance_tier", "text", (col) => col.notNull().defaultTo("inferred"))
+      .execute();
+  }
+  await sql`CREATE INDEX IF NOT EXISTS idx_entities_provenance_tier ON entities(provenance_tier)`.execute(db);
+  const typedDb = db as Kysely<MigrationDb>;
+  await backfillStructural(typedDb);
+  await backfillHumanConfirmed(typedDb);
+  await backfillDeclared(typedDb);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_entities_provenance_tier`.execute(db);
+  if (!(await hasColumn(db, "entities", "provenance_tier"))) return;
+  await db.schema.alterTable("entities").dropColumn("provenance_tier").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 125;
+const EXPECTED_MIGRATION_COUNT = 126;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -158,6 +158,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[122]).toBe("127-work-cycles-connector");
     expect(names[123]).toBe("128-work-cycles-connector-key");
     expect(names[124]).toBe("129-container-name-qualification");
+    expect(names[125]).toBe("130-entity-provenance-tier");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 125;
+const EXPECTED_MIGRATION_COUNT = 126;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -181,6 +181,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[122]).toBe("127-work-cycles-connector");
     expect(names[123]).toBe("128-work-cycles-connector-key");
     expect(names[124]).toBe("129-container-name-qualification");
+    expect(names[125]).toBe("130-entity-provenance-tier");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/repositories/entities.test.ts
+++ b/packages/server/src/db/repositories/entities.test.ts
@@ -66,6 +66,32 @@ describe("createEntityRepository createMention", () => {
     await db.destroy();
   });
 
+  it("persists caller-supplied declared and structural provenance tiers on creation", async () => {
+    const declared = await repo.upsertEntity({
+      name: "Manual Product",
+      sourceType: "product",
+      provenanceTier: "declared",
+    });
+    const structural = await repo.upsertEntityFromTool({
+      name: "Seeded Project",
+      sourceType: "project",
+      source: "linear",
+      sourceId: "linear-seeded-project",
+      provenanceTier: "structural",
+    });
+
+    const rows = await db
+      .selectFrom("entities")
+      .select(["id", "provenance_tier"])
+      .where("id", "in", [declared.id, structural.id])
+      .orderBy("provenance_tier", "asc")
+      .execute();
+    expect(rows).toEqual([
+      { id: declared.id, provenance_tier: "declared" },
+      { id: structural.id, provenance_tier: "structural" },
+    ]);
+  });
+
   it("is idempotent for the same entity, file, and relation", async () => {
     const entity = await repo.upsertPersonEntity({
       name: "Beetu",

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -3,6 +3,7 @@ import type { Kysely, RawBuilder, Selectable } from "kysely";
 import { sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../../entities/profile-facts";
+import type { ProvenanceTier } from "../../entities/provenance";
 import { resolveLiveEntity, resolveLiveEntityId, resolveSourceRefToLiveEntityId } from "../../entities/redirect";
 import { parseTimestampMs } from "../../timestamps";
 import { isPg } from "../dialect";
@@ -130,6 +131,7 @@ export interface UpsertEntityData {
   metadata?: Record<string, unknown>;
   sourceRefId?: string | null;
   status?: string;
+  provenanceTier?: ProvenanceTier;
 }
 
 export interface UpsertEntityFromToolData {
@@ -140,6 +142,7 @@ export interface UpsertEntityFromToolData {
   sourceUrl?: string;
   sourceRefId?: string;
   metadata?: Record<string, unknown>;
+  provenanceTier?: ProvenanceTier;
 }
 
 export interface UpsertPersonEntityData {
@@ -148,6 +151,7 @@ export interface UpsertPersonEntityData {
   subtype: "internal" | "external";
   source: string;
   sourceId: string;
+  provenanceTier?: ProvenanceTier;
 }
 
 export type EntityContactPointKind = "email" | "phone" | "linkedin" | "whatsapp";
@@ -305,6 +309,7 @@ export function createEntityRepository(db: Kysely<DB>) {
           metadata: data.metadata ? JSON.stringify(data.metadata) : null,
           source_ref_id: data.sourceRefId ?? null,
           status: data.status ?? "confirmed",
+          provenance_tier: data.provenanceTier ?? "inferred",
           hotness: 0,
           created_at: now,
           updated_at: now,
@@ -1044,6 +1049,7 @@ export function createEntityRepository(db: Kysely<DB>) {
           metadata: data.metadata ? JSON.stringify(data.metadata) : null,
           source_ref_id: data.sourceRefId ?? null,
           status: "confirmed",
+          provenance_tier: data.provenanceTier ?? "inferred",
           hotness: 0,
           created_at: now,
           updated_at: now,
@@ -1076,6 +1082,10 @@ export function createEntityRepository(db: Kysely<DB>) {
      * done client-side so the same path works on SQLite and Postgres.
      * Returns whether the row was newly created so materialization summaries
      * don't count updates as new entities.
+     *
+     * Dormant legacy helper retained for compatibility; new materializers
+     * should route through the reviewed/propose paths and pass an explicit
+     * provenance tier.
      */
     async upsertLlmExtractedEntity(
       data: UpsertEntityData,
@@ -1123,6 +1133,7 @@ export function createEntityRepository(db: Kysely<DB>) {
           metadata: data.metadata ? JSON.stringify(data.metadata) : null,
           source_ref_id: null,
           status: data.status ?? "confirmed",
+          provenance_tier: data.provenanceTier ?? "inferred",
           hotness: 0,
           created_at: now,
           updated_at: now,
@@ -1337,6 +1348,7 @@ export function createEntityRepository(db: Kysely<DB>) {
           metadata: JSON.stringify(metadata),
           source_ref_id: null,
           status: "confirmed",
+          provenance_tier: data.provenanceTier ?? "inferred",
           hotness: 0,
           created_at: now,
           updated_at: now,
@@ -1380,6 +1392,7 @@ export function createEntityRepository(db: Kysely<DB>) {
           metadata: JSON.stringify(metadata),
           source_ref_id: null,
           status: "confirmed",
+          provenance_tier: data.provenanceTier ?? "inferred",
           hotness: 0,
           created_at: now,
           updated_at: now,

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -324,6 +324,35 @@ export function createEntityRepository(db: Kysely<DB>) {
         .executeTakeFirstOrThrow();
     },
 
+    async createEntity(data: UpsertEntityData) {
+      const id = randomUUID();
+      const now = new Date().toISOString();
+      await db
+        .insertInto("entities")
+        .values({
+          id,
+          name: data.name,
+          source_type: data.sourceType,
+          subtype: data.subtype ?? null,
+          aliases: data.aliases ? JSON.stringify(data.aliases) : null,
+          metadata: data.metadata ? JSON.stringify(data.metadata) : null,
+          source_ref_id: data.sourceRefId ?? null,
+          status: data.status ?? "confirmed",
+          provenance_tier: data.provenanceTier ?? "inferred",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+
+      return await db
+        .selectFrom("entities")
+        .selectAll()
+        .where("id", "=", id)
+        .where(whereLiveEntity())
+        .executeTakeFirstOrThrow();
+    },
+
     /**
      * Fetch an entity. When `viewer` is omitted the entity is returned without
      * RBAC — internal/server callers use this to operate on entities directly

--- a/packages/server/src/db/repositories/settings.ts
+++ b/packages/server/src/db/repositories/settings.ts
@@ -6,6 +6,11 @@ import type { DB } from "../schema";
 export interface OrgContext {
   description?: string;
   industry?: string;
+  /**
+   * Dynamic extraction calibration is deliberately excluded from the prompt
+   * version/fact key, so edits affect only future extraction runs.
+   */
+  disambiguationGuidance?: string;
 }
 
 export function parseOrgContext(raw: string | null | undefined): OrgContext | null {
@@ -19,10 +24,24 @@ export function parseOrgContext(raw: string | null | undefined): OrgContext | nu
     if (typeof parsed.industry === "string" && parsed.industry.trim().length > 0) {
       result.industry = parsed.industry.trim();
     }
-    return result.description || result.industry ? result : null;
+    if (typeof parsed.disambiguationGuidance === "string" && parsed.disambiguationGuidance.trim().length > 0) {
+      result.disambiguationGuidance = parsed.disambiguationGuidance.trim();
+    }
+    return result.description || result.industry || result.disambiguationGuidance ? result : null;
   } catch {
     return null;
   }
+}
+
+export function serializeOrgContext(context: OrgContext): string | null {
+  const next: Record<string, string> = {};
+  const description = context.description?.trim() ?? "";
+  const industry = context.industry?.trim() ?? "";
+  const disambiguationGuidance = context.disambiguationGuidance?.trim() ?? "";
+  if (description.length > 0) next.description = description;
+  if (industry.length > 0) next.industry = industry;
+  if (disambiguationGuidance.length > 0) next.disambiguationGuidance = disambiguationGuidance;
+  return Object.keys(next).length > 0 ? JSON.stringify(next) : null;
 }
 
 const SENSITIVE_FIELDS = new Set<string>([

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -654,6 +654,7 @@ export interface EntitiesTable {
   metadata: string | null;
   source_ref_id: string | null;
   status: string;
+  provenance_tier: Generated<string>;
   hotness: number;
   created_at: string;
   updated_at: string;

--- a/packages/server/src/entities/domain-promotion.ts
+++ b/packages/server/src/entities/domain-promotion.ts
@@ -229,6 +229,7 @@ export async function sweepDomainPromotions(db: Kysely<DB>, logger: Logger): Pro
         evidence: evidenceFiles.map((indexedFileId) => ({ indexedFileId, note: `domain_promotion:${domain}` })),
         triggeredByUserId: candidate.first_observed_by_user_id ?? "system",
         metadata: { origin: "domain_promotion", domain },
+        provenanceTier: "inferred",
       },
     );
 

--- a/packages/server/src/entities/materialize-birth-gate.test.ts
+++ b/packages/server/src/entities/materialize-birth-gate.test.ts
@@ -6,12 +6,12 @@ import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
 import { materializeUnmaterializedFacts } from "./materialize";
 import type { ProposeEntityType } from "./propose";
-import { confirmReview } from "./resolve";
 
 const USER_ID = "user-1";
 const CONNECTOR_ID = "connector-1";
 const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
 const A1_BIRTH_GATE_TYPES: Set<ProposeEntityType> = new Set(["project", "product", "team"]);
+const PRODUCT_LIVE_TYPES: Set<ProposeEntityType> = new Set(["product"]);
 
 async function seedConnector(db: Kysely<DB>, source = "google_drive"): Promise<void> {
   const now = new Date().toISOString();
@@ -81,30 +81,39 @@ async function upsertLlmMention(db: Kysely<DB>, fileId: string, name: string, ty
   });
 }
 
-async function upsertStructuralSeed(
+async function upsertLlmRelation(
   db: Kysely<DB>,
-  input: { fileId: string; sourceType: string; name: string; sourceId: string; source?: string; aliases?: string[] },
+  input: {
+    fileId: string;
+    relationType: "builds";
+    source: { name: string; type: string };
+    target: { name: string; type: string };
+  },
 ): Promise<void> {
-  const source = input.source ?? "linear";
   const repo = createIndexedFileFactRepository(db);
   await repo.upsertFact({
     indexedFileId: input.fileId,
     connectorConfigId: CONNECTOR_ID,
     createdByUserId: USER_ID,
-    source,
-    factType: "structural_seed",
-    relation: "seeded",
-    subjectName: input.name,
-    subjectSource: source,
-    subjectSourceId: input.sourceId,
+    contentHash: `hash-${input.fileId}`,
+    source: "llm_extraction",
+    factType: "llm_relation",
+    relation: input.relationType,
+    subjectName: input.source.name,
+    subjectSource: "llm_extraction",
+    subjectSourceId: `${input.fileId}:hash-${input.fileId}:llm-extraction-v8:${input.relationType}:${input.source.name}:${input.target.name}`,
+    contextSnippet: `${input.source.name} ${input.relationType} ${input.target.name}`,
     raw: {
-      name: input.name,
-      sourceType: input.sourceType,
-      source: source,
-      sourceId: input.sourceId,
-      aliases: input.aliases,
-      providerFileId: input.sourceId,
-      sourcePath: `${source}/${input.sourceId}`,
+      contentHash: `hash-${input.fileId}`,
+      promptVersion: "llm-extraction-v8",
+      model: "gemini",
+      relationType: input.relationType,
+      confidence: 0.92,
+      sourceConfidence: 0.9,
+      targetConfidence: 0.9,
+      context: `${input.source.name} ${input.relationType} ${input.target.name}`,
+      source: { ...input.source, variations: [] },
+      target: { ...input.target, variations: [] },
     },
   });
 }
@@ -138,7 +147,7 @@ describe("A1 birth gate", () => {
     await db.destroy();
   });
 
-  it("queues a conversational product birth gate and confirmReview creates the entity", async () => {
+  it("queues unmatched product mentions live while the global birth gate stays dry-run", async () => {
     await seedConnector(db);
     await seedFile(db, "file-1");
     await upsertLlmMention(db, "file-1", "Canvas Copilot", "product");
@@ -146,81 +155,25 @@ describe("A1 birth gate", () => {
     await materializeUnmaterializedFacts(db, createTestLogger(), {
       llmPromotionThreshold: 1,
       birthGateTypes: A1_BIRTH_GATE_TYPES,
-      birthGateDryRun: false,
+      birthGateLiveTypes: PRODUCT_LIVE_TYPES,
+      birthGateDryRun: true,
     });
 
     expect(await countEntitiesByType(db, "product")).toBe(0);
     expect(await countQueueRows(db)).toBe(1);
     const row = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
     expect(row.candidate_reason).toBe("birth-gated");
+    expect(row.entity_type).toBe("product");
     expect(row.source).toBe("llm_extraction");
     expect(row.source_id).toBe("file-1:hash-file-1:llm-extraction-v8:Canvas Copilot");
-    if (!row.candidate_generated_at) throw new Error("missing candidate_generated_at");
-
-    const result = await confirmReview({ db, userId: USER_ID }, row.id, {
-      candidateGeneratedAt: row.candidate_generated_at,
-    });
-
-    expect(result.targetEntityId).toBeTruthy();
-    expect(await countEntitiesByType(db, "product")).toBe(1);
+    expect(row.status).toBe("pending");
   });
 
-  it("drops conversational team mentions and queues Linear team structural seeds", async () => {
-    await seedConnector(db, "linear");
-    await seedFile(db, "file-1", "linear");
-    await seedFile(db, "file-2", "linear");
-    await upsertLlmMention(db, "file-1", "Platform Team", "team");
-
-    await materializeUnmaterializedFacts(db, createTestLogger(), {
-      llmPromotionThreshold: 1,
-      birthGateTypes: A1_BIRTH_GATE_TYPES,
-      birthGateDryRun: false,
-    });
-
-    expect(await countEntitiesByType(db, "team")).toBe(0);
-    expect(await countQueueRows(db)).toBe(0);
-
-    await upsertStructuralSeed(db, {
-      fileId: "file-2",
-      sourceType: "team",
-      name: "Sketch Platform",
-      sourceId: "team-1",
-      source: "linear",
-      aliases: ["Platform"],
-    });
-    await materializeUnmaterializedFacts(db, createTestLogger(), {
-      birthGateTypes: A1_BIRTH_GATE_TYPES,
-      birthGateDryRun: false,
-    });
-
-    expect(await countEntitiesByType(db, "team")).toBe(0);
-    expect(await countQueueRows(db)).toBe(1);
-    const row = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
-    expect(row).toMatchObject({
-      entity_type: "team",
-      seed_source: "linear",
-      seed_source_id: "team-1",
-      seed_aliases: '["Platform"]',
-    });
-    if (!row.candidate_generated_at) throw new Error("missing candidate_generated_at");
-
-    const result = await confirmReview({ db, userId: USER_ID }, row.id, {
-      candidateGeneratedAt: row.candidate_generated_at,
-    });
-    const team = await db
-      .selectFrom("entities")
-      .selectAll()
-      .where("id", "=", result.targetEntityId)
-      .executeTakeFirstOrThrow();
-    expect(team.name).toBe("Sketch Platform");
-    expect(JSON.parse(team.aliases ?? "[]")).toEqual(expect.arrayContaining(["Platform"]));
-  });
-
-  it("links exact product matches under the gate and flag-off product mentions still auto-create", async () => {
+  it("links declared product mentions without writing a review row", async () => {
     await seedConnector(db);
     await seedFile(db, "file-1");
     const entityRepo = createEntityRepository(db);
-    await entityRepo.upsertEntity({
+    const declared = await entityRepo.upsertEntity({
       name: "Canvas Copilot",
       sourceType: "product",
       status: "confirmed",
@@ -231,14 +184,49 @@ describe("A1 birth gate", () => {
     await materializeUnmaterializedFacts(db, createTestLogger(), {
       llmPromotionThreshold: 1,
       birthGateTypes: A1_BIRTH_GATE_TYPES,
-      birthGateDryRun: false,
+      birthGateLiveTypes: PRODUCT_LIVE_TYPES,
+      birthGateDryRun: true,
     });
 
     expect(await countEntitiesByType(db, "product")).toBe(1);
     expect(await countQueueRows(db)).toBe(0);
+    await expect(
+      db.selectFrom("entity_mentions").selectAll().where("entity_id", "=", declared.id).execute(),
+    ).resolves.toHaveLength(1);
+  });
 
-    await db.destroy();
-    db = await createTestDb();
+  it("keeps project births dry-run while unmatched relation product endpoints are queued", async () => {
+    await seedConnector(db);
+    await seedFile(db, "file-1");
+    await upsertLlmMention(db, "file-1", "Atlas Migration", "project");
+    await upsertLlmRelation(db, {
+      fileId: "file-1",
+      relationType: "builds",
+      source: { name: "Acme", type: "company" },
+      target: { name: "Canvas Copilot", type: "product" },
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: A1_BIRTH_GATE_TYPES,
+      birthGateLiveTypes: PRODUCT_LIVE_TYPES,
+      birthGateDryRun: true,
+    });
+
+    expect(await countEntitiesByType(db, "project")).toBe(1);
+    expect(await countEntitiesByType(db, "company")).toBe(1);
+    expect(await countEntitiesByType(db, "product")).toBe(0);
+    expect(await countQueueRows(db)).toBe(1);
+    const row = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(row).toMatchObject({
+      entity_type: "product",
+      proposed_name: "Canvas Copilot",
+      candidate_reason: "birth-gated",
+      status: "pending",
+    });
+  });
+
+  it("auto-creates product mentions with the gate off (EXPERIMENTAL_FLAG invisible)", async () => {
     await seedConnector(db);
     await seedFile(db, "file-1");
     await upsertLlmMention(db, "file-1", "Canvas Copilot", "product");
@@ -246,7 +234,8 @@ describe("A1 birth gate", () => {
     await materializeUnmaterializedFacts(db, createTestLogger(), {
       llmPromotionThreshold: 1,
       birthGateTypes: new Set(),
-      birthGateDryRun: false,
+      birthGateLiveTypes: new Set(),
+      birthGateDryRun: true,
     });
 
     expect(await countEntitiesByType(db, "product")).toBe(1);

--- a/packages/server/src/entities/materialize-birth-gate.test.ts
+++ b/packages/server/src/entities/materialize-birth-gate.test.ts
@@ -224,6 +224,7 @@ describe("A1 birth gate", () => {
       name: "Canvas Copilot",
       sourceType: "product",
       status: "confirmed",
+      provenanceTier: "declared",
     });
     await upsertLlmMention(db, "file-1", "Canvas Copilot", "product");
 

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -20,6 +20,7 @@ import {
   removeFromCandidatePool,
 } from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
+import { canUseEntityAsMatchTarget } from "./provenance";
 
 const DEFAULT_LLM_PROMOTION_THRESHOLD = 2;
 const DEFAULT_LLM_TASK_CORROBORATION_THRESHOLD = 2;
@@ -78,6 +79,7 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
   const dedupEntriesByType = new Map<ProposeEntityType, CandidatePoolEntry[]>();
   for (const t of supportedTypes) dedupEntriesByType.set(t, []);
   for (const e of entities) {
+    if (!canUseEntityAsMatchTarget(e.source_type, e.provenance_tier)) continue;
     const entityType = e.source_type as ProposeEntityType;
     entitiesByType.get(entityType)?.push(e);
     dedupEntriesByType.get(entityType)?.push({ entityId: e.id, valueKind: "name", value: e.name });
@@ -106,6 +108,7 @@ async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
     .execute();
   const bySourceRef = new Map<string, EntityRow>();
   for (const row of sourceRefs) {
+    if (!canUseEntityAsMatchTarget(row.source_type, row.provenance_tier)) continue;
     bySourceRef.set(`${row.source}:${row.source_id}`, row as unknown as EntityRow);
   }
   const domainRows = await db
@@ -171,6 +174,7 @@ export function registerEntity(index: LookupIndex, entity: EntityRow): void {
   const existingPersonScopeKeys = index.personScopeKeysByEntityId.get(entity.id);
   unregisterEntity(index, entity.id);
   const entityType = entity.source_type as ProposeEntityType;
+  if (!canUseEntityAsMatchTarget(entityType, entity.provenance_tier)) return;
   const typeBucket = index.entitiesByType.get(entityType);
   if (typeBucket && !typeBucket.some((p) => p.id === entity.id)) typeBucket.push(entity);
   const nameKey = normalizeEntityMatchName(entityType, entity.name);
@@ -268,6 +272,7 @@ export async function refreshResolvedEntityIndex(db: Kysely<DB>, index: LookupIn
     if (indexedEntity.id === entity.id) index.bySourceRef.delete(key);
   }
   registerEntity(index, row);
+  if (!canUseEntityAsMatchTarget(row.source_type, row.provenance_tier)) return;
   const scopeKeys = await buildPersonScopeKeys(db, row.source_type === "person" ? [row] : []);
   const personScopeKeys = scopeKeys.get(row.id);
   if (personScopeKeys) index.personScopeKeysByEntityId.set(row.id, personScopeKeys);

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -27,6 +27,7 @@ const DEFAULT_LLM_TASK_CORROBORATION_THRESHOLD = 2;
 let configuredLlmPromotionThreshold = DEFAULT_LLM_PROMOTION_THRESHOLD;
 let configuredLlmTaskCorroborationThreshold = DEFAULT_LLM_TASK_CORROBORATION_THRESHOLD;
 let configuredBirthGateTypes = new Set<ProposeEntityType>();
+let configuredBirthGateLiveTypes = new Set<ProposeEntityType>();
 let configuredBirthGateDryRun = true;
 let configuredExperimentalFlag = false;
 
@@ -40,6 +41,7 @@ export function configureMaterializeDefaults(opts: {
   llmPromotionThreshold?: number;
   llmTaskCorroborationThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
+  birthGateLiveTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
 }): void {
@@ -50,6 +52,7 @@ export function configureMaterializeDefaults(opts: {
     configuredLlmTaskCorroborationThreshold = Math.floor(opts.llmTaskCorroborationThreshold);
   }
   if (opts.birthGateTypes) configuredBirthGateTypes = new Set(opts.birthGateTypes);
+  if (opts.birthGateLiveTypes) configuredBirthGateLiveTypes = new Set(opts.birthGateLiveTypes);
   if (typeof opts.birthGateDryRun === "boolean") configuredBirthGateDryRun = opts.birthGateDryRun;
   if (typeof opts.experimentalFlag === "boolean") configuredExperimentalFlag = opts.experimentalFlag;
 }
@@ -286,6 +289,7 @@ export interface BuildMaterializeDepsOptions {
   llmTaskCorroborationThreshold?: number;
   logger?: Logger;
   birthGateTypes?: Set<ProposeEntityType>;
+  birthGateLiveTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
 }
@@ -309,6 +313,7 @@ export async function buildMaterializeDeps(
       ? Math.floor(opts.llmTaskCorroborationThreshold)
       : configuredLlmTaskCorroborationThreshold;
   const birthGateTypes = new Set(opts.birthGateTypes ?? configuredBirthGateTypes);
+  const birthGateLiveTypes = new Set(opts.birthGateLiveTypes ?? configuredBirthGateLiveTypes);
   const birthGateDryRun = opts.birthGateDryRun ?? configuredBirthGateDryRun;
   const experimentalFlag = opts.experimentalFlag ?? configuredExperimentalFlag;
 
@@ -370,6 +375,7 @@ export async function buildMaterializeDeps(
     llmPromotionThreshold,
     llmTaskCorroborationThreshold,
     birthGateTypes,
+    birthGateLiveTypes,
     birthGateDryRun,
     experimentalFlag,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),

--- a/packages/server/src/entities/materialize-llm-mentions.ts
+++ b/packages/server/src/entities/materialize-llm-mentions.ts
@@ -77,6 +77,7 @@ export async function materializeNonPersonLlmEntity(
       triggeredByUserId,
       aliases: variations,
       metadata: { origin: "ai" },
+      provenanceTier: "inferred",
       evidenceDomain: typeof raw.evidenceDomain === "string" ? raw.evidenceDomain : null,
     },
   );

--- a/packages/server/src/entities/materialize-llm-mentions.ts
+++ b/packages/server/src/entities/materialize-llm-mentions.ts
@@ -63,6 +63,7 @@ export async function materializeNonPersonLlmEntity(
       lookup: deps.lookup,
       logger: deps.logger,
       birthGateTypes: deps.birthGateTypes,
+      birthGateLiveTypes: deps.birthGateLiveTypes,
       birthGateDryRun: deps.birthGateDryRun,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-person.ts
+++ b/packages/server/src/entities/materialize-person.ts
@@ -44,6 +44,7 @@ export async function materializePersonSeed(
       sourceId: fact.subject_source_id,
       evidence: fact.indexed_file_id ? [{ indexedFileId: fact.indexed_file_id }] : [],
       triggeredByUserId,
+      provenanceTier: "structural",
       strictPersonScopeGate: true,
     },
   );
@@ -214,6 +215,7 @@ export async function materializePersonFact(
           evidence: fact.indexed_file_id ? [{ indexedFileId: fact.indexed_file_id }] : [],
           triggeredByUserId,
           aliases: variations,
+          provenanceTier: "inferred",
           precomputedCandidates,
           skipFuzzy,
         },

--- a/packages/server/src/entities/materialize-project.ts
+++ b/packages/server/src/entities/materialize-project.ts
@@ -49,6 +49,7 @@ export async function materializeProjectSeed(
       evidence: fact.indexed_file_id ? [{ indexedFileId: fact.indexed_file_id }] : [],
       triggeredByUserId,
       metadata,
+      provenanceTier: "structural",
     },
   );
 

--- a/packages/server/src/entities/materialize-project.ts
+++ b/packages/server/src/entities/materialize-project.ts
@@ -36,6 +36,7 @@ export async function materializeProjectSeed(
       lookup: deps.lookup,
       logger: deps.logger,
       birthGateTypes: deps.birthGateTypes,
+      birthGateLiveTypes: deps.birthGateLiveTypes,
       birthGateDryRun: deps.birthGateDryRun,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,

--- a/packages/server/src/entities/materialize-relations.ts
+++ b/packages/server/src/entities/materialize-relations.ts
@@ -254,6 +254,7 @@ async function materializeRelationEndpoint(
       lookup: deps.lookup,
       logger: deps.logger,
       birthGateTypes: deps.birthGateTypes,
+      birthGateLiveTypes: deps.birthGateLiveTypes,
       birthGateDryRun: deps.birthGateDryRun,
       readEmail: deps.readEmail,
       onEntityResolved: deps.onEntityResolved,
@@ -270,7 +271,8 @@ async function materializeRelationEndpoint(
       metadata: { origin: "ai", relationEndpoint: true },
       provenanceTier: "inferred",
       evidenceDomain: typeof raw.evidenceDomain === "string" ? raw.evidenceDomain : null,
-      queueInsteadOfCreate: endpoint.type === "project",
+      queueInsteadOfCreate:
+        endpoint.type === "project" || (endpoint.type === "product" && deps.birthGateTypes.has("product")),
     },
   );
   if (result.kind === "queued") {

--- a/packages/server/src/entities/materialize-relations.ts
+++ b/packages/server/src/entities/materialize-relations.ts
@@ -268,6 +268,7 @@ async function materializeRelationEndpoint(
       triggeredByUserId,
       aliases: endpoint.variations,
       metadata: { origin: "ai", relationEndpoint: true },
+      provenanceTier: "inferred",
       evidenceDomain: typeof raw.evidenceDomain === "string" ? raw.evidenceDomain : null,
       queueInsteadOfCreate: endpoint.type === "project",
     },

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -177,6 +177,7 @@ export async function replaySourceFacts(
     llmTaskCorroborationThreshold: opts.llmTaskCorroborationThreshold,
     logger,
     birthGateTypes: opts.birthGateTypes,
+    birthGateLiveTypes: opts.birthGateLiveTypes,
     birthGateDryRun: opts.birthGateDryRun,
     experimentalFlag: opts.experimentalFlag,
   });
@@ -248,6 +249,7 @@ async function materializeUnmaterializedFactsInner(
     llmTaskCorroborationThreshold: opts.llmTaskCorroborationThreshold,
     logger,
     birthGateTypes: opts.birthGateTypes,
+    birthGateLiveTypes: opts.birthGateLiveTypes,
     birthGateDryRun: opts.birthGateDryRun,
     experimentalFlag: opts.experimentalFlag,
   });

--- a/packages/server/src/entities/materialize-spine-candidate.ts
+++ b/packages/server/src/entities/materialize-spine-candidate.ts
@@ -160,6 +160,7 @@ async function upsertEntityFromSeed(
     sourceUrl: input.sourceUrl,
     sourceRefId: input.sourceRefId,
     metadata: input.metadata,
+    provenanceTier: "structural",
   })) as unknown as EntityRow;
   return applySeedAliases(deps, entity, input.aliases);
 }

--- a/packages/server/src/entities/materialize-structural.ts
+++ b/packages/server/src/entities/materialize-structural.ts
@@ -53,6 +53,7 @@ export async function materializeStructuralSeed(
     sourceUrl,
     sourceRefId: fact.indexed_file_id ?? undefined,
     metadata,
+    provenanceTier: "structural",
   })) as unknown as EntityRow;
   if (subjectSource === "zoho_crm" && sourceType === "company") {
     const domains = readCrmAccountDomains(metadataFromRaw);

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -60,6 +60,7 @@ export interface MaterializeDeps {
   countActiveLlmFilesForName: (normalizedName: string, mentionType: MentionType) => Promise<number>;
   llmTaskCorroborationThreshold: number;
   birthGateTypes: Set<ProposeEntityType>;
+  birthGateLiveTypes: Set<ProposeEntityType>;
   birthGateDryRun: boolean;
   experimentalFlag: boolean;
 }
@@ -90,6 +91,7 @@ export interface ReplaySourceFactsOptions {
   llmPromotionThreshold?: number;
   llmTaskCorroborationThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
+  birthGateLiveTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
 }
@@ -104,6 +106,7 @@ export interface MaterializeUnmaterializedOptions {
   llmPromotionThreshold?: number;
   llmTaskCorroborationThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
+  birthGateLiveTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
   factTypes?: IndexedFileFactType[];

--- a/packages/server/src/entities/merge.test.ts
+++ b/packages/server/src/entities/merge.test.ts
@@ -50,7 +50,13 @@ async function seedFile(db: Kysely<DB>, id: string): Promise<void> {
     .execute();
 }
 
-async function seedEntity(db: Kysely<DB>, id: string, name: string, sourceType = "person"): Promise<void> {
+async function seedEntity(
+  db: Kysely<DB>,
+  id: string,
+  name: string,
+  sourceType = "person",
+  provenanceTier = "inferred",
+): Promise<void> {
   await db
     .insertInto("entities")
     .values({
@@ -62,6 +68,7 @@ async function seedEntity(db: Kysely<DB>, id: string, name: string, sourceType =
       metadata: null,
       source_ref_id: null,
       status: "confirmed",
+      provenance_tier: provenanceTier,
       hotness: 0,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
@@ -153,6 +160,17 @@ describe("entity merge core", () => {
       merged_into_entity_id: "survivor",
     });
     await expect(db.selectFrom("entities").selectAll().where(whereLiveEntity()).execute()).resolves.toHaveLength(2);
+  });
+
+  it("keeps the strongest provenance tier when merging declared and inferred entities", async () => {
+    await seedEntity(db, "survivor", "Alex", "person", "inferred");
+    await seedEntity(db, "loser", "Alex Product Owner", "person", "declared");
+
+    await mergeEntities(db, { survivorId: "survivor", loserId: "loser", userId: USER_ID });
+
+    await expect(
+      db.selectFrom("entities").select(["provenance_tier"]).where("id", "=", "survivor").executeTakeFirst(),
+    ).resolves.toEqual({ provenance_tier: "declared" });
   });
 
   it("unmerges re-pointed rows, collisions, self-loops, and relationship evidence", async () => {

--- a/packages/server/src/entities/merge.ts
+++ b/packages/server/src/entities/merge.ts
@@ -16,6 +16,7 @@ import type {
 } from "../db/schema";
 import { parseAliasesString } from "./materialize-json";
 import { normalizeStrict } from "./name-dedup";
+import { strongestProvenanceTier } from "./provenance";
 
 type Entity = Selectable<EntitiesTable>;
 type Mention = Selectable<EntityMentionsTable>;
@@ -112,6 +113,10 @@ function isAliasAddedMove(move: EntityMergeMove): move is Extract<EntityMergeMov
 
 function updatedCount(result: { numUpdatedRows?: bigint | number | string } | undefined): number {
   return Number(result?.numUpdatedRows ?? 0);
+}
+
+function mergedProvenanceTier(survivor: Entity, loser: Entity): string {
+  return strongestProvenanceTier(survivor.provenance_tier, loser.provenance_tier);
 }
 
 async function fetchRawEntity(db: Kysely<DB>, entityId: string): Promise<Entity | undefined> {
@@ -1016,6 +1021,13 @@ export async function mergeEntitiesInTransaction(
   if (survivor && loser) await carryLoserAliasesToSurvivor(db, loser, survivor, moves);
 
   const now = new Date().toISOString();
+  if (survivor && loser) {
+    await db
+      .updateTable("entities")
+      .set({ provenance_tier: mergedProvenanceTier(survivor, loser), updated_at: now })
+      .where("id", "=", input.survivorId)
+      .execute();
+  }
   const tombstone = await db
     .updateTable("entities")
     .set({ deleted_at: now, merged_into_entity_id: input.survivorId, updated_at: now })

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -809,20 +809,22 @@ describe("proposeEntity", () => {
     expect(companies.map((c) => c.name)).toEqual(["Canvas Labs"]);
   });
 
-  it("16. product version normalization links Claude 3 and Claude-3 but keeps Claude 3.5 separate", async () => {
+  it("16. declared product version normalization links Claude 3 and Claude-3 but keeps Claude 3.5 separate", async () => {
     const entityRepo = createEntityRepository(db);
     const claude3 = await entityRepo.upsertEntity({
       name: "Claude 3",
       sourceType: "product",
       subtype: "external",
       status: "confirmed",
+      provenanceTier: "declared",
     });
-    const before = await db.selectFrom("entities").selectAll().execute();
+    const materializeDeps = await buildMaterializeDeps(db);
     const deps = {
-      entityRepo,
-      reviewRepo: createEntityReviewRepo(db),
-      lookup: makeLookup(() => before),
-      readEmail,
+      entityRepo: materializeDeps.entityRepo,
+      reviewRepo: materializeDeps.reviewRepo,
+      lookup: materializeDeps.lookup,
+      readEmail: materializeDeps.readEmail,
+      onEntityResolved: materializeDeps.onEntityResolved,
     };
 
     const linked = await proposeEntity(deps, {
@@ -856,7 +858,53 @@ describe("proposeEntity", () => {
     expect(products.map((p) => p.name).sort()).toEqual(["Claude 3", "Claude 3.5"]);
   });
 
-  it("17. precomputed LLM candidates queue after exact-name fast-path is checked", async () => {
+  it("17. inferred product source-ref and exact-name matches are not eligible match targets", async () => {
+    const entityRepo = createEntityRepository(db);
+    const legacy = await entityRepo.upsertEntity({
+      name: "Claude Legacy",
+      sourceType: "product",
+      subtype: "external",
+      status: "confirmed",
+      provenanceTier: "inferred",
+    });
+    await entityRepo.upsertSourceRef({
+      entityId: legacy.id,
+      source: "llm_extraction",
+      sourceId: "product:claude-legacy",
+    });
+    const materializeDeps = await buildMaterializeDeps(db);
+    expect(
+      materializeDeps.index.byNormalizedName.get(normalizeName("Claude Legacy"))?.map((e) => e.id) ?? [],
+    ).not.toContain(legacy.id);
+    expect(materializeDeps.index.bySourceRef.has("llm_extraction:product:claude-legacy")).toBe(false);
+
+    const result = await proposeEntity(
+      {
+        entityRepo: materializeDeps.entityRepo,
+        reviewRepo: materializeDeps.reviewRepo,
+        lookup: materializeDeps.lookup,
+        readEmail: materializeDeps.readEmail,
+        onEntityResolved: materializeDeps.onEntityResolved,
+      },
+      {
+        name: "Claude Legacy",
+        entityType: "product",
+        subtype: "external",
+        source: "llm_extraction",
+        sourceId: "product:claude-legacy",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("created");
+    if (result.kind !== "created") throw new Error("unreachable");
+    expect(result.entity.id).not.toBe(legacy.id);
+    const products = await db.selectFrom("entities").selectAll().where("source_type", "=", "product").execute();
+    expect(products.map((product) => product.id).sort()).toEqual([legacy.id, result.entity.id].sort());
+  });
+
+  it("18. precomputed LLM candidates queue after exact-name fast-path is checked", async () => {
     const entityRepo = createEntityRepository(db);
     const exact = await entityRepo.upsertPersonEntity({
       name: "Sarah Chen",
@@ -915,7 +963,7 @@ describe("proposeEntity", () => {
     expect(queue.candidate_reason).toBe("llm-ambiguous");
   });
 
-  it("18. evidenceDomain links a token-overlapping company before fuzzy queueing", async () => {
+  it("19. evidenceDomain links a token-overlapping company before fuzzy queueing", async () => {
     const entityRepo = createEntityRepository(db);
     const domainsRepo = createEntityDomainsRepository(db);
     const canvas = await entityRepo.upsertEntity({
@@ -1087,12 +1135,14 @@ describe("proposeEntity", () => {
       sourceType: "product",
       subtype: "external",
       status: "confirmed",
+      provenanceTier: "human_confirmed",
     });
     const cold = await entityRepo.upsertEntity({
       name: "Aviation Edge",
       sourceType: "product",
       subtype: "external",
       status: "confirmed",
+      provenanceTier: "human_confirmed",
     });
     await db.updateTable("entities").set({ hotness: 17 }).where("id", "=", hot.id).execute();
     await db.updateTable("entities").set({ hotness: 0 }).where("id", "=", cold.id).execute();

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -26,7 +26,7 @@ import type { EntityDomainsRepository } from "../db/repositories/entity-domains"
 import type { EntityReviewRepository } from "../db/repositories/entity-review";
 import type { EntitiesTable } from "../db/schema";
 import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "./affiliations";
-import type { ProvenanceTier } from "./provenance";
+import { type ProvenanceTier, canUseEntityAsMatchTarget } from "./provenance";
 
 export type Entity = Selectable<EntitiesTable>;
 
@@ -193,6 +193,12 @@ function canAutoLinkNameDedupCandidate(input: ProposeInput, candidate: RankedCan
   return true;
 }
 
+function isEligibleMatchTarget(input: Pick<ProposeInput, "entityType">, entity: Entity): boolean {
+  return (
+    entity.source_type === input.entityType && canUseEntityAsMatchTarget(entity.source_type, entity.provenance_tier)
+  );
+}
+
 /**
  * Prefix match: candidate's tokens start with the same first name AND
  * either match a "first + last-initial" pattern (e.g. proposed "Bob C"
@@ -290,7 +296,8 @@ async function persistEntity(
     return { entity: matched, created: false };
   }
 
-  const entity = await deps.entityRepo.upsertEntity({
+  const createEntity = input.entityType === "product" ? deps.entityRepo.createEntity : deps.entityRepo.upsertEntity;
+  const entity = await createEntity({
     name: input.name,
     sourceType: input.entityType,
     subtype: input.subtype,
@@ -534,7 +541,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
 
   if (input.source && input.sourceId) {
     const found = await deps.entityRepo.getEntityBySourceRef(input.source, input.sourceId);
-    if (found && found.source_type === input.entityType) {
+    if (found && isEligibleMatchTarget(input, found)) {
       await deps.entityRepo.upsertSourceRef({
         entityId: found.id,
         source: input.source,
@@ -585,9 +592,9 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
   const nameMatches = deps.lookup.getByNormalizedName(normalized);
   const aliasMatches = deps.lookup.getByAlias?.(normalized) ?? [];
   const exactById = new Map<string, Entity>();
-  for (const e of nameMatches) if (e.source_type === input.entityType) exactById.set(e.id, e);
-  for (const e of aliasMatches) if (e.source_type === input.entityType) exactById.set(e.id, e);
-  for (const e of deps.lookup.listByType(input.entityType)) {
+  for (const e of nameMatches) if (isEligibleMatchTarget(input, e)) exactById.set(e.id, e);
+  for (const e of aliasMatches) if (isEligibleMatchTarget(input, e)) exactById.set(e.id, e);
+  for (const e of deps.lookup.listByType(input.entityType).filter((entity) => isEligibleMatchTarget(input, entity))) {
     if (normalizeMatchName(input.entityType, e.name) === normalized) exactById.set(e.id, e);
     for (const alias of parseAliases(e.aliases)) {
       if (normalizeMatchName(input.entityType, alias) === normalized) exactById.set(e.id, e);
@@ -637,7 +644,9 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
     }
   }
 
-  const dedupCandidates = deps.lookup.findNameDedupCandidates?.(input.entityType, input.name) ?? [];
+  const dedupCandidates = (deps.lookup.findNameDedupCandidates?.(input.entityType, input.name) ?? []).filter(
+    (candidate) => isEligibleMatchTarget(input, candidate.entity),
+  );
   if (dedupCandidates.length > 0) {
     let ranked: RankedCandidate[] = dedupCandidates.map((candidate) => ({
       entity: candidate.entity,
@@ -654,11 +663,13 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
   }
 
   if (input.precomputedCandidates && input.precomputedCandidates.length > 0) {
-    let ranked = input.precomputedCandidates.map((c) => ({
-      entity: c.entity,
-      score: c.score,
-      reason: c.reason ?? ("llm-ambiguous" as const),
-    }));
+    let ranked = input.precomputedCandidates
+      .filter((candidate) => isEligibleMatchTarget(input, candidate.entity))
+      .map((c) => ({
+        entity: c.entity,
+        score: c.score,
+        reason: c.reason ?? ("llm-ambiguous" as const),
+      }));
     const filtered: RankedCandidate[] = [];
     for (const r of ranked) {
       const rejected = await deps.reviewRepo.isRejected(r.entity.id, normalized);
@@ -675,7 +686,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
   }
 
   // 4) Fuzzy-rank against same-type entities.
-  const candidates = deps.lookup.listByType(input.entityType);
+  const candidates = deps.lookup.listByType(input.entityType).filter((entity) => isEligibleMatchTarget(input, entity));
   let ranked = rank(input.entityType, input.name, candidates);
 
   // 5) Drop candidates that have a sticky rejection for this normalized name.

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -26,6 +26,7 @@ import type { EntityDomainsRepository } from "../db/repositories/entity-domains"
 import type { EntityReviewRepository } from "../db/repositories/entity-review";
 import type { EntitiesTable } from "../db/schema";
 import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "./affiliations";
+import type { ProvenanceTier } from "./provenance";
 
 export type Entity = Selectable<EntitiesTable>;
 
@@ -60,6 +61,7 @@ export interface ProposeInput {
   triggeredByUserId: string;
   aliases?: string[];
   metadata?: Record<string, unknown>;
+  provenanceTier?: ProvenanceTier;
   evidenceDomain?: string | null;
   precomputedCandidates?: Array<{ entity: Entity; score: number; reason?: CandidateReason }>;
   skipFuzzy?: boolean;
@@ -273,6 +275,7 @@ async function persistEntity(
       subtype: input.subtype,
       source: input.source,
       sourceId: input.sourceId,
+      provenanceTier: input.provenanceTier ?? "inferred",
     };
     const entity = await deps.entityRepo.createPersonEntity(personData);
     return { entity, created: true };
@@ -294,6 +297,7 @@ async function persistEntity(
     aliases: input.aliases,
     metadata: input.metadata,
     status: "confirmed",
+    provenanceTier: input.provenanceTier ?? "inferred",
   });
   await deps.entityRepo.upsertSourceRef({
     entityId: entity.id,

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -129,6 +129,7 @@ export interface ProposeDeps {
   lookup: EntityLookup;
   logger?: Logger;
   birthGateTypes?: Set<ProposeEntityType>;
+  birthGateLiveTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   /** Read an entity's email from its metadata JSON. */
   readEmail: (entity: Entity) => string | null;
@@ -438,7 +439,8 @@ async function birthGateOrCreate(
   branch: "skipFuzzy" | "ranked_empty",
 ): Promise<ProposeResult> {
   if (deps.birthGateTypes?.has(input.entityType)) {
-    if (deps.birthGateDryRun ?? true) {
+    const effectiveDryRun = (deps.birthGateDryRun ?? true) && !deps.birthGateLiveTypes?.has(input.entityType);
+    if (effectiveDryRun) {
       deps.logger?.info(
         { event: "would_birth_gate", type: input.entityType, name: input.name, path: input.source, branch },
         "would_birth_gate",

--- a/packages/server/src/entities/provenance.ts
+++ b/packages/server/src/entities/provenance.ts
@@ -1,5 +1,7 @@
 export type ProvenanceTier = "declared" | "human_confirmed" | "structural" | "inferred";
 
+export const PRODUCT_MATCH_TARGET_PROVENANCE_TIERS = new Set<ProvenanceTier>(["declared", "human_confirmed"]);
+
 const PROVENANCE_TIER_PRECEDENCE: Record<ProvenanceTier, number> = {
   inferred: 0,
   structural: 1,
@@ -18,4 +20,12 @@ function toProvenanceTier(value: string | null | undefined): ProvenanceTier {
     return value;
   }
   return "inferred";
+}
+
+export function canUseEntityAsMatchTarget(
+  entityType: string | null | undefined,
+  provenanceTier: string | null | undefined,
+): boolean {
+  if (entityType !== "product") return true;
+  return provenanceTier === "declared" || provenanceTier === "human_confirmed";
 }

--- a/packages/server/src/entities/provenance.ts
+++ b/packages/server/src/entities/provenance.ts
@@ -1,0 +1,21 @@
+export type ProvenanceTier = "declared" | "human_confirmed" | "structural" | "inferred";
+
+const PROVENANCE_TIER_PRECEDENCE: Record<ProvenanceTier, number> = {
+  inferred: 0,
+  structural: 1,
+  human_confirmed: 2,
+  declared: 3,
+};
+
+export function strongestProvenanceTier(a: string | null | undefined, b: string | null | undefined): ProvenanceTier {
+  const left = toProvenanceTier(a);
+  const right = toProvenanceTier(b);
+  return PROVENANCE_TIER_PRECEDENCE[left] >= PROVENANCE_TIER_PRECEDENCE[right] ? left : right;
+}
+
+function toProvenanceTier(value: string | null | undefined): ProvenanceTier {
+  if (value === "declared" || value === "human_confirmed" || value === "structural" || value === "inferred") {
+    return value;
+  }
+  return "inferred";
+}

--- a/packages/server/src/entities/rank.test.ts
+++ b/packages/server/src/entities/rank.test.ts
@@ -12,6 +12,7 @@ function person(id: string, name: string): Entity {
     metadata: null,
     source_ref_id: null,
     status: "confirmed",
+    provenance_tier: "inferred",
     hotness: 0,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",

--- a/packages/server/src/entities/recreate.ts
+++ b/packages/server/src/entities/recreate.ts
@@ -60,10 +60,28 @@ async function countTable(db: Kysely<DB>, table: string): Promise<number> {
 }
 
 async function deleteTable(db: Kysely<DB>, table: string): Promise<number> {
+  if (table === "entities") return deleteRecreatableEntities(db);
   const count = await countTable(db, table);
   if (count === 0) return 0;
   try {
     await sql`DELETE FROM ${sql.raw(table)}`.execute(db);
+    return count;
+  } catch (err) {
+    if (isMissingTableError(err)) return 0;
+    throw err;
+  }
+}
+
+async function deleteRecreatableEntities(db: Kysely<DB>): Promise<number> {
+  try {
+    const before = await db
+      .selectFrom("entities")
+      .select(db.fn.countAll<number>().as("count"))
+      .where("provenance_tier", "!=", "declared")
+      .executeTakeFirst();
+    const count = Number(before?.count ?? 0);
+    if (count === 0) return 0;
+    await db.deleteFrom("entities").where("provenance_tier", "!=", "declared").execute();
     return count;
   } catch (err) {
     if (isMissingTableError(err)) return 0;

--- a/packages/server/src/entities/resolve.ts
+++ b/packages/server/src/entities/resolve.ts
@@ -719,6 +719,7 @@ export async function confirmReview(ctx: ResolveCtx, reviewId: string, opts: Con
             sourceType: row.entity_type,
             source: row.source,
             sourceId: row.source_id,
+            provenanceTier: "human_confirmed",
           });
         } else {
           throw new ResolveError(
@@ -735,6 +736,7 @@ export async function confirmReview(ctx: ResolveCtx, reviewId: string, opts: Con
           sourceType: row.entity_type,
           source: row.seed_source,
           sourceId: row.seed_source_id,
+          provenanceTier: "human_confirmed",
         });
       }
     } else {
@@ -969,6 +971,7 @@ export async function rejectReview(ctx: ResolveCtx, reviewId: string, opts: Reje
           subtype: "internal" | "external";
           source: string;
           sourceId: string;
+          provenanceTier: "human_confirmed";
         } = {
           // Reject-created entities default to 'external'. The user has
           // told us this is a separate identity from the suggested
@@ -977,6 +980,7 @@ export async function rejectReview(ctx: ResolveCtx, reviewId: string, opts: Reje
           subtype: "external",
           source: sourceFromEvidence,
           sourceId,
+          provenanceTier: "human_confirmed",
         };
         if (row.proposed_email) personData.email = row.proposed_email;
         const created = await trxCtx.entityRepo.upsertPersonEntity(personData);
@@ -990,6 +994,7 @@ export async function rejectReview(ctx: ResolveCtx, reviewId: string, opts: Reje
           sourceType: row.entity_type,
           source: sourceFromEvidence,
           sourceId,
+          provenanceTier: "human_confirmed",
         });
         target = created;
       }


### PR DESCRIPTION
Stacked context-graph slice 17/27.

Base: `feat/context-graph-16-connector-name-qualification`
Head: `feat/context-graph-17-provenance-product-gates`

Adds universal entity provenance tiering and product gate calibration.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`