### PR TITLE
feat: add structural graph spine

### DIFF
--- a/packages/server/src/api/entities/maintenance-routes.ts
+++ b/packages/server/src/api/entities/maintenance-routes.ts
@@ -201,6 +201,7 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
           lockAlreadyHeld: true,
           llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
           coMentionContributesToThreshold: config.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
+          experimentalFlag: config.EXPERIMENTAL_FLAG,
           onProgress: (progress) => {
             job.progress = progress;
           },
@@ -585,6 +586,7 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
           lockAlreadyHeld: true,
           llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
           coMentionContributesToThreshold: config.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
+          experimentalFlag: config.EXPERIMENTAL_FLAG,
           materializeFactTypes: factTypes.length > 0 ? factTypes : undefined,
           onProgress: (progress) => {
             job.progress = progress;

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -108,6 +108,9 @@ export async function createServer(config: Config, options?: CreateServerOptions
     birthGateLiveTypes: config.EXPERIMENTAL_FLAG
       ? new Set<ProposeEntityType>(["product"])
       : new Set<ProposeEntityType>(),
+    structuralAutoBirthTypes: config.EXPERIMENTAL_FLAG
+      ? new Set<ProposeEntityType>(["project"])
+      : new Set<ProposeEntityType>(),
     birthGateDryRun: config.BIRTH_GATE_DRY_RUN,
     experimentalFlag: config.EXPERIMENTAL_FLAG,
   });

--- a/packages/server/src/connectors/post-sync.isolated.test.ts
+++ b/packages/server/src/connectors/post-sync.isolated.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTaskRepository } from "../db/repositories/tasks";
 import { assignMembership, upsertWorkCycle } from "../db/repositories/work-cycles";
 import type { DB } from "../db/schema";
+import { reconcileStructuralAssigneeContributesTo } from "../entities/structural-assignee";
 import { createTestDb, createTestLogger } from "../test-utils";
 import { floorRetryForDomains } from "./engagement-floor";
 import { runPostSyncGraphPipeline } from "./post-sync";
@@ -14,6 +15,17 @@ vi.mock("../entities/materialize", () => ({
 
 vi.mock("../entities/co-mention-sweep", () => ({
   sweepCoMentionContributesTo: vi.fn().mockResolvedValue({ examined: 0, promoted: 0 }),
+}));
+
+vi.mock("../entities/structural-assignee", () => ({
+  reconcileStructuralAssigneeContributesTo: vi.fn().mockResolvedValue({
+    scannedPairs: 0,
+    upsertedRelationships: 0,
+    addedEvidence: 0,
+    removedEvidence: 0,
+    removedCoMentionEvidence: 0,
+    removedRelationships: 0,
+  }),
 }));
 
 vi.mock("./engagement-floor", () => ({
@@ -51,10 +63,86 @@ describe("runPostSyncGraphPipeline", () => {
       });
 
       expect(materializeUnmaterializedFacts).toHaveBeenCalledTimes(1);
+      expect(reconcileStructuralAssigneeContributesTo).not.toHaveBeenCalled();
       expect(sweepCoMentionContributesTo).toHaveBeenCalledTimes(1);
       expect(sweepCoMentionContributesTo).toHaveBeenCalledWith(db, expect.anything(), {
         scope: { kind: "files", indexedFileIds: ["file-1", "file-2"] },
         threshold: 4,
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("runs the structural assignee producer for affected files before the co-mention sweep when experimental", async () => {
+    const { sweepCoMentionContributesTo } = await import("../entities/co-mention-sweep");
+    const db = await createTestDb();
+    const logger = createTestLogger();
+
+    try {
+      await runPostSyncGraphPipeline({
+        db,
+        syncLogger: logger,
+        affectedIndexedFileIds: ["file-1", "file-2"],
+        experimentalFlag: true,
+        coMentionContributesToThreshold: 4,
+      });
+
+      expect(reconcileStructuralAssigneeContributesTo).toHaveBeenCalledTimes(1);
+      expect(reconcileStructuralAssigneeContributesTo).toHaveBeenCalledWith(db, expect.anything(), {
+        scope: { kind: "files", indexedFileIds: ["file-1", "file-2"] },
+      });
+      expect(sweepCoMentionContributesTo).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(reconcileStructuralAssigneeContributesTo).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(sweepCoMentionContributesTo).mock.invocationCallOrder[0],
+      );
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("runs the structural assignee producer for reanchored task ids when files were not affected", async () => {
+    const db = await createTestDb();
+    const logger = createTestLogger();
+
+    try {
+      await seedConnector(db, "connector-reanchor");
+      await seedIndexedFile(db, "connector-reanchor", "old-file");
+      await seedProjectWithSourceRef(db, "old-project", "Old Project", "linear", "old-project");
+      const task = await createTaskRepository(db).upsertTask({
+        parentEntityId: null,
+        parentSourceRef: "linear:old-project",
+        parentName: "Old Project",
+        source: "linear",
+        externalRef: "old-task",
+        title: "Old task",
+        status: "open",
+        statusRaw: "open",
+        statusAuthority: "external",
+        assigneeEntityId: null,
+        priority: null,
+        dueAt: null,
+        provenance: "structural",
+        sourceTaskId: "old-task",
+      });
+      await createTaskRepository(db).upsertEvidence(task.taskId, "file", "old-file");
+      await seedStructuralTaskFact(db, {
+        connectorConfigId: "connector-reanchor",
+        fileId: "old-file",
+        source: "linear",
+        sourceTaskId: "old-task",
+      });
+
+      await runPostSyncGraphPipeline({
+        db,
+        syncLogger: logger,
+        affectedIndexedFileIds: [],
+        experimentalFlag: true,
+      });
+
+      expect(reconcileStructuralAssigneeContributesTo).toHaveBeenCalledTimes(1);
+      expect(reconcileStructuralAssigneeContributesTo).toHaveBeenCalledWith(db, expect.anything(), {
+        scope: { kind: "tasks", taskIds: [task.taskId] },
       });
     } finally {
       await db.destroy();
@@ -226,6 +314,90 @@ async function seedConnector(db: Kysely<DB>, connectorConfigId: string): Promise
       credentials: "{}",
       created_by: `${connectorConfigId}-user`,
       scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedIndexedFile(db: Kysely<DB>, connectorConfigId: string, indexedFileId: string): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: indexedFileId,
+      connector_config_id: connectorConfigId,
+      provider_file_id: indexedFileId,
+      file_name: `${indexedFileId}.txt`,
+      file_type: "issue",
+      content_category: "structured",
+      content: indexedFileId,
+      source: "linear",
+      content_hash: `hash-${indexedFileId}`,
+      synced_at: new Date().toISOString(),
+    })
+    .execute();
+}
+
+async function seedProjectWithSourceRef(
+  db: Kysely<DB>,
+  entityId: string,
+  name: string,
+  source: string,
+  sourceId: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id: entityId,
+      name,
+      source_type: "project",
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await db
+    .insertInto("entity_source_refs")
+    .values({
+      id: `${entityId}-ref`,
+      entity_id: entityId,
+      source,
+      source_id: sourceId,
+      source_url: null,
+      last_seen_at: now,
+    })
+    .execute();
+}
+
+async function seedStructuralTaskFact(
+  db: Kysely<DB>,
+  input: { connectorConfigId: string; fileId: string; source: string; sourceTaskId: string },
+): Promise<void> {
+  await db
+    .insertInto("indexed_file_facts")
+    .values({
+      id: `${input.sourceTaskId}-fact`,
+      indexed_file_id: input.fileId,
+      connector_config_id: input.connectorConfigId,
+      created_by_user_id: `${input.connectorConfigId}-user`,
+      source: input.source,
+      fact_type: "structural_task",
+      relation: "mentioned",
+      subject_name: input.sourceTaskId,
+      subject_email: null,
+      subject_source: input.source,
+      subject_source_id: input.sourceTaskId,
+      context_snippet: null,
+      raw: "{}",
+      fact_key: `${input.source}:structural_task:${input.sourceTaskId}`,
+      last_seen_sync_run_id: "sync-new",
+      deleted_at: null,
+      content_hash: null,
+      materialized_at: new Date().toISOString(),
     })
     .execute();
 }

--- a/packages/server/src/connectors/post-sync.ts
+++ b/packages/server/src/connectors/post-sync.ts
@@ -5,6 +5,7 @@ import { reconcileWorkCycles } from "../db/repositories/work-cycles";
 import type { DB } from "../db/schema";
 import { sweepCoMentionContributesTo } from "../entities/co-mention-sweep";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
+import { reconcileStructuralAssigneeContributesTo } from "../entities/structural-assignee";
 import { floorRetryForDomains } from "./engagement-floor";
 import { sweepDomainPromotions } from "./smart-enrichment";
 
@@ -40,8 +41,28 @@ export async function runPostSyncGraphPipeline({
   const taskRepo = createTaskRepository(db);
   const reanchoredTasks = await taskRepo.reanchorNullParentTasks();
   const expiredTasks = await taskRepo.expireOrphanedTasks(source);
-  if (reanchoredTasks > 0 || expiredTasks > 0) {
-    syncLogger.info({ reanchoredTasks, expiredTasks }, "Post-sync task sweep complete");
+  if (reanchoredTasks.count > 0 || expiredTasks > 0) {
+    syncLogger.info({ reanchoredTasks: reanchoredTasks.count, expiredTasks }, "Post-sync task sweep complete");
+  }
+  if (experimentalFlag) {
+    if (affectedIndexedFileIds.length > 0) {
+      await reconcileStructuralAssigneeContributesTo(
+        db,
+        syncLogger.child({ component: "structural-assignee-producer" }),
+        {
+          scope: { kind: "files", indexedFileIds: affectedIndexedFileIds },
+        },
+      );
+    }
+    if (reanchoredTasks.taskIds.length > 0) {
+      await reconcileStructuralAssigneeContributesTo(
+        db,
+        syncLogger.child({ component: "structural-assignee-producer" }),
+        {
+          scope: { kind: "tasks", taskIds: reanchoredTasks.taskIds },
+        },
+      );
+    }
   }
   if (experimentalFlag && runCycleReconcile && connectorConfigId && syncRunId) {
     const closedWorkCycles = await reconcileWorkCycles(db, {

--- a/packages/server/src/connectors/sync-co-mention-full-sweep.isolated.test.ts
+++ b/packages/server/src/connectors/sync-co-mention-full-sweep.isolated.test.ts
@@ -1,0 +1,123 @@
+import type { Kysely } from "kysely";
+import type { Logger } from "pino";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DB } from "../db/schema";
+import { createTestDb } from "../test-utils";
+
+const CO_MENTION_FULL_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const BASE_TIME = new Date("2026-01-01T00:00:00.000Z");
+
+vi.mock("../entities/co-mention-sweep", () => ({
+  sweepCoMentionContributesTo: vi.fn(),
+}));
+
+vi.mock("../entities/feature-archive-sweep", () => ({
+  runFeatureArchiveSweep: vi.fn(),
+}));
+
+type SpyLogger = Logger & {
+  child: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+};
+
+function createSpyLogger(): SpyLogger {
+  const logger = {
+    child: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as SpyLogger;
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+async function loadRunAllSyncs() {
+  vi.resetModules();
+  const coMentionModule = await import("../entities/co-mention-sweep");
+  const featureArchiveModule = await import("../entities/feature-archive-sweep");
+  const sweepCoMentionContributesTo = vi.mocked(coMentionModule.sweepCoMentionContributesTo);
+  const runFeatureArchiveSweep = vi.mocked(featureArchiveModule.runFeatureArchiveSweep);
+  sweepCoMentionContributesTo.mockReset();
+  sweepCoMentionContributesTo.mockResolvedValue({
+    scannedPairs: 0,
+    upsertedRelationships: 0,
+    addedEvidence: 0,
+    removedEvidence: 0,
+    removedRelationships: 0,
+  });
+  runFeatureArchiveSweep.mockReset();
+  runFeatureArchiveSweep.mockResolvedValue({
+    scanned: 0,
+    archived: 0,
+    skippedRecent: 0,
+    skippedEnoughMentions: 0,
+    skippedNonLlmEvidence: 0,
+  });
+  const syncModule = await import("./sync");
+  return { runAllSyncs: syncModule.runAllSyncs, sweepCoMentionContributesTo };
+}
+
+describe("runAllSyncs co-mention full sweep cadence", () => {
+  let db: Kysely<DB> | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    if (db) {
+      await db.destroy();
+      db = null;
+    }
+  });
+
+  it("runs the full sweep on the first scheduled sync and passes the configured threshold", async () => {
+    const { runAllSyncs, sweepCoMentionContributesTo } = await loadRunAllSyncs();
+    db = await createTestDb();
+    const logger = createSpyLogger();
+
+    await runAllSyncs(db, logger, { appConfig: { CO_MENTION_CONTRIBUTES_TO_THRESHOLD: 4 } });
+
+    expect(sweepCoMentionContributesTo).toHaveBeenCalledTimes(1);
+    expect(sweepCoMentionContributesTo).toHaveBeenCalledWith(db, logger, {
+      scope: { kind: "full" },
+      threshold: 4,
+    });
+    expect(logger.child).toHaveBeenCalledWith({ component: "co-mention-full-sweep" });
+  });
+
+  it("throttles the full sweep until the interval elapses", async () => {
+    const { runAllSyncs, sweepCoMentionContributesTo } = await loadRunAllSyncs();
+    db = await createTestDb();
+    const logger = createSpyLogger();
+
+    await runAllSyncs(db, logger);
+    await runAllSyncs(db, logger);
+
+    expect(sweepCoMentionContributesTo).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date(BASE_TIME.getTime() + CO_MENTION_FULL_SWEEP_INTERVAL_MS + 1));
+    await runAllSyncs(db, logger);
+
+    expect(sweepCoMentionContributesTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs and resolves when the full sweep fails", async () => {
+    const { runAllSyncs, sweepCoMentionContributesTo } = await loadRunAllSyncs();
+    db = await createTestDb();
+    const logger = createSpyLogger();
+    const err = new Error("sweep failed");
+    sweepCoMentionContributesTo.mockRejectedValueOnce(err);
+
+    await expect(runAllSyncs(db, logger)).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith({ err }, "Co-mention full sweep failed");
+  });
+});

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -17,6 +17,7 @@ import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import { inferAffiliationFromEmail } from "../entities/affiliations";
+import { sweepCoMentionContributesTo } from "../entities/co-mention-sweep";
 import { runFeatureArchiveSweep } from "../entities/feature-archive-sweep";
 import { isRecreateActive } from "../entities/recreate-state";
 import { resolveConnectorCredentials } from "./credential-providers";
@@ -541,7 +542,9 @@ const SYNC_CONCURRENCY = 4;
 const STALE_SYNCING_THRESHOLD_MS = 60 * 60 * 1000;
 const DEFAULT_SYNC_INTERVAL_MS = 30 * 60 * 1000;
 const FEATURE_ARCHIVE_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const CO_MENTION_FULL_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
 let lastFeatureArchiveSweepAt = 0;
+let lastCoMentionFullSweepAt = 0;
 
 async function resolveConnectorCredentialsForSync(params: {
   db: Kysely<DB>;
@@ -629,6 +632,18 @@ export async function runAllSyncs(db: Kysely<DB>, logger: Logger, deps?: SyncSch
       });
     } catch (err) {
       logger.error({ err }, "Feature archive sweep failed");
+    }
+  }
+
+  if (now - lastCoMentionFullSweepAt >= CO_MENTION_FULL_SWEEP_INTERVAL_MS) {
+    lastCoMentionFullSweepAt = now;
+    try {
+      await sweepCoMentionContributesTo(db, logger.child({ component: "co-mention-full-sweep" }), {
+        scope: { kind: "full" },
+        threshold: deps?.appConfig?.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
+      });
+    } catch (err) {
+      logger.error({ err }, "Co-mention full sweep failed");
     }
   }
 }

--- a/packages/server/src/db/repositories/entity-domains.test.ts
+++ b/packages/server/src/db/repositories/entity-domains.test.ts
@@ -2,7 +2,7 @@ import type { Kysely } from "kysely";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTestDb } from "../../test-utils";
 import type { DB } from "../schema";
-import { createEntityDomainsRepository, normalizeWebsiteDomain } from "./entity-domains";
+import { createEntityDomainsRepository, normalizeWebsiteDomain, relationshipSourceRank } from "./entity-domains";
 
 describe("entity domains repository", () => {
   let db: Kysely<DB> | null = null;
@@ -15,6 +15,10 @@ describe("entity domains repository", () => {
   });
 
   async function seedCompany(id: string, name: string) {
+    await seedEntity(id, name, "company");
+  }
+
+  async function seedEntity(id: string, name: string, sourceType: string) {
     if (!db) throw new Error("missing db");
     const now = new Date().toISOString();
     await db
@@ -22,11 +26,47 @@ describe("entity domains repository", () => {
       .values({
         id,
         name,
-        source_type: "company",
+        source_type: sourceType,
         status: "confirmed",
         hotness: 0,
         created_at: now,
         updated_at: now,
+      })
+      .execute();
+  }
+
+  async function seedFile(id: string) {
+    if (!db) throw new Error("missing db");
+    const now = new Date().toISOString();
+    await db
+      .insertInto("users")
+      .values({ id: "domain-user", name: "Domain User", email: "domain@example.com" })
+      .onConflict((oc) => oc.column("id").doNothing())
+      .execute();
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "domain-connector",
+        connector_type: "fireflies",
+        auth_type: "oauth",
+        credentials: "{}",
+        created_by: "domain-user",
+      })
+      .onConflict((oc) => oc.column("id").doNothing())
+      .execute();
+    await db
+      .insertInto("indexed_files")
+      .values({
+        id,
+        connector_config_id: "domain-connector",
+        provider_file_id: id,
+        file_name: `${id}.txt`,
+        file_type: "meeting",
+        content_category: "meeting",
+        source: "fireflies",
+        content_hash: `hash-${id}`,
+        is_archived: 0,
+        synced_at: now,
       })
       .execute();
   }
@@ -36,6 +76,13 @@ describe("entity domains repository", () => {
     expect(normalizeWebsiteDomain("acme.com/about")).toBe("acme.com");
     expect(normalizeWebsiteDomain("localhost:3000")).toBeNull();
     expect(normalizeWebsiteDomain("127.0.0.1")).toBeNull();
+  });
+
+  it("ranks contributes_to sources for conflict ownership", () => {
+    expect(relationshipSourceRank("structural_assignee")).toBe(3);
+    expect(relationshipSourceRank("llm_extraction")).toBe(2);
+    expect(relationshipSourceRank("co_mention")).toBe(1);
+    expect(relationshipSourceRank("manual")).toBe(0);
   });
 
   it("claims safe authoritative corporate domains and skips personal/shared seeds", async () => {
@@ -123,5 +170,102 @@ describe("entity domains repository", () => {
       { domain: "auto.com", source: "observed", entity_id: "globex" },
       { domain: "manual.com", source: "manual", entity_id: "globex" },
     ]);
+  });
+
+  it("lets higher ranked contributes_to sources take ownership on conflict", async () => {
+    db = await createTestDb();
+    await seedEntity("person-rank-up", "Priya", "person");
+    await seedEntity("project-rank-up", "Project Atlas", "project");
+    const domainsRepo = createEntityDomainsRepository(db);
+
+    await domainsRepo.upsertRelationship({
+      sourceEntityId: "person-rank-up",
+      targetEntityId: "project-rank-up",
+      relationshipType: "contributes_to",
+      confidence: "INFERRED",
+      confidenceScore: 0.84,
+      source: "co_mention",
+    });
+    await domainsRepo.upsertRelationship({
+      sourceEntityId: "person-rank-up",
+      targetEntityId: "project-rank-up",
+      relationshipType: "contributes_to",
+      confidence: "EXTRACTED",
+      confidenceScore: 0.9,
+      source: "llm_extraction",
+    });
+
+    const row = await db.selectFrom("entity_relationships").selectAll().executeTakeFirstOrThrow();
+    expect(row).toMatchObject({
+      source: "llm_extraction",
+      confidence: "EXTRACTED",
+      confidence_score: 0.9,
+    });
+  });
+
+  it("preserves source and confidence when an existing contributes_to source outranks the incoming source", async () => {
+    db = await createTestDb();
+    await seedEntity("person-rank-guard", "Meera", "person");
+    await seedEntity("project-rank-guard", "Project Guard", "project");
+    const domainsRepo = createEntityDomainsRepository(db);
+
+    await domainsRepo.upsertRelationship({
+      sourceEntityId: "person-rank-guard",
+      targetEntityId: "project-rank-guard",
+      relationshipType: "contributes_to",
+      confidence: "INFERRED",
+      confidenceScore: 0.9,
+      source: "structural_assignee",
+    });
+    await domainsRepo.upsertRelationship({
+      sourceEntityId: "person-rank-guard",
+      targetEntityId: "project-rank-guard",
+      relationshipType: "contributes_to",
+      confidence: "EXTRACTED",
+      confidenceScore: 0.97,
+      source: "llm_extraction",
+    });
+
+    const row = await db.selectFrom("entity_relationships").selectAll().executeTakeFirstOrThrow();
+    expect(row).toMatchObject({
+      source: "structural_assignee",
+      confidence: "INFERRED",
+      confidence_score: 0.97,
+    });
+  });
+
+  it("prunes structural assignee evidence by task note while preserving other evidence", async () => {
+    db = await createTestDb();
+    await seedEntity("person-prune", "Nina", "person");
+    await seedEntity("project-prune", "Project Prune", "project");
+    await seedFile("prune-file");
+    const domainsRepo = createEntityDomainsRepository(db);
+    const relationshipId = await domainsRepo.upsertRelationship({
+      sourceEntityId: "person-prune",
+      targetEntityId: "project-prune",
+      relationshipType: "contributes_to",
+      confidence: "INFERRED",
+      confidenceScore: 0.9,
+      source: "structural_assignee",
+    });
+    const keepNote = "structural_assignee:task:keep-task";
+    const staleNote = "structural_assignee:task:stale-task";
+    await domainsRepo.addEvidence({ relationshipId, indexedFileId: "prune-file", note: keepNote, sourceFactId: null });
+    await domainsRepo.addEvidence({ relationshipId, indexedFileId: "prune-file", note: staleNote, sourceFactId: null });
+    await domainsRepo.addEvidence({
+      relationshipId,
+      indexedFileId: "prune-file",
+      note: "llm_relation:contributes_to",
+      sourceFactId: null,
+    });
+
+    const removed = await domainsRepo.deleteStructuralAssigneeEvidenceForRelationships(
+      [relationshipId],
+      new Set([`note:${relationshipId}:prune-file:-1:${keepNote}`]),
+    );
+
+    const evidence = await db.selectFrom("entity_relationship_evidence").select(["note"]).orderBy("note").execute();
+    expect(removed).toBe(1);
+    expect(evidence.map((row) => row.note)).toEqual(["llm_relation:contributes_to", keepNote]);
   });
 });

--- a/packages/server/src/db/repositories/entity-domains.ts
+++ b/packages/server/src/db/repositories/entity-domains.ts
@@ -81,6 +81,13 @@ export interface AddRelationshipEvidenceInput {
   sourceFactId?: string | null;
 }
 
+export function relationshipSourceRank(source: string | null | undefined): number {
+  if (source === "structural_assignee") return 3;
+  if (source === "llm_extraction") return 2;
+  if (source === "co_mention") return 1;
+  return 0;
+}
+
 /**
  * Lowercase + trim the part after `@`. Returns null for malformed input.
  * Subdomains are conservative: `mail.acme.com` only normalizes to `acme.com`
@@ -151,6 +158,14 @@ export function createEntityDomainsRepository(db: Kysely<DB>) {
   async function upsertRelationship(input: UpsertRelationshipInput): Promise<string> {
     const validFrom = input.validFrom ?? "";
     const id = randomUUID();
+    const incomingRank = relationshipSourceRank(input.source);
+    const existingRank = sql<number>`CASE entity_relationships.source
+      WHEN 'structural_assignee' THEN 3
+      WHEN 'llm_extraction' THEN 2
+      WHEN 'co_mention' THEN 1
+      ELSE 0
+    END`;
+    const preserveRankedOwner = sql<boolean>`EXCLUDED.relationship_type = 'contributes_to' AND ${incomingRank} < ${existingRank}`;
     const greatest = isPg(db)
       ? sql`GREATEST(entity_relationships.confidence_score, EXCLUDED.confidence_score)`
       : sql`max(entity_relationships.confidence_score, EXCLUDED.confidence_score)`;
@@ -161,9 +176,15 @@ export function createEntityDomainsRepository(db: Kysely<DB>) {
         (${id}, ${input.sourceEntityId}, ${input.targetEntityId}, ${input.relationshipType}, ${input.confidence}, ${input.confidenceScore}, ${input.source}, ${validFrom}, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
       ON CONFLICT (source_entity_id, target_entity_id, relationship_type, valid_from)
       DO UPDATE SET
-        confidence = EXCLUDED.confidence,
+        confidence = CASE
+          WHEN ${preserveRankedOwner} THEN entity_relationships.confidence
+          ELSE EXCLUDED.confidence
+        END,
         confidence_score = ${greatest},
-        source = EXCLUDED.source,
+        source = CASE
+          WHEN ${preserveRankedOwner} THEN entity_relationships.source
+          ELSE EXCLUDED.source
+        END,
         updated_at = CURRENT_TIMESTAMP
     `.execute(db);
     const row = await db
@@ -372,6 +393,23 @@ export function createEntityDomainsRepository(db: Kysely<DB>) {
         .where("relationship_id", "in", relationshipIds)
         .where("source_fact_id", "is", null)
         .where("note", "like", "co_mention:%");
+      const keep = [...keepEvidenceKeys];
+      if (keep.length > 0) {
+        query = query.where("evidence_key", "not in", keep);
+      }
+      const result = await query.executeTakeFirst();
+      return Number(result.numDeletedRows ?? 0);
+    },
+
+    async deleteStructuralAssigneeEvidenceForRelationships(
+      relationshipIds: string[],
+      keepEvidenceKeys: Set<string> = new Set(),
+    ): Promise<number> {
+      if (relationshipIds.length === 0) return 0;
+      let query = db
+        .deleteFrom("entity_relationship_evidence")
+        .where("relationship_id", "in", relationshipIds)
+        .where("note", "like", "structural_assignee:%");
       const keep = [...keepEvidenceKeys];
       if (keep.length > 0) {
         query = query.where("evidence_key", "not in", keep);

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -51,6 +51,13 @@ export type PromoteBriefTaskResult =
   | { status: "collated"; taskId: string }
   | { status: "upserted"; taskId: string; created: boolean };
 
+export interface ReanchorNullParentTasksResult {
+  count: number;
+  taskIds: string[];
+  indexedFileIds: string[];
+  parentEntityIds: string[];
+}
+
 export interface LoadOpenDurableTasksForBriefOptions {
   userId: string;
   userEmails: string[];
@@ -170,7 +177,7 @@ export function createTaskRepository(db: Kysely<DB>) {
       return { status: "upserted", ...result };
     },
 
-    async reanchorNullParentTasks(): Promise<number> {
+    async reanchorNullParentTasks(): Promise<ReanchorNullParentTasksResult> {
       const rows = await db
         .selectFrom("tasks")
         .select(["id", "parent_source_ref", "parent_name"])
@@ -178,18 +185,39 @@ export function createTaskRepository(db: Kysely<DB>) {
         .where("valid_to", "is", null)
         .execute();
       let count = 0;
+      const taskIds: string[] = [];
+      const parentEntityIds = new Set<string>();
       for (const task of rows) {
         const parent = await findLiveProjectForTask(db, task.parent_source_ref, task.parent_name);
         if (!parent || parent.id === TEST_ACCOUNT_ENTITY_ID) continue;
-        await db
+        const result = await db
           .updateTable("tasks")
           .set({ parent_entity_id: parent.id, updated_at: new Date().toISOString() })
           .where("id", "=", task.id)
           .where("parent_entity_id", "is", null)
           .execute();
-        count++;
+        const updated = Number(result[0]?.numUpdatedRows ?? 0);
+        if (updated === 0) continue;
+        count += updated;
+        taskIds.push(task.id);
+        parentEntityIds.add(parent.id);
       }
-      return count;
+      const evidenceRows =
+        taskIds.length > 0
+          ? await db
+              .selectFrom("task_evidence")
+              .select("ref_id")
+              .distinct()
+              .where("task_id", "in", taskIds)
+              .where("kind", "=", "file")
+              .execute()
+          : [];
+      return {
+        count,
+        taskIds,
+        indexedFileIds: evidenceRows.map((row) => row.ref_id),
+        parentEntityIds: [...parentEntityIds],
+      };
     },
 
     async expireOrphanedTasks(source?: string): Promise<number> {

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -220,6 +220,18 @@ export function createTaskRepository(db: Kysely<DB>) {
       };
     },
 
+    async listStructuralTaskIdsByParentEntityIds(parentEntityIds: string[]): Promise<string[]> {
+      if (parentEntityIds.length === 0) return [];
+      const rows = await db
+        .selectFrom("tasks")
+        .select("id")
+        .where("provenance", "=", "structural")
+        .where("valid_to", "is", null)
+        .where("parent_entity_id", "in", parentEntityIds)
+        .execute();
+      return rows.map((row) => row.id);
+    },
+
     async expireOrphanedTasks(source?: string): Promise<number> {
       const now = new Date().toISOString();
       let query = db

--- a/packages/server/src/entities/materialize-birth-gate.test.ts
+++ b/packages/server/src/entities/materialize-birth-gate.test.ts
@@ -226,6 +226,31 @@ describe("A1 birth gate", () => {
     });
   });
 
+  it("does not let structural auto-birth bypass the LLM project birth gate", async () => {
+    await seedConnector(db);
+    await seedFile(db, "file-1");
+    await upsertLlmMention(db, "file-1", "Atlas Migration", "project");
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      llmPromotionThreshold: 1,
+      birthGateTypes: new Set<ProposeEntityType>(["project", "product", "team"]),
+      birthGateLiveTypes: new Set<ProposeEntityType>(),
+      structuralAutoBirthTypes: new Set<ProposeEntityType>(["project"]),
+      birthGateDryRun: false,
+    });
+
+    expect(await countEntitiesByType(db, "project")).toBe(0);
+    expect(await countQueueRows(db)).toBe(1);
+    const row = await db.selectFrom("entity_review_queue").selectAll().executeTakeFirstOrThrow();
+    expect(row).toMatchObject({
+      entity_type: "project",
+      proposed_name: "Atlas Migration",
+      candidate_reason: "birth-gated",
+      source: "llm_extraction",
+      status: "pending",
+    });
+  });
+
   it("auto-creates product mentions with the gate off (EXPERIMENTAL_FLAG invisible)", async () => {
     await seedConnector(db);
     await seedFile(db, "file-1");

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -30,6 +30,7 @@ let configuredLlmPromotionThreshold = DEFAULT_LLM_PROMOTION_THRESHOLD;
 let configuredLlmTaskCorroborationThreshold = DEFAULT_LLM_TASK_CORROBORATION_THRESHOLD;
 let configuredBirthGateTypes = new Set<ProposeEntityType>();
 let configuredBirthGateLiveTypes = new Set<ProposeEntityType>();
+let configuredStructuralAutoBirthTypes = new Set<ProposeEntityType>();
 let configuredBirthGateDryRun = true;
 let configuredExperimentalFlag = false;
 
@@ -44,6 +45,7 @@ export function configureMaterializeDefaults(opts: {
   llmTaskCorroborationThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateLiveTypes?: Set<ProposeEntityType>;
+  structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
 }): void {
@@ -55,6 +57,7 @@ export function configureMaterializeDefaults(opts: {
   }
   if (opts.birthGateTypes) configuredBirthGateTypes = new Set(opts.birthGateTypes);
   if (opts.birthGateLiveTypes) configuredBirthGateLiveTypes = new Set(opts.birthGateLiveTypes);
+  if (opts.structuralAutoBirthTypes) configuredStructuralAutoBirthTypes = new Set(opts.structuralAutoBirthTypes);
   if (typeof opts.birthGateDryRun === "boolean") configuredBirthGateDryRun = opts.birthGateDryRun;
   if (typeof opts.experimentalFlag === "boolean") configuredExperimentalFlag = opts.experimentalFlag;
 }
@@ -282,6 +285,7 @@ export interface BuildMaterializeDepsOptions {
   logger?: Logger;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateLiveTypes?: Set<ProposeEntityType>;
+  structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
 }
@@ -306,6 +310,7 @@ export async function buildMaterializeDeps(
       : configuredLlmTaskCorroborationThreshold;
   const birthGateTypes = new Set(opts.birthGateTypes ?? configuredBirthGateTypes);
   const birthGateLiveTypes = new Set(opts.birthGateLiveTypes ?? configuredBirthGateLiveTypes);
+  const structuralAutoBirthTypes = new Set(opts.structuralAutoBirthTypes ?? configuredStructuralAutoBirthTypes);
   const birthGateDryRun = opts.birthGateDryRun ?? configuredBirthGateDryRun;
   const experimentalFlag = opts.experimentalFlag ?? configuredExperimentalFlag;
 
@@ -368,6 +373,7 @@ export async function buildMaterializeDeps(
     llmTaskCorroborationThreshold,
     birthGateTypes,
     birthGateLiveTypes,
+    structuralAutoBirthTypes,
     birthGateDryRun,
     experimentalFlag,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -178,6 +178,7 @@ export async function replaySourceFacts(
     logger,
     birthGateTypes: opts.birthGateTypes,
     birthGateLiveTypes: opts.birthGateLiveTypes,
+    structuralAutoBirthTypes: opts.structuralAutoBirthTypes,
     birthGateDryRun: opts.birthGateDryRun,
     experimentalFlag: opts.experimentalFlag,
   });
@@ -250,6 +251,7 @@ async function materializeUnmaterializedFactsInner(
     logger,
     birthGateTypes: opts.birthGateTypes,
     birthGateLiveTypes: opts.birthGateLiveTypes,
+    structuralAutoBirthTypes: opts.structuralAutoBirthTypes,
     birthGateDryRun: opts.birthGateDryRun,
     experimentalFlag: opts.experimentalFlag,
   });

--- a/packages/server/src/entities/materialize-spine-candidate.ts
+++ b/packages/server/src/entities/materialize-spine-candidate.ts
@@ -80,8 +80,10 @@ export async function materializeSpineCandidate(
 
   const reviewRow = await deps.reviewRepo.findSeedReviewRow(args.subjectSource, args.subjectSourceId);
   const autoBirth = !args.forceQueue && deps.structuralAutoBirthTypes.has(spineType) && !reviewRow;
+  const shouldQueue =
+    Boolean(reviewRow) || args.forceQueue || (deps.birthGateTypes.has(spineType) && !deps.birthGateDryRun);
 
-  if (!autoBirth && (args.forceQueue || (deps.birthGateTypes.has(spineType) && !deps.birthGateDryRun))) {
+  if (!autoBirth && shouldQueue) {
     const owner = deps.resolveOwner(fact);
     if (!owner) return { kind: "skipped_missing_owner", reason: "missing_fact_owner" };
 

--- a/packages/server/src/entities/materialize-spine-candidate.ts
+++ b/packages/server/src/entities/materialize-spine-candidate.ts
@@ -78,7 +78,10 @@ export async function materializeSpineCandidate(
     return { kind: "entity_linked", entity, mentionWritten: Boolean(fact.indexed_file_id), countEntity: false };
   }
 
-  if (args.forceQueue || (deps.birthGateTypes.has(spineType) && !deps.birthGateDryRun)) {
+  const reviewRow = await deps.reviewRepo.findSeedReviewRow(args.subjectSource, args.subjectSourceId);
+  const autoBirth = !args.forceQueue && deps.structuralAutoBirthTypes.has(spineType) && !reviewRow;
+
+  if (!autoBirth && (args.forceQueue || (deps.birthGateTypes.has(spineType) && !deps.birthGateDryRun))) {
     const owner = deps.resolveOwner(fact);
     if (!owner) return { kind: "skipped_missing_owner", reason: "missing_fact_owner" };
 

--- a/packages/server/src/entities/materialize-structural-gate.test.ts
+++ b/packages/server/src/entities/materialize-structural-gate.test.ts
@@ -8,11 +8,20 @@ import { createTestDb, createTestLogger } from "../test-utils";
 import { buildMaterializeDeps, materializeUnmaterializedFacts } from "./materialize";
 import { materializeStructuralSeed } from "./materialize-structural";
 import type { IndexedFileFactRow } from "./materialize-types";
+import type { ProposeEntityType } from "./propose";
 
 const USER_ID = "user-1";
 const CONNECTOR_ID = "connector-1";
 const FILE_ID = "file-1";
 const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
+
+function birthGateTypes(): Set<ProposeEntityType> {
+  return new Set<ProposeEntityType>(["project", "product", "team"]);
+}
+
+function structuralAutoBirthTypes(): Set<ProposeEntityType> {
+  return new Set<ProposeEntityType>(["project"]);
+}
 
 async function countEntitiesBySourceType(db: Kysely<DB>, sourceType: string): Promise<number> {
   const row = await db
@@ -233,6 +242,81 @@ describe("materializeStructuralSeed project birth gate", () => {
     expect(entity).toMatchObject({ name: "Workspace", source_type: "clickup_workspace" });
     await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(0);
   });
+
+  it("auto-births current connector project seeds as structural under the project birth gate", async () => {
+    await seedConnectorFile(db);
+    await seedStructuralFact(db, {
+      sourceType: "project",
+      subjectName: "Apollo",
+      subjectSourceId: "P-live",
+    });
+
+    await materializeUnmaterializedFacts(db, createTestLogger(), {
+      birthGateTypes: birthGateTypes(),
+      structuralAutoBirthTypes: structuralAutoBirthTypes(),
+    });
+
+    const project = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("source_type", "=", "project")
+      .where("id", "!=", TEST_ACCOUNT_ENTITY_ID)
+      .executeTakeFirstOrThrow();
+    expect(project).toMatchObject({
+      name: "Apollo",
+      provenance_tier: "structural",
+    });
+    await expect(
+      db
+        .selectFrom("entity_source_refs")
+        .selectAll()
+        .where("entity_id", "=", project.id)
+        .where("source", "=", "linear")
+        .where("source_id", "=", "P-live")
+        .execute(),
+    ).resolves.toHaveLength(1);
+    expect(await countReviewQueueRows(db)).toBe(0);
+  });
+
+  it.each(["rejected", "pending"] as const)(
+    "does not auto-birth a structurally declared project with an existing %s review row",
+    async (status) => {
+      await seedConnectorFile(db);
+      const reviewRepo = createEntityReviewRepo(db);
+      const { row } = await reviewRepo.upsertSeedReviewRow({
+        proposedName: "Sketch",
+        normalizedName: "sketch",
+        entityType: "project",
+        seedSource: "linear",
+        seedSourceId: "P-existing",
+        candidateEntityId: null,
+        triggeredByUserId: USER_ID,
+      });
+      if (status === "rejected") {
+        await db.updateTable("entity_review_queue").set({ status }).where("id", "=", row.id).execute();
+      }
+      await seedStructuralFact(db, {
+        sourceType: "project",
+        subjectName: "Sketch",
+        subjectSourceId: "P-existing",
+      });
+
+      await materializeUnmaterializedFacts(db, createTestLogger(), {
+        birthGateTypes: birthGateTypes(),
+        structuralAutoBirthTypes: structuralAutoBirthTypes(),
+      });
+
+      expect(await countEntitiesBySourceType(db, "project")).toBe(0);
+      const reviews = await db.selectFrom("entity_review_queue").selectAll().execute();
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0]).toMatchObject({
+        id: row.id,
+        seed_source: "linear",
+        seed_source_id: "P-existing",
+        status,
+      });
+    },
+  );
 
   it("A0 documents current structural seed path creating replay-dispatched project and team seeds but queueing linear_project containers until A1 flips it", async () => {
     await seedConnectorFile(db);

--- a/packages/server/src/entities/materialize-task.test.ts
+++ b/packages/server/src/entities/materialize-task.test.ts
@@ -250,7 +250,12 @@ describe("structural task materialization", () => {
     const project = await seedProject(db, { name: "Queued Project", source: "linear", sourceId: "proj-queued" });
     const reanchored = await createTaskRepository(db).reanchorNullParentTasks();
     const after = await db.selectFrom("tasks").selectAll().executeTakeFirstOrThrow();
-    expect(reanchored).toBe(1);
+    expect(reanchored).toMatchObject({
+      count: 1,
+      taskIds: [before.id],
+      indexedFileIds: ["file-1"],
+      parentEntityIds: [project.id],
+    });
     expect(after.parent_entity_id).toBe(project.id);
   });
 

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -61,6 +61,7 @@ export interface MaterializeDeps {
   llmTaskCorroborationThreshold: number;
   birthGateTypes: Set<ProposeEntityType>;
   birthGateLiveTypes: Set<ProposeEntityType>;
+  structuralAutoBirthTypes: Set<ProposeEntityType>;
   birthGateDryRun: boolean;
   experimentalFlag: boolean;
 }
@@ -92,6 +93,7 @@ export interface ReplaySourceFactsOptions {
   llmTaskCorroborationThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateLiveTypes?: Set<ProposeEntityType>;
+  structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
 }
@@ -107,6 +109,7 @@ export interface MaterializeUnmaterializedOptions {
   llmTaskCorroborationThreshold?: number;
   birthGateTypes?: Set<ProposeEntityType>;
   birthGateLiveTypes?: Set<ProposeEntityType>;
+  structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
   factTypes?: IndexedFileFactType[];

--- a/packages/server/src/entities/recreate-structural-assignee.test.ts
+++ b/packages/server/src/entities/recreate-structural-assignee.test.ts
@@ -1,0 +1,255 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
+import type { DB } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { buildMaterializeDeps, type BuildMaterializeDepsOptions, configureMaterializeDefaults } from "./materialize";
+import type { ProposeEntityType } from "./propose";
+import { recreateEntityGraph } from "./recreate";
+
+const USER_ID = "recreate-structural-user";
+const CONNECTOR_ID = "recreate-structural-connector";
+const PERSON_SOURCE_ID = "user-priya";
+const PROJECT_SOURCE_ID = "proj-atlas";
+const TASK_SOURCE_ID = "task-atlas-1";
+
+type MaterializeDefaultsSnapshot = Pick<
+  BuildMaterializeDepsOptions,
+  | "llmPromotionThreshold"
+  | "llmTaskCorroborationThreshold"
+  | "birthGateTypes"
+  | "birthGateLiveTypes"
+  | "structuralAutoBirthTypes"
+  | "birthGateDryRun"
+  | "experimentalFlag"
+>;
+
+async function snapshotMaterializeDefaults(db: Kysely<DB>): Promise<MaterializeDefaultsSnapshot> {
+  const deps = await buildMaterializeDeps(db);
+  return {
+    llmPromotionThreshold: deps.llmPromotionThreshold,
+    llmTaskCorroborationThreshold: deps.llmTaskCorroborationThreshold,
+    birthGateTypes: new Set(deps.birthGateTypes),
+    birthGateLiveTypes: new Set(deps.birthGateLiveTypes),
+    structuralAutoBirthTypes: new Set(deps.structuralAutoBirthTypes),
+    birthGateDryRun: deps.birthGateDryRun,
+    experimentalFlag: deps.experimentalFlag,
+  };
+}
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: USER_ID,
+      name: "Recreate Structural User",
+      email: "recreate-structural@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedFile(db: Kysely<DB>, id: string): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      file_name: `${id}.txt`,
+      file_type: "issue",
+      content_category: "structured",
+      content: id,
+      source: "linear",
+      content_hash: `hash-${id}`,
+      is_archived: 0,
+      synced_at: now,
+    })
+    .execute();
+}
+
+async function seedStructuralFacts(db: Kysely<DB>): Promise<void> {
+  await seedFile(db, "task-file");
+  const factRepo = createIndexedFileFactRepository(db);
+
+  await factRepo.upsertFact({
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    source: "linear",
+    factType: "structural_seed",
+    relation: "seeded",
+    subjectName: "Atlas Launch",
+    subjectSource: "linear",
+    subjectSourceId: PROJECT_SOURCE_ID,
+    raw: { sourceType: "project", sourceUrl: "https://linear.app/project/atlas" },
+  });
+
+  await factRepo.upsertFact({
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    source: "linear",
+    factType: "person_seed",
+    relation: "seeded",
+    subjectName: "Priya Shah",
+    subjectEmail: "priya@example.com",
+    subjectSource: "linear",
+    subjectSourceId: PERSON_SOURCE_ID,
+    raw: { subtype: "internal" },
+  });
+
+  await factRepo.upsertFact({
+    indexedFileId: "task-file",
+    connectorConfigId: CONNECTOR_ID,
+    createdByUserId: USER_ID,
+    source: "linear",
+    factType: "structural_task",
+    relation: "mentioned",
+    subjectName: "Build account spine",
+    subjectSource: "linear",
+    subjectSourceId: TASK_SOURCE_ID,
+    raw: {
+      indexedFileId: "task-file",
+      task: {
+        sourceTaskId: TASK_SOURCE_ID,
+        externalRef: "SKETCH-1",
+        title: "Build account spine",
+        statusType: "started",
+        statusRaw: "In Progress",
+        project: { name: "Atlas Launch", source: "linear", sourceId: PROJECT_SOURCE_ID },
+        assignee: {
+          name: "Priya Shah",
+          email: "priya@example.com",
+          source: "linear",
+          sourceId: PERSON_SOURCE_ID,
+        },
+      },
+    },
+  });
+}
+
+async function seedCoMentionFacts(db: Kysely<DB>, fileIds: string[]): Promise<void> {
+  const factRepo = createIndexedFileFactRepository(db);
+  for (const fileId of fileIds) {
+    await seedFile(db, fileId);
+    await factRepo.upsertFact({
+      indexedFileId: fileId,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      factType: "assignee",
+      relation: "assigned",
+      subjectName: "Priya Shah",
+      subjectEmail: "priya@example.com",
+      subjectSource: "linear",
+      subjectSourceId: PERSON_SOURCE_ID,
+      raw: {
+        providerFileId: fileId,
+        sourceRefKey: `linear:${PERSON_SOURCE_ID}`,
+        assignee: { name: "Priya Shah", email: "priya@example.com", source: "linear", sourceId: PERSON_SOURCE_ID },
+      },
+    });
+    await factRepo.upsertFact({
+      indexedFileId: fileId,
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      factType: "parent_entity",
+      relation: "mentioned",
+      subjectName: "Atlas Launch",
+      subjectSource: "linear",
+      subjectSourceId: PROJECT_SOURCE_ID,
+      raw: {
+        providerFileId: fileId,
+        parent: { source: "linear", sourceId: PROJECT_SOURCE_ID },
+      },
+    });
+  }
+}
+
+async function runRecreate(db: Kysely<DB>, experimentalFlag: boolean): Promise<void> {
+  configureMaterializeDefaults({
+    structuralAutoBirthTypes: new Set<ProposeEntityType>(["project"]),
+    experimentalFlag: true,
+  });
+  await recreateEntityGraph({
+    db,
+    logger: createTestLogger(),
+    triggeredByUserId: USER_ID,
+    experimentalFlag,
+    skipEnrichment: true,
+    coMentionContributesToThreshold: 2,
+  });
+}
+
+async function contributesToRows(db: Kysely<DB>) {
+  return db
+    .selectFrom("entity_relationships")
+    .select(["source", "relationship_type", "confidence"])
+    .where("relationship_type", "=", "contributes_to")
+    .orderBy("source", "asc")
+    .execute();
+}
+
+describe("recreateEntityGraph structural assignee rebuild", () => {
+  let db: Kysely<DB>;
+  let previousMaterializeDefaults: MaterializeDefaultsSnapshot | undefined;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    previousMaterializeDefaults = await snapshotMaterializeDefaults(db);
+    await seedBase(db);
+  });
+
+  afterEach(async () => {
+    if (previousMaterializeDefaults) configureMaterializeDefaults(previousMaterializeDefaults);
+    await db.destroy();
+  });
+
+  it("mints a structural_assignee contributes_to edge during reconstruct", async () => {
+    await seedStructuralFacts(db);
+
+    await runRecreate(db, true);
+
+    const relationships = await contributesToRows(db);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({
+      source: "structural_assignee",
+      relationship_type: "contributes_to",
+      confidence: "INFERRED",
+    });
+  });
+
+  it("does not mint structural_assignee edges when experimentalFlag is false", async () => {
+    await seedStructuralFacts(db);
+
+    await runRecreate(db, false);
+
+    const relationships = await contributesToRows(db);
+    expect(relationships.filter((row) => row.source === "structural_assignee")).toHaveLength(0);
+  });
+
+  it("keeps structural_assignee precedence over recreate co-mention sweep", async () => {
+    await seedStructuralFacts(db);
+    await seedCoMentionFacts(db, ["co-mention-1", "co-mention-2"]);
+
+    await runRecreate(db, true);
+
+    const relationships = await contributesToRows(db);
+    expect(relationships.map((row) => row.source)).toEqual(["structural_assignee"]);
+  });
+});

--- a/packages/server/src/entities/recreate.ts
+++ b/packages/server/src/entities/recreate.ts
@@ -5,10 +5,12 @@ import { type EnrichmentResult, isEnrichmentActive, linkEntitiesByDeterministicM
 import { type DomainSweepResult, sweepDomainPromotions } from "../connectors/smart-enrichment";
 import { getSyncProgress, seedTeamDirectoryEntities } from "../connectors/sync";
 import type { IndexedFileFactType } from "../db/repositories/indexed-file-facts";
+import { createTaskRepository } from "../db/repositories/tasks";
 import type { DB } from "../db/schema";
 import { sweepCoMentionContributesTo } from "./co-mention-sweep";
 import { type MaterializeFactsSummary, type MaterializeProgress, materializeUnmaterializedFacts } from "./materialize";
 import { isRecreateActive, withRecreateLock } from "./recreate-state";
+import { reconcileStructuralAssigneeContributesTo } from "./structural-assignee";
 
 export type { ReplayFactsSummary } from "./materialize";
 
@@ -307,6 +309,11 @@ export interface RecreateDeps {
   llmPromotionThreshold?: number;
   coMentionContributesToThreshold?: number;
   /**
+   * Enables experimental rebuild phases that must stay invisible when the
+   * org-level experimental flag is off.
+   */
+  experimentalFlag?: boolean;
+  /**
    * Restrict the materialize replay to a subset of fact types. Used by
    * category reset+rebuild to avoid replaying unrelated pending facts.
    */
@@ -346,6 +353,17 @@ export async function recreateEntityGraph(deps: RecreateDeps): Promise<RecreateS
     });
 
     if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
+    if (deps.experimentalFlag) {
+      const taskRepo = createTaskRepository(db);
+      await taskRepo.reanchorNullParentTasks();
+      if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
+      await taskRepo.expireOrphanedTasks();
+      if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
+      await reconcileStructuralAssigneeContributesTo(db, logger.child({ component: "recreate-structural-assignee" }), {
+        scope: { kind: "full" },
+      });
+      if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
+    }
     // Domain promotions run between materialize and deterministic linking so
     // any new company entity (and its `works_at` edges) is visible to the
     // linker. Sweep also runs on every live sync — keep the two paths

--- a/packages/server/src/entities/reenrich.ts
+++ b/packages/server/src/entities/reenrich.ts
@@ -550,6 +550,7 @@ export async function runReenrichJob(deps: ReenrichDeps): Promise<ReenrichSummar
         lockAlreadyHeld: true,
         llmPromotionThreshold: deps.llmPromotionThreshold,
         coMentionContributesToThreshold: deps.coMentionContributesToThreshold,
+        experimentalFlag: deps.experimentalFlag,
         materializeFactTypes: deps.materializeFactTypes ?? [...AI_EXTRACTION_FACT_TYPES],
         onProgress: deps.onProgress,
         shouldCancel: deps.shouldCancel,

--- a/packages/server/src/entities/review.test.ts
+++ b/packages/server/src/entities/review.test.ts
@@ -204,6 +204,83 @@ async function seedReviewRow(
   return { id, candidateGeneratedAt: now };
 }
 
+async function seedEntity(
+  db: Kysely<DB>,
+  opts: { name: string; sourceType: string; id?: string; status?: string },
+): Promise<string> {
+  const id = opts.id ?? randomUUID();
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name: opts.name,
+      source_type: opts.sourceType,
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: opts.status ?? "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  return id;
+}
+
+async function seedStructuralTask(
+  db: Kysely<DB>,
+  opts: {
+    sourceTaskId: string;
+    fileId: string;
+    assigneeEntityId: string | null;
+    parentEntityId: string | null;
+    parentName: string | null;
+    parentSourceRef?: string | null;
+  },
+): Promise<string> {
+  const repo = createTaskRepository(db);
+  const result = await repo.upsertTask({
+    parentEntityId: opts.parentEntityId,
+    parentSourceRef: opts.parentSourceRef ?? null,
+    parentName: opts.parentName,
+    source: "linear",
+    externalRef: opts.sourceTaskId,
+    title: opts.sourceTaskId,
+    status: "open",
+    statusRaw: "open",
+    statusAuthority: "external",
+    assigneeEntityId: opts.assigneeEntityId,
+    priority: null,
+    dueAt: null,
+    provenance: "structural",
+    sourceTaskId: opts.sourceTaskId,
+  });
+  await repo.upsertEvidence(result.taskId, "file", opts.fileId);
+  return result.taskId;
+}
+
+async function structuralContributesToRows(db: Kysely<DB>) {
+  return db
+    .selectFrom("entity_relationships")
+    .selectAll()
+    .where("relationship_type", "=", "contributes_to")
+    .where("source", "=", "structural_assignee")
+    .orderBy("source_entity_id")
+    .execute();
+}
+
+async function structuralContributesToEvidenceNotes(db: Kysely<DB>, relationshipId: string): Promise<string[]> {
+  const rows = await db
+    .selectFrom("entity_relationship_evidence")
+    .select("note")
+    .where("relationship_id", "=", relationshipId)
+    .orderBy("note")
+    .execute();
+  return rows.map((row) => row.note ?? "");
+}
+
 describe("entity-review routes — mounting", () => {
   it("returns 200 without EXPERIMENTAL_FLAG (Files is GA, route always mounted)", async () => {
     const db = await createTestDb();
@@ -732,6 +809,166 @@ describe("entity-review A4 backend", () => {
     expect(rejectReplay.status).toBe(200);
     const rejectReplayBody = (await rejectReplay.json()) as { results: Array<{ ok: boolean }> };
     expect(rejectReplayBody.results.every((result) => result.ok)).toBe(true);
+  });
+
+  it("batch confirm backfills structural assignee contributes_to for confirmed project tasks", async () => {
+    const projectName = "A4 Batch Backfill Project";
+    const personId = await seedEntity(db, { name: "A4 Batch Person", sourceType: "person" });
+    const projectId = await seedEntity(db, { name: projectName, sourceType: "project" });
+    const review = await seedReviewRow(db, {
+      proposedName: projectName,
+      entityType: "project",
+      triggeredBy: ownerId,
+      evidenceFileIds: ["a4-owner-file"],
+      candidateEntityId: projectId,
+    });
+    const anchoredTaskId = await seedStructuralTask(db, {
+      sourceTaskId: "a4-batch-anchored-task",
+      fileId: "a4-owner-file",
+      assigneeEntityId: personId,
+      parentEntityId: projectId,
+      parentName: projectName,
+    });
+    const reanchoredTaskId = await seedStructuralTask(db, {
+      sourceTaskId: "a4-batch-reanchored-task",
+      fileId: "a4-owner-file",
+      assigneeEntityId: personId,
+      parentEntityId: null,
+      parentName: projectName,
+    });
+
+    const res = await app.request("/api/entity-review/confirm-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: ownerCookie },
+      body: JSON.stringify({
+        items: [{ reviewId: review.id, candidateGeneratedAt: review.candidateGeneratedAt }],
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const relationships = await structuralContributesToRows(db);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({
+      source_entity_id: personId,
+      target_entity_id: projectId,
+      confidence: "INFERRED",
+      confidence_score: 0.9,
+      source: "structural_assignee",
+    });
+    await expect(structuralContributesToEvidenceNotes(db, relationships[0].id)).resolves.toEqual(
+      [`structural_assignee:task:${anchoredTaskId}`, `structural_assignee:task:${reanchoredTaskId}`].sort(),
+    );
+    const reanchoredTask = await db
+      .selectFrom("tasks")
+      .select("parent_entity_id")
+      .where("id", "=", reanchoredTaskId)
+      .executeTakeFirstOrThrow();
+    expect(reanchoredTask.parent_entity_id).toBe(projectId);
+  });
+
+  it("single confirm backfills structural assignee contributes_to for confirmed project tasks", async () => {
+    const projectName = "A4 Single Backfill Project";
+    const personId = await seedEntity(db, { name: "A4 Single Person", sourceType: "person" });
+    const review = await seedReviewRow(db, {
+      proposedName: projectName,
+      entityType: "project",
+      triggeredBy: ownerId,
+      evidenceFileIds: ["a4-owner-file"],
+      source: "linear",
+      sourceId: "a4-single-backfill-project",
+      candidateReason: "birth-gated",
+    });
+    const taskId = await seedStructuralTask(db, {
+      sourceTaskId: "a4-single-reanchored-task",
+      fileId: "a4-owner-file",
+      assigneeEntityId: personId,
+      parentEntityId: null,
+      parentName: projectName,
+      parentSourceRef: "linear:a4-single-backfill-project",
+    });
+
+    const res = await app.request(`/api/entity-review/${review.id}/confirm`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: ownerCookie },
+      body: JSON.stringify({ candidateGeneratedAt: review.candidateGeneratedAt }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { targetEntityId: string };
+
+    const relationships = await structuralContributesToRows(db);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({
+      source_entity_id: personId,
+      target_entity_id: body.targetEntityId,
+      confidence: "INFERRED",
+      confidence_score: 0.9,
+      source: "structural_assignee",
+    });
+    await expect(structuralContributesToEvidenceNotes(db, relationships[0].id)).resolves.toEqual([
+      `structural_assignee:task:${taskId}`,
+    ]);
+    const task = await db
+      .selectFrom("tasks")
+      .select("parent_entity_id")
+      .where("id", "=", taskId)
+      .executeTakeFirstOrThrow();
+    expect(task.parent_entity_id).toBe(body.targetEntityId);
+  });
+
+  it("does not run confirm-time structural assignee backfill when experimental flag is off", async () => {
+    const projectName = "A4 Flag Off Backfill Project";
+    const personId = await seedEntity(db, { name: "A4 Flag Off Person", sourceType: "person" });
+    const single = await seedReviewRow(db, {
+      proposedName: projectName,
+      entityType: "project",
+      triggeredBy: ownerId,
+      evidenceFileIds: ["a4-owner-file"],
+      source: "linear",
+      sourceId: "a4-flag-off-backfill-project",
+      candidateReason: "birth-gated",
+    });
+    const singleTaskId = await seedStructuralTask(db, {
+      sourceTaskId: "a4-flag-off-single-task",
+      fileId: "a4-owner-file",
+      assigneeEntityId: personId,
+      parentEntityId: null,
+      parentName: projectName,
+      parentSourceRef: "linear:a4-flag-off-backfill-project",
+    });
+
+    const offCookie = await login(offApp, OWNER_EMAIL);
+    const singleRes = await offApp.request(`/api/entity-review/${single.id}/confirm`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: offCookie },
+      body: JSON.stringify({ candidateGeneratedAt: single.candidateGeneratedAt }),
+    });
+    expect(singleRes.status).toBe(200);
+    const singleTask = await db
+      .selectFrom("tasks")
+      .select("parent_entity_id")
+      .where("id", "=", singleTaskId)
+      .executeTakeFirstOrThrow();
+    expect(singleTask.parent_entity_id).toBeNull();
+    await expect(structuralContributesToRows(db)).resolves.toHaveLength(0);
+
+    const batch = await seedReviewRow(db, {
+      proposedName: "A4 Flag Off Batch Backfill Project",
+      entityType: "project",
+      triggeredBy: ownerId,
+      evidenceFileIds: ["a4-owner-file"],
+      source: "linear",
+      sourceId: "a4-flag-off-batch-backfill-project",
+      candidateReason: "birth-gated",
+    });
+    const batchRes = await offApp.request("/api/entity-review/confirm-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: offCookie },
+      body: JSON.stringify({
+        items: [{ reviewId: batch.id, candidateGeneratedAt: batch.candidateGeneratedAt }],
+      }),
+    });
+    expect(batchRes.status).toBe(404);
+    await expect(structuralContributesToRows(db)).resolves.toHaveLength(0);
   });
 
   it("reclassify changes type, merges compatible collisions, and refuses incompatible source or seed refs", async () => {

--- a/packages/server/src/entities/review.ts
+++ b/packages/server/src/entities/review.ts
@@ -30,6 +30,7 @@
  */
 import { type Context, Hono } from "hono";
 import type { Kysely } from "kysely";
+import type { Logger } from "pino";
 import { getContentViewer, isAdmin } from "../api/auth-helpers";
 import type { Config } from "../config";
 import { createEntityRepository } from "../db/repositories/entities";
@@ -38,6 +39,7 @@ import { createIndexedFileFactRepository } from "../db/repositories/indexed-file
 import { createTaskRepository } from "../db/repositories/tasks";
 import type { DB } from "../db/schema";
 import { ResolveError, confirmReview, dismissReview, reclassifyReview, rejectReview } from "./resolve";
+import { reconcileStructuralAssigneeContributesTo } from "./structural-assignee";
 
 function readEmail(metadata: string | null): string | null {
   if (!metadata) return null;
@@ -126,7 +128,25 @@ function batchError(err: unknown): { code: string; message: string } {
   return { code: "INTERNAL_ERROR", message: "unexpected batch item failure" };
 }
 
-export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, "EXPERIMENTAL_FLAG"> }) {
+async function backfillStructuralAssigneeForConfirmedProjects(
+  db: Kysely<DB>,
+  logger: Logger,
+  projectEntityIds: string[],
+): Promise<void> {
+  const uniqueProjectEntityIds = [...new Set(projectEntityIds)];
+  if (uniqueProjectEntityIds.length === 0) return;
+  const taskRepo = createTaskRepository(db);
+  const reanchored = await taskRepo.reanchorNullParentTasks();
+  const existingTaskIds = await taskRepo.listStructuralTaskIdsByParentEntityIds(uniqueProjectEntityIds);
+  const taskIds = [...new Set([...reanchored.taskIds, ...existingTaskIds])];
+  if (taskIds.length === 0) return;
+  await reconcileStructuralAssigneeContributesTo(db, logger, { scope: { kind: "tasks", taskIds } });
+}
+
+export function entityReviewRoutes(
+  db: Kysely<DB>,
+  deps: { config: Pick<Config, "EXPERIMENTAL_FLAG">; logger: Logger },
+) {
   const app = new Hono();
 
   app.get("/", async (c) => {
@@ -237,7 +257,7 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
         targetEntityId?: string;
         error?: { code: string; message: string };
       }> = [];
-      let confirmedProject = false;
+      const confirmedProjectTargetEntityIds = new Set<string>();
       for (const item of body.items) {
         const reviewId = item.reviewId ?? "";
         if (!item.reviewId || !item.candidateGeneratedAt) {
@@ -267,14 +287,14 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
             mergeIntoEntityId: item.mergeIntoEntityId,
             candidateGeneratedAt: item.candidateGeneratedAt,
           });
-          confirmedProject ||= result.row.entity_type === "project";
+          if (result.row.entity_type === "project") confirmedProjectTargetEntityIds.add(result.targetEntityId);
           results.push({ reviewId: item.reviewId, ok: true, targetEntityId: result.targetEntityId });
         } catch (err) {
           results.push({ reviewId: item.reviewId, ok: false, error: batchError(err) });
         }
       }
-      if (confirmedProject) {
-        await createTaskRepository(db).reanchorNullParentTasks();
+      if (deps.config.EXPERIMENTAL_FLAG && confirmedProjectTargetEntityIds.size > 0) {
+        await backfillStructuralAssigneeForConfirmedProjects(db, deps.logger, [...confirmedProjectTargetEntityIds]);
       }
       return c.json({ results });
     });
@@ -452,6 +472,9 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { config: Pick<Config, 
         candidateGeneratedAt: body.candidateGeneratedAt,
         nameOverride: body.nameOverride,
       });
+      if (deps.config.EXPERIMENTAL_FLAG && result.row.entity_type === "project") {
+        await backfillStructuralAssigneeForConfirmedProjects(db, deps.logger, [result.targetEntityId]);
+      }
       return c.json({
         row: result.row,
         targetEntityId: result.targetEntityId,

--- a/packages/server/src/entities/structural-assignee.test.ts
+++ b/packages/server/src/entities/structural-assignee.test.ts
@@ -1,0 +1,353 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createTaskRepository } from "../db/repositories/tasks";
+import type { DB } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { sweepCoMentionContributesTo } from "./co-mention-sweep";
+import { reconcileStructuralAssigneeContributesTo } from "./structural-assignee";
+
+const USER_ID = "structural-assignee-user";
+const CONNECTOR_ID = "structural-assignee-connector";
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("users")
+    .values({
+      id: USER_ID,
+      name: "Structural Assignee User",
+      email: "structural-assignee@example.com",
+      email_verified_at: now,
+      password_hash: "x",
+      auth_role: "admin",
+    })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "linear",
+      auth_type: "api_key",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedFile(db: Kysely<DB>, id: string, archived = false): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: id,
+      file_name: `${id}.txt`,
+      file_type: "issue",
+      content_category: "structured",
+      content: id,
+      source: "linear",
+      content_hash: `hash-${id}`,
+      is_archived: archived ? 1 : 0,
+      synced_at: now,
+    })
+    .execute();
+}
+
+async function seedEntity(db: Kysely<DB>, id: string, name: string, sourceType: string): Promise<string> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: sourceType,
+      subtype: "external",
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  return id;
+}
+
+async function seedStructuralTask(
+  db: Kysely<DB>,
+  input: {
+    sourceTaskId: string;
+    fileId: string;
+    assigneeEntityId: string | null;
+    parentEntityId: string | null;
+  },
+): Promise<string> {
+  const repo = createTaskRepository(db);
+  const result = await repo.upsertTask({
+    parentEntityId: input.parentEntityId,
+    parentSourceRef: null,
+    parentName: input.parentEntityId ? "Project" : null,
+    source: "linear",
+    externalRef: input.sourceTaskId,
+    title: input.sourceTaskId,
+    status: "open",
+    statusRaw: "open",
+    statusAuthority: "external",
+    assigneeEntityId: input.assigneeEntityId,
+    priority: null,
+    dueAt: null,
+    provenance: "structural",
+    sourceTaskId: input.sourceTaskId,
+  });
+  await repo.upsertEvidence(result.taskId, "file", input.fileId);
+  return result.taskId;
+}
+
+async function seedExtractedCoMentions(
+  db: Kysely<DB>,
+  personId: string,
+  targetId: string,
+  fileIds: string[],
+): Promise<void> {
+  const repo = createEntityRepository(db);
+  for (const fileId of fileIds) {
+    await repo.createMention({
+      entityId: personId,
+      indexedFileId: fileId,
+      confidence: "EXTRACTED",
+      source: "test",
+      relation: "mentioned",
+    });
+    await repo.createMention({
+      entityId: targetId,
+      indexedFileId: fileId,
+      confidence: "EXTRACTED",
+      source: "test",
+      relation: "mentioned",
+    });
+  }
+}
+
+async function relationshipRows(db: Kysely<DB>) {
+  return db.selectFrom("entity_relationships").selectAll().orderBy("source_entity_id").execute();
+}
+
+async function evidenceRows(db: Kysely<DB>) {
+  return db.selectFrom("entity_relationship_evidence").selectAll().orderBy("note").execute();
+}
+
+describe("reconcileStructuralAssigneeContributesTo", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedBase(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("creates one structural edge with task-note evidence and is idempotent", async () => {
+    const personId = await seedEntity(db, "person-happy", "Priya", "person");
+    const projectId = await seedEntity(db, "project-happy", "Atlas", "project");
+    await seedFile(db, "happy-file");
+    const taskId = await seedStructuralTask(db, {
+      sourceTaskId: "happy-task",
+      fileId: "happy-file",
+      assigneeEntityId: personId,
+      parentEntityId: projectId,
+    });
+
+    await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "files", indexedFileIds: ["happy-file"] },
+    });
+    await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "files", indexedFileIds: ["happy-file"] },
+    });
+
+    const relationships = await relationshipRows(db);
+    const evidence = await evidenceRows(db);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({
+      source_entity_id: personId,
+      target_entity_id: projectId,
+      relationship_type: "contributes_to",
+      confidence: "INFERRED",
+      confidence_score: 0.9,
+      source: "structural_assignee",
+      valid_from: "",
+    });
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0]).toMatchObject({
+      relationship_id: relationships[0].id,
+      indexed_file_id: "happy-file",
+      chunk_index: -1,
+      note: `structural_assignee:task:${taskId}`,
+      source_fact_id: null,
+    });
+  });
+
+  it("prunes the old assignee edge on reassignment and keeps the new edge", async () => {
+    const personA = await seedEntity(db, "person-reassign-a", "A", "person");
+    const personB = await seedEntity(db, "person-reassign-b", "B", "person");
+    const projectId = await seedEntity(db, "project-reassign", "Reassign", "project");
+    await seedFile(db, "reassign-file");
+    await seedStructuralTask(db, {
+      sourceTaskId: "reassign-task",
+      fileId: "reassign-file",
+      assigneeEntityId: personA,
+      parentEntityId: projectId,
+    });
+    await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "files", indexedFileIds: ["reassign-file"] },
+    });
+
+    await seedStructuralTask(db, {
+      sourceTaskId: "reassign-task",
+      fileId: "reassign-file",
+      assigneeEntityId: personB,
+      parentEntityId: projectId,
+    });
+    const summary = await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "files", indexedFileIds: ["reassign-file"] },
+    });
+
+    const relationships = await relationshipRows(db);
+    expect(summary.removedEvidence).toBe(1);
+    expect(summary.removedRelationships).toBe(1);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({
+      source_entity_id: personB,
+      target_entity_id: projectId,
+      source: "structural_assignee",
+    });
+  });
+
+  it("does not create an edge for a task without a parent project", async () => {
+    const personId = await seedEntity(db, "person-orphan", "No Parent", "person");
+    await seedFile(db, "orphan-file");
+    await seedStructuralTask(db, {
+      sourceTaskId: "orphan-task",
+      fileId: "orphan-file",
+      assigneeEntityId: personId,
+      parentEntityId: null,
+    });
+
+    await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "files", indexedFileIds: ["orphan-file"] },
+    });
+
+    expect(await relationshipRows(db)).toHaveLength(0);
+    expect(await evidenceRows(db)).toHaveLength(0);
+  });
+
+  it("creates an edge from task scope when the supporting file was not touched", async () => {
+    const personId = await seedEntity(db, "person-task-scope", "Task Scope", "person");
+    const projectId = await seedEntity(db, "project-task-scope", "Old Project", "project");
+    await seedFile(db, "old-file");
+    const taskId = await seedStructuralTask(db, {
+      sourceTaskId: "old-task",
+      fileId: "old-file",
+      assigneeEntityId: personId,
+      parentEntityId: projectId,
+    });
+
+    await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "tasks", taskIds: [taskId] },
+    });
+
+    const relationships = await relationshipRows(db);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({ source_entity_id: personId, target_entity_id: projectId });
+    expect((await evidenceRows(db))[0].note).toBe(`structural_assignee:task:${taskId}`);
+  });
+
+  it("removes the structural edge when the task expires before reconciliation", async () => {
+    const personId = await seedEntity(db, "person-expired", "Expired", "person");
+    const projectId = await seedEntity(db, "project-expired", "Expired Project", "project");
+    await seedFile(db, "expired-file");
+    const taskId = await seedStructuralTask(db, {
+      sourceTaskId: "expired-task",
+      fileId: "expired-file",
+      assigneeEntityId: personId,
+      parentEntityId: projectId,
+    });
+    await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "tasks", taskIds: [taskId] },
+    });
+
+    await db.updateTable("tasks").set({ valid_to: new Date().toISOString() }).where("id", "=", taskId).execute();
+    const summary = await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "tasks", taskIds: [taskId] },
+    });
+
+    expect(summary.removedEvidence).toBe(1);
+    expect(summary.removedRelationships).toBe(1);
+    expect(await relationshipRows(db)).toHaveLength(0);
+    expect(await evidenceRows(db)).toHaveLength(0);
+  });
+
+  it("removes co-mention evidence when structural takes over the same pair", async () => {
+    const personId = await seedEntity(db, "person-takeover", "Takeover", "person");
+    const projectId = await seedEntity(db, "project-takeover", "Takeover Project", "project");
+    await seedFile(db, "takeover-1");
+    await seedFile(db, "takeover-2");
+    await seedFile(db, "takeover-3");
+    await seedExtractedCoMentions(db, personId, projectId, ["takeover-1", "takeover-2", "takeover-3"]);
+    await sweepCoMentionContributesTo(db, createTestLogger(), { threshold: 3 });
+    expect((await evidenceRows(db)).map((row) => row.note)).toEqual([
+      `co_mention:${personId}:${projectId}`,
+      `co_mention:${personId}:${projectId}`,
+      `co_mention:${personId}:${projectId}`,
+    ]);
+    const taskId = await seedStructuralTask(db, {
+      sourceTaskId: "takeover-task",
+      fileId: "takeover-1",
+      assigneeEntityId: personId,
+      parentEntityId: projectId,
+    });
+
+    const summary = await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "tasks", taskIds: [taskId] },
+    });
+
+    const relationships = await relationshipRows(db);
+    const evidence = await evidenceRows(db);
+    expect(summary.removedCoMentionEvidence).toBe(3);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({ source: "structural_assignee", confidence: "INFERRED" });
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].note).toBe(`structural_assignee:task:${taskId}`);
+  });
+
+  it("keeps co-mention from adding evidence once a structural edge exists", async () => {
+    const personId = await seedEntity(db, "person-defer", "Defer", "person");
+    const projectId = await seedEntity(db, "project-defer", "Defer Project", "project");
+    await seedFile(db, "defer-task-file");
+    await seedFile(db, "defer-mention-1");
+    await seedFile(db, "defer-mention-2");
+    const taskId = await seedStructuralTask(db, {
+      sourceTaskId: "defer-task",
+      fileId: "defer-task-file",
+      assigneeEntityId: personId,
+      parentEntityId: projectId,
+    });
+    await reconcileStructuralAssigneeContributesTo(db, createTestLogger(), {
+      scope: { kind: "tasks", taskIds: [taskId] },
+    });
+    await seedExtractedCoMentions(db, personId, projectId, ["defer-mention-1", "defer-mention-2"]);
+
+    await sweepCoMentionContributesTo(db, createTestLogger(), { threshold: 2 });
+
+    const relationships = await relationshipRows(db);
+    const evidence = await evidenceRows(db);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({ source: "structural_assignee" });
+    expect(evidence.map((row) => row.note)).toEqual([`structural_assignee:task:${taskId}`]);
+  });
+});

--- a/packages/server/src/entities/structural-assignee.ts
+++ b/packages/server/src/entities/structural-assignee.ts
@@ -1,0 +1,323 @@
+import type { Kysely } from "kysely";
+import type { Logger } from "pino";
+import { whereLiveEntity } from "../db/repositories/entities";
+import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
+import { TEST_ACCOUNT_ENTITY_ID } from "../db/repositories/tasks";
+import type { DB } from "../db/schema";
+
+const STRUCTURAL_ASSIGNEE_SOURCE = "structural_assignee";
+const STRUCTURAL_ASSIGNEE_RELATIONSHIP_TYPE = "contributes_to";
+const STRUCTURAL_ASSIGNEE_CONFIDENCE = "INFERRED";
+const STRUCTURAL_ASSIGNEE_CONFIDENCE_SCORE = 0.9;
+const STRUCTURAL_ASSIGNEE_NOTE_PREFIX = "structural_assignee:";
+
+export type StructuralAssigneeScope =
+  | { kind: "full" }
+  | { kind: "files"; indexedFileIds: string[] }
+  | { kind: "tasks"; taskIds: string[] };
+
+export interface StructuralAssigneeOptions {
+  scope?: StructuralAssigneeScope;
+}
+
+export interface StructuralAssigneeSummary {
+  scannedPairs: number;
+  upsertedRelationships: number;
+  addedEvidence: number;
+  removedEvidence: number;
+  removedCoMentionEvidence: number;
+  removedRelationships: number;
+}
+
+interface Pair {
+  personEntityId: string;
+  targetEntityId: string;
+}
+
+interface StructuralTaskRow extends Pair {
+  taskId: string;
+  indexedFileId: string;
+}
+
+interface ManagedRelationship extends Pair {
+  id: string;
+}
+
+function pairKey(pair: Pair): string {
+  return `${pair.personEntityId}\u0000${pair.targetEntityId}`;
+}
+
+function noteForTask(taskId: string): string {
+  return `${STRUCTURAL_ASSIGNEE_NOTE_PREFIX}task:${taskId}`;
+}
+
+function evidenceKey(relationshipId: string, indexedFileId: string, note: string): string {
+  return `note:${relationshipId}:${indexedFileId}:-1:${note}`;
+}
+
+async function queryStructuralTaskRows(
+  db: Kysely<DB>,
+  filter?: {
+    indexedFileIds?: string[];
+    taskIds?: string[];
+    personEntityIds?: string[];
+    targetEntityIds?: string[];
+  },
+): Promise<StructuralTaskRow[]> {
+  if (filter?.indexedFileIds?.length === 0) return [];
+  if (filter?.taskIds?.length === 0) return [];
+  if (filter?.personEntityIds?.length === 0) return [];
+  if (filter?.targetEntityIds?.length === 0) return [];
+
+  let query = db
+    .selectFrom("tasks as t")
+    .innerJoin("entities as assignee", "assignee.id", "t.assignee_entity_id")
+    .innerJoin("entities as parent", "parent.id", "t.parent_entity_id")
+    .innerJoin("task_evidence as te", "te.task_id", "t.id")
+    .innerJoin("indexed_files as f", "f.id", "te.ref_id")
+    .select([
+      "t.id as taskId",
+      "t.assignee_entity_id as personEntityId",
+      "t.parent_entity_id as targetEntityId",
+      "te.ref_id as indexedFileId",
+    ])
+    .where("t.provenance", "=", "structural")
+    .where("t.valid_to", "is", null)
+    .where("t.assignee_entity_id", "is not", null)
+    .where("t.parent_entity_id", "is not", null)
+    .where("assignee.source_type", "=", "person")
+    .where("assignee.id", "!=", TEST_ACCOUNT_ENTITY_ID)
+    .where(whereLiveEntity("assignee"))
+    .where("parent.source_type", "=", "project")
+    .where("parent.id", "!=", TEST_ACCOUNT_ENTITY_ID)
+    .where(whereLiveEntity("parent"))
+    .where("te.kind", "=", "file")
+    .where("f.is_archived", "=", 0);
+
+  if (filter?.indexedFileIds) query = query.where("te.ref_id", "in", filter.indexedFileIds);
+  if (filter?.taskIds) query = query.where("t.id", "in", filter.taskIds);
+  if (filter?.personEntityIds) query = query.where("t.assignee_entity_id", "in", filter.personEntityIds);
+  if (filter?.targetEntityIds) query = query.where("t.parent_entity_id", "in", filter.targetEntityIds);
+
+  const rows = await query.execute();
+  return rows.flatMap((row) =>
+    row.personEntityId && row.targetEntityId
+      ? [
+          {
+            taskId: row.taskId,
+            personEntityId: row.personEntityId,
+            targetEntityId: row.targetEntityId,
+            indexedFileId: row.indexedFileId,
+          },
+        ]
+      : [],
+  );
+}
+
+async function observedPairsForFiles(db: Kysely<DB>, indexedFileIds: string[]): Promise<Map<string, Pair>> {
+  const rows = await queryStructuralTaskRows(db, { indexedFileIds });
+  return pairsFromRows(rows);
+}
+
+async function observedPairsForTasks(db: Kysely<DB>, taskIds: string[]): Promise<Map<string, Pair>> {
+  const rows = await queryStructuralTaskRows(db, { taskIds });
+  return pairsFromRows(rows);
+}
+
+function pairsFromRows(rows: StructuralTaskRow[]): Map<string, Pair> {
+  const pairs = new Map<string, Pair>();
+  for (const row of rows) {
+    const pair = { personEntityId: row.personEntityId, targetEntityId: row.targetEntityId };
+    pairs.set(pairKey(pair), pair);
+  }
+  return pairs;
+}
+
+async function existingStructuralPairsForFiles(db: Kysely<DB>, indexedFileIds: string[]): Promise<Map<string, Pair>> {
+  if (indexedFileIds.length === 0) return new Map();
+  const rows = await db
+    .selectFrom("entity_relationship_evidence as ev")
+    .innerJoin("entity_relationships as rel", "rel.id", "ev.relationship_id")
+    .select(["rel.source_entity_id as personEntityId", "rel.target_entity_id as targetEntityId"])
+    .where("ev.indexed_file_id", "in", indexedFileIds)
+    .where("ev.note", "like", `${STRUCTURAL_ASSIGNEE_NOTE_PREFIX}%`)
+    .where("rel.source", "=", STRUCTURAL_ASSIGNEE_SOURCE)
+    .where("rel.relationship_type", "=", STRUCTURAL_ASSIGNEE_RELATIONSHIP_TYPE)
+    .where("rel.confidence", "=", STRUCTURAL_ASSIGNEE_CONFIDENCE)
+    .where("rel.valid_from", "=", "")
+    .execute();
+  const pairs = new Map<string, Pair>();
+  for (const row of rows) {
+    const pair = { personEntityId: row.personEntityId, targetEntityId: row.targetEntityId };
+    pairs.set(pairKey(pair), pair);
+  }
+  return pairs;
+}
+
+async function existingStructuralPairsForTasks(db: Kysely<DB>, taskIds: string[]): Promise<Map<string, Pair>> {
+  if (taskIds.length === 0) return new Map();
+  const notes = taskIds.map(noteForTask);
+  const rows = await db
+    .selectFrom("entity_relationship_evidence as ev")
+    .innerJoin("entity_relationships as rel", "rel.id", "ev.relationship_id")
+    .select(["rel.source_entity_id as personEntityId", "rel.target_entity_id as targetEntityId"])
+    .where("ev.note", "in", notes)
+    .where("rel.source", "=", STRUCTURAL_ASSIGNEE_SOURCE)
+    .where("rel.relationship_type", "=", STRUCTURAL_ASSIGNEE_RELATIONSHIP_TYPE)
+    .where("rel.confidence", "=", STRUCTURAL_ASSIGNEE_CONFIDENCE)
+    .where("rel.valid_from", "=", "")
+    .execute();
+  const pairs = new Map<string, Pair>();
+  for (const row of rows) {
+    const pair = { personEntityId: row.personEntityId, targetEntityId: row.targetEntityId };
+    pairs.set(pairKey(pair), pair);
+  }
+  return pairs;
+}
+
+async function candidatePairs(db: Kysely<DB>, scope: StructuralAssigneeScope): Promise<Map<string, Pair> | null> {
+  if (scope.kind === "full") return null;
+  const pairs =
+    scope.kind === "files"
+      ? await observedPairsForFiles(db, scope.indexedFileIds)
+      : await observedPairsForTasks(db, scope.taskIds);
+  const existing =
+    scope.kind === "files"
+      ? await existingStructuralPairsForFiles(db, scope.indexedFileIds)
+      : await existingStructuralPairsForTasks(db, scope.taskIds);
+  for (const [key, pair] of existing) pairs.set(key, pair);
+  return pairs;
+}
+
+async function supportByPair(
+  db: Kysely<DB>,
+  candidates: Map<string, Pair> | null,
+): Promise<Map<string, StructuralTaskRow[]>> {
+  if (candidates && candidates.size === 0) return new Map();
+  const rows = candidates
+    ? await queryStructuralTaskRows(db, {
+        personEntityIds: [...new Set([...candidates.values()].map((p) => p.personEntityId))],
+        targetEntityIds: [...new Set([...candidates.values()].map((p) => p.targetEntityId))],
+      })
+    : await queryStructuralTaskRows(db);
+  const support = new Map<string, StructuralTaskRow[]>();
+  for (const row of rows) {
+    const key = pairKey(row);
+    if (candidates && !candidates.has(key)) continue;
+    const existing = support.get(key);
+    if (existing) existing.push(row);
+    else support.set(key, [row]);
+  }
+  return support;
+}
+
+async function managedRelationships(
+  db: Kysely<DB>,
+  candidates: Map<string, Pair> | null,
+): Promise<Map<string, ManagedRelationship>> {
+  let query = db
+    .selectFrom("entity_relationships")
+    .select(["id", "source_entity_id as personEntityId", "target_entity_id as targetEntityId"])
+    .where("source", "=", STRUCTURAL_ASSIGNEE_SOURCE)
+    .where("relationship_type", "=", STRUCTURAL_ASSIGNEE_RELATIONSHIP_TYPE)
+    .where("confidence", "=", STRUCTURAL_ASSIGNEE_CONFIDENCE)
+    .where("valid_from", "=", "");
+
+  if (candidates) {
+    if (candidates.size === 0) return new Map();
+    query = query
+      .where("source_entity_id", "in", [...new Set([...candidates.values()].map((p) => p.personEntityId))])
+      .where("target_entity_id", "in", [...new Set([...candidates.values()].map((p) => p.targetEntityId))]);
+  }
+
+  const rows = await query.execute();
+  const relationships = new Map<string, ManagedRelationship>();
+  for (const row of rows) {
+    const relationship = { id: row.id, personEntityId: row.personEntityId, targetEntityId: row.targetEntityId };
+    const key = pairKey(relationship);
+    if (!candidates || candidates.has(key)) relationships.set(key, relationship);
+  }
+  return relationships;
+}
+
+export async function reconcileStructuralAssigneeContributesTo(
+  db: Kysely<DB>,
+  logger: Logger,
+  opts: StructuralAssigneeOptions = {},
+): Promise<StructuralAssigneeSummary> {
+  const scope = opts.scope ?? { kind: "full" };
+  const candidates = await candidatePairs(db, scope);
+  const support = await supportByPair(db, candidates);
+  const managed = await managedRelationships(db, candidates);
+  const scannedPairs = candidates ? candidates.size : support.size;
+  const pairValues = candidates
+    ? [...candidates.values()]
+    : [...support.keys()].map((key) => {
+        const [personEntityId, targetEntityId] = key.split("\u0000");
+        return { personEntityId, targetEntityId };
+      });
+  const domainsRepo = createEntityDomainsRepository(db);
+  const keepEvidenceKeys = new Set<string>();
+  const touchedManagedRelationshipIds = new Set<string>([...managed.values()].map((rel) => rel.id));
+  const upsertedRelationshipIds = new Set<string>();
+  let upsertedRelationships = 0;
+  let addedEvidence = 0;
+
+  for (const pair of pairValues) {
+    const rows = support.get(pairKey(pair)) ?? [];
+    if (rows.length === 0) continue;
+    const relationshipId = await domainsRepo.upsertRelationship({
+      sourceEntityId: pair.personEntityId,
+      targetEntityId: pair.targetEntityId,
+      relationshipType: STRUCTURAL_ASSIGNEE_RELATIONSHIP_TYPE,
+      confidence: STRUCTURAL_ASSIGNEE_CONFIDENCE,
+      confidenceScore: STRUCTURAL_ASSIGNEE_CONFIDENCE_SCORE,
+      source: STRUCTURAL_ASSIGNEE_SOURCE,
+      validFrom: "",
+    });
+    upsertedRelationships++;
+    touchedManagedRelationshipIds.add(relationshipId);
+    upsertedRelationshipIds.add(relationshipId);
+    for (const row of rows) {
+      const note = noteForTask(row.taskId);
+      await domainsRepo.addEvidence({
+        relationshipId,
+        indexedFileId: row.indexedFileId,
+        chunkIndex: -1,
+        note,
+        sourceFactId: null,
+      });
+      keepEvidenceKeys.add(evidenceKey(relationshipId, row.indexedFileId, note));
+      addedEvidence++;
+    }
+  }
+
+  const removedCoMentionEvidence = await domainsRepo.deleteCoMentionEvidenceForRelationships([
+    ...upsertedRelationshipIds,
+  ]);
+  const removedEvidence = await domainsRepo.deleteStructuralAssigneeEvidenceForRelationships(
+    [...touchedManagedRelationshipIds],
+    keepEvidenceKeys,
+  );
+  const removedRelationships = await domainsRepo.cleanupEmptyRelationships();
+  logger.debug(
+    {
+      scope: scope.kind,
+      scannedPairs,
+      upsertedRelationships,
+      addedEvidence,
+      removedEvidence,
+      removedCoMentionEvidence,
+      removedRelationships,
+    },
+    "Structural assignee contributes_to reconciliation complete",
+  );
+  return {
+    scannedPairs,
+    upsertedRelationships,
+    addedEvidence,
+    removedEvidence,
+    removedCoMentionEvidence,
+    removedRelationships,
+  };
+}

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -460,7 +460,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   if (config.EXPERIMENTAL_FLAG) {
     app.route("/api/products", productRoutes(db));
   }
-  app.route("/api/entity-review", entityReviewRoutes(db, { config }));
+  app.route("/api/entity-review", entityReviewRoutes(db, { config, logger }));
   app.route("/api/api-tokens", apiTokenRoutes(db, { baseUrl: config.BASE_URL }));
   mountPublicMcpServer({
     app,


### PR DESCRIPTION
Stacked context-graph slice 20/27.

Base: `feat/context-graph-19-org-review-surface`
Head: `feat/context-graph-20-structural-spine`

Adds the structural contributes_to graph spine.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`