### PR TITLE
feat: add org review surface

### DIFF
--- a/packages/web/src/components/app-sidebar.tsx
+++ b/packages/web/src/components/app-sidebar.tsx
@@ -63,6 +63,11 @@ interface NavItem {
   experimentalOnly?: boolean;
   /** Optional render-prop for a trailing element (e.g. a count badge). */
   trailing?: React.ReactNode;
+  /**
+   * When experimental, relabel to "Your org" and show a pending-review count
+   * badge scoped to the org-taxonomy spine.
+   */
+  yourOrgBadge?: boolean;
 }
 
 const allPrimaryNav: NavItem[] = [
@@ -71,7 +76,7 @@ const allPrimaryNav: NavItem[] = [
   { label: "Chat", icon: <ChatCircleIcon size={18} />, href: "/chat" },
   { label: "Channels", icon: <HashIcon size={18} />, href: "/channels" },
   { label: "Files", icon: <FolderSimpleIcon size={18} />, href: "/files" },
-  { label: "Projects", icon: <FoldersIcon size={18} />, href: "/projects", adminOnly: true },
+  { label: "Projects", icon: <FoldersIcon size={18} />, href: "/projects", adminOnly: true, yourOrgBadge: true },
   { label: "Team", icon: <UsersThreeIcon size={18} />, href: "/team" },
   { label: "Automations", icon: <CalendarDotsIcon size={18} />, href: "/scheduled-tasks" },
   { label: "Skills", icon: <BrainIcon size={18} />, href: "/skills" },
@@ -122,6 +127,13 @@ export function AppSidebar({
   });
 
   const experimentalEnabled = setupStatus?.experimentalFlag === true;
+  const { data: yourOrgReview } = useQuery({
+    queryKey: ["entity-review", "band-count", "spine"],
+    queryFn: () => api.entityReview.list({ limit: 0, types: ["product", "project", "team"] }),
+    enabled: experimentalEnabled && role === "admin",
+    refetchInterval: 30000,
+  });
+  const yourOrgCount = yourOrgReview?.total ?? 0;
   const primaryNav = allPrimaryNav.filter((item) => {
     if (item.adminOnly && role !== "admin" && !(item.memberVisibleWhenExperimental && experimentalEnabled))
       return false;
@@ -164,19 +176,28 @@ export function AppSidebar({
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {primaryNav.map((item) => (
-                <SidebarMenuItem key={item.href}>
-                  <SidebarMenuButton
-                    isActive={isNavItemActive(location.pathname, item.href)}
-                    onClick={() => !item.disabled && navigate({ to: item.href })}
-                    disabled={item.disabled}
-                    tooltip={item.label}
-                  >
-                    {item.icon}
-                    <span className="flex-1">{item.label}</span>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
+              {primaryNav.map((item) => {
+                const yourOrg = item.yourOrgBadge && experimentalEnabled;
+                const label = yourOrg ? "Your org" : item.label;
+                return (
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton
+                      isActive={isNavItemActive(location.pathname, item.href)}
+                      onClick={() => !item.disabled && navigate({ to: item.href })}
+                      disabled={item.disabled}
+                      tooltip={label}
+                    >
+                      {item.icon}
+                      <span className="flex-1">{label}</span>
+                      {yourOrg && yourOrgCount > 0 ? (
+                        <Badge variant="secondary" className="h-4 min-w-4 justify-center px-1 text-[10px] tabular-nums">
+                          {yourOrgCount}
+                        </Badge>
+                      ) : null}
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
               {setupStatus?.managedUrl && role === "admin" ? (
                 <SidebarMenuItem>
                   <SidebarMenuButton asChild tooltip="Account">

--- a/packages/web/src/components/entity-drawer/drawer-kit.tsx
+++ b/packages/web/src/components/entity-drawer/drawer-kit.tsx
@@ -1,0 +1,40 @@
+/**
+ * Shared visual primitives for the entity drawer and its lookalikes (e.g. the
+ * review inspect sheet). Single source of truth so those surfaces stay visually
+ * identical — same tokens, same borders, same spacing.
+ */
+import { cn } from "@sketch/ui/lib/utils";
+import type { ReactNode } from "react";
+
+/** Small uppercase mono section label (e.g. "Summary", "Tasks under this"). */
+export function SectionLabel({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={cn("font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground", className)}>
+      {children}
+    </div>
+  );
+}
+
+/** Accent-tinted bordered card with a {@link SectionLabel} header. */
+export function SectionCard({ accent, label, children }: { accent: string; label: string; children: ReactNode }) {
+  return (
+    <section className="rounded-lg border p-4" style={{ borderColor: `${accent}33` }}>
+      <SectionLabel className="mb-2">{label}</SectionLabel>
+      {children}
+    </section>
+  );
+}
+
+/** Bordered, hairline-divided list — the row container used across drawer lists. */
+export function EntryList({ children }: { children: ReactNode }) {
+  return <ul className="flex flex-col divide-y rounded-md border bg-background">{children}</ul>;
+}
+
+/** The muted mono source tag shown at the start of an entry row. */
+export function SourceTag({ children }: { children: ReactNode }) {
+  return (
+    <span className="shrink-0 rounded-sm bg-muted px-1 py-0.5 font-mono text-[9px] uppercase text-muted-foreground">
+      {children}
+    </span>
+  );
+}

--- a/packages/web/src/components/entity-drawer/entity-drawer.tsx
+++ b/packages/web/src/components/entity-drawer/entity-drawer.tsx
@@ -46,6 +46,7 @@ import { cn } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
+import { SectionCard, SectionLabel } from "./drawer-kit";
 import { ScopePanel } from "./scope-panel";
 import { TimelineStrip } from "./timeline-strip";
 
@@ -430,17 +431,14 @@ function SummaryBlock({ entity, accent }: { entity: EntityDetail; accent: string
   const crmBrief = entity.profile.crmActivityBrief;
   const hasContent = identity.length > 0 || activity.length > 0 || Boolean(crmBrief);
   return (
-    <section aria-label="Summary" className="rounded-lg border p-4" style={{ borderColor: `${accent}33` }}>
-      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">Summary</div>
+    <SectionCard accent={accent} label="Summary">
       {hasContent ? (
         <div className="space-y-2 text-sm leading-snug">
           {identity ? <p>{identity}</p> : null}
           {activity ? <p className="text-muted-foreground">{activity}</p> : null}
           {crmBrief ? (
             <div className="border-t pt-2">
-              <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
-                CRM Activity
-              </div>
+              <SectionLabel className="mb-1">CRM Activity</SectionLabel>
               <p>{crmBrief.summary}</p>
               <p className="mt-1 text-[11px] text-muted-foreground">
                 {crmBrief.activityCount} {crmBrief.activityCount === 1 ? "activity" : "activities"} · updated{" "}
@@ -452,7 +450,7 @@ function SummaryBlock({ entity, accent }: { entity: EntityDetail; accent: string
       ) : (
         <p className="text-sm text-muted-foreground">No summary yet.</p>
       )}
-    </section>
+    </SectionCard>
   );
 }
 

--- a/packages/web/src/components/entity-drawer/timeline-strip.tsx
+++ b/packages/web/src/components/entity-drawer/timeline-strip.tsx
@@ -15,6 +15,7 @@ import {
   PhoneIcon,
   SparkleIcon,
 } from "@phosphor-icons/react";
+import { EntryList, SectionLabel, SourceTag } from "./drawer-kit";
 
 interface TimelineStripProps {
   groups: EntityTimelineGroup[];
@@ -84,9 +85,7 @@ function TimelineRow({
     >
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="shrink-0 rounded-sm bg-muted px-1 py-0.5 font-mono text-[9px] uppercase text-muted-foreground">
-            {item.sourceType}
-          </span>
+          <SourceTag>{item.sourceType}</SourceTag>
           <span className="truncate text-sm font-medium">{item.fileName}</span>
           {item.mentionCount > 1 ? (
             <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-[9px] text-muted-foreground">
@@ -116,16 +115,14 @@ export function TimelineStrip({ groups, onSelectItem }: TimelineStripProps) {
       <div className="flex flex-col gap-3">
         {groups.map((group) => (
           <div key={group.month} className="flex flex-col">
-            <h4 className="mb-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-              {monthLabel(group.month)}
-            </h4>
-            <ul className="flex flex-col divide-y rounded-md border bg-background">
+            <SectionLabel className="mb-1.5 font-medium">{monthLabel(group.month)}</SectionLabel>
+            <EntryList>
               {group.items.map((item) => (
                 <li key={item.fileId}>
                   <TimelineRow item={item} onSelectItem={onSelectItem} />
                 </li>
               ))}
-            </ul>
+            </EntryList>
           </div>
         ))}
       </div>

--- a/packages/web/src/components/entity-review/add-entity-dialog.tsx
+++ b/packages/web/src/components/entity-review/add-entity-dialog.tsx
@@ -1,0 +1,97 @@
+/**
+ * Shared "Add entity" dialog. One control creates any taxonomy entity; the
+ * type picker defaults to whatever the host surface emphasises (Your Org
+ * defaults to `product`, the Files explorer to `company`).
+ *
+ * Products route through the declare path (`api.products.create`) so declaring
+ * one that already exists as an inferred guess upgrades it in place instead of
+ * creating a duplicate; every other type uses the generic entity create. Both
+ * paths land the row at `provenance_tier = declared` (a human assertion).
+ */
+import { api } from "@/lib/api";
+import { Button } from "@sketch/ui/components/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@sketch/ui/components/dialog";
+import { Input } from "@sketch/ui/components/input";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+
+const ENTITY_TYPES = ["product", "company", "client", "project", "team", "person"] as const;
+
+export function AddEntityDialog({
+  open,
+  onOpenChange,
+  defaultType = "company",
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultType?: string;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [type, setType] = useState(defaultType);
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const trimmed = name.trim();
+      if (type === "product") {
+        await api.products.create({ name: trimmed });
+      } else {
+        await api.entities.create({ name: trimmed, sourceType: type });
+      }
+    },
+    onSuccess: () => {
+      toast.success(`Entity "${name.trim()}" created.`);
+      onOpenChange(false);
+      setName("");
+      setType(defaultType);
+      queryClient.invalidateQueries({ queryKey: ["entities"] });
+      queryClient.invalidateQueries({ queryKey: ["products"] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Add entity</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Name</p>
+            <Input
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+              className="mt-1 text-sm"
+              placeholder="e.g. CanvasX, Epik, Product Alpha"
+            />
+          </div>
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Type</p>
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {ENTITY_TYPES.map((t) => (
+                <Button
+                  key={t}
+                  size="sm"
+                  variant={type === t ? "default" : "outline"}
+                  className="h-7 text-xs"
+                  onClick={() => setType(t)}
+                >
+                  {t}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <Button
+            className="w-full text-xs"
+            onClick={() => createMutation.mutate()}
+            disabled={createMutation.isPending || !name.trim()}
+          >
+            {createMutation.isPending ? "Creating..." : "Create entity"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/entity-review/entity-format.ts
+++ b/packages/web/src/components/entity-review/entity-format.ts
@@ -1,0 +1,54 @@
+import type { EntityListItem, EntityReviewQueueRow } from "@/lib/api";
+
+/** Map a raw entity/source type to a human-readable label. */
+export function humanSourceType(sourceType: string): string {
+  const map: Record<string, string> = {
+    clickup_space: "Space",
+    clickup_folder: "Folder",
+    clickup_workspace: "Workspace",
+    linear_project: "Project",
+    notion_database: "Database",
+    notion_page: "Page",
+    person: "Person",
+    project: "Project",
+    company: "Company",
+    product: "Product",
+    team: "Team",
+    other: "Other",
+  };
+  return map[sourceType] ?? sourceType;
+}
+
+/** Map a connector/source slug to a human-readable product name. */
+export function humanConnector(source: string): string {
+  const map: Record<string, string> = {
+    clickup: "ClickUp",
+    linear: "Linear",
+    notion: "Notion",
+    fireflies: "Fireflies",
+    gmail: "Gmail",
+    slack: "Slack",
+    github: "GitHub",
+    jira: "Jira",
+    llm_relation: "AI",
+    llm_extraction: "AI",
+  };
+  return map[source] ?? source.charAt(0).toUpperCase() + source.slice(1);
+}
+
+/**
+ * Where a review row was born. A `seed_source` means it was pulled structurally
+ * from a tracker (ClickUp / Linear); a bare `source` means an AI extraction
+ * inferred it from that connector's documents. Returns null when neither is set.
+ */
+export function birthOrigin(row: EntityReviewQueueRow): { kind: "tracker" | "ai"; label: string } | null {
+  if (row.seed_source) return { kind: "tracker", label: humanConnector(row.seed_source) };
+  if (row.source) return { kind: "ai", label: `AI · ${humanConnector(row.source)}` };
+  return null;
+}
+
+/** Read an entity's email out of its metadata blob, if present. */
+export function entityEmail(entity: EntityListItem | null): string | null {
+  const value = entity?.metadata?.email;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/packages/web/src/components/entity-review/review-band.test.tsx
+++ b/packages/web/src/components/entity-review/review-band.test.tsx
@@ -1,0 +1,180 @@
+import { server } from "@/test/msw";
+import { renderWithProviders } from "@/test/utils";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import { ReviewBand } from "./review-band";
+
+function birthRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "rev-1",
+    proposed_name: "Canvasx",
+    normalized_name: "canvasx",
+    entity_type: "team",
+    proposed_email: null,
+    candidate_entity_id: null,
+    candidate_score: null,
+    candidate_reason: null,
+    candidate_generated_at: "2026-06-28T00:00:00.000Z",
+    source: null,
+    source_id: null,
+    seed_source: "clickup",
+    seed_source_id: "clickup:team:canvasx",
+    first_seen_at: "2026-06-28T00:00:00.000Z",
+    last_seen_at: "2026-06-28T00:00:00.000Z",
+    occurrence_count: 1,
+    status: "pending",
+    triggered_by_user_id: "u1",
+    review_started_at: null,
+    review_started_by: null,
+    backfill_cursor: null,
+    resolved_by: null,
+    resolved_at: null,
+    resolved_entity_id: null,
+    evidenceCount: 0,
+    sourceBreakdown: [],
+    candidate: null,
+    ...overrides,
+  };
+}
+
+describe("ReviewBand birth rows", () => {
+  it("shows a tracker origin chip and dismisses inline without opening the reconcile drawer", async () => {
+    const dismiss = vi.fn();
+    server.use(
+      http.get("/api/entity-review", () => HttpResponse.json({ rows: [birthRow()], total: 1 })),
+      http.post("/api/entity-review/:id/dismiss", async ({ params, request }) => {
+        dismiss({ id: params.id, body: await request.json() });
+        return HttpResponse.json({ row: birthRow({ status: "dismissed" }), idempotent: false });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ReviewBand types={["team"]} />);
+
+    expect(await screen.findByText("Canvasx")).toBeInTheDocument();
+    expect(screen.getByText("ClickUp")).toBeInTheDocument();
+    expect(screen.getByTestId("birth-confirm")).toBeInTheDocument();
+    expect(screen.getByTestId("birth-merge")).toBeInTheDocument();
+    expect(screen.queryByTestId("reconcile-proposed")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("birth-dismiss"));
+
+    await waitFor(() => expect(dismiss).toHaveBeenCalledTimes(1));
+    expect(dismiss.mock.calls[0][0]).toMatchObject({
+      id: "rev-1",
+      body: { candidateGeneratedAt: "2026-06-28T00:00:00.000Z" },
+    });
+  });
+
+  it("opens a read-only inspect sheet listing the linked files for an AI-inferred birth", async () => {
+    const aiRow = birthRow({
+      source: "fireflies",
+      source_id: "fireflies:team:canvasx",
+      seed_source: null,
+      seed_source_id: null,
+      candidate_reason: "birth-gated",
+      evidenceCount: 1,
+    });
+    server.use(
+      http.get("/api/entity-review", () => HttpResponse.json({ rows: [aiRow], total: 1 })),
+      http.get("/api/entity-review/:id", () =>
+        HttpResponse.json({
+          row: aiRow,
+          evidence: [
+            {
+              id: "ev-1",
+              review_id: "rev-1",
+              indexed_file_id: "file-1",
+              source: "fireflies",
+              note: null,
+              seen_at: "2026-06-28T00:00:00.000Z",
+              file: { name: "Kickoff sync", providerUrl: null, sourcePath: null },
+            },
+          ],
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ReviewBand types={["team"]} />);
+
+    expect(await screen.findByText("AI · Fireflies")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("birth-inspect"));
+
+    expect(await screen.findByText("Linked files (1)")).toBeInTheDocument();
+    expect(screen.getByText("Kickoff sync")).toBeInTheDocument();
+    // Inspect is one-column: the two-column reconcile layout never renders.
+    expect(screen.queryByTestId("reconcile-proposed")).not.toBeInTheDocument();
+  });
+
+  it("lists the tasks under a tracker seed in the inspect sheet", async () => {
+    server.use(
+      http.get("/api/entity-review", () => HttpResponse.json({ rows: [birthRow()], total: 1 })),
+      http.get("/api/entity-review/:id", () =>
+        HttpResponse.json({
+          row: birthRow(),
+          evidence: [],
+          childTaskCount: 3,
+          childTasks: [
+            {
+              indexedFileId: "f1",
+              name: "SKE-1: Alpha",
+              fileType: "issue",
+              providerUrl: "https://linear.app/1",
+              source: "linear",
+            },
+            { indexedFileId: "f2", name: "SKE-2: Beta", fileType: "issue", providerUrl: null, source: "linear" },
+          ],
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ReviewBand types={["team"]} />);
+
+    await user.click(await screen.findByTestId("birth-inspect"));
+
+    expect(await screen.findByText("Tasks under this (3)")).toBeInTheDocument();
+    expect(screen.getByText("SKE-1: Alpha")).toBeInTheDocument();
+    expect(screen.getByText("SKE-2: Beta")).toBeInTheDocument();
+    // count (3) exceeds the listed rows (2) → an honest "+ 1 more".
+    expect(screen.getByText("+ 1 more")).toBeInTheDocument();
+  });
+
+  it("confirms a renamed birth, sending the edited name as nameOverride", async () => {
+    const confirm = vi.fn();
+    server.use(
+      http.get("/api/entity-review", () => HttpResponse.json({ rows: [birthRow()], total: 1 })),
+      http.get("/api/entity-review/:id", () => HttpResponse.json({ row: birthRow(), evidence: [] })),
+      http.post("/api/entity-review/:id/confirm", async ({ request }) => {
+        confirm(await request.json());
+        return HttpResponse.json({
+          row: birthRow({ status: "confirmed" }),
+          targetEntityId: "ent-1",
+          shortCircuited: false,
+          mergedStaleEntityId: null,
+          idempotent: false,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ReviewBand types={["team"]} />);
+
+    await user.click(await screen.findByTestId("birth-inspect"));
+
+    const input = await screen.findByTestId("birth-name-input");
+    await user.clear(input);
+    await user.type(input, "CanvasX");
+    await user.click(screen.getByTestId("birth-inspect-confirm"));
+
+    await waitFor(() => expect(confirm).toHaveBeenCalledTimes(1));
+    expect(confirm.mock.calls[0][0]).toMatchObject({
+      candidateGeneratedAt: "2026-06-28T00:00:00.000Z",
+      nameOverride: "CanvasX",
+    });
+  });
+});

--- a/packages/web/src/components/entity-review/review-band.tsx
+++ b/packages/web/src/components/entity-review/review-band.tsx
@@ -1,0 +1,999 @@
+import { EntryList, SectionCard, SectionLabel, SourceTag } from "@/components/entity-drawer/drawer-kit";
+/**
+ * Shared entity-review band + reconcile sheet.
+ *
+ * Extracted from Files → Entities so the same reconcile UI is reused verbatim
+ * on the Your Org surface. Two consumers:
+ *   - {@link GhostReviewRow} + {@link ReviewDetailSheet} — the explorer renders
+ *     ghost rows inline inside its own table, then opens the sheet.
+ *   - {@link ReviewBand} — a self-contained band (used by Your Org) that fetches
+ *     a type-scoped slice of the queue, splits it into "Confirm new" (no
+ *     candidate) vs "Possible duplicates" (a match was suggested), and owns the
+ *     sheet.
+ *
+ * Clicking a row opens a reconcile drawer with two side-by-side columns —
+ * Proposed | Suggested existing — and inline ✓/✗ icon-buttons on the candidate
+ * card. ✗ flips the right column to a "What instead?" chooser (search +
+ * create-as-new). Orphan rows (no suggested candidate) open directly in chooser
+ * mode.
+ */
+import { EntityPicker } from "@/components/entity-picker";
+import { detailKey, useReviewMutations } from "@/components/review-actions";
+import type {
+  ChildTask,
+  EntityListItem,
+  EntityMention,
+  EntityReviewEvidenceRow,
+  EntityReviewQueueRow,
+} from "@/lib/api";
+import { api } from "@/lib/api";
+import { EntityAvatar, entityAccent } from "@/lib/entity-ui";
+import { formatRelativeTime } from "@/routes/files/file-list";
+import {
+  ArrowLeftIcon,
+  ArrowSquareOutIcon,
+  CheckIcon,
+  CubeIcon,
+  PlugsConnectedIcon,
+  PlusIcon,
+  SparkleIcon,
+  UserIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
+import { Button } from "@sketch/ui/components/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@sketch/ui/components/dialog";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@sketch/ui/components/sheet";
+import { Skeleton } from "@sketch/ui/components/skeleton";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { birthOrigin, entityEmail, humanSourceType } from "./entity-format";
+
+/**
+ * Self-contained review band scoped to a set of entity types. Fetches the
+ * type-scoped queue slice, partitions it into births vs possible-duplicates,
+ * and owns the reconcile sheet. Renders nothing when the scoped queue is empty.
+ */
+export function ReviewBand({ types, title = "Needs your review" }: { types: string[]; title?: string }) {
+  const queryClient = useQueryClient();
+  const [selectedReviewId, setSelectedReviewId] = useState<string | null>(null);
+  const [inspectBirthId, setInspectBirthId] = useState<string | null>(null);
+  const { data } = useQuery({
+    queryKey: ["entity-review", "band", types.join(",")],
+    queryFn: () => api.entityReview.list({ limit: 200, types }),
+  });
+  const rows = data?.rows ?? [];
+  const total = data?.total ?? rows.length;
+
+  /**
+   * Births resolve inline, so refreshing the band, sidebar badge, and Files
+   * band together means invalidating the whole `["entity-review"]` prefix: the
+   * band key is NOT under `LIST_KEY`, so the mutation hook's list-scoped
+   * invalidation alone would miss it.
+   */
+  const refreshAfterResolve = () => {
+    queryClient.invalidateQueries({ queryKey: ["entity-review"] });
+    queryClient.invalidateQueries({ queryKey: ["entities"] });
+  };
+
+  if (rows.length === 0) return null;
+
+  const births = rows.filter((r) => !r.candidate);
+  const duplicates = rows.filter((r) => r.candidate);
+
+  return (
+    <section className="mb-9 overflow-hidden rounded-xl border border-amber-300/60 bg-amber-50/40 dark:border-amber-700/50 dark:bg-amber-950/20">
+      <div className="flex items-baseline justify-between border-b border-amber-300/50 px-3 py-2 dark:border-amber-700/40">
+        <span className="font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-amber-700 dark:text-amber-400">
+          {title} · {total}
+        </span>
+      </div>
+      {births.length > 0 ? (
+        <>
+          <GroupHeader label="Confirm new" count={births.length} />
+          {births.map((row) => (
+            <BirthRow
+              key={`review-${row.id}`}
+              row={row}
+              onResolved={refreshAfterResolve}
+              onInspect={setInspectBirthId}
+            />
+          ))}
+        </>
+      ) : null}
+      {duplicates.length > 0 ? (
+        <>
+          <GroupHeader label="Possible duplicates" count={duplicates.length} />
+          {duplicates.map((row) => (
+            <GhostReviewRow key={`review-${row.id}`} row={row} onSelect={setSelectedReviewId} />
+          ))}
+        </>
+      ) : null}
+      <ReviewDetailSheet reviewId={selectedReviewId} onClose={() => setSelectedReviewId(null)} />
+      <BirthInspectSheet
+        reviewId={inspectBirthId}
+        onResolved={refreshAfterResolve}
+        onClose={() => setInspectBirthId(null)}
+      />
+    </section>
+  );
+}
+
+function GroupHeader({ label, count }: { label: string; count: number }) {
+  return (
+    <div className="border-b border-amber-300/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-amber-700/80 dark:border-amber-700/30 dark:text-amber-400/70">
+      {label} · {count}
+    </div>
+  );
+}
+
+/**
+ * A small chip naming where a birth row came from: a tracker pull (ClickUp /
+ * Linear) or an AI extraction from a connector's documents (Fireflies / Gmail).
+ */
+function OriginChip({ row }: { row: EntityReviewQueueRow }) {
+  const origin = birthOrigin(row);
+  if (!origin) return null;
+  return (
+    <Badge
+      variant="outline"
+      className={
+        origin.kind === "ai"
+          ? "gap-1 border-violet-300 text-[9px] text-violet-700 dark:border-violet-700 dark:text-violet-300"
+          : "gap-1 text-[9px]"
+      }
+    >
+      {origin.kind === "ai" ? <SparkleIcon size={9} weight="fill" /> : <PlugsConnectedIcon size={9} />}
+      {origin.label}
+    </Badge>
+  );
+}
+
+/**
+ * A birth row (proposed entity with no candidate match). It resolves inline —
+ * Confirm creates the entity from its seed, Dismiss drops it without creating
+ * anything, Merge… opens a search-only picker for the "actually a duplicate"
+ * escape hatch. The actions only appear on hover/focus to keep the list calm;
+ * clicking the row body opens a read-only inspect sheet (origin + linked files).
+ * No reconcile drawer: a birth is not a merge, so there's nothing to compare.
+ */
+function BirthRow({
+  row,
+  onResolved,
+  onInspect,
+}: {
+  row: EntityReviewQueueRow;
+  onResolved: () => void;
+  onInspect: (id: string) => void;
+}) {
+  const isPerson = row.entity_type === "person";
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const mutations = useReviewMutations(row, onResolved);
+
+  return (
+    <div
+      className="group border-b border-border bg-amber-50/40 last:border-b-0 dark:bg-amber-950/20"
+      data-testid={`review-row-${row.id}`}
+    >
+      <div className="flex items-center gap-3 px-3 py-2.5 text-sm">
+        <button
+          type="button"
+          onClick={() => onInspect(row.id)}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left hover:opacity-80"
+          data-testid="birth-inspect"
+        >
+          {isPerson ? (
+            <UserIcon size={14} className="shrink-0 text-muted-foreground" />
+          ) : (
+            <CubeIcon size={14} className="shrink-0 text-muted-foreground" />
+          )}
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">{row.proposed_name}</p>
+            <span className="mt-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+              <Badge variant="outline" className="text-[9px]">
+                {humanSourceType(row.entity_type)}
+              </Badge>
+              <OriginChip row={row} />
+              {row.evidenceCount > 0 ? <span>· {row.evidenceCount} linked</span> : null}
+            </span>
+          </div>
+        </button>
+
+        <div className="flex shrink-0 items-center gap-1.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => mutations.confirm()}
+            disabled={mutations.isPending}
+            className="h-7 gap-1 border-emerald-400 text-emerald-700 hover:bg-emerald-50 hover:text-emerald-800 dark:border-emerald-600 dark:text-emerald-300 dark:hover:bg-emerald-950/40"
+            data-testid="birth-confirm"
+          >
+            <CheckIcon size={13} weight="bold" />
+            Confirm
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setMergeOpen(true)}
+            disabled={mutations.isPending}
+            className="h-7 gap-1"
+            data-testid="birth-merge"
+          >
+            Merge…
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => mutations.dismiss()}
+            disabled={mutations.isPending}
+            className="h-7 gap-1 text-muted-foreground hover:text-foreground"
+            data-testid="birth-dismiss"
+          >
+            <XIcon size={13} />
+            Dismiss
+          </Button>
+        </div>
+      </div>
+
+      {mutations.errorCopy ? (
+        <p className="px-3 pb-2 text-[11px] text-destructive">{mutations.errorCopy.message}</p>
+      ) : null}
+
+      <MergePickerDialog
+        open={mergeOpen}
+        onOpenChange={setMergeOpen}
+        row={row}
+        onPick={(entityId) => {
+          setMergeOpen(false);
+          mutations.mergeInto(entityId);
+        }}
+      />
+    </div>
+  );
+}
+
+/** Muted one-liner for the inspect Summary card (mirrors the drawer's activity line). */
+function inspectActivityLine(childTaskCount: number, fileCount: number): string {
+  const parts: string[] = [];
+  if (childTaskCount > 0) parts.push(`${childTaskCount} ${childTaskCount === 1 ? "task" : "tasks"} under it`);
+  if (fileCount > 0) parts.push(`${fileCount} linked ${fileCount === 1 ? "file" : "files"}`);
+  if (parts.length === 0) return "Not yet in your org.";
+  return `${parts.join(" · ")}. Not yet in your org.`;
+}
+
+/**
+ * Read-only inspect sheet for a birth row, styled to match {@link EntityDrawer}
+ * so a proposed entity reads like a real one: accent top-stripe header, avatar,
+ * serif name, and `font-mono` section labels in accent-tinted cards. Shows
+ * where the proposal came from + the tasks/files behind it, plus the same
+ * Confirm / Merge… / Dismiss actions. One column — a birth has no candidate to
+ * compare against, so the reconcile layout doesn't apply.
+ */
+function BirthInspectSheet({
+  reviewId,
+  onResolved,
+  onClose,
+}: {
+  reviewId: string | null;
+  onResolved: () => void;
+  onClose: () => void;
+}) {
+  const { data: detail, isLoading } = useQuery({
+    queryKey: reviewId ? detailKey(reviewId) : ["entity-review", "detail", "none"],
+    queryFn: () => api.entityReview.get(reviewId as string),
+    enabled: !!reviewId,
+  });
+  const row = detail?.row;
+  const evidence: EntityReviewEvidenceRow[] = detail?.evidence ?? [];
+  const childTasks: ChildTask[] = detail?.childTasks ?? [];
+  const childTaskCount = detail?.childTaskCount ?? 0;
+
+  return (
+    <Sheet open={!!reviewId} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-[720px]">
+        <SheetTitle className="sr-only">{row ? `Review: ${row.proposed_name}` : "Review"}</SheetTitle>
+        <SheetDescription className="sr-only">
+          Inspect where this proposed entity came from and which tasks and files are linked to it.
+        </SheetDescription>
+        {isLoading ? (
+          <div className="space-y-4 p-6">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : !row ? (
+          <div className="p-6 text-sm text-muted-foreground">Review row not found.</div>
+        ) : (
+          <BirthInspectBody
+            key={row.id}
+            row={row}
+            evidence={evidence}
+            childTasks={childTasks}
+            childTaskCount={childTaskCount}
+            onResolved={() => {
+              onResolved();
+              onClose();
+            }}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function BirthInspectBody({
+  row,
+  evidence,
+  childTasks,
+  childTaskCount,
+  onResolved,
+}: {
+  row: EntityReviewQueueRow;
+  evidence: EntityReviewEvidenceRow[];
+  childTasks: ChildTask[];
+  childTaskCount: number;
+  onResolved: () => void;
+}) {
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const [name, setName] = useState(row.proposed_name);
+  const mutations = useReviewMutations(row, onResolved);
+  const origin = birthOrigin(row);
+  const trimmedName = name.trim();
+  const nameOverride = trimmedName && trimmedName !== row.proposed_name ? trimmedName : undefined;
+  const identity = { id: row.id, name: row.proposed_name, sourceType: row.entity_type };
+  const accent = entityAccent(identity);
+
+  return (
+    <>
+      <div
+        className="sticky top-0 z-10 border-b bg-background px-6 pb-4 pt-5"
+        style={{ borderTopColor: accent, borderTopWidth: 3 }}
+      >
+        <div className="flex items-start gap-3">
+          <EntityAvatar entity={identity} size="lg" />
+          <div className="min-w-0 flex-1">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={mutations.isPending}
+              aria-label="Name"
+              placeholder="Name"
+              className="w-full rounded-sm bg-transparent font-serif text-[20px] leading-tight outline-none placeholder:text-muted-foreground/40 focus:bg-muted/40"
+              data-testid="birth-name-input"
+            />
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+              <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
+                {humanSourceType(row.entity_type)}
+              </Badge>
+              <OriginChip row={row} />
+              <Badge variant="secondary" className="text-[10px]">
+                new
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-4">
+        <SectionCard accent={accent} label="Summary">
+          <div className="space-y-1 text-sm leading-snug">
+            <p>
+              New {humanSourceType(row.entity_type).toLowerCase()}
+              {origin ? ` from ${origin.label}` : ""}.
+            </p>
+            <p className="text-muted-foreground">{inspectActivityLine(childTaskCount, evidence.length)}</p>
+          </div>
+        </SectionCard>
+
+        {childTaskCount > 0 ? (
+          <div className="flex flex-col">
+            <SectionLabel className="mb-1.5 font-medium">Tasks under this ({childTaskCount})</SectionLabel>
+            <EntryList>
+              {childTasks.map((t) => (
+                <li key={t.indexedFileId}>
+                  <div className="flex w-full items-center gap-2 px-3 py-2">
+                    <SourceTag>{t.source}</SourceTag>
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium">{t.name}</span>
+                    {t.providerUrl ? (
+                      <a
+                        href={t.providerUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 text-muted-foreground hover:text-foreground"
+                      >
+                        <ArrowSquareOutIcon size={12} />
+                      </a>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+              {childTaskCount > childTasks.length ? (
+                <li className="px-3 py-2 text-[10px] text-muted-foreground">
+                  + {childTaskCount - childTasks.length} more
+                </li>
+              ) : null}
+            </EntryList>
+          </div>
+        ) : null}
+
+        {evidence.length > 0 || childTaskCount === 0 ? (
+          <div className="flex flex-col">
+            <SectionLabel className="mb-1.5 font-medium">Linked files ({evidence.length})</SectionLabel>
+            {evidence.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                {origin?.kind === "tracker"
+                  ? "Pulled from the connector's structure — no document evidence."
+                  : "No linked files."}
+              </p>
+            ) : (
+              <EntryList>
+                {evidence.map((e) => (
+                  <li key={e.id}>
+                    <div className="flex w-full flex-col gap-1 px-3 py-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <SourceTag>{e.source}</SourceTag>
+                          <span className="truncate text-sm font-medium">{e.file.name}</span>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <span className="text-[10px] text-muted-foreground">{formatRelativeTime(e.seen_at)}</span>
+                          {e.file.providerUrl ? (
+                            <a
+                              href={e.file.providerUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-muted-foreground hover:text-foreground"
+                            >
+                              <ArrowSquareOutIcon size={12} />
+                            </a>
+                          ) : null}
+                        </div>
+                      </div>
+                      {e.file.sourcePath ? (
+                        <p className="line-clamp-2 text-[11px] text-muted-foreground">{e.file.sourcePath}</p>
+                      ) : null}
+                    </div>
+                  </li>
+                ))}
+              </EntryList>
+            )}
+          </div>
+        ) : null}
+
+        {mutations.errorCopy ? <p className="text-xs text-destructive">{mutations.errorCopy.message}</p> : null}
+      </div>
+
+      <div className="flex items-center gap-2 border-t bg-background px-6 py-3">
+        <Button
+          size="sm"
+          onClick={() => mutations.confirm({ nameOverride })}
+          disabled={mutations.isPending || trimmedName.length === 0}
+          className="h-7 gap-1 bg-emerald-600 text-[11px] text-white hover:bg-emerald-700"
+          data-testid="birth-inspect-confirm"
+        >
+          <CheckIcon size={12} weight="bold" />
+          Confirm new
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setMergeOpen(true)}
+          disabled={mutations.isPending}
+          className="h-7 gap-1 text-[11px]"
+          data-testid="birth-inspect-merge"
+        >
+          Merge…
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => mutations.dismiss()}
+          disabled={mutations.isPending}
+          className="ml-auto h-7 gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+          data-testid="birth-inspect-dismiss"
+        >
+          <XIcon size={12} />
+          Dismiss
+        </Button>
+      </div>
+
+      <MergePickerDialog
+        open={mergeOpen}
+        onOpenChange={setMergeOpen}
+        row={row}
+        onPick={(entityId) => {
+          setMergeOpen(false);
+          mutations.mergeInto(entityId);
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * Search-only picker for the birth-row "Merge…" escape hatch. Wraps the shared
+ * {@link EntityPicker} scoped to the row's type. Deliberately NOT the full
+ * reconcile sheet — a birth merge only needs a target, no evidence compare.
+ */
+function MergePickerDialog({
+  open,
+  onOpenChange,
+  row,
+  onPick,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  row: EntityReviewQueueRow;
+  onPick: (entityId: string) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-base">Merge "{row.proposed_name}" into…</DialogTitle>
+          <DialogDescription>
+            Pick an existing {humanSourceType(row.entity_type).toLowerCase()} this is a duplicate of. No new entity is
+            created.
+          </DialogDescription>
+        </DialogHeader>
+        <EntityPicker entityType={row.entity_type} onPick={onPick} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * "Ghost" row representing a pending entity_review_queue row. Subtle styling
+ * (amber tint + Under-review label). Click opens the reconcile drawer.
+ */
+export function GhostReviewRow({ row, onSelect }: { row: EntityReviewQueueRow; onSelect: (id: string) => void }) {
+  const isPerson = row.entity_type === "person";
+  return (
+    <div className="border-b border-border last:border-b-0" data-testid={`review-row-${row.id}`}>
+      <button
+        type="button"
+        onClick={() => onSelect(row.id)}
+        className="flex w-full cursor-pointer items-center gap-3 bg-amber-50/40 px-3 py-2.5 text-left text-sm hover:bg-amber-50 dark:bg-amber-950/20 dark:hover:bg-amber-950/30"
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          {isPerson ? (
+            <UserIcon size={14} className="shrink-0 text-muted-foreground" />
+          ) : (
+            <CubeIcon size={14} className="shrink-0 text-muted-foreground" />
+          )}
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">{row.proposed_name}</p>
+            <p className="truncate text-[11px] text-muted-foreground">
+              <span className="font-medium text-amber-700 dark:text-amber-400">Under review</span>
+              {row.candidate?.name ? <> · suggests {row.candidate.name}</> : <> · no suggested match</>}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex w-32 items-center justify-center gap-1.5">
+          <Badge variant="outline" className="text-[10px]">
+            {humanSourceType(row.entity_type)}
+          </Badge>
+        </div>
+
+        <span className="w-16 text-center font-mono text-xs text-muted-foreground">
+          {row.evidenceCount > 0 ? row.evidenceCount : "-"}
+        </span>
+
+        <div className="flex w-20 items-center justify-center gap-1">
+          <Badge
+            variant="outline"
+            className="border-amber-300 text-[10px] text-amber-700 dark:border-amber-700 dark:text-amber-400"
+          >
+            review
+          </Badge>
+        </div>
+
+        <div className="w-24 text-right">
+          <span className="text-xs text-muted-foreground">{formatRelativeTime(row.last_seen_at)}</span>
+        </div>
+      </button>
+    </div>
+  );
+}
+
+export function ReviewDetailSheet({ reviewId, onClose }: { reviewId: string | null; onClose: () => void }) {
+  const { data: detail, isLoading } = useQuery({
+    queryKey: reviewId ? detailKey(reviewId) : ["entity-review", "detail", "none"],
+    queryFn: () => api.entityReview.get(reviewId as string),
+    enabled: !!reviewId,
+  });
+
+  const row = detail?.row;
+  const evidence: EntityReviewEvidenceRow[] = detail?.evidence ?? [];
+
+  return (
+    <Sheet open={!!reviewId} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="flex w-full flex-col sm:max-w-3xl">
+        <SheetHeader>
+          <SheetTitle className="text-base">
+            {isLoading ? "Loading..." : row ? `Reconcile: ${row.proposed_name}` : "Review"}
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            Compare the proposed entity against suggested existing matches, then confirm or reject the reconciliation.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-3">
+          {isLoading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-40 rounded-lg" />
+            </div>
+          ) : !row ? (
+            <p className="text-sm text-muted-foreground">Review row not found.</p>
+          ) : (
+            <ReconcileBody key={row.id} row={row} evidence={evidence} onClose={onClose} />
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ReconcileBody({
+  row,
+  evidence,
+  onClose,
+}: {
+  row: EntityReviewQueueRow;
+  evidence: EntityReviewEvidenceRow[];
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  // Initial mode: chooser for orphans (nothing to confirm), candidate otherwise.
+  const hasOriginalCandidate = !!row.candidate_entity_id;
+  const [mode, setMode] = useState<"candidate" | "chooser">(hasOriginalCandidate ? "candidate" : "chooser");
+  // When set, the candidate card previews a picked entity instead of the row's default suggestion.
+  const [pickedEntityId, setPickedEntityId] = useState<string | null>(null);
+
+  const mutations = useReviewMutations(row, () => {
+    queryClient.invalidateQueries({ queryKey: ["entities"] });
+    queryClient.invalidateQueries({ queryKey: ["entity-review"] });
+    onClose();
+  });
+
+  const activeCandidateId = mode === "candidate" ? (pickedEntityId ?? row.candidate_entity_id ?? null) : null;
+
+  const { data: candidateEntity } = useQuery({
+    queryKey: ["entity-detail", activeCandidateId],
+    queryFn: () => api.entities.get(activeCandidateId as string),
+    enabled: !!activeCandidateId,
+  });
+
+  const { data: candidateMentionsData } = useQuery({
+    queryKey: ["entity-mentions", activeCandidateId, { limit: 20 }],
+    queryFn: () => api.entities.mentions(activeCandidateId as string, { limit: 20 }),
+    enabled: !!activeCandidateId,
+  });
+
+  const candidate = candidateEntity?.entity ?? null;
+  const candidateMentions = candidateMentionsData?.mentions ?? [];
+  const isPickedPreview = pickedEntityId !== null;
+
+  return (
+    <div className="grid min-h-0 flex-1 auto-rows-fr grid-cols-1 gap-3 md:grid-cols-2">
+      <ReconcileColumn
+        title="Proposed"
+        toneClass="border-amber-400 bg-amber-50/40 dark:border-amber-400/60 dark:bg-amber-950/20"
+        name={row.proposed_name}
+        typeLabel={humanSourceType(row.entity_type)}
+        email={row.proposed_email}
+        evidence={evidence}
+      />
+      {mode === "candidate" ? (
+        <CandidateView
+          row={row}
+          candidateEntity={candidate}
+          candidateMentions={candidateMentions}
+          isPickedPreview={isPickedPreview}
+          isPending={mutations.isPending}
+          errorMessage={mutations.errorCopy?.message ?? null}
+          onConfirm={() => {
+            if (pickedEntityId) mutations.mergeInto(pickedEntityId);
+            else mutations.confirm();
+          }}
+          onReject={() => {
+            mutations.clearError();
+            setMode("chooser");
+          }}
+        />
+      ) : (
+        <ChooserView
+          row={row}
+          isPending={mutations.isPending}
+          errorMessage={mutations.errorCopy?.message ?? null}
+          canBackToCandidate={hasOriginalCandidate && !isPickedPreview}
+          onBack={() => {
+            mutations.clearError();
+            setMode("candidate");
+          }}
+          onPick={(entityId) => {
+            mutations.clearError();
+            setPickedEntityId(entityId);
+            setMode("candidate");
+          }}
+          onCreateNew={() => mutations.reject()}
+        />
+      )}
+    </div>
+  );
+}
+
+function ReconcileColumn({
+  title,
+  toneClass,
+  name,
+  typeLabel,
+  email,
+  evidence,
+}: {
+  title: string;
+  toneClass: string;
+  name: string;
+  typeLabel: string;
+  email: string | null;
+  evidence: EntityReviewEvidenceRow[];
+}) {
+  return (
+    <div className={`flex min-h-0 flex-col rounded-lg border ${toneClass}`} data-testid="reconcile-proposed">
+      <div className="border-b border-current/10 px-3 py-2">
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">{title}</p>
+        <p className="mt-0.5 truncate text-sm font-semibold">{name}</p>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className="text-[10px]">
+            {typeLabel}
+          </Badge>
+          {email ? <span className="text-[11px] text-muted-foreground">{email}</span> : null}
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col px-3 py-2">
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          Evidence ({evidence.length})
+        </p>
+        {evidence.length === 0 ? (
+          <p className="mt-1 text-xs text-muted-foreground">No evidence rows.</p>
+        ) : (
+          <ul className="mt-1 flex-1 space-y-1 overflow-y-auto">
+            {evidence.map((e) => (
+              <li key={e.id} className="rounded-md border border-border bg-background p-2 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Badge variant="outline" className="shrink-0 text-[9px]">
+                      {e.source}
+                    </Badge>
+                    <span className="truncate font-medium">{e.file.name}</span>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <span className="text-[10px] text-muted-foreground">{formatRelativeTime(e.seen_at)}</span>
+                    {e.file.providerUrl ? (
+                      <a
+                        href={e.file.providerUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-muted-foreground hover:text-foreground"
+                      >
+                        <ArrowSquareOutIcon size={12} />
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+                {e.file.sourcePath ? (
+                  <p className="mt-1 text-[10px] text-muted-foreground/60">{e.file.sourcePath}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Right column when the reconcile body is showing a candidate (the original
+ * suggestion OR a picked one). Header carries the candidate name + ✓/✗
+ * icon-buttons; body shows recent mentions.
+ *
+ * When `isPickedPreview` is true the column is tinted emerald and the title
+ * reads "PICKED — CONFIRM TO MERGE" so the user knows the ✓ will merge into
+ * the picked target instead of the row's original suggestion.
+ */
+function CandidateView({
+  row,
+  candidateEntity,
+  candidateMentions,
+  isPickedPreview,
+  isPending,
+  errorMessage,
+  onConfirm,
+  onReject,
+}: {
+  row: EntityReviewQueueRow;
+  candidateEntity: EntityListItem | null;
+  candidateMentions: EntityMention[];
+  isPickedPreview: boolean;
+  isPending: boolean;
+  errorMessage: string | null;
+  onConfirm: () => void;
+  onReject: () => void;
+}) {
+  const sectionTitle = isPickedPreview ? "Picked — confirm to merge" : "Suggested existing";
+  const email = entityEmail(candidateEntity) ?? (isPickedPreview ? null : row.candidate?.email);
+  return (
+    <div
+      className={`flex min-h-0 flex-col rounded-lg border bg-muted/20 ${
+        isPickedPreview ? "border-emerald-400 dark:border-emerald-600" : "border-border"
+      }`}
+      data-testid="reconcile-candidate"
+    >
+      <div className="flex items-start justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="min-w-0">
+          <p
+            className={`text-[10px] font-medium uppercase tracking-wider ${
+              isPickedPreview ? "text-emerald-700 dark:text-emerald-400" : "text-muted-foreground"
+            }`}
+          >
+            {sectionTitle}
+          </p>
+          <p className="mt-0.5 truncate text-sm font-semibold">{candidateEntity?.name ?? row.candidate?.name ?? "…"}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            {candidateEntity ? (
+              <Badge variant="outline" className="text-[10px]">
+                {humanSourceType(candidateEntity.sourceType)}
+              </Badge>
+            ) : null}
+            {email ? <span className="text-[11px] text-muted-foreground">{email}</span> : null}
+            {row.candidate_reason && !isPickedPreview ? (
+              <span className="text-[11px] text-muted-foreground">· {row.candidate_reason}</span>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            aria-label="Confirm merge"
+            data-testid="confirm-merge"
+            className="rounded-md border border-emerald-400 bg-emerald-50 p-1.5 text-emerald-700 hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/70"
+          >
+            <CheckIcon size={14} weight="bold" />
+          </button>
+          <button
+            type="button"
+            onClick={onReject}
+            disabled={isPending}
+            aria-label="Reject this match"
+            data-testid="reject-match"
+            className="rounded-md border border-foreground/25 bg-background p-1.5 text-foreground/80 hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <XIcon size={14} weight="bold" />
+          </button>
+        </div>
+      </div>
+      {errorMessage ? (
+        <div className="border-b border-border px-3 py-2 text-xs text-destructive">{errorMessage}</div>
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col px-3 py-2">
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          Recent mentions ({candidateMentions.length})
+        </p>
+        {candidateMentions.length === 0 ? (
+          <p className="mt-1 text-xs text-muted-foreground">No mentions yet.</p>
+        ) : (
+          <ul className="mt-1 flex-1 space-y-1 overflow-y-auto">
+            {candidateMentions.map((m) => (
+              <li key={m.id} className="rounded-md border border-border bg-background p-2 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Badge variant="outline" className="shrink-0 text-[9px]">
+                      {m.file.source}
+                    </Badge>
+                    <span className="truncate font-medium">{m.file.fileName}</span>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <span className="text-[10px] text-muted-foreground">{formatRelativeTime(m.sourceDate)}</span>
+                    {m.file.providerUrl ? (
+                      <a
+                        href={m.file.providerUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-muted-foreground hover:text-foreground"
+                      >
+                        <ArrowSquareOutIcon size={12} />
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+                {m.file.sourcePath ? (
+                  <p className="mt-1 text-[10px] text-muted-foreground/60">{m.file.sourcePath}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Right column when the reconcile body is in chooser mode — either because
+ * the row is an orphan (no original candidate) or the user clicked ✗ on a
+ * candidate. Shows a search box for picking an existing entity + a
+ * "Create as new" fallback button.
+ *
+ * When the row HAS an original candidate to return to, a back arrow next
+ * to the title brings the user back to the candidate view.
+ */
+function ChooserView({
+  row,
+  isPending,
+  errorMessage,
+  canBackToCandidate,
+  onBack,
+  onPick,
+  onCreateNew,
+}: {
+  row: EntityReviewQueueRow;
+  isPending: boolean;
+  errorMessage: string | null;
+  canBackToCandidate: boolean;
+  onBack: () => void;
+  onPick: (entityId: string) => void;
+  onCreateNew: () => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-col rounded-lg border border-border" data-testid="reconcile-candidate">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        {canBackToCandidate ? (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back to suggested candidate"
+            className="rounded-md p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <ArrowLeftIcon size={14} />
+          </button>
+        ) : null}
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">What instead?</p>
+      </div>
+      {errorMessage ? (
+        <div className="border-b border-border px-3 py-2 text-xs text-destructive">{errorMessage}</div>
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col gap-3 px-3 py-3">
+        <div>
+          <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Search for a match</p>
+          <div className="mt-2">
+            <EntityPicker
+              entityType={row.entity_type}
+              excludeEntityId={row.candidate_entity_id ?? undefined}
+              onPick={onPick}
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-px flex-1 bg-border" />
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">or</span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onCreateNew}
+          disabled={isPending}
+          className="gap-1.5"
+          data-testid="create-new"
+        >
+          <PlusIcon size={14} />
+          Create as new {row.entity_type}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/review-actions.tsx
+++ b/packages/web/src/components/review-actions.tsx
@@ -33,8 +33,8 @@ export const countKey = (search?: string) => ["entity-review", "count", search ?
 export const detailKey = (id: string) => ["entity-review", "detail", id] as const;
 
 export interface ResolveResult {
-  kind: "confirmed" | "rejected";
-  targetEntityId: string;
+  kind: "confirmed" | "rejected" | "dismissed";
+  targetEntityId: string | null;
 }
 
 export interface ResolveCopy {
@@ -88,12 +88,17 @@ function copyForError(err: unknown): ResolveCopy {
  * resolve path needs.
  */
 export interface UseReviewMutationsResult {
-  /** Confirm the row's default suggested candidate. No-op if the row has no candidate. */
-  confirm: () => void;
+  /**
+   * Confirm the row. For a birth (no candidate) this creates the entity from
+   * its seed; pass `nameOverride` to create it under a different name.
+   */
+  confirm: (opts?: { nameOverride?: string }) => void;
   /** Reject the proposal — server creates a brand-new entity. */
   reject: () => void;
   /** Confirm with a host-picked target entity (overrides the row's suggested candidate). */
   mergeInto: (entityId: string) => void;
+  /** Drop a pending birth row without creating an entity; suppresses re-proposal. */
+  dismiss: () => void;
   isPending: boolean;
   errorCopy: ResolveCopy | null;
   clearError: () => void;
@@ -140,10 +145,11 @@ export function useReviewMutations(
   };
 
   const confirmMutation = useMutation({
-    mutationFn: (input: { mergeIntoEntityId?: string }) =>
+    mutationFn: (input: { mergeIntoEntityId?: string; nameOverride?: string }) =>
       api.entityReview.confirm(row.id, {
         candidateGeneratedAt,
         ...(input.mergeIntoEntityId ? { mergeIntoEntityId: input.mergeIntoEntityId } : {}),
+        ...(input.nameOverride ? { nameOverride: input.nameOverride } : {}),
       }),
     onMutate,
     onError,
@@ -163,11 +169,22 @@ export function useReviewMutations(
     },
   });
 
+  const dismissMutation = useMutation({
+    mutationFn: (_: undefined) => api.entityReview.dismiss(row.id, { candidateGeneratedAt }),
+    onMutate,
+    onError,
+    onSuccess: () => {
+      onSuccessCommon();
+      onResolved?.({ kind: "dismissed", targetEntityId: null });
+    },
+  });
+
   return {
-    confirm: () => confirmMutation.mutate({}),
+    confirm: (opts?: { nameOverride?: string }) => confirmMutation.mutate({ nameOverride: opts?.nameOverride }),
     reject: () => rejectMutation.mutate(undefined),
     mergeInto: (entityId: string) => confirmMutation.mutate({ mergeIntoEntityId: entityId }),
-    isPending: confirmMutation.isPending || rejectMutation.isPending,
+    dismiss: () => dismissMutation.mutate(undefined),
+    isPending: confirmMutation.isPending || rejectMutation.isPending || dismissMutation.isPending,
     errorCopy,
     clearError: () => setErrorCopy(null),
   };

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -261,10 +261,16 @@ export interface EntityReviewQueueRow {
   candidate_score: number | null;
   candidate_reason: string | null;
   candidate_generated_at: string | null;
+  /** LLM-extraction origin (e.g. "fireflies"); null for structural seeds. */
+  source: string | null;
+  source_id: string | null;
+  /** Structural-seed origin (e.g. "clickup"); null for LLM extractions. */
+  seed_source: string | null;
+  seed_source_id: string | null;
   first_seen_at: string;
   last_seen_at: string;
   occurrence_count: number;
-  status: "pending" | "confirmed" | "rejected" | "confirming";
+  status: "pending" | "confirmed" | "rejected" | "confirming" | "dismissed";
   triggered_by_user_id: string;
   review_started_at: string | null;
   review_started_by: string | null;
@@ -312,9 +318,30 @@ export interface EntityReviewListResponse {
   total: number;
 }
 
+/** A product on the curated closed list (declared or human_confirmed). */
+export interface CuratedProduct {
+  id: string;
+  name: string;
+  aliases: string[];
+  hotness: number;
+  provenance_tier: string;
+}
+
+/** A tracker task/issue under a seed's parent project/team (review preview). */
+export interface ChildTask {
+  indexedFileId: string;
+  name: string;
+  fileType: string | null;
+  providerUrl: string | null;
+  source: string;
+}
+
 export interface EntityReviewDetailResponse {
   row: EntityReviewQueueRow;
   evidence: EntityReviewEvidenceRow[];
+  /** Present only for structural-seed rows: tasks under the parent. */
+  childTasks?: ChildTask[];
+  childTaskCount?: number;
 }
 
 export interface EntityReviewConfirmResult {
@@ -330,6 +357,11 @@ export interface EntityReviewRejectResult {
   targetEntityId: string;
   reResolvedToExisting: boolean;
   createdEntityId: string | null;
+  idempotent: boolean;
+}
+
+export interface EntityReviewDismissResult {
+  row: EntityReviewQueueRow;
   idempotent: boolean;
 }
 
@@ -2530,21 +2562,33 @@ export const api = {
       return request<{ containers: BindableContainer[] }>("/api/projects/bindable-containers");
     },
   },
+  products: {
+    list() {
+      return request<{ products: CuratedProduct[] }>("/api/products");
+    },
+    create(body: { name: string; aliases?: string[] }) {
+      return request<{ entity: CuratedProduct }>("/api/products", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    },
+  },
   entityReview: {
-    list(opts?: { limit?: number; offset?: number; search?: string }) {
+    list(opts?: { limit?: number; offset?: number; search?: string; types?: string[] }) {
       const params = new URLSearchParams();
       // `limit=0` is a meaningful value (count-only mode) — send it explicitly.
       if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
       if (opts?.offset) params.set("offset", String(opts.offset));
       const search = opts?.search?.trim();
       if (search) params.set("q", search);
+      if (opts?.types && opts.types.length > 0) params.set("types", opts.types.join(","));
       const qs = params.toString();
       return request<EntityReviewListResponse>(`/api/entity-review${qs ? `?${qs}` : ""}`);
     },
     get(id: string) {
       return request<EntityReviewDetailResponse>(`/api/entity-review/${id}`);
     },
-    confirm(id: string, body: { candidateGeneratedAt: string; mergeIntoEntityId?: string }) {
+    confirm(id: string, body: { candidateGeneratedAt: string; mergeIntoEntityId?: string; nameOverride?: string }) {
       return request<EntityReviewConfirmResult>(`/api/entity-review/${id}/confirm`, {
         method: "POST",
         body: JSON.stringify(body),
@@ -2552,6 +2596,12 @@ export const api = {
     },
     reject(id: string, body: { candidateGeneratedAt: string; rejectAgainstEntityId?: string }) {
       return request<EntityReviewRejectResult>(`/api/entity-review/${id}/reject`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    },
+    dismiss(id: string, body: { candidateGeneratedAt: string }) {
+      return request<EntityReviewDismissResult>(`/api/entity-review/${id}/dismiss`, {
         method: "POST",
         body: JSON.stringify(body),
       });

--- a/packages/web/src/routes/files/entity-explorer.tsx
+++ b/packages/web/src/routes/files/entity-explorer.tsx
@@ -11,12 +11,14 @@ import { ConnectorLogo } from "@/components/connector-logos";
  * column to a "What instead?" chooser (search + create-as-new). Orphan
  * rows (no suggested candidate) open directly in chooser mode.
  */
-import { EntityPicker } from "@/components/entity-picker";
+import { AddEntityDialog } from "@/components/entity-review/add-entity-dialog";
+import { humanSourceType } from "@/components/entity-review/entity-format";
+import { GhostReviewRow, ReviewDetailSheet } from "@/components/entity-review/review-band";
 import { GraphRebuildDialog, type GraphRebuildDialogPrefill } from "@/components/graph-rebuild-dialog";
 import { RebuildBanner } from "@/components/rebuild-banner";
-import { countKey, detailKey, listKey, useReviewMutations } from "@/components/review-actions";
+import { countKey, listKey } from "@/components/review-actions";
 import { useRebuildJob } from "@/hooks/use-rebuild-job";
-import type { EntityListItem, EntityMention, EntityReviewEvidenceRow, EntityReviewQueueRow } from "@/lib/api";
+import type { EntityListItem, EntityReviewQueueRow } from "@/lib/api";
 import { api } from "@/lib/api";
 import { useEntityUi } from "@/lib/entity-ui";
 import {
@@ -60,24 +62,6 @@ const TYPE_GROUPS: { label: string; types: string[] }[] = [
   { label: "Pages", types: ["notion_page"] },
 ];
 
-function humanSourceType(sourceType: string): string {
-  const map: Record<string, string> = {
-    clickup_space: "Space",
-    clickup_folder: "Folder",
-    clickup_workspace: "Workspace",
-    linear_project: "Project",
-    notion_database: "Database",
-    notion_page: "Page",
-    person: "Person",
-    project: "Project",
-    company: "Company",
-    product: "Product",
-    team: "Team",
-    other: "Other",
-  };
-  return map[sourceType] ?? sourceType;
-}
-
 /** Derive the connector source from entity sourceType (e.g., "clickup_space" → "clickup"). */
 function sourceFromType(sourceType: string): string | null {
   if (sourceType.startsWith("clickup_")) return "clickup";
@@ -85,11 +69,6 @@ function sourceFromType(sourceType: string): string | null {
   if (sourceType.startsWith("linear_")) return "linear";
   if (sourceType.startsWith("google_drive")) return "google_drive";
   return null;
-}
-
-function entityEmail(entity: EntityListItem | null): string | null {
-  const value = entity?.metadata?.email;
-  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function entityContext(entity: EntityListItem): string | null {
@@ -125,25 +104,11 @@ export function EntityExplorer() {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showRebuildDialog, setShowRebuildDialog] = useState(false);
   const [rebuildPrefill, setRebuildPrefill] = useState<GraphRebuildDialogPrefill | null>(null);
-  const [newName, setNewName] = useState("");
-  const [newType, setNewType] = useState("company");
 
   const rebuildState = useRebuildJob({ enabled: isAdmin });
   const overlayRebuilding =
     rebuildState.activeJob !== null &&
     (rebuildState.activeJob.job.phase === "resetting" || rebuildState.activeJob.job.phase === "wiping");
-
-  const createMutation = useMutation({
-    mutationFn: () => api.entities.create({ name: newName.trim(), sourceType: newType }),
-    onSuccess: () => {
-      toast.success(`Entity "${newName.trim()}" created.`);
-      setShowAddDialog(false);
-      setNewName("");
-      setNewType("company");
-      queryClient.invalidateQueries({ queryKey: ["entities"] });
-    },
-    onError: (err: Error) => toast.error(err.message),
-  });
 
   const cleanupMutation = useMutation({
     mutationFn: () => api.entities.deleteTentative(),
@@ -191,19 +156,26 @@ export function EntityExplorer() {
   const total = data?.total ?? 0;
   const tentativeCount = entities.filter((e) => e.status === "tentative").length;
 
+  // When the experimental Your Org surface is live it owns the org-taxonomy
+  // spine (product/project/team), so this band narrows to person/company to
+  // avoid a row appearing in two places. Flag off → unchanged (all types here).
+  const { data: setupStatus } = useQuery({ queryKey: ["setup", "status"], queryFn: () => api.setup.status() });
+  const reviewTypes = setupStatus?.experimentalFlag ? ["person", "company"] : undefined;
+  const reviewScope = reviewTypes?.join(",") ?? "all";
+
   // ECR-03B inline review surface — two-stage fetch:
   // the cheap count probe gates the (heavier) list query.
   const { data: reviewCount } = useQuery({
-    queryKey: countKey(debouncedSearch),
-    queryFn: () => api.entityReview.list({ limit: 0, search: debouncedSearch || undefined }),
+    queryKey: [...countKey(debouncedSearch), reviewScope],
+    queryFn: () => api.entityReview.list({ limit: 0, search: debouncedSearch || undefined, types: reviewTypes }),
     refetchInterval: 30000,
   });
   const reviewTotal = reviewCount?.total ?? 0;
   const hasPendingReviews = reviewTotal > 0;
 
   const { data: reviewList } = useQuery({
-    queryKey: listKey(debouncedSearch),
-    queryFn: () => api.entityReview.list({ limit: 200, search: debouncedSearch || undefined }),
+    queryKey: [...listKey(debouncedSearch), reviewScope],
+    queryFn: () => api.entityReview.list({ limit: 200, search: debouncedSearch || undefined, types: reviewTypes }),
     enabled: hasPendingReviews,
   });
 
@@ -388,47 +360,7 @@ export function EntityExplorer() {
         )}
       </div>
 
-      <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
-        <DialogContent className="sm:max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Add Entity</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-3">
-            <div>
-              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Name</p>
-              <Input
-                value={newName}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setNewName(e.target.value)}
-                className="mt-1 text-sm"
-                placeholder="e.g. CanvasX, Epik, Product Alpha"
-              />
-            </div>
-            <div>
-              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Type</p>
-              <div className="mt-1 flex flex-wrap gap-1.5">
-                {["company", "product", "client", "project", "team", "person"].map((t) => (
-                  <Button
-                    key={t}
-                    size="sm"
-                    variant={newType === t ? "default" : "outline"}
-                    className="h-7 text-xs"
-                    onClick={() => setNewType(t)}
-                  >
-                    {t}
-                  </Button>
-                ))}
-              </div>
-            </div>
-            <Button
-              className="w-full text-xs"
-              onClick={() => createMutation.mutate()}
-              disabled={createMutation.isPending || !newName.trim()}
-            >
-              {createMutation.isPending ? "Creating..." : "Create Entity"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <AddEntityDialog open={showAddDialog} onOpenChange={setShowAddDialog} defaultType="company" />
 
       <GraphRebuildDialog
         open={showRebuildDialog}
@@ -510,463 +442,6 @@ function EntityRow({ entity, onSelect }: { entity: EntityListItem; onSelect: (id
           </span>
         </div>
       </button>
-    </div>
-  );
-}
-
-/**
- * "Ghost" row representing a pending entity_review_queue row sitting at
- * the top of the entities table. Same columns as a real row, but with
- * subtle styling (dashed left border + amber tint + Under-review label).
- * Click opens the drawer in review mode.
- */
-function GhostReviewRow({ row, onSelect }: { row: EntityReviewQueueRow; onSelect: (id: string) => void }) {
-  const isPerson = row.entity_type === "person";
-  return (
-    <div className="border-b border-border last:border-b-0" data-testid={`review-row-${row.id}`}>
-      <button
-        type="button"
-        onClick={() => onSelect(row.id)}
-        className="flex w-full cursor-pointer items-center gap-3 bg-amber-50/40 px-3 py-2.5 text-left text-sm hover:bg-amber-50 dark:bg-amber-950/20 dark:hover:bg-amber-950/30"
-      >
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          {isPerson ? (
-            <UserIcon size={14} className="shrink-0 text-muted-foreground" />
-          ) : (
-            <CubeIcon size={14} className="shrink-0 text-muted-foreground" />
-          )}
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium">{row.proposed_name}</p>
-            <p className="truncate text-[11px] text-muted-foreground">
-              <span className="font-medium text-amber-700 dark:text-amber-400">Under review</span>
-              {row.candidate?.name ? <> · suggests {row.candidate.name}</> : <> · no suggested match</>}
-            </p>
-          </div>
-        </div>
-
-        <div className="flex w-32 items-center justify-center gap-1.5">
-          <Badge variant="outline" className="text-[10px]">
-            {humanSourceType(row.entity_type)}
-          </Badge>
-        </div>
-
-        <span className="w-16 text-center text-xs font-mono text-muted-foreground">
-          {row.evidenceCount > 0 ? row.evidenceCount : "-"}
-        </span>
-
-        <div className="flex w-20 items-center justify-center gap-1">
-          <Badge
-            variant="outline"
-            className="border-amber-300 text-[10px] text-amber-700 dark:border-amber-700 dark:text-amber-400"
-          >
-            review
-          </Badge>
-        </div>
-
-        <div className="w-24 text-right">
-          <span className="text-xs text-muted-foreground">{formatRelativeTime(row.last_seen_at)}</span>
-        </div>
-      </button>
-    </div>
-  );
-}
-
-function ReviewDetailSheet({ reviewId, onClose }: { reviewId: string | null; onClose: () => void }) {
-  const { data: detail, isLoading } = useQuery({
-    queryKey: reviewId ? detailKey(reviewId) : ["entity-review", "detail", "none"],
-    queryFn: () => api.entityReview.get(reviewId as string),
-    enabled: !!reviewId,
-  });
-
-  const row = detail?.row;
-  const evidence: EntityReviewEvidenceRow[] = detail?.evidence ?? [];
-
-  return (
-    <Sheet open={!!reviewId} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent side="right" className="flex w-full flex-col sm:max-w-3xl">
-        <SheetHeader>
-          <SheetTitle className="text-base">
-            {isLoading ? "Loading..." : row ? `Reconcile: ${row.proposed_name}` : "Review"}
-          </SheetTitle>
-          <SheetDescription className="sr-only">
-            Compare the proposed entity against suggested existing matches, then confirm or reject the reconciliation.
-          </SheetDescription>
-        </SheetHeader>
-        <div className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-3">
-          {isLoading ? (
-            <div className="space-y-4">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-40 rounded-lg" />
-            </div>
-          ) : !row ? (
-            <p className="text-sm text-muted-foreground">Review row not found.</p>
-          ) : (
-            <ReconcileBody key={row.id} row={row} evidence={evidence} onClose={onClose} />
-          )}
-        </div>
-      </SheetContent>
-    </Sheet>
-  );
-}
-
-function ReconcileBody({
-  row,
-  evidence,
-  onClose,
-}: {
-  row: EntityReviewQueueRow;
-  evidence: EntityReviewEvidenceRow[];
-  onClose: () => void;
-}) {
-  const queryClient = useQueryClient();
-  // Initial mode: chooser for orphans (nothing to confirm), candidate otherwise.
-  const hasOriginalCandidate = !!row.candidate_entity_id;
-  const [mode, setMode] = useState<"candidate" | "chooser">(hasOriginalCandidate ? "candidate" : "chooser");
-  // When set, the candidate card previews a picked entity instead of the row's default suggestion.
-  const [pickedEntityId, setPickedEntityId] = useState<string | null>(null);
-
-  const mutations = useReviewMutations(row, () => {
-    queryClient.invalidateQueries({ queryKey: ["entities"] });
-    onClose();
-  });
-
-  const activeCandidateId = mode === "candidate" ? (pickedEntityId ?? row.candidate_entity_id ?? null) : null;
-
-  const { data: candidateEntity } = useQuery({
-    queryKey: ["entity-detail", activeCandidateId],
-    queryFn: () => api.entities.get(activeCandidateId as string),
-    enabled: !!activeCandidateId,
-  });
-
-  const { data: candidateMentionsData } = useQuery({
-    queryKey: ["entity-mentions", activeCandidateId, { limit: 20 }],
-    queryFn: () => api.entities.mentions(activeCandidateId as string, { limit: 20 }),
-    enabled: !!activeCandidateId,
-  });
-
-  const candidate = candidateEntity?.entity ?? null;
-  const candidateMentions = candidateMentionsData?.mentions ?? [];
-  const isPickedPreview = pickedEntityId !== null;
-
-  return (
-    <div className="grid min-h-0 flex-1 auto-rows-fr grid-cols-1 gap-3 md:grid-cols-2">
-      <ReconcileColumn
-        title="Proposed"
-        toneClass="border-amber-400 bg-amber-50/40 dark:border-amber-400/60 dark:bg-amber-950/20"
-        name={row.proposed_name}
-        typeLabel={humanSourceType(row.entity_type)}
-        email={row.proposed_email}
-        evidence={evidence}
-      />
-      {mode === "candidate" ? (
-        <CandidateView
-          row={row}
-          candidateEntity={candidate}
-          candidateMentions={candidateMentions}
-          isPickedPreview={isPickedPreview}
-          isPending={mutations.isPending}
-          errorMessage={mutations.errorCopy?.message ?? null}
-          onConfirm={() => {
-            if (pickedEntityId) mutations.mergeInto(pickedEntityId);
-            else mutations.confirm();
-          }}
-          onReject={() => {
-            mutations.clearError();
-            setMode("chooser");
-          }}
-        />
-      ) : (
-        <ChooserView
-          row={row}
-          isPending={mutations.isPending}
-          errorMessage={mutations.errorCopy?.message ?? null}
-          canBackToCandidate={hasOriginalCandidate && !isPickedPreview}
-          onBack={() => {
-            mutations.clearError();
-            setMode("candidate");
-          }}
-          onPick={(entityId) => {
-            mutations.clearError();
-            setPickedEntityId(entityId);
-            setMode("candidate");
-          }}
-          onCreateNew={() => mutations.reject()}
-        />
-      )}
-    </div>
-  );
-}
-
-function ReconcileColumn({
-  title,
-  toneClass,
-  name,
-  typeLabel,
-  email,
-  evidence,
-}: {
-  title: string;
-  toneClass: string;
-  name: string;
-  typeLabel: string;
-  email: string | null;
-  evidence: EntityReviewEvidenceRow[];
-}) {
-  return (
-    <div className={`flex min-h-0 flex-col rounded-lg border ${toneClass}`} data-testid="reconcile-proposed">
-      <div className="border-b border-current/10 px-3 py-2">
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">{title}</p>
-        <p className="mt-0.5 truncate text-sm font-semibold">{name}</p>
-        <div className="mt-1 flex flex-wrap items-center gap-1.5">
-          <Badge variant="outline" className="text-[10px]">
-            {typeLabel}
-          </Badge>
-          {email ? <span className="text-[11px] text-muted-foreground">{email}</span> : null}
-        </div>
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col px-3 py-2">
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Evidence ({evidence.length})
-        </p>
-        {evidence.length === 0 ? (
-          <p className="mt-1 text-xs text-muted-foreground">No evidence rows.</p>
-        ) : (
-          <ul className="mt-1 flex-1 space-y-1 overflow-y-auto">
-            {evidence.map((e) => (
-              <li key={e.id} className="rounded-md border border-border bg-background p-2 text-xs">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <Badge variant="outline" className="shrink-0 text-[9px]">
-                      {e.source}
-                    </Badge>
-                    <span className="truncate font-medium">{e.file.name}</span>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    <span className="text-[10px] text-muted-foreground">{formatRelativeTime(e.seen_at)}</span>
-                    {e.file.providerUrl ? (
-                      <a
-                        href={e.file.providerUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-muted-foreground hover:text-foreground"
-                      >
-                        <ArrowSquareOutIcon size={12} />
-                      </a>
-                    ) : null}
-                  </div>
-                </div>
-                {e.file.sourcePath ? (
-                  <p className="mt-1 text-[10px] text-muted-foreground/60">{e.file.sourcePath}</p>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Right column when the reconcile body is showing a candidate (the original
- * suggestion OR a picked one). Header carries the candidate name + ✓/✗
- * icon-buttons; body shows recent mentions.
- *
- * When `isPickedPreview` is true the column is tinted emerald and the title
- * reads "PICKED — CONFIRM TO MERGE" so the user knows the ✓ will merge into
- * the picked target instead of the row's original suggestion.
- */
-function CandidateView({
-  row,
-  candidateEntity,
-  candidateMentions,
-  isPickedPreview,
-  isPending,
-  errorMessage,
-  onConfirm,
-  onReject,
-}: {
-  row: EntityReviewQueueRow;
-  candidateEntity: EntityListItem | null;
-  candidateMentions: EntityMention[];
-  isPickedPreview: boolean;
-  isPending: boolean;
-  errorMessage: string | null;
-  onConfirm: () => void;
-  onReject: () => void;
-}) {
-  const sectionTitle = isPickedPreview ? "Picked — confirm to merge" : "Suggested existing";
-  const email = entityEmail(candidateEntity) ?? (isPickedPreview ? null : row.candidate?.email);
-  return (
-    <div
-      className={`flex min-h-0 flex-col rounded-lg border bg-muted/20 ${
-        isPickedPreview ? "border-emerald-400 dark:border-emerald-600" : "border-border"
-      }`}
-      data-testid="reconcile-candidate"
-    >
-      <div className="flex items-start justify-between gap-2 border-b border-border px-3 py-2">
-        <div className="min-w-0">
-          <p
-            className={`text-[10px] font-medium uppercase tracking-wider ${
-              isPickedPreview ? "text-emerald-700 dark:text-emerald-400" : "text-muted-foreground"
-            }`}
-          >
-            {sectionTitle}
-          </p>
-          <p className="mt-0.5 truncate text-sm font-semibold">{candidateEntity?.name ?? row.candidate?.name ?? "…"}</p>
-          <div className="mt-1 flex flex-wrap items-center gap-1.5">
-            {candidateEntity ? (
-              <Badge variant="outline" className="text-[10px]">
-                {humanSourceType(candidateEntity.sourceType)}
-              </Badge>
-            ) : null}
-            {email ? <span className="text-[11px] text-muted-foreground">{email}</span> : null}
-            {row.candidate_reason && !isPickedPreview ? (
-              <span className="text-[11px] text-muted-foreground">· {row.candidate_reason}</span>
-            ) : null}
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={isPending}
-            aria-label="Confirm merge"
-            data-testid="confirm-merge"
-            className="rounded-md border border-emerald-400 bg-emerald-50 p-1.5 text-emerald-700 hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/70"
-          >
-            <CheckIcon size={14} weight="bold" />
-          </button>
-          <button
-            type="button"
-            onClick={onReject}
-            disabled={isPending}
-            aria-label="Reject this match"
-            data-testid="reject-match"
-            className="rounded-md border border-foreground/25 bg-background p-1.5 text-foreground/80 hover:bg-muted hover:text-foreground disabled:opacity-50"
-          >
-            <XIcon size={14} weight="bold" />
-          </button>
-        </div>
-      </div>
-      {errorMessage ? (
-        <div className="border-b border-border px-3 py-2 text-xs text-destructive">{errorMessage}</div>
-      ) : null}
-      <div className="flex min-h-0 flex-1 flex-col px-3 py-2">
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Recent mentions ({candidateMentions.length})
-        </p>
-        {candidateMentions.length === 0 ? (
-          <p className="mt-1 text-xs text-muted-foreground">No mentions yet.</p>
-        ) : (
-          <ul className="mt-1 flex-1 space-y-1 overflow-y-auto">
-            {candidateMentions.map((m) => (
-              <li key={m.id} className="rounded-md border border-border bg-background p-2 text-xs">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <Badge variant="outline" className="shrink-0 text-[9px]">
-                      {m.file.source}
-                    </Badge>
-                    <span className="truncate font-medium">{m.file.fileName}</span>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    <span className="text-[10px] text-muted-foreground">{formatRelativeTime(m.sourceDate)}</span>
-                    {m.file.providerUrl ? (
-                      <a
-                        href={m.file.providerUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-muted-foreground hover:text-foreground"
-                      >
-                        <ArrowSquareOutIcon size={12} />
-                      </a>
-                    ) : null}
-                  </div>
-                </div>
-                {m.file.sourcePath ? (
-                  <p className="mt-1 text-[10px] text-muted-foreground/60">{m.file.sourcePath}</p>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Right column when the reconcile body is in chooser mode — either because
- * the row is an orphan (no original candidate) or the user clicked ✗ on a
- * candidate. Shows a search box for picking an existing entity + a
- * "Create as new" fallback button.
- *
- * When the row HAS an original candidate to return to, a back arrow next
- * to the title brings the user back to the candidate view.
- */
-function ChooserView({
-  row,
-  isPending,
-  errorMessage,
-  canBackToCandidate,
-  onBack,
-  onPick,
-  onCreateNew,
-}: {
-  row: EntityReviewQueueRow;
-  isPending: boolean;
-  errorMessage: string | null;
-  canBackToCandidate: boolean;
-  onBack: () => void;
-  onPick: (entityId: string) => void;
-  onCreateNew: () => void;
-}) {
-  return (
-    <div className="flex min-h-0 flex-col rounded-lg border border-border" data-testid="reconcile-candidate">
-      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-        {canBackToCandidate ? (
-          <button
-            type="button"
-            onClick={onBack}
-            aria-label="Back to suggested candidate"
-            className="rounded-md p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            <ArrowLeftIcon size={14} />
-          </button>
-        ) : null}
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">What instead?</p>
-      </div>
-      {errorMessage ? (
-        <div className="border-b border-border px-3 py-2 text-xs text-destructive">{errorMessage}</div>
-      ) : null}
-      <div className="flex min-h-0 flex-1 flex-col gap-3 px-3 py-3">
-        <div>
-          <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Search for a match</p>
-          <div className="mt-2">
-            <EntityPicker
-              entityType={row.entity_type}
-              excludeEntityId={row.candidate_entity_id ?? undefined}
-              onPick={onPick}
-            />
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-px flex-1 bg-border" />
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">or</span>
-          <div className="h-px flex-1 bg-border" />
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onCreateNew}
-          disabled={isPending}
-          className="gap-1.5"
-          data-testid="create-new"
-        >
-          <PlusIcon size={14} />
-          Create as new {row.entity_type}
-        </Button>
-      </div>
     </div>
   );
 }

--- a/packages/web/src/routes/projects/index.test.tsx
+++ b/packages/web/src/routes/projects/index.test.tsx
@@ -66,4 +66,25 @@ describe("ProjectsPage", () => {
 
     expect(await screen.findByText(/No projects yet/i)).toBeInTheDocument();
   });
+
+  it("renders the Your Org surface with a product tier chip when experimental", async () => {
+    server.use(
+      http.get("/api/setup/status", () =>
+        HttpResponse.json({ completed: true, botName: "Sketch", experimentalFlag: true }),
+      ),
+      http.get("/api/products", () =>
+        HttpResponse.json({
+          products: [{ id: "prod-1", name: "Canvas Copilot", aliases: [], hotness: 3, provenance_tier: "declared" }],
+        }),
+      ),
+      http.get("/api/entities", () => HttpResponse.json({ entities: [], total: 0 })),
+    );
+    projectsReturn([DERIVED_WIRED]);
+    renderWithProviders(<ProjectsPage />);
+
+    expect(await screen.findByText("Your org")).toBeInTheDocument();
+    expect(await screen.findByText("Canvas Copilot")).toBeInTheDocument();
+    expect(screen.getByText("declared")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/routes/projects/index.tsx
+++ b/packages/web/src/routes/projects/index.tsx
@@ -1,25 +1,35 @@
 /**
- * Projects — a first-class destination for the project entities the graph
- * tracks. The index lists every confirmed project and groups it on the one axis
- * that earns its place at a glance: **does it have data flowing in yet?**
+ * Your Org — the curation home for what the org is made of: the products,
+ * projects, and teams the graph tracks, plus the review band where the LLM's
+ * proposals get confirmed or merged before they join the curated set.
  *
- * - **Needs sources** — born (derived from a connector container or defined by
- *   hand) but no data sources resolved up its spine. The wiring backlog.
- * - **Active** — at least one effective data source; the graph is feeding it.
+ * Sections:
+ * - **Review band** — pending product/project/team rows, split into confirm-new
+ *   vs possible-duplicates. The org-taxonomy spine only; person/company review
+ *   stays in Files → Entities.
+ * - **Products** — the declared closed list (declared + human_confirmed) that
+ *   calibrates extraction. `+ Add` declares one.
+ * - **Projects** — the lifecycle spine: needs-sources vs active.
+ * - **Teams** — structural teams seeded from connectors.
  *
- * A row opens the shared {@link EntityDrawer} (its Scope tab is where data
- * sources, members, and sub-projects get wired, and the header carries Merge) —
- * the same side sheet every entity uses, so projects reuse all of it. Real data
- * via {@link api.projects.list}.
+ * Rows open the shared {@link EntityDrawer}. The page is built edit-ready: each
+ * type will grow user-editable per-type fields, and a user edit is a `declared`
+ * assertion.
  */
-import { type ProjectSummary, api } from "@/lib/api";
+import { AddEntityDialog } from "@/components/entity-review/add-entity-dialog";
+import { ReviewBand } from "@/components/entity-review/review-band";
+import { type CuratedProduct, type EntityListItem, type ProjectSummary, api } from "@/lib/api";
 import { useEntityUi } from "@/lib/entity-ui";
-import { CaretRightIcon, FolderSimpleIcon } from "@phosphor-icons/react";
+import { CaretRightIcon, CubeIcon, FolderSimpleIcon, PlusIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { Badge } from "@sketch/ui/components/badge";
+import { Button } from "@sketch/ui/components/button";
 import { Skeleton } from "@sketch/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
+import { useState } from "react";
 import { dashboardRoute } from "../dashboard";
+
+const SPINE_TYPES = ["product", "project", "team"];
 
 export const projectsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
@@ -28,61 +38,156 @@ export const projectsRoute = createRoute({
 });
 
 export function ProjectsPage() {
+  const [showAdd, setShowAdd] = useState(false);
+  const { data: setupStatus } = useQuery({ queryKey: ["setup", "status"], queryFn: () => api.setup.status() });
+  const yourOrg = setupStatus?.experimentalFlag === true;
+
+  // Flag off → the GA Projects-only page, unchanged. Flag on → the full Your
+  // Org surface (review band + products + teams + the curated add control).
+  return (
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
+      <div className="mb-7 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-[22px] font-medium text-foreground">{yourOrg ? "Your org" : "Projects"}</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            {yourOrg
+              ? "The products, projects, and teams the graph is made of — confirm what the system proposes, and declare what it should already know."
+              : "Each project is a slice of the graph. Born from a connector or defined by you, then wired to the data sources that feed it."}
+          </p>
+        </div>
+        {yourOrg ? (
+          <Button variant="outline" size="sm" className="h-7 shrink-0 gap-1.5 text-xs" onClick={() => setShowAdd(true)}>
+            <PlusIcon size={12} />
+            Add
+          </Button>
+        ) : null}
+      </div>
+
+      {yourOrg ? (
+        <>
+          <ReviewBand types={SPINE_TYPES} />
+          <ProductsSection />
+          <ProjectsSection legacyLabels={false} />
+          <TeamsSection />
+          <AddEntityDialog open={showAdd} onOpenChange={setShowAdd} defaultType="product" />
+        </>
+      ) : (
+        <ProjectsSection legacyLabels />
+      )}
+    </div>
+  );
+}
+
+function ProductsSection() {
+  const { data, isLoading } = useQuery({ queryKey: ["products"], queryFn: () => api.products.list() });
+  const products = data?.products ?? [];
+  return (
+    <section>
+      <GroupLabel label="Products" note={`${products.length} declared`} accent />
+      {isLoading ? (
+        <Skeleton className="h-12 w-full" />
+      ) : products.length === 0 ? (
+        <EmptyHint>No products yet — declare one with “Add”, or confirm a proposal above.</EmptyHint>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {products.map((p) => (
+            <ProductRow key={p.id} product={p} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ProductRow({ product }: { product: CuratedProduct }) {
+  const ui = useEntityUi();
+  const cold = product.hotness <= 0;
+  return (
+    <button
+      type="button"
+      onClick={() => ui.openEntity(product.id)}
+      className="group flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left transition-colors hover:bg-muted/40"
+    >
+      <CubeIcon size={16} aria-hidden className="shrink-0 text-muted-foreground/60" />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
+          <span className="text-[14px] font-medium text-foreground">{product.name}</span>
+          <TierBadge tier={product.provenance_tier} />
+        </div>
+        {cold ? (
+          <p className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.05em] text-muted-foreground/60">
+            not seen in any source yet
+          </p>
+        ) : null}
+      </div>
+      <CaretRightIcon
+        size={14}
+        aria-hidden
+        className="shrink-0 text-muted-foreground/30 group-hover:text-muted-foreground"
+      />
+    </button>
+  );
+}
+
+function TierBadge({ tier }: { tier: string }) {
+  const label = tier === "human_confirmed" ? "confirmed" : tier;
+  const tone =
+    tier === "declared"
+      ? "border-emerald-300 text-emerald-700 dark:border-emerald-700 dark:text-emerald-400"
+      : tier === "human_confirmed"
+        ? "border-sky-300 text-sky-700 dark:border-sky-700 dark:text-sky-400"
+        : "text-muted-foreground";
+  return (
+    <Badge variant="outline" className={`text-[9px] uppercase tracking-wider ${tone}`}>
+      {label}
+    </Badge>
+  );
+}
+
+function ProjectsSection({ legacyLabels }: { legacyLabels: boolean }) {
   const { data, isLoading } = useQuery({ queryKey: ["projects", "index"], queryFn: () => api.projects.list() });
   const projects = data?.projects ?? [];
   const needsSources = projects.filter((p) => p.sourceCount === 0);
   const active = projects.filter((p) => p.sourceCount > 0);
-
-  return (
-    <div className="mx-auto box-content max-w-4xl px-10 py-8">
-      <div className="mb-7">
-        <h1 className="text-xl font-semibold text-foreground">Projects</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Each project is a slice of the graph. Born from a connector or defined by you, then wired to the data sources
-          that feed it.
-        </p>
-      </div>
-
-      {isLoading ? (
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-14 w-full" />
-          <Skeleton className="h-14 w-full" />
-          <Skeleton className="h-14 w-full" />
-        </div>
-      ) : projects.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border py-12 text-center text-[12.5px] text-muted-foreground">
+  const needsLabel = legacyLabels ? "Needs sources" : "Projects · needs sources";
+  const activeLabel = legacyLabels ? "Active" : "Projects · active";
+  if (!isLoading && projects.length === 0) {
+    return (
+      <section>
+        {legacyLabels ? null : <GroupLabel label="Projects" note="0 tracked" />}
+        <EmptyHint>
           No projects yet — they appear here as the graph derives them from your connectors, or when you define one.
-        </p>
-      ) : (
-        <>
-          {needsSources.length > 0 ? (
-            <section>
-              <GroupLabel label="Needs sources" note={`${needsSources.length} born · not wired yet`} accent />
-              <div className="flex flex-col gap-1">
-                {needsSources.map((project) => (
-                  <ProjectRow key={project.id} project={project} />
-                ))}
-              </div>
-            </section>
-          ) : null}
-
-          <section>
-            <GroupLabel label="Active" note={`${active.length} fed by the graph`} />
-            {active.length > 0 ? (
-              <div className="flex flex-col gap-1">
-                {active.map((project) => (
-                  <ProjectRow key={project.id} project={project} />
-                ))}
-              </div>
-            ) : (
-              <p className="rounded-xl border border-dashed border-border py-8 text-center text-[12.5px] text-muted-foreground">
-                Nothing fed yet — open a project above to wire its data sources.
-              </p>
-            )}
-          </section>
-        </>
-      )}
-    </div>
+        </EmptyHint>
+      </section>
+    );
+  }
+  return (
+    <>
+      {needsSources.length > 0 ? (
+        <section>
+          <GroupLabel label={needsLabel} note={`${needsSources.length} born · not wired yet`} accent={legacyLabels} />
+          <div className="flex flex-col gap-1">
+            {needsSources.map((project) => (
+              <ProjectRow key={project.id} project={project} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+      <section>
+        <GroupLabel label={activeLabel} note={`${active.length} fed by the graph`} />
+        {isLoading ? (
+          <Skeleton className="h-12 w-full" />
+        ) : active.length > 0 ? (
+          <div className="flex flex-col gap-1">
+            {active.map((project) => (
+              <ProjectRow key={project.id} project={project} />
+            ))}
+          </div>
+        ) : (
+          <EmptyHint>Nothing fed yet — open a project to wire its data sources.</EmptyHint>
+        )}
+      </section>
+    </>
   );
 }
 
@@ -97,7 +202,6 @@ function ProjectRow({ project }: { project: ProjectSummary }) {
       ? `${project.subProjectCount} ${project.subProjectCount === 1 ? "sub-project" : "sub-projects"}`
       : null,
   ].filter(Boolean);
-
   return (
     <button
       type="button"
@@ -134,6 +238,55 @@ function ProjectRow({ project }: { project: ProjectSummary }) {
   );
 }
 
+function TeamsSection() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["entities", "team"],
+    queryFn: () => api.entities.list({ type: "team", limit: 100 }),
+  });
+  const teams = data?.entities ?? [];
+  if (!isLoading && teams.length === 0) return null;
+  return (
+    <section>
+      <GroupLabel label="Teams" note={`${teams.length} structural`} />
+      {isLoading ? (
+        <Skeleton className="h-12 w-full" />
+      ) : (
+        <div className="flex flex-col gap-1">
+          {teams.map((team) => (
+            <TeamRow key={team.id} team={team} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TeamRow({ team }: { team: EntityListItem }) {
+  const ui = useEntityUi();
+  return (
+    <button
+      type="button"
+      onClick={() => ui.openEntity(team.id)}
+      className="group flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left transition-colors hover:bg-muted/40"
+    >
+      <UsersThreeIcon size={16} aria-hidden className="shrink-0 text-muted-foreground/60" />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
+          <span className="text-[14px] font-medium text-foreground">{team.name}</span>
+          <Badge variant="outline" className="text-[9px] uppercase tracking-wider text-muted-foreground">
+            structural
+          </Badge>
+        </div>
+      </div>
+      <CaretRightIcon
+        size={14}
+        aria-hidden
+        className="shrink-0 text-muted-foreground/30 group-hover:text-muted-foreground"
+      />
+    </button>
+  );
+}
+
 function GroupLabel({ label, note, accent }: { label: string; note: string; accent?: boolean }) {
   return (
     <div className="mb-3 mt-9 flex items-baseline justify-between border-b border-border/60 pb-2 first:mt-0">
@@ -147,5 +300,13 @@ function GroupLabel({ label, note, accent }: { label: string; note: string; acce
       </span>
       <span className="font-mono text-[10px] tracking-[0.04em] text-muted-foreground/70">{note}</span>
     </div>
+  );
+}
+
+function EmptyHint({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border py-8 text-center text-[12.5px] text-muted-foreground">
+      {children}
+    </p>
   );
 }


### PR DESCRIPTION
Stacked context-graph slice 19/27.

Base: `feat/context-graph-18-declared-products-birth-preview`
Head: `feat/context-graph-19-org-review-surface`

Adds the web review surface and shared drawer affordances.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`