### PR TITLE
feat: add declared products and birth preview

### DIFF
--- a/packages/server/src/api/products.test.ts
+++ b/packages/server/src/api/products.test.ts
@@ -210,4 +210,32 @@ describe("declared products API", () => {
       .execute();
     expect(mentions).toHaveLength(1);
   });
+
+  it("lists human_confirmed products alongside declared ones, excluding inferred", async () => {
+    const repo = createEntityRepository(db);
+    await repo.createEntity({
+      name: "Declared One",
+      sourceType: "product",
+      status: "confirmed",
+      provenanceTier: "declared",
+    });
+    await repo.createEntity({
+      name: "Confirmed One",
+      sourceType: "product",
+      status: "confirmed",
+      provenanceTier: "human_confirmed",
+    });
+    await repo.createEntity({
+      name: "Inferred One",
+      sourceType: "product",
+      status: "confirmed",
+      provenanceTier: "inferred",
+    });
+
+    const res = await app.request("/api/products", { headers: { Cookie: cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { products: Array<{ name: string; provenance_tier: string }> };
+    expect(body.products.map((p) => p.name)).toEqual(["Confirmed One", "Declared One"]);
+    expect(body.products.map((p) => p.provenance_tier)).toEqual(["human_confirmed", "declared"]);
+  });
 });

--- a/packages/server/src/api/products.test.ts
+++ b/packages/server/src/api/products.test.ts
@@ -1,0 +1,213 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hashPassword } from "../auth/password";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { materializeUnmaterializedFacts } from "../entities/materialize";
+import type { ProposeEntityType } from "../entities/propose";
+import { createApp } from "../http";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+
+const PASSWORD = "testpassword123";
+const ADMIN_EMAIL = "admin@test.com";
+const CONNECTOR_ID = "connector-1";
+const PRODUCT_BIRTH_GATE_TYPES: Set<ProposeEntityType> = new Set(["project", "product", "team"]);
+const PRODUCT_LIVE_TYPES: Set<ProposeEntityType> = new Set(["product"]);
+
+async function seedAdmin(db: Kysely<DB>): Promise<{ id: string }> {
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  await settings.create();
+  await users.create({
+    name: "admin",
+    email: ADMIN_EMAIL,
+    emailVerified: true,
+    passwordHash: await hashPassword(PASSWORD),
+    authRole: "admin",
+  });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+  const admin = await users.findByEmail(ADMIN_EMAIL);
+  if (!admin) throw new Error("admin missing");
+  return { id: admin.id };
+}
+
+async function login(app: ReturnType<typeof createApp>): Promise<string> {
+  const res = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: PASSWORD }),
+  });
+  return res.headers.get("set-cookie") ?? "";
+}
+
+async function seedConnector(db: Kysely<DB>, ownerId: string): Promise<void> {
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "google_drive",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: ownerId,
+    })
+    .execute();
+}
+
+async function seedFile(db: Kysely<DB>, id: string): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      file_name: `${id}.md`,
+      file_type: "doc",
+      content_category: "document",
+      source: "google_drive",
+      content_hash: `hash-${id}`,
+      is_archived: 0,
+      synced_at: now,
+    })
+    .execute();
+}
+
+async function upsertLlmProductMention(db: Kysely<DB>, fileId: string, name: string, ownerId: string): Promise<void> {
+  const repo = createIndexedFileFactRepository(db);
+  await repo.upsertFact({
+    indexedFileId: fileId,
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: ownerId,
+    contentHash: `hash-${fileId}`,
+    source: "llm_extraction",
+    factType: "llm_extracted",
+    relation: "mentioned",
+    subjectName: name,
+    subjectSource: "llm_extraction",
+    subjectSourceId: `${fileId}:hash-${fileId}:llm-extraction-v8:${name}`,
+    raw: {
+      contentHash: `hash-${fileId}`,
+      promptVersion: "llm-extraction-v8",
+      model: "gemini",
+      mention: name,
+      type: "product",
+      variations: [],
+    },
+  });
+}
+
+async function countProducts(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entities")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .where("source_type", "=", "product")
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function countReviewRows(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entity_review_queue")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+describe("declared products API", () => {
+  let db: Kysely<DB>;
+  let app: ReturnType<typeof createApp>;
+  let cookie: string;
+  let adminId: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    const admin = await seedAdmin(db);
+    adminId = admin.id;
+    app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    cookie = await login(app);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("declares a new product immediately as a single declared entity", async () => {
+    const res = await app.request("/api/products", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Canvas Copilot", aliases: ["Canvas AI"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      entity: { id: string; name: string; aliases: string[]; provenance_tier: string };
+    };
+    expect(body.entity).toMatchObject({
+      name: "Canvas Copilot",
+      aliases: ["Canvas AI"],
+      provenance_tier: "declared",
+    });
+    expect(await countProducts(db)).toBe(1);
+
+    const listRes = await app.request("/api/products", { headers: { Cookie: cookie } });
+    expect(listRes.status).toBe(200);
+    const listBody = (await listRes.json()) as { products: Array<{ id: string; name: string }> };
+    expect(listBody.products).toEqual([
+      { id: body.entity.id, name: "Canvas Copilot", aliases: ["Canvas AI"], hotness: 0, provenance_tier: "declared" },
+    ]);
+  });
+
+  it("upgrades an existing inferred product in place without creating a duplicate", async () => {
+    const repo = createEntityRepository(db);
+    const inferred = await repo.createEntity({
+      name: "Claude-3",
+      sourceType: "product",
+      status: "confirmed",
+      provenanceTier: "inferred",
+    });
+
+    const res = await app.request("/api/products", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Claude 3" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entity: { id: string; provenance_tier: string } };
+    expect(body.entity).toMatchObject({ id: inferred.id, provenance_tier: "declared" });
+    expect(await countProducts(db)).toBe(1);
+    const row = await db.selectFrom("entities").selectAll().where("id", "=", inferred.id).executeTakeFirstOrThrow();
+    expect(row.provenance_tier).toBe("declared");
+  });
+
+  it("links later LLM product mentions to the declared product without a new entity or review row", async () => {
+    await seedConnector(db, adminId);
+    await seedFile(db, "file-1");
+    const declareRes = await app.request("/api/products", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Canvas Copilot" }),
+    });
+    const declared = (await declareRes.json()) as { entity: { id: string } };
+    await upsertLlmProductMention(db, "file-1", "Canvas Copilot", adminId);
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: PRODUCT_BIRTH_GATE_TYPES,
+      birthGateLiveTypes: PRODUCT_LIVE_TYPES,
+      birthGateDryRun: true,
+    });
+
+    expect(await countProducts(db)).toBe(1);
+    expect(await countReviewRows(db)).toBe(0);
+    const mentions = await db
+      .selectFrom("entity_mentions")
+      .selectAll()
+      .where("entity_id", "=", declared.entity.id)
+      .execute();
+    expect(mentions).toHaveLength(1);
+  });
+});

--- a/packages/server/src/api/products.ts
+++ b/packages/server/src/api/products.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { z } from "zod";
+import { createEntityRepository } from "../db/repositories/entities";
+import type { DB } from "../db/schema";
+
+const declareProductBodySchema = z.object({
+  name: z.string().trim().min(1),
+  aliases: z.array(z.string().trim().min(1)).optional(),
+});
+
+function parseAliases(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export function productRoutes(db: Kysely<DB>) {
+  const routes = new Hono();
+  const repo = createEntityRepository(db);
+
+  routes.post("/", async (c) => {
+    const parsed = declareProductBodySchema.safeParse(await c.req.json());
+    if (!parsed.success) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "name is required" } }, 400);
+    }
+
+    const entity = await repo.declareProduct(parsed.data);
+    return c.json({
+      entity: {
+        id: entity.id,
+        name: entity.name,
+        aliases: parseAliases(entity.aliases),
+        hotness: Number(entity.hotness ?? 0),
+        provenance_tier: entity.provenance_tier,
+      },
+    });
+  });
+
+  routes.get("/", async (c) => {
+    const products = await repo.listDeclaredProducts();
+    return c.json({ products });
+  });
+
+  return routes;
+}

--- a/packages/server/src/api/products.ts
+++ b/packages/server/src/api/products.ts
@@ -42,7 +42,7 @@ export function productRoutes(db: Kysely<DB>) {
   });
 
   routes.get("/", async (c) => {
-    const products = await repo.listDeclaredProducts();
+    const products = await repo.listCuratedProducts();
     return c.json({ products });
   });
 

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Kysely, RawBuilder, Selectable } from "kysely";
 import { sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
+import { normalizeEntityMatchName } from "../../entities/match-normalize";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../../entities/profile-facts";
 import type { ProvenanceTier } from "../../entities/provenance";
 import { resolveLiveEntity, resolveLiveEntityId, resolveSourceRefToLiveEntityId } from "../../entities/redirect";
@@ -134,6 +135,19 @@ export interface UpsertEntityData {
   provenanceTier?: ProvenanceTier;
 }
 
+export interface DeclareProductData {
+  name: string;
+  aliases?: string[];
+}
+
+export interface DeclaredProductListEntry {
+  id: string;
+  name: string;
+  aliases: string[];
+  hotness: number;
+  provenance_tier: string;
+}
+
 export interface UpsertEntityFromToolData {
   name: string;
   sourceType: string;
@@ -209,6 +223,52 @@ function normalizeLinkedin(value: string): string {
   return decodeURIComponent(parts[inIndex + 1]).toLowerCase();
 }
 
+function parseAliasesString(aliases: string | null): string[] {
+  if (!aliases) return [];
+  try {
+    const parsed = JSON.parse(aliases);
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeAliasInput(aliases: string[] | undefined): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const alias of aliases ?? []) {
+    const trimmed = alias.trim();
+    if (!trimmed) continue;
+    const key = normalizeEntityMatchName("product", trimmed);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function mergeAliases(existing: string | null, incoming: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const alias of [...parseAliasesString(existing), ...incoming]) {
+    const key = normalizeEntityMatchName("product", alias);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(alias);
+  }
+  return out;
+}
+
+function toDeclaredProductListEntry(entity: Selectable<EntitiesTable>): DeclaredProductListEntry {
+  return {
+    id: entity.id,
+    name: entity.name,
+    aliases: parseAliasesString(entity.aliases),
+    hotness: Number(entity.hotness ?? 0),
+    provenance_tier: entity.provenance_tier,
+  };
+}
+
 export function normalizeContactPointValue(kind: EntityContactPointKind, value: string): string {
   if (kind === "email") {
     const normalized = value.trim().toLowerCase();
@@ -268,6 +328,35 @@ async function loadCrmActivityBrief(db: Kysely<DB>, entityId: string): Promise<E
 }
 
 export function createEntityRepository(db: Kysely<DB>) {
+  async function createEntityRow(data: UpsertEntityData) {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await db
+      .insertInto("entities")
+      .values({
+        id,
+        name: data.name,
+        source_type: data.sourceType,
+        subtype: data.subtype ?? null,
+        aliases: data.aliases ? JSON.stringify(data.aliases) : null,
+        metadata: data.metadata ? JSON.stringify(data.metadata) : null,
+        source_ref_id: data.sourceRefId ?? null,
+        status: data.status ?? "confirmed",
+        provenance_tier: data.provenanceTier ?? "inferred",
+        hotness: 0,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
+
+    return await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("id", "=", id)
+      .where(whereLiveEntity())
+      .executeTakeFirstOrThrow();
+  }
+
   return {
     // ── CRUD ──
 
@@ -325,32 +414,95 @@ export function createEntityRepository(db: Kysely<DB>) {
     },
 
     async createEntity(data: UpsertEntityData) {
-      const id = randomUUID();
-      const now = new Date().toISOString();
-      await db
-        .insertInto("entities")
-        .values({
-          id,
-          name: data.name,
-          source_type: data.sourceType,
-          subtype: data.subtype ?? null,
-          aliases: data.aliases ? JSON.stringify(data.aliases) : null,
-          metadata: data.metadata ? JSON.stringify(data.metadata) : null,
-          source_ref_id: data.sourceRefId ?? null,
-          status: data.status ?? "confirmed",
-          provenance_tier: data.provenanceTier ?? "inferred",
-          hotness: 0,
-          created_at: now,
-          updated_at: now,
-        })
-        .execute();
+      return await createEntityRow(data);
+    },
 
-      return await db
+    /**
+     * Declare a product as user-asserted ground truth. If duplicate live
+     * product rows share the normalized product name from the pre-gate window,
+     * the hottest and then most-mentioned row is upgraded and the others are
+     * left untouched so declaration stays non-blocking.
+     */
+    async declareProduct(data: DeclareProductData) {
+      const name = data.name.trim();
+      if (!name) throw new Error("Product name cannot be empty");
+      const aliases = normalizeAliasInput(data.aliases);
+      const incomingKeys = new Set(
+        [name, ...aliases].map((value) => normalizeEntityMatchName("product", value)).filter(Boolean),
+      );
+      const products = await db
         .selectFrom("entities")
         .selectAll()
-        .where("id", "=", id)
+        .where("source_type", "=", "product")
         .where(whereLiveEntity())
-        .executeTakeFirstOrThrow();
+        .execute();
+      const matches = products.filter((product) => {
+        const keys = [product.name, ...parseAliasesString(product.aliases)]
+          .map((value) => normalizeEntityMatchName("product", value))
+          .filter(Boolean);
+        return keys.some((key) => incomingKeys.has(key));
+      });
+
+      if (matches.length > 0) {
+        const mentionCounts = new Map<string, number>();
+        const counts = await db
+          .selectFrom("entity_mentions")
+          .select(["entity_id", (eb) => eb.fn.count<number>("id").as("mention_count")])
+          .where(
+            "entity_id",
+            "in",
+            matches.map((match) => match.id),
+          )
+          .groupBy("entity_id")
+          .execute();
+        for (const row of counts) mentionCounts.set(row.entity_id, Number(row.mention_count));
+        const best = [...matches].sort((a, b) => {
+          const hotnessDelta = Number(b.hotness ?? 0) - Number(a.hotness ?? 0);
+          if (hotnessDelta !== 0) return hotnessDelta;
+          const mentionDelta = (mentionCounts.get(b.id) ?? 0) - (mentionCounts.get(a.id) ?? 0);
+          if (mentionDelta !== 0) return mentionDelta;
+          return a.id.localeCompare(b.id);
+        })[0];
+        if (best.provenance_tier === "declared") return best;
+
+        const mergedAliases = mergeAliases(best.aliases, aliases);
+        const now = new Date().toISOString();
+        await db
+          .updateTable("entities")
+          .set({
+            aliases: mergedAliases.length > 0 ? JSON.stringify(mergedAliases) : best.aliases,
+            provenance_tier: "declared",
+            updated_at: now,
+          })
+          .where("id", "=", best.id)
+          .execute();
+        return await db
+          .selectFrom("entities")
+          .selectAll()
+          .where("id", "=", best.id)
+          .where(whereLiveEntity())
+          .executeTakeFirstOrThrow();
+      }
+
+      return await createEntityRow({
+        name,
+        sourceType: "product",
+        aliases,
+        status: "confirmed",
+        provenanceTier: "declared",
+      });
+    },
+
+    async listDeclaredProducts(): Promise<DeclaredProductListEntry[]> {
+      const rows = await db
+        .selectFrom("entities")
+        .selectAll()
+        .where("source_type", "=", "product")
+        .where("provenance_tier", "=", "declared")
+        .where(whereLiveEntity())
+        .orderBy("name", "asc")
+        .execute();
+      return rows.map(toDeclaredProductListEntry);
     },
 
     /**

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -493,12 +493,21 @@ export function createEntityRepository(db: Kysely<DB>) {
       });
     },
 
-    async listDeclaredProducts(): Promise<DeclaredProductListEntry[]> {
+    /**
+     * The curated product closed list shown on the Your Org surface: products
+     * the user has blessed, either by declaring them (`declared`) or by
+     * approving a proposal from the review queue (`human_confirmed`). This is
+     * the same tier set extraction matches against
+     * ({@link PRODUCT_MATCH_TARGET_PROVENANCE_TIERS}); raw `inferred` guesses are
+     * excluded so the curation home only shows trusted products. Each row keeps
+     * its tier so the UI can chip declared vs confirmed.
+     */
+    async listCuratedProducts(): Promise<DeclaredProductListEntry[]> {
       const rows = await db
         .selectFrom("entities")
         .selectAll()
         .where("source_type", "=", "product")
-        .where("provenance_tier", "=", "declared")
+        .where("provenance_tier", "in", ["declared", "human_confirmed"])
         .where(whereLiveEntity())
         .orderBy("name", "asc")
         .execute();

--- a/packages/server/src/db/repositories/entity-review.ts
+++ b/packages/server/src/db/repositories/entity-review.ts
@@ -88,7 +88,7 @@ export interface UpsertEvidenceInput {
   seenAt?: string;
 }
 
-const TERMINAL_STATUSES = new Set(["confirmed", "rejected", "confirming"]);
+const TERMINAL_STATUSES = new Set(["confirmed", "rejected", "confirming", "dismissed"]);
 const SPINE_ENTITY_TYPES = new Set(["project", "product", "team"]);
 const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
 
@@ -426,8 +426,12 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
       limit: number;
       offset?: number;
       search?: string;
+      types?: string[];
     }) {
       let q = db.selectFrom("entity_review_queue").selectAll().where("status", "=", "pending");
+      if (opts.types && opts.types.length > 0) {
+        q = q.where("entity_type", "in", opts.types);
+      }
       if (!opts.isAdmin) {
         if (!opts.ownerUserId) return [];
         const ownerUserId = opts.ownerUserId;
@@ -463,11 +467,19 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
      * Count of `pending` rows under the same visibility predicate as
      * `listPending`. Used by the badge endpoint and by list pagination.
      */
-    async countPending(opts: { ownerUserId?: string; isAdmin: boolean; search?: string }): Promise<number> {
+    async countPending(opts: {
+      ownerUserId?: string;
+      isAdmin: boolean;
+      search?: string;
+      types?: string[];
+    }): Promise<number> {
       let q = db
         .selectFrom("entity_review_queue")
         .select(db.fn.countAll<number>().as("c"))
         .where("status", "=", "pending");
+      if (opts.types && opts.types.length > 0) {
+        q = q.where("entity_type", "in", opts.types);
+      }
       if (!opts.isAdmin) {
         if (!opts.ownerUserId) return 0;
         const ownerUserId = opts.ownerUserId;
@@ -777,6 +789,29 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
         .set({
           status,
           resolved_entity_id: resolvedEntityId,
+          resolved_by: by,
+          resolved_at: new Date().toISOString(),
+        })
+        .where("id", "=", reviewId)
+        .where("status", "=", "pending")
+        .where("candidate_generated_at", "=", candidateGeneratedAt)
+        .execute();
+      return Number(result[0]?.numUpdatedRows ?? 0) > 0;
+    },
+
+    /**
+     * Terminal "dismissed" transition: the proposal is dropped without creating
+     * an entity. Same compare-and-swap as {@link markResolved} (only a still-
+     * pending row at the validated candidate snapshot wins), but leaves
+     * `resolved_entity_id` null — a dismissed row has no entity. A `dismissed`
+     * status is terminal (in `TERMINAL_STATUSES`), so the same key is never
+     * re-proposed.
+     */
+    async markDismissed(reviewId: string, by: string, candidateGeneratedAt: string): Promise<boolean> {
+      const result = await db
+        .updateTable("entity_review_queue")
+        .set({
+          status: "dismissed",
           resolved_by: by,
           resolved_at: new Date().toISOString(),
         })

--- a/packages/server/src/db/repositories/indexed-file-facts.test.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.test.ts
@@ -515,4 +515,99 @@ describe("createIndexedFileFactRepository", () => {
     });
     expect(result.skipped).toBeUndefined();
   });
+
+  describe("childTasksForParent", () => {
+    async function seedTaskFile(opts: {
+      fileId: string;
+      source: string;
+      parentSourceId: string;
+      name: string;
+      providerUrl?: string | null;
+      sourceUpdatedAt?: string;
+      factId?: string;
+    }): Promise<void> {
+      await db
+        .insertInto("connector_configs")
+        .values({
+          id: `cc-${opts.source}`,
+          connector_type: opts.source,
+          auth_type: "api_key",
+          credentials: "{}",
+          created_by: "user-1",
+        })
+        .onConflict((oc) => oc.column("id").doNothing())
+        .execute();
+      await db
+        .insertInto("indexed_files")
+        .values({
+          id: opts.fileId,
+          connector_config_id: `cc-${opts.source}`,
+          provider_file_id: `pf-${opts.fileId}`,
+          file_name: opts.name,
+          file_type: "issue",
+          content_category: "document",
+          source: opts.source,
+          provider_url: opts.providerUrl ?? null,
+          source_updated_at: opts.sourceUpdatedAt ?? "2026-01-01T00:00:00.000Z",
+          synced_at: "2026-01-01T00:00:00.000Z",
+        })
+        .onConflict((oc) => oc.column("id").doNothing())
+        .execute();
+      await db
+        .insertInto("indexed_file_facts")
+        .values({
+          id: opts.factId ?? `pf-fact-${opts.fileId}`,
+          indexed_file_id: opts.fileId,
+          source: opts.source,
+          fact_type: "parent_entity",
+          relation: "mentioned",
+          subject_source_id: opts.parentSourceId,
+          fact_key: `pk-${opts.factId ?? opts.fileId}`,
+        })
+        .execute();
+    }
+
+    it("returns the true distinct total while capping the list, and excludes other connectors", async () => {
+      const repo = createIndexedFileFactRepository(db);
+      for (let i = 0; i < 5; i++) {
+        await seedTaskFile({
+          fileId: `linear-task-${i}`,
+          source: "linear",
+          parentSourceId: "team-1",
+          name: `SKE-${i}`,
+          providerUrl: `https://linear.app/issue/${i}`,
+          sourceUpdatedAt: `2026-01-0${i + 1}T00:00:00.000Z`,
+        });
+      }
+      // A task with two parent_entity facts must count once (dedup by file).
+      await seedTaskFile({
+        fileId: "linear-task-0",
+        source: "linear",
+        parentSourceId: "team-1",
+        name: "SKE-0",
+        factId: "second-fact-for-0",
+      });
+      // Decoy: same parent id under a different connector must NOT leak in.
+      await seedTaskFile({
+        fileId: "clickup-task-x",
+        source: "clickup",
+        parentSourceId: "team-1",
+        name: "CU-x",
+      });
+
+      const result = await repo.childTasksForParent({ source: "linear", parentSourceId: "team-1", limit: 3 });
+
+      expect(result.total).toBe(5);
+      expect(result.tasks).toHaveLength(3);
+      expect(typeof result.total).toBe("number");
+      expect(result.tasks.map((t) => t.name)).not.toContain("CU-x");
+      expect(result.tasks[0]).toMatchObject({ source: "linear", providerUrl: expect.stringContaining("linear.app") });
+    });
+
+    it("returns an empty result for a parent with no child tasks", async () => {
+      const repo = createIndexedFileFactRepository(db);
+      const result = await repo.childTasksForParent({ source: "linear", parentSourceId: "nope", limit: 50 });
+      expect(result).toEqual({ tasks: [], total: 0 });
+    });
+  });
 });

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";
 import type { IndexedFileFactRaw, LlmTaskCandidate, LlmTaskFactRaw } from "../../connectors/types";
 import type { DB } from "../schema";
+import { type FileViewer, fileVisibilityPredicate } from "./connectors";
 
 export type IndexedFileFactType =
   | "attendee"
@@ -881,14 +882,18 @@ export function createIndexedFileFactRepository(db: Kysely<DB>) {
       source: string;
       parentSourceId: string;
       limit: number;
+      viewer?: FileViewer;
     }): Promise<{ tasks: ChildTask[]; total: number }> {
-      const base = db
+      let base = db
         .selectFrom("indexed_file_facts as f")
         .innerJoin("indexed_files as i", "i.id", "f.indexed_file_id")
         .where("f.fact_type", "=", "parent_entity")
         .where("f.source", "=", opts.source)
         .where("f.subject_source_id", "=", opts.parentSourceId)
         .where("f.deleted_at", "is", null);
+      if (opts.viewer && !opts.viewer.isAdmin) {
+        base = base.where(fileVisibilityPredicate(opts.viewer, "i"));
+      }
 
       const countRow = await base
         .select((eb) => eb.fn.count("f.indexed_file_id").distinct().as("c"))

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -604,6 +604,15 @@ function requireNonEmpty(value: string | null | undefined, name: string): string
   return trimmed;
 }
 
+/** A tracker task/issue that sits under a parent project/team, for review preview. */
+export interface ChildTask {
+  indexedFileId: string;
+  name: string;
+  fileType: string | null;
+  providerUrl: string | null;
+  source: string;
+}
+
 export function createIndexedFileFactRepository(db: Kysely<DB>) {
   return {
     async upsertFact(input: UpsertIndexedFileFactInput): Promise<void> {
@@ -857,6 +866,57 @@ export function createIndexedFileFactRepository(db: Kysely<DB>) {
         if (matched.length >= limit) return matched;
       }
       return matched;
+    },
+
+    /**
+     * Tasks/issues that sit directly under a tracker parent (project / team),
+     * for previewing a structural-seed review row. Joins `parent_entity` facts
+     * — each emitted by a child task file and keyed by the parent's tracker id —
+     * back to their `indexed_files`. Matches on BOTH `source` and the parent id
+     * so a numeric ClickUp id can't collide with a Linear UUID. Returns the true
+     * distinct `total` (count is independent of the capped list) and a list
+     * capped at `limit`, deterministically ordered (recency, then id).
+     */
+    async childTasksForParent(opts: {
+      source: string;
+      parentSourceId: string;
+      limit: number;
+    }): Promise<{ tasks: ChildTask[]; total: number }> {
+      const base = db
+        .selectFrom("indexed_file_facts as f")
+        .innerJoin("indexed_files as i", "i.id", "f.indexed_file_id")
+        .where("f.fact_type", "=", "parent_entity")
+        .where("f.source", "=", opts.source)
+        .where("f.subject_source_id", "=", opts.parentSourceId)
+        .where("f.deleted_at", "is", null);
+
+      const countRow = await base
+        .select((eb) => eb.fn.count("f.indexed_file_id").distinct().as("c"))
+        .executeTakeFirst();
+
+      const rows = await base
+        .select([
+          "i.id as indexedFileId",
+          "i.file_name as name",
+          "i.file_type as fileType",
+          "i.provider_url as providerUrl",
+          "i.source as source",
+          "i.source_updated_at as sourceUpdatedAt",
+        ])
+        .distinct()
+        .orderBy("i.source_updated_at", "desc")
+        .orderBy("i.id", "asc")
+        .limit(opts.limit)
+        .execute();
+
+      const tasks: ChildTask[] = rows.map((r) => ({
+        indexedFileId: r.indexedFileId,
+        name: r.name,
+        fileType: r.fileType,
+        providerUrl: r.providerUrl,
+        source: r.source,
+      }));
+      return { tasks, total: Number(countRow?.c ?? 0) };
     },
   };
 }

--- a/packages/server/src/entities/match-normalize.ts
+++ b/packages/server/src/entities/match-normalize.ts
@@ -1,0 +1,15 @@
+import { normalizeName } from "../connectors/name-normalize";
+
+export function normalizeEntityMatchName(entityType: string, name: string): string {
+  if (entityType !== "product") return normalizeName(name);
+  return normalizeName(
+    name
+      .replace(/([a-zA-Z])([0-9])/g, "$1 $2")
+      .replace(/([0-9])([a-zA-Z])/g, "$1 $2")
+      .replace(/[-_]+/g, " "),
+  );
+}
+
+export function normalizeMatchName(entityType: string, name: string): string {
+  return normalizeEntityMatchName(entityType, name);
+}

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -1,6 +1,5 @@
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
-import { normalizeName } from "../connectors/name-normalize";
 import { createEntityRepository, whereLiveEntity } from "../db/repositories/entities";
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
@@ -8,6 +7,7 @@ import { createEntitySuppressionRepository } from "../db/repositories/entity-sup
 import type { DB } from "../db/schema";
 import { personScopeKey, personScopeKeyId } from "./affiliations";
 import { type MentionType, normalizeMentionType } from "./graph";
+import { normalizeEntityMatchName } from "./match-normalize";
 import { parseAliasesString, readJsonObject, readPersonEmailFromMetadata } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, LookupIndex, MaterializeDeps } from "./materialize-types";
 import {
@@ -21,6 +21,8 @@ import {
 } from "./name-dedup";
 import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
 import { canUseEntityAsMatchTarget } from "./provenance";
+
+export { normalizeEntityMatchName } from "./match-normalize";
 
 const DEFAULT_LLM_PROMOTION_THRESHOLD = 2;
 const DEFAULT_LLM_TASK_CORROBORATION_THRESHOLD = 2;
@@ -55,16 +57,6 @@ export function configureMaterializeDefaults(opts: {
   if (opts.birthGateLiveTypes) configuredBirthGateLiveTypes = new Set(opts.birthGateLiveTypes);
   if (typeof opts.birthGateDryRun === "boolean") configuredBirthGateDryRun = opts.birthGateDryRun;
   if (typeof opts.experimentalFlag === "boolean") configuredExperimentalFlag = opts.experimentalFlag;
-}
-
-export function normalizeEntityMatchName(entityType: string, name: string): string {
-  if (entityType !== "product") return normalizeName(name);
-  return normalizeName(
-    name
-      .replace(/([a-zA-Z])([0-9])/g, "$1 $2")
-      .replace(/([0-9])([a-zA-Z])/g, "$1 $2")
-      .replace(/[-_]+/g, " "),
-  );
 }
 
 async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -26,6 +26,7 @@ import type { EntityDomainsRepository } from "../db/repositories/entity-domains"
 import type { EntityReviewRepository } from "../db/repositories/entity-review";
 import type { EntitiesTable } from "../db/schema";
 import { isTrustedPersonScopeKey, personScopeKey, personScopeKeyId } from "./affiliations";
+import { normalizeMatchName } from "./match-normalize";
 import { type ProvenanceTier, canUseEntityAsMatchTarget } from "./provenance";
 
 export type Entity = Selectable<EntitiesTable>;
@@ -152,16 +153,6 @@ function tokenize(name: string): string[] {
     .split(" ")
     .map((t) => t.replace(/\.$/, ""))
     .filter((t) => t.length > 0);
-}
-
-function normalizeMatchName(entityType: ProposeEntityType, name: string): string {
-  if (entityType !== "product") return normalizeName(name);
-  return normalizeName(
-    name
-      .replace(/([a-zA-Z])([0-9])/g, "$1 $2")
-      .replace(/([0-9])([a-zA-Z])/g, "$1 $2")
-      .replace(/[-_]+/g, " "),
-  );
 }
 
 function parseAliases(aliases: string | null): string[] {

--- a/packages/server/src/entities/resolve.test.ts
+++ b/packages/server/src/entities/resolve.test.ts
@@ -18,7 +18,7 @@ import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
 import { materializeUnmaterializedFacts } from "./materialize";
 import { type Entity, type EntityLookup, proposeEntity } from "./propose";
-import { ResolveError, confirmReview, rejectReview } from "./resolve";
+import { ResolveError, confirmReview, dismissReview, rejectReview } from "./resolve";
 
 const USER_ID = "user-1";
 
@@ -1157,5 +1157,198 @@ describe("rejectReview", () => {
       .execute();
     expect(e1Rejections).toHaveLength(1);
     expect(e2Rejections).toHaveLength(1);
+  });
+});
+
+describe("dismissReview", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function seedBirthRow(): Promise<string> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await db
+      .insertInto("entity_review_queue")
+      .values({
+        id,
+        proposed_name: "Canvasx",
+        normalized_name: normalizeName("Canvasx"),
+        entity_type: "team",
+        candidate_entity_id: null,
+        candidate_score: null,
+        candidate_reason: "birth-gated",
+        candidate_generated_at: now,
+        first_seen_at: now,
+        last_seen_at: now,
+        occurrence_count: 1,
+        status: "pending",
+        triggered_by_user_id: USER_ID,
+        source: "clickup",
+        source_id: "clickup:team:canvasx",
+      })
+      .execute();
+    return id;
+  }
+
+  async function countEntities(): Promise<number> {
+    const row = await db
+      .selectFrom("entities")
+      .select((eb) => eb.fn.countAll<number>().as("c"))
+      .executeTakeFirstOrThrow();
+    return Number(row.c);
+  }
+
+  it("marks the row dismissed and creates no entity", async () => {
+    const reviewId = await seedBirthRow();
+    const row = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", reviewId)
+      .executeTakeFirstOrThrow();
+
+    const result = await dismissReview({ db, userId: USER_ID }, reviewId, {
+      candidateGeneratedAt: row.candidate_generated_at as string,
+    });
+
+    expect(result.idempotent).toBe(false);
+    expect(result.row.status).toBe("dismissed");
+    expect(result.row.resolved_entity_id).toBeNull();
+    expect(result.row.resolved_by).toBe(USER_ID);
+    expect(await countEntities()).toBe(0);
+  });
+
+  it("rejects confirm on an already-dismissed row and creates no entity", async () => {
+    const reviewId = await seedBirthRow();
+    const row = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", reviewId)
+      .executeTakeFirstOrThrow();
+    await dismissReview({ db, userId: USER_ID }, reviewId, {
+      candidateGeneratedAt: row.candidate_generated_at as string,
+    });
+
+    await expect(
+      confirmReview({ db, userId: USER_ID }, reviewId, { candidateGeneratedAt: row.candidate_generated_at as string }),
+    ).rejects.toMatchObject({ code: "CANDIDATE_DRIFT" });
+    expect(await countEntities()).toBe(0);
+  });
+
+  it("rejects mergeInto (confirm-with-merge) on an already-dismissed row, linking nothing", async () => {
+    const reviewId = await seedBirthRow();
+    const row = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", reviewId)
+      .executeTakeFirstOrThrow();
+    const existing = await createEntityRepository(db).createEntity({
+      name: "Canvas X Team",
+      sourceType: "team",
+      status: "confirmed",
+      provenanceTier: "structural",
+    });
+    await dismissReview({ db, userId: USER_ID }, reviewId, {
+      candidateGeneratedAt: row.candidate_generated_at as string,
+    });
+
+    await expect(
+      confirmReview({ db, userId: USER_ID }, reviewId, {
+        candidateGeneratedAt: row.candidate_generated_at as string,
+        mergeIntoEntityId: existing.id,
+      }),
+    ).rejects.toMatchObject({ code: "CANDIDATE_DRIFT" });
+    // Only the pre-existing entity remains; no link/merge created.
+    expect(await countEntities()).toBe(1);
+    const mentions = await db.selectFrom("entity_mentions").selectAll().where("entity_id", "=", existing.id).execute();
+    expect(mentions).toHaveLength(0);
+  });
+});
+
+describe("confirmReview — birth rename (nameOverride)", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function seedBirthRow(): Promise<string> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await db
+      .insertInto("entity_review_queue")
+      .values({
+        id,
+        proposed_name: "canvasx",
+        normalized_name: normalizeName("canvasx"),
+        entity_type: "team",
+        candidate_entity_id: null,
+        candidate_score: null,
+        candidate_reason: "birth-gated",
+        candidate_generated_at: now,
+        first_seen_at: now,
+        last_seen_at: now,
+        occurrence_count: 1,
+        status: "pending",
+        triggered_by_user_id: USER_ID,
+        source: "clickup",
+        source_id: "clickup:team:canvasx",
+      })
+      .execute();
+    return id;
+  }
+
+  it("creates the entity under the override name and keeps the original as an alias", async () => {
+    const reviewId = await seedBirthRow();
+    const row = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", reviewId)
+      .executeTakeFirstOrThrow();
+
+    const result = await confirmReview({ db, userId: USER_ID }, reviewId, {
+      candidateGeneratedAt: row.candidate_generated_at as string,
+      nameOverride: "CanvasX",
+    });
+
+    const entity = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("id", "=", result.targetEntityId)
+      .executeTakeFirstOrThrow();
+    expect(entity.name).toBe("CanvasX");
+    const aliases: string[] = JSON.parse(entity.aliases || "[]");
+    expect(aliases).toContain("canvasx");
+  });
+
+  it("falls back to proposed_name when nameOverride is blank", async () => {
+    const reviewId = await seedBirthRow();
+    const row = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", reviewId)
+      .executeTakeFirstOrThrow();
+
+    const result = await confirmReview({ db, userId: USER_ID }, reviewId, {
+      candidateGeneratedAt: row.candidate_generated_at as string,
+      nameOverride: "   ",
+    });
+
+    const entity = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("id", "=", result.targetEntityId)
+      .executeTakeFirstOrThrow();
+    expect(entity.name).toBe("canvasx");
   });
 });

--- a/packages/server/src/entities/resolve.ts
+++ b/packages/server/src/entities/resolve.ts
@@ -93,6 +93,13 @@ export interface ConfirmOptions {
   mergeIntoEntityId?: string;
   /** From the client's view of the row — must match row.candidate_generated_at. */
   candidateGeneratedAt: string;
+  /**
+   * Rename the entity at confirm time (births only). When creating from a seed,
+   * the entity is created under this name instead of `proposed_name`, and the
+   * original `proposed_name` is preserved as an alias so the connector's name
+   * still resolves. Ignored on a merge into an existing target.
+   */
+  nameOverride?: string;
 }
 
 export interface RejectOptions {
@@ -120,6 +127,12 @@ export interface RejectResult {
   /** New entity id when step 3 created one; same as targetEntityId in that case. */
   createdEntityId: string | null;
   /** True when the 200 is a no-op replay of an already-rejected row. */
+  idempotent: boolean;
+}
+
+export interface DismissResult {
+  row: QueueRow;
+  /** True when the 200 is a no-op replay of an already-dismissed row. */
   idempotent: boolean;
 }
 
@@ -680,6 +693,12 @@ export async function confirmReview(ctx: ResolveCtx, reviewId: string, opts: Con
         currentRow: row,
       });
     }
+    if (row.status === "dismissed") {
+      throw new ResolveError("CANDIDATE_DRIFT", "row already dismissed", {
+        currentStatus: row.status,
+        currentRow: row,
+      });
+    }
     if (row.status === "confirming") {
       throw new ResolveError("ALREADY_CONFIRMING", "row is mid-confirm (chunked backfill in progress)");
     }
@@ -701,12 +720,14 @@ export async function confirmReview(ctx: ResolveCtx, reviewId: string, opts: Con
       opts.mergeIntoEntityId !== row.candidate_entity_id;
 
     // 2. Existence check + type check.
+    const createName = opts.nameOverride?.trim() || row.proposed_name;
+    const renamed = createName !== row.proposed_name;
     let target: Entity;
     if (!targetId) {
       if (!row.seed_source || !row.seed_source_id) {
         if (row.candidate_reason === "birth-gated" && row.source && row.source_id) {
           target = await trxCtx.entityRepo.upsertEntityFromTool({
-            name: row.proposed_name,
+            name: createName,
             sourceType: row.entity_type,
             source: row.source,
             sourceId: row.source_id,
@@ -723,13 +744,14 @@ export async function confirmReview(ctx: ResolveCtx, reviewId: string, opts: Con
         }
       } else {
         target = await trxCtx.entityRepo.upsertEntityFromTool({
-          name: row.proposed_name,
+          name: createName,
           sourceType: row.entity_type,
           source: row.seed_source,
           sourceId: row.seed_source_id,
           provenanceTier: "human_confirmed",
         });
       }
+      if (renamed) await trxCtx.entityRepo.appendAlias(target.id, row.proposed_name);
     } else {
       const fetchedTarget = await fetchEntity(trxCtx, targetId);
       if (!fetchedTarget) {
@@ -907,6 +929,12 @@ export async function rejectReview(ctx: ResolveCtx, reviewId: string, opts: Reje
         currentRow: row,
       });
     }
+    if (row.status === "dismissed") {
+      throw new ResolveError("CANDIDATE_DRIFT", "row already dismissed", {
+        currentStatus: row.status,
+        currentRow: row,
+      });
+    }
     if (row.status === "confirming") {
       throw new ResolveError("ALREADY_CONFIRMING", "row is mid-confirm");
     }
@@ -1027,6 +1055,68 @@ export async function rejectReview(ctx: ResolveCtx, reviewId: string, opts: Reje
     const refreshedRow = await markResolvedOrThrow(trxCtx, row, "rejected", target.id);
 
     return { row: refreshedRow, targetEntityId: target.id, reResolvedToExisting, createdEntityId, idempotent: false };
+  });
+}
+
+/**
+ * Dismiss a pending review row: drop the proposal WITHOUT creating an entity.
+ * Used for birth rows the reviewer judges not real (e.g. a junk structural
+ * seed). Mirrors {@link rejectReview}'s terminal/drift guards but writes no
+ * entity, no mention, and no alias rejection. The terminal `dismissed` status
+ * suppresses the same key from being re-proposed (it is in `TERMINAL_STATUSES`).
+ */
+export async function dismissReview(
+  ctx: ResolveCtx,
+  reviewId: string,
+  opts: { candidateGeneratedAt: string },
+): Promise<DismissResult> {
+  return ctx.db.transaction().execute(async (trx) => {
+    const trxCtx: ResolveTxnCtx = {
+      db: trx,
+      repo: createEntityReviewRepo(trx),
+      entityRepo: createEntityRepository(trx),
+      userId: ctx.userId,
+      now: ctx.now ?? new Date().toISOString(),
+      logger: ctx.logger,
+    };
+    const row = await fetchRow(trxCtx, reviewId);
+
+    // Idempotent replay against an already-dismissed row.
+    if (row.status === "dismissed") {
+      return { row, idempotent: true };
+    }
+    // Any other terminal status cannot transition to dismissed.
+    if (row.status === "confirmed" || row.status === "rejected") {
+      throw new ResolveError("CANDIDATE_DRIFT", `row already ${row.status}`, {
+        currentStatus: row.status,
+        currentRow: row,
+      });
+    }
+    if (row.status === "confirming") {
+      throw new ResolveError("ALREADY_CONFIRMING", "row is mid-confirm");
+    }
+
+    // Compare-and-swap on the candidate snapshot this request validated.
+    if (row.candidate_generated_at !== opts.candidateGeneratedAt) {
+      throw new ResolveError("CANDIDATE_DRIFT", "candidate_generated_at mismatch", {
+        actual: row.candidate_generated_at,
+        provided: opts.candidateGeneratedAt,
+        currentRow: row,
+      });
+    }
+    if (!row.candidate_generated_at) {
+      throw new ResolveError("CANDIDATE_DRIFT", "row missing candidate_generated_at", { currentRow: row });
+    }
+
+    const won = await trxCtx.repo.markDismissed(row.id, ctx.userId, row.candidate_generated_at);
+    if (!won) {
+      const currentRow = await fetchRow(trxCtx, row.id);
+      throw new ResolveError("CANDIDATE_DRIFT", "row was resolved or refreshed by another request", {
+        currentStatus: currentRow.status,
+        currentRow,
+      });
+    }
+    return { row: await fetchRow(trxCtx, row.id), idempotent: false };
   });
 }
 

--- a/packages/server/src/entities/resolve.ts
+++ b/packages/server/src/entities/resolve.ts
@@ -35,6 +35,7 @@ import { createIndexedFileFactRepository } from "../db/repositories/indexed-file
 import type { DB, EntitiesTable, EntityContactPointsTable } from "../db/schema";
 import { inferAffiliationFromEmail } from "./affiliations";
 import { finalizeLinkedDomainCandidates } from "./domain-promotion";
+import { normalizeEntityMatchName } from "./match-normalize";
 import {
   type MaterializeResult,
   buildMaterializeDeps,
@@ -179,16 +180,6 @@ function parseAliases(raw: string | null): string[] {
   } catch {
     return [];
   }
-}
-
-function normalizeEntityMatchName(entityType: string, name: string): string {
-  if (entityType !== "product") return normalizeName(name);
-  return normalizeName(
-    name
-      .replace(/([a-zA-Z])([0-9])/g, "$1 $2")
-      .replace(/([0-9])([a-zA-Z])/g, "$1 $2")
-      .replace(/[-_]+/g, " "),
-  );
 }
 
 function shouldMarkHeldFactMaterialized(result: MaterializeResult): boolean {

--- a/packages/server/src/entities/review.test.ts
+++ b/packages/server/src/entities/review.test.ts
@@ -1192,7 +1192,10 @@ describe("entity-review routes — child tasks preview", () => {
         label: "Other Space",
       })
       .execute();
-    await db.insertInto("access_scope_members").values({ access_scope_id: "scope-other", email: OTHER_EMAIL }).execute();
+    await db
+      .insertInto("access_scope_members")
+      .values({ access_scope_id: "scope-other", email: OTHER_EMAIL })
+      .execute();
     await seedChildTask("task-visible", "team-2", "SKE-3: Visible");
     await seedChildTask("task-hidden", "team-2", "SKE-4: Hidden", {
       configId: "config-other",

--- a/packages/server/src/entities/review.test.ts
+++ b/packages/server/src/entities/review.test.ts
@@ -11,6 +11,7 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hashPassword } from "../auth/password";
 import { normalizeName } from "../connectors/name-normalize";
+import { createEntityReviewRepo } from "../db/repositories/entity-review";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createTaskRepository } from "../db/repositories/tasks";
 import { createUserRepository } from "../db/repositories/users";
@@ -481,6 +482,58 @@ describe("entity-review routes — list endpoint shape", () => {
   });
 });
 
+describe("entity-review routes — types filter", () => {
+  let db: Kysely<DB>;
+  let app: ReturnType<typeof createApp>;
+  let ownerId: string;
+  let adminCookie: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUsers(db);
+    ownerId = await userIdByEmail(db, OWNER_EMAIL);
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+      logger: createTestLogger(),
+    });
+    adminCookie = await login(app, ADMIN_EMAIL);
+    // One row per type: two spine types (product, team) plus a non-spine
+    // person row that must never leak through a spine-scoped filter.
+    await seedReviewRow(db, { proposedName: "Canvas Copilot", entityType: "product", triggeredBy: ownerId });
+    await seedReviewRow(db, { proposedName: "Platform Team", entityType: "team", triggeredBy: ownerId });
+    await seedReviewRow(db, { proposedName: "Simran Suri", entityType: "person", triggeredBy: ownerId });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("?types=product filters to product rows with a matching total", async () => {
+    const res = await app.request("/api/entity-review?types=product", { headers: { Cookie: adminCookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<{ entity_type: string }>; total: number };
+    expect(body.total).toBe(1);
+    expect(body.rows.map((r) => r.entity_type)).toEqual(["product"]);
+  });
+
+  it("filters by any entity type (not just the spine) and ignores unknown tokens", async () => {
+    // `person` is non-spine — the filter is generic, so it must work; `bogus`
+    // matches no rows and must not error or leak.
+    const res = await app.request("/api/entity-review?types=person,bogus", { headers: { Cookie: adminCookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<{ entity_type: string }>; total: number };
+    expect(body.total).toBe(1);
+    expect(body.rows.map((r) => r.entity_type)).toEqual(["person"]);
+  });
+
+  it("no types param leaves results unfiltered (regression guard)", async () => {
+    const res = await app.request("/api/entity-review", { headers: { Cookie: adminCookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<{ entity_type: string }>; total: number };
+    expect(body.total).toBe(3);
+    expect(new Set(body.rows.map((r) => r.entity_type))).toEqual(new Set(["product", "team", "person"]));
+  });
+});
+
 describe("entity-review A4 backend", () => {
   let db: Kysely<DB>;
   let app: ReturnType<typeof createApp>;
@@ -923,5 +976,210 @@ describe("entity-review A4 backend", () => {
       body: JSON.stringify({ candidateGeneratedAt: single.candidateGeneratedAt }),
     });
     expect(singleRes.status).toBe(200);
+  });
+});
+
+describe("entity-review routes — dismiss endpoint", () => {
+  let db: Kysely<DB>;
+  let app: ReturnType<typeof createApp>;
+  let ownerId: string;
+  let otherCookie: string;
+  let ownerCookie: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUsers(db);
+    ownerId = await userIdByEmail(db, OWNER_EMAIL);
+    await seedConnectorConfig(db, "config-owner", ownerId);
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+      logger: createTestLogger(),
+    });
+    ownerCookie = await login(app, OWNER_EMAIL);
+    otherCookie = await login(app, OTHER_EMAIL);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("400 without candidateGeneratedAt, 403 for non-owner", async () => {
+    const seed = await seedReviewRow(db, {
+      proposedName: "Canvasx",
+      entityType: "team",
+      triggeredBy: ownerId,
+      source: "clickup",
+      sourceId: "clickup:team:canvasx",
+      candidateReason: "birth-gated",
+    });
+
+    const badRes = await app.request(`/api/entity-review/${seed.id}/dismiss`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: ownerCookie },
+      body: JSON.stringify({}),
+    });
+    expect(badRes.status).toBe(400);
+
+    const forbiddenRes = await app.request(`/api/entity-review/${seed.id}/dismiss`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: otherCookie },
+      body: JSON.stringify({ candidateGeneratedAt: seed.candidateGeneratedAt }),
+    });
+    expect(forbiddenRes.status).toBe(403);
+
+    const after = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", seed.id)
+      .executeTakeFirstOrThrow();
+    expect(after.status).toBe("pending");
+  });
+
+  it("dismisses a birth row, creates no entity, and a later re-sync does not re-propose it", async () => {
+    const seed = await seedReviewRow(db, {
+      proposedName: "Canvasx",
+      entityType: "team",
+      triggeredBy: ownerId,
+      source: "clickup",
+      sourceId: "clickup:team:canvasx",
+      candidateReason: "birth-gated",
+    });
+
+    const res = await app.request(`/api/entity-review/${seed.id}/dismiss`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: ownerCookie },
+      body: JSON.stringify({ candidateGeneratedAt: seed.candidateGeneratedAt }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { row: { status: string }; idempotent: boolean };
+    expect(body.row.status).toBe("dismissed");
+    expect(body.idempotent).toBe(false);
+
+    const entityCount = await db
+      .selectFrom("entities")
+      .select((eb) => eb.fn.countAll<number>().as("c"))
+      .executeTakeFirstOrThrow();
+    expect(Number(entityCount.c)).toBe(0);
+
+    // A later sync re-proposes the same source key: it must stay dismissed.
+    const repo = createEntityReviewRepo(db);
+    const resync = await repo.upsertQueueRow({
+      proposedName: "Canvasx",
+      normalizedName: normalizeName("Canvasx"),
+      entityType: "team",
+      source: "clickup",
+      sourceId: "clickup:team:canvasx",
+      candidateEntityId: null,
+      candidateScore: null,
+      candidateReason: "birth-gated",
+      triggeredByUserId: ownerId,
+    });
+    expect(resync.skipEvidence).toBe(true);
+
+    const afterResync = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", seed.id)
+      .executeTakeFirstOrThrow();
+    expect(afterResync.status).toBe("dismissed");
+
+    const pending = await db
+      .selectFrom("entity_review_queue")
+      .select((eb) => eb.fn.countAll<number>().as("c"))
+      .where("status", "=", "pending")
+      .executeTakeFirstOrThrow();
+    expect(Number(pending.c)).toBe(0);
+  });
+});
+
+describe("entity-review routes — child tasks preview", () => {
+  let db: Kysely<DB>;
+  let app: ReturnType<typeof createApp>;
+  let ownerId: string;
+  let ownerCookie: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUsers(db);
+    ownerId = await userIdByEmail(db, OWNER_EMAIL);
+    await seedConnectorConfig(db, "config-owner", ownerId);
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+      logger: createTestLogger(),
+    });
+    ownerCookie = await login(app, OWNER_EMAIL);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function seedChildTask(fileId: string, parentSourceId: string, name: string, source = "linear") {
+    await db
+      .insertInto("indexed_files")
+      .values({
+        id: fileId,
+        connector_config_id: "config-owner",
+        provider_file_id: `pf-${fileId}`,
+        file_name: name,
+        file_type: "issue",
+        content_category: "document",
+        source,
+        provider_url: `https://linear.app/${fileId}`,
+        synced_at: new Date().toISOString(),
+        source_updated_at: new Date().toISOString(),
+      })
+      .execute();
+    await db
+      .insertInto("indexed_file_facts")
+      .values({
+        id: `fact-${fileId}`,
+        indexed_file_id: fileId,
+        source,
+        fact_type: "parent_entity",
+        relation: "mentioned",
+        subject_source_id: parentSourceId,
+        fact_key: `key-${fileId}`,
+      })
+      .execute();
+  }
+
+  it("returns child tasks for a structural-seed row, joined by parent source id", async () => {
+    const seed = await seedReviewRow(db, {
+      proposedName: "Sketch",
+      entityType: "team",
+      triggeredBy: ownerId,
+      seedSource: "linear",
+      seedSourceId: "team-1",
+    });
+    await seedChildTask("task-1", "team-1", "SKE-1: First");
+    await seedChildTask("task-2", "team-1", "SKE-2: Second");
+
+    const res = await app.request(`/api/entity-review/${seed.id}`, { headers: { Cookie: ownerCookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      childTaskCount: number;
+      childTasks: Array<{ name: string; providerUrl: string | null }>;
+    };
+    expect(body.childTaskCount).toBe(2);
+    expect(body.childTasks.map((t) => t.name).sort()).toEqual(["SKE-1: First", "SKE-2: Second"]);
+    expect(body.childTasks.every((t) => t.providerUrl?.includes("linear.app"))).toBe(true);
+  });
+
+  it("omits child tasks for a non-seed (LLM) row", async () => {
+    const seed = await seedReviewRow(db, {
+      proposedName: "Acme Co",
+      entityType: "company",
+      triggeredBy: ownerId,
+      source: "fireflies",
+      sourceId: "fireflies:company:acme",
+      candidateReason: "birth-gated",
+    });
+    // A parent_entity fact keyed on the same string must not be reachable for an LLM row.
+    await seedChildTask("task-3", "fireflies:company:acme", "Should not appear");
+
+    const res = await app.request(`/api/entity-review/${seed.id}`, { headers: { Cookie: ownerCookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { childTasks?: unknown; childTaskCount?: unknown };
+    expect(body.childTasks).toBeUndefined();
+    expect(body.childTaskCount).toBeUndefined();
   });
 });

--- a/packages/server/src/entities/review.test.ts
+++ b/packages/server/src/entities/review.test.ts
@@ -1095,13 +1095,16 @@ describe("entity-review routes — child tasks preview", () => {
   let db: Kysely<DB>;
   let app: ReturnType<typeof createApp>;
   let ownerId: string;
+  let otherId: string;
   let ownerCookie: string;
 
   beforeEach(async () => {
     db = await createTestDb();
     await seedUsers(db);
     ownerId = await userIdByEmail(db, OWNER_EMAIL);
+    otherId = await userIdByEmail(db, OTHER_EMAIL);
     await seedConnectorConfig(db, "config-owner", ownerId);
+    await seedConnectorConfig(db, "config-other", otherId);
     app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
       logger: createTestLogger(),
     });
@@ -1112,18 +1115,25 @@ describe("entity-review routes — child tasks preview", () => {
     await db.destroy();
   });
 
-  async function seedChildTask(fileId: string, parentSourceId: string, name: string, source = "linear") {
+  async function seedChildTask(
+    fileId: string,
+    parentSourceId: string,
+    name: string,
+    opts: { source?: string; configId?: string; accessScopeId?: string | null } = {},
+  ) {
+    const source = opts.source ?? "linear";
     await db
       .insertInto("indexed_files")
       .values({
         id: fileId,
-        connector_config_id: "config-owner",
+        connector_config_id: opts.configId ?? "config-owner",
         provider_file_id: `pf-${fileId}`,
         file_name: name,
         file_type: "issue",
         content_category: "document",
         source,
         provider_url: `https://linear.app/${fileId}`,
+        access_scope_id: opts.accessScopeId ?? null,
         synced_at: new Date().toISOString(),
         source_updated_at: new Date().toISOString(),
       })
@@ -1162,6 +1172,41 @@ describe("entity-review routes — child tasks preview", () => {
     expect(body.childTaskCount).toBe(2);
     expect(body.childTasks.map((t) => t.name).sort()).toEqual(["SKE-1: First", "SKE-2: Second"]);
     expect(body.childTasks.every((t) => t.providerUrl?.includes("linear.app"))).toBe(true);
+  });
+
+  it("filters child tasks through file visibility for member viewers", async () => {
+    const seed = await seedReviewRow(db, {
+      proposedName: "Sketch",
+      entityType: "team",
+      triggeredBy: ownerId,
+      seedSource: "linear",
+      seedSourceId: "team-2",
+    });
+    await db
+      .insertInto("access_scopes")
+      .values({
+        id: "scope-other",
+        connector_config_id: "config-other",
+        scope_type: "space",
+        provider_scope_id: "space-other",
+        label: "Other Space",
+      })
+      .execute();
+    await db.insertInto("access_scope_members").values({ access_scope_id: "scope-other", email: OTHER_EMAIL }).execute();
+    await seedChildTask("task-visible", "team-2", "SKE-3: Visible");
+    await seedChildTask("task-hidden", "team-2", "SKE-4: Hidden", {
+      configId: "config-other",
+      accessScopeId: "scope-other",
+    });
+
+    const res = await app.request(`/api/entity-review/${seed.id}`, { headers: { Cookie: ownerCookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      childTaskCount: number;
+      childTasks: Array<{ name: string }>;
+    };
+    expect(body.childTaskCount).toBe(1);
+    expect(body.childTasks.map((t) => t.name)).toEqual(["SKE-3: Visible"]);
   });
 
   it("omits child tasks for a non-seed (LLM) row", async () => {

--- a/packages/server/src/entities/review.ts
+++ b/packages/server/src/entities/review.ts
@@ -7,6 +7,7 @@
  *                             AFTER the owner-scope check passes
  *   POST   /:id/confirm       resolve via confirmReview()
  *   POST   /:id/reject        resolve via rejectReview()
+ *   POST   /:id/dismiss       drop a pending row (no entity) via dismissReview()
  *
  * Owner-scope: matches row.triggered_by_user_id OR is admin. Rows whose
  * evidence files were created by other users are admin-only — detected
@@ -33,9 +34,10 @@ import { isAdmin } from "../api/auth-helpers";
 import type { Config } from "../config";
 import { createEntityRepository } from "../db/repositories/entities";
 import { createEntityReviewRepo, readReviewFreezeMs } from "../db/repositories/entity-review";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
 import { createTaskRepository } from "../db/repositories/tasks";
 import type { DB } from "../db/schema";
-import { ResolveError, confirmReview, reclassifyReview, rejectReview } from "./resolve";
+import { ResolveError, confirmReview, dismissReview, reclassifyReview, rejectReview } from "./resolve";
 
 function readEmail(metadata: string | null): string | null {
   if (!metadata) return null;
@@ -144,12 +146,33 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
       return c.json({ error: { code: "BAD_REQUEST", message: "only status=pending supported in v1" } }, 400);
     }
     const search = c.req.query("q")?.trim() || undefined;
+    // Optional `types` CSV filter on entity_type — a generic allow-list each
+    // caller scopes itself (Your Org passes the taxonomy spine; the Files band
+    // passes person/company). Tokens are trimmed/de-duped; unknown values are
+    // harmless (they match no rows under the parameterized `in`).
+    const typesRaw = c.req.query("types");
+    const types = typesRaw
+      ? Array.from(
+          new Set(
+            typesRaw
+              .split(",")
+              .map((t) => t.trim())
+              .filter(Boolean),
+          ),
+        )
+      : undefined;
+    const typesFilter = types && types.length > 0 ? types : undefined;
 
     const repo = createEntityReviewRepo(db);
     const callerIsAdmin = isAdmin(c);
     const callerId = c.get("sub");
 
-    const total = await repo.countPending({ ownerUserId: callerId, isAdmin: callerIsAdmin, search });
+    const total = await repo.countPending({
+      ownerUserId: callerId,
+      isAdmin: callerIsAdmin,
+      search,
+      types: typesFilter,
+    });
 
     if (countOnly) {
       return c.json({ rows: [], total });
@@ -161,6 +184,7 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
       limit,
       offset,
       search,
+      types: typesFilter,
     });
 
     // Evidence summary per visible row.
@@ -386,6 +410,21 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
     }));
 
     const enrichedRow = { ...baseRow, evidenceCount: evidence.length, sourceBreakdown, candidate };
+
+    // Structural-seed rows (project/team pulled from a tracker) carry no file
+    // evidence — the seed fact has no indexed_file_id. Surface the child tasks
+    // that sit under the parent instead, so review has context. Read-only join;
+    // skipped entirely for non-seed rows.
+    if (baseRow.seed_source && baseRow.seed_source_id) {
+      const factRepo = createIndexedFileFactRepository(db);
+      const { tasks, total } = await factRepo.childTasksForParent({
+        source: baseRow.seed_source,
+        parentSourceId: baseRow.seed_source_id,
+        limit: 50,
+      });
+      return c.json({ row: enrichedRow, evidence: enrichedEvidence, childTasks: tasks, childTaskCount: total });
+    }
+
     return c.json({ row: enrichedRow, evidence: enrichedEvidence });
   });
 
@@ -394,6 +433,7 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
     const body = (await c.req.json().catch(() => ({}))) as {
       mergeIntoEntityId?: string;
       candidateGeneratedAt?: string;
+      nameOverride?: string;
     };
     if (!body.candidateGeneratedAt) {
       return c.json({ error: { code: "BAD_REQUEST", message: "candidateGeneratedAt is required" } }, 400);
@@ -409,6 +449,7 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
       const result = await confirmReview({ db, userId: c.get("sub") }, id, {
         mergeIntoEntityId: body.mergeIntoEntityId,
         candidateGeneratedAt: body.candidateGeneratedAt,
+        nameOverride: body.nameOverride,
       });
       return c.json({
         row: result.row,
@@ -450,6 +491,29 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
         createdEntityId: result.createdEntityId,
         idempotent: result.idempotent,
       });
+    } catch (err) {
+      return handleResolveError(c, err);
+    }
+  });
+
+  app.post("/:id/dismiss", async (c) => {
+    const id = c.req.param("id");
+    const body = (await c.req.json().catch(() => ({}))) as { candidateGeneratedAt?: string };
+    if (!body.candidateGeneratedAt) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "candidateGeneratedAt is required" } }, 400);
+    }
+
+    const repo = createEntityReviewRepo(db);
+    const row = await repo.getById(id);
+    if (!row) return c.json({ error: { code: "NOT_FOUND", message: "review row not found" } }, 404);
+    const denied = await denyIfNotOwnerOrAdmin(c, repo, row);
+    if (denied) return denied;
+
+    try {
+      const result = await dismissReview({ db, userId: c.get("sub") }, id, {
+        candidateGeneratedAt: body.candidateGeneratedAt,
+      });
+      return c.json({ row: result.row, idempotent: result.idempotent });
     } catch (err) {
       return handleResolveError(c, err);
     }

--- a/packages/server/src/entities/review.ts
+++ b/packages/server/src/entities/review.ts
@@ -30,7 +30,7 @@
  */
 import { type Context, Hono } from "hono";
 import type { Kysely } from "kysely";
-import { isAdmin } from "../api/auth-helpers";
+import { getContentViewer, isAdmin } from "../api/auth-helpers";
 import type { Config } from "../config";
 import { createEntityRepository } from "../db/repositories/entities";
 import { createEntityReviewRepo, readReviewFreezeMs } from "../db/repositories/entity-review";
@@ -421,6 +421,7 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
         source: baseRow.seed_source,
         parentSourceId: baseRow.seed_source_id,
         limit: 50,
+        viewer: getContentViewer(c),
       });
       return c.json({ row: enrichedRow, evidence: enrichedEvidence, childTasks: tasks, childTaskCount: total });
     }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -23,6 +23,7 @@ import { localClaudeSessionEventRoutes } from "./api/local-claude-sessions";
 import { localDeviceRoutes } from "./api/local-devices";
 import { mcpServerRoutes } from "./api/mcp-servers";
 import { createAuthMiddleware } from "./api/middleware";
+import { productRoutes } from "./api/products";
 import { createProjectRoutes } from "./api/projects";
 import { providerIdentityRoutes } from "./api/provider-identities";
 import { scheduledTaskRoutes } from "./api/scheduled-tasks";
@@ -456,6 +457,9 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   }
   app.route("/api/entities", entityRoutes(db, { logger, config }));
   app.route("/api/projects", createProjectRoutes(db));
+  if (config.EXPERIMENTAL_FLAG) {
+    app.route("/api/products", productRoutes(db));
+  }
   app.route("/api/entity-review", entityReviewRoutes(db, { config }));
   app.route("/api/api-tokens", apiTokenRoutes(db, { baseUrl: config.BASE_URL }));
   mountPublicMcpServer({


### PR DESCRIPTION
Stacked context-graph slice 18/27.

Base: `feat/context-graph-17-provenance-product-gates`
Head: `feat/context-graph-18-declared-products-birth-preview`

Adds declared product handling plus backend birth preview support.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`