### PR TITLE
feat: add feature producer

### DIFF
--- a/packages/server/scripts/probe-extraction.ts
+++ b/packages/server/scripts/probe-extraction.ts
@@ -1,0 +1,132 @@
+/**
+ * Read-only LLM extraction probe.
+ *
+ * Runs the live `extractEntities` prompt against real indexed files using the
+ * configured Gemini key, and prints raw mentions + relations. Writes NOTHING:
+ * no DB mutations, no materialization, no dumps — so it never pollutes the
+ * entity graph. Used to score the extraction prompt's DO-NOT / disambiguation
+ * rules against natural data.
+ *
+ *   tsx scripts/probe-extraction.ts <fileId> [<fileId> ...]
+ */
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { buildFileScopedKnownEntities } from "../src/connectors/file-scope-context";
+import { createGeminiGenerator } from "../src/connectors/gemini-generate";
+import { buildParticipantBlock } from "../src/connectors/participant-block";
+import { extractEntities } from "../src/connectors/smart-enrichment";
+import type { DB } from "../src/db/schema";
+import { parseOrgContext } from "../src/db/repositories/settings";
+
+const DB_PATH = "/Users/hkalra/projects/claude/sketch/data/sketch.db";
+const EXPERIMENTAL = true;
+
+async function main() {
+  const fileIds = process.argv.slice(2);
+  if (fileIds.length === 0) {
+    console.error("usage: tsx scripts/probe-extraction.ts <fileId> [<fileId> ...]");
+    process.exit(1);
+  }
+
+  const sqliteDb = new Database(DB_PATH, { readonly: true });
+  const db = new Kysely<DB>({ dialect: new SqliteDialect({ database: sqliteDb }) });
+
+  const settings = await db
+    .selectFrom("settings")
+    .select(["org_name", "org_context", "gemini_api_key"])
+    .where("id", "=", "default")
+    .executeTakeFirstOrThrow();
+
+  if (!settings.gemini_api_key) throw new Error("no gemini_api_key in settings");
+  const parsed = parseOrgContext(settings.org_context);
+  const orgContext = settings.org_context
+    ? {
+        orgName: settings.org_name ?? undefined,
+        description: parsed?.description,
+        industry: parsed?.industry,
+        disambiguationGuidance: parsed?.disambiguationGuidance,
+      }
+    : null;
+
+  const generator = createGeminiGenerator(settings.gemini_api_key);
+
+  for (const fileId of fileIds) {
+    const file = await db
+      .selectFrom("indexed_files")
+      .select([
+        "id",
+        "file_name",
+        "content",
+        "content_category",
+        "file_type",
+        "source_path",
+        "content_hash",
+        "connector_config_id",
+        "source_created_at",
+        "source_updated_at",
+      ])
+      .where("id", "=", fileId)
+      .executeTakeFirst();
+
+    if (!file || !file.content) {
+      console.log(`\n##### ${fileId} — NOT FOUND or empty content`);
+      continue;
+    }
+
+    const knownEntities = await buildFileScopedKnownEntities(
+      { db, experimentalFlag: EXPERIMENTAL } as never,
+      file.id,
+      [],
+      file.content,
+    );
+    const participantBlock = await buildParticipantBlock({ db } as never, {
+      fileId: file.id,
+      fileContent: file.content,
+    });
+
+    const fileContext = {
+      id: file.id,
+      fileName: file.file_name,
+      content: file.content,
+      threadContext: null,
+      contentCategory: file.content_category,
+      fileType: file.file_type,
+      source: file.source_path?.split("/")[0] ?? "unknown",
+      sourcePath: file.source_path,
+      contentHash: file.content_hash,
+      connectorConfigId: file.connector_config_id,
+      sourceCreatedAt: file.source_created_at,
+      sourceUpdatedAt: file.source_updated_at,
+    };
+
+    const result = await extractEntities(
+      generator,
+      fileContext as never,
+      orgContext,
+      knownEntities,
+      participantBlock,
+      undefined,
+      EXPERIMENTAL,
+    );
+
+    console.log(`\n${"#".repeat(78)}`);
+    console.log(`# ${file.file_type} | ${file.file_name}`);
+    console.log(`# id=${file.id} chars=${file.content.length} known=${knownEntities.length}`);
+    console.log("#".repeat(78));
+    console.log("\nMENTIONS:");
+    for (const m of result.mentions) {
+      console.log(`  [${m.type}] ${m.mention}  (conf ${m.confidence})`);
+    }
+    console.log("\nRELATIONS:");
+    for (const r of result.relations) {
+      console.log(`  ${r.source.name} (${r.source.type}) --${r.type}--> ${r.target.name} (${r.target.type})  (conf ${r.confidence})`);
+    }
+  }
+
+  await db.destroy();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/server/src/connectors/engagement-floor.ts
+++ b/packages/server/src/connectors/engagement-floor.ts
@@ -43,6 +43,7 @@ import {
 } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
 import { isRoleAccountEmail } from "../entities/affiliations";
+import { isEmailProviderName } from "../entities/validators";
 import { cleanupEmptyRelationships, cleanupRelationshipEvidenceForFacts } from "../entities/materialize";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
 import { yieldToEventLoop } from "../lib/event-loop";
@@ -146,6 +147,10 @@ export async function applyEngagementFloor(
     if (await domainsRepo.isPersonalOrShared(domain)) continue;
     const company = await domainsRepo.lookupCompanyByDomain(domain);
     if (!company) continue;
+    // Defends against a poisoned domain table: an LLM-minted webmail-brand
+    // company (e.g. "Gmail") can register gmail.com as a corporate domain, which
+    // would pass isPersonalOrShared and surface here as an engagement company.
+    if (isEmailProviderName(company.name)) continue;
     const dedupKey = `${name.toLowerCase()}|${company.id}`;
     if (seen.has(dedupKey)) continue;
     seen.add(dedupKey);

--- a/packages/server/src/connectors/smart-enrichment-feature-producer.integration.test.ts
+++ b/packages/server/src/connectors/smart-enrichment-feature-producer.integration.test.ts
@@ -1,0 +1,436 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely, Selectable } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEntityRepository } from "../db/repositories/entities";
+import { buildIndexedFileFactKey } from "../db/repositories/indexed-file-facts";
+import type { DB, IndexedFileFactsTable, SubEntitiesTable } from "../db/schema";
+import { createTestLogger, createTestPgDb } from "../test-utils";
+import type { GeminiGenerator } from "./gemini-generate";
+import { smartEnrichFile } from "./smart-enrichment";
+
+const USER_ID = "feature-producer-user";
+const CONNECTOR_ID = "feature-producer-connector";
+const PROMPT_VERSION = "llm-extraction-v9";
+let db: Kysely<DB>;
+
+type Mention = {
+  mention: string;
+  type: string;
+  variations: string[];
+  confidence?: number;
+  parentProduct?: string;
+};
+
+describe("smartEnrichFile LLM feature producer postgres", () => {
+  beforeEach(async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+  }, 30000);
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("attaches corroborated LLM features under a declared product without entity leakage", async () => {
+    const product = await seedProduct(db, "Canvas CRM");
+    const beforeProductCount = await countEntitiesByType(db, "product");
+    const files = [
+      {
+        id: `feature-happy-${randomUUID()}`,
+        hash: "hash-feature-happy-1",
+        content: "Canvas CRM includes CRM Analytics for pipeline reporting.",
+      },
+      {
+        id: `feature-happy-${randomUUID()}`,
+        hash: "hash-feature-happy-2",
+        content: "The CRM Analytics screen in Canvas CRM tracks conversion and revenue.",
+      },
+    ];
+    for (const file of files) await seedFile(db, file);
+
+    const generator = generatorWithMentions([
+      {
+        mention: "CRM Analytics",
+        type: "feature",
+        parentProduct: "Canvas CRM",
+        variations: ["Analytics screen"],
+        confidence: 0.94,
+      },
+    ]);
+    for (const file of files) {
+      await smartEnrichFile(deps(generator, true), fileContext(file));
+    }
+
+    const feature = await currentFeatureRows(db, "crm analytics");
+    expect(feature).toHaveLength(1);
+    expect(feature[0]).toMatchObject({
+      kind: "feature",
+      parent_entity_id: product.id,
+      parent_scope_key: product.id,
+      normalized_name: "crm analytics",
+      provenance: "corroborated_llm",
+      valid_to: null,
+    });
+    expect(await countEntitiesByType(db, "product")).toBe(beforeProductCount);
+    await expect(db.selectFrom("entities").selectAll().where("name", "=", "CRM Analytics").execute()).resolves.toEqual(
+      [],
+    );
+    await expect(
+      db.selectFrom("indexed_file_facts").selectAll().where("fact_type", "=", "llm_extracted").execute(),
+    ).resolves.toEqual([]);
+    await expect(
+      db.selectFrom("entity_candidates").selectAll().where("name", "=", "CRM Analytics").execute(),
+    ).resolves.toEqual([]);
+    await expect(
+      db.selectFrom("entity_mentions").selectAll().where("source", "=", "llm_extraction").execute(),
+    ).resolves.toEqual([]);
+
+    const featureFacts = await activeFeatureFacts(db);
+    expect(featureFacts).toHaveLength(2);
+    const raws = featureFacts.map((fact) => readFeatureRaw(fact.raw));
+    for (const file of files) {
+      expect(raws.some((raw) => raw.featureId.includes(file.id))).toBe(true);
+    }
+    expect(new Set(raws.map((raw) => raw.corroborationKey)).size).toBe(1);
+  }, 30000);
+
+  it("drops unresolved and ambiguous parents while keeping flag-off fact keys unchanged", async () => {
+    const missingParentFile = {
+      id: `feature-missing-parent-${randomUUID()}`,
+      hash: "hash-feature-missing-parent",
+      content: "Ghost Analytics is listed as a module in Ghost Product.",
+    };
+    await seedFile(db, missingParentFile);
+    await smartEnrichFile(
+      deps(
+        generatorWithMentions([
+          {
+            mention: "Ghost Analytics",
+            type: "feature",
+            parentProduct: "Ghost Product",
+            variations: [],
+            confidence: 0.94,
+          },
+        ]),
+        true,
+      ),
+      fileContext(missingParentFile),
+    );
+    expect(await activeFeatureFacts(db)).toHaveLength(0);
+    expect(await countFeatureSubEntities(db)).toBe(0);
+    expect(await countEntitiesByType(db, "product")).toBe(0);
+
+    await seedProduct(db, "Ambiguous Product");
+    await seedProduct(db, "Ambiguous Product");
+    const ambiguousFile = {
+      id: `feature-ambiguous-parent-${randomUUID()}`,
+      hash: "hash-feature-ambiguous-parent",
+      content: "Shared Analytics belongs inside Ambiguous Product.",
+    };
+    await seedFile(db, ambiguousFile);
+    await smartEnrichFile(
+      deps(
+        generatorWithMentions([
+          {
+            mention: "Shared Analytics",
+            type: "feature",
+            parentProduct: "Ambiguous Product",
+            variations: [],
+            confidence: 0.93,
+          },
+        ]),
+        true,
+      ),
+      fileContext(ambiguousFile),
+    );
+    expect(await activeFeatureFacts(db)).toHaveLength(0);
+    expect(await countFeatureSubEntities(db)).toBe(0);
+
+    const flagOffFile = {
+      id: `feature-flag-off-${randomUUID()}`,
+      hash: "hash-feature-flag-off",
+      content: "CRM Analytics is discussed as a product candidate.",
+    };
+    await seedFile(db, flagOffFile);
+    let capturedPrompt = "";
+    await smartEnrichFile(
+      deps(
+        generatorWithMentions(
+          [{ mention: "CRM Analytics", type: "product", variations: [], confidence: 0.95 }],
+          (prompt) => {
+            capturedPrompt = prompt;
+          },
+        ),
+        false,
+      ),
+      fileContext(flagOffFile),
+    );
+
+    expect(capturedPrompt).not.toContain('"feature"');
+    expect(capturedPrompt).not.toContain("parentProduct");
+    const fact = await db
+      .selectFrom("indexed_file_facts")
+      .selectAll()
+      .where("indexed_file_id", "=", flagOffFile.id)
+      .where("fact_type", "=", "llm_extracted")
+      .where("subject_name", "=", "CRM Analytics")
+      .executeTakeFirstOrThrow();
+    expect(fact.fact_key).toBe(
+      buildIndexedFileFactKey({
+        indexedFileId: flagOffFile.id,
+        connectorConfigId: CONNECTOR_ID,
+        createdByUserId: USER_ID,
+        contentHash: flagOffFile.hash,
+        source: "llm_extraction",
+        factType: "llm_extracted",
+        relation: "mentioned",
+        subjectName: "CRM Analytics",
+        subjectSource: "llm_extraction",
+        subjectSourceId: `${flagOffFile.id}:${flagOffFile.hash}:${PROMPT_VERSION}:CRM Analytics`,
+        contextSnippet: null,
+        raw: {
+          contentHash: flagOffFile.hash,
+          promptVersion: PROMPT_VERSION,
+          model: "gemini",
+          mention: "CRM Analytics",
+          type: "product",
+          variations: [],
+          confidence: 0.95,
+        },
+      }),
+    );
+    expect(await db.selectFrom("indexed_file_facts").selectAll().where("fact_type", "=", "feature").execute()).toEqual(
+      [],
+    );
+  }, 30000);
+
+  it("corroborates across files and supersedes the feature when support drops below threshold", async () => {
+    const product = await seedProduct(db, "Canvas CRM");
+    const firstFile = {
+      id: `feature-lifecycle-${randomUUID()}`,
+      hash: "hash-feature-lifecycle-1",
+      content: "Canvas CRM has Usage Dashboards for revenue teams.",
+    };
+    const secondFile = {
+      id: `feature-lifecycle-${randomUUID()}`,
+      hash: "hash-feature-lifecycle-2",
+      content: "Usage Dashboards in Canvas CRM show renewal health.",
+    };
+    await seedFile(db, firstFile);
+    await seedFile(db, secondFile);
+
+    const featureGenerator = generatorWithMentions([
+      {
+        mention: "Usage Dashboards",
+        type: "feature",
+        parentProduct: "Canvas CRM",
+        variations: ["Dashboards"],
+        confidence: 0.94,
+      },
+    ]);
+    await smartEnrichFile(deps(featureGenerator, true), fileContext(firstFile));
+    expect(await activeFeatureFacts(db)).toHaveLength(1);
+    expect(await currentFeatureRows(db, "usage dashboards")).toHaveLength(0);
+
+    await smartEnrichFile(deps(featureGenerator, true), fileContext(secondFile));
+    let current = await currentFeatureRows(db, "usage dashboards");
+    expect(current).toHaveLength(1);
+    expect(current[0]).toMatchObject({ parent_entity_id: product.id, provenance: "corroborated_llm" });
+    await expect(currentEvidenceRefs(db, current[0].id, "file")).resolves.toEqual([firstFile.id, secondFile.id].sort());
+
+    const updatedSecondFile = {
+      ...secondFile,
+      hash: "hash-feature-lifecycle-2b",
+      content: "Canvas CRM release notes cover cleanup work without that dashboard module.",
+    };
+    await updateFileContent(db, updatedSecondFile);
+    await smartEnrichFile(deps(generatorWithMentions([]), true), fileContext(updatedSecondFile));
+
+    const secondFact = await db
+      .selectFrom("indexed_file_facts")
+      .selectAll()
+      .where("indexed_file_id", "=", secondFile.id)
+      .where("fact_type", "=", "feature")
+      .executeTakeFirstOrThrow();
+    expect(secondFact.deleted_at).not.toBeNull();
+    current = await currentFeatureRows(db, "usage dashboards");
+    expect(current).toHaveLength(0);
+    const allRows = await featureRows(db, "usage dashboards");
+    expect(allRows).toHaveLength(1);
+    expect(allRows[0].valid_to).not.toBeNull();
+    await expect(currentEvidenceRefs(db, allRows[0].id, "file")).resolves.toEqual([]);
+  }, 30000);
+});
+
+function deps(generator: GeminiGenerator, experimentalFlag: boolean) {
+  return {
+    db,
+    logger: createTestLogger(),
+    generator,
+    embeddingProvider: null,
+    experimentalFlag,
+  };
+}
+
+function generatorWithMentions(mentions: Mention[], capturePrompt?: (prompt: string) => void): GeminiGenerator {
+  return {
+    generate: async () => "Summary for the indexed file.",
+    generateJSON: async <T>(prompt: string, opts?: { label?: string }) => {
+      if (opts?.label?.startsWith("extractEntities")) {
+        capturePrompt?.(prompt);
+        return { mentions, relations: [] } as T;
+      }
+      return {} as T;
+    },
+  } as GeminiGenerator;
+}
+
+async function seedBase(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("users")
+    .values({ id: USER_ID, name: "Feature Producer User", email: "feature-producer@example.com" })
+    .execute();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: CONNECTOR_ID,
+      connector_type: "google_drive",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: USER_ID,
+      scope_config: "{}",
+    })
+    .execute();
+}
+
+async function seedProduct(db: Kysely<DB>, name: string) {
+  return createEntityRepository(db).createEntity({
+    name,
+    sourceType: "product",
+    status: "confirmed",
+    provenanceTier: "declared",
+  });
+}
+
+async function seedFile(db: Kysely<DB>, file: { id: string; hash: string; content: string }): Promise<void> {
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: file.id,
+      connector_config_id: CONNECTOR_ID,
+      provider_file_id: file.id,
+      provider_url: null,
+      file_name: `${file.id}.txt`,
+      file_type: "doc",
+      content_category: "document",
+      content: file.content,
+      source: "google_drive",
+      source_path: "/features",
+      content_hash: file.hash,
+      source_created_at: new Date().toISOString(),
+      source_updated_at: new Date().toISOString(),
+      synced_at: new Date().toISOString(),
+      access_scope_id: null,
+      share_with_everyone: 1,
+    })
+    .execute();
+}
+
+async function updateFileContent(db: Kysely<DB>, file: { id: string; hash: string; content: string }): Promise<void> {
+  await db
+    .updateTable("indexed_files")
+    .set({
+      content: file.content,
+      content_hash: file.hash,
+      summary_status: "pending",
+      source_updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", file.id)
+    .execute();
+}
+
+function fileContext(file: { id: string; hash: string; content: string }): Parameters<typeof smartEnrichFile>[1] {
+  return {
+    id: file.id,
+    fileName: `${file.id}.txt`,
+    content: file.content,
+    contentCategory: "document",
+    fileType: "doc",
+    source: "google_drive",
+    sourcePath: "/features",
+    contentHash: file.hash,
+    connectorConfigId: CONNECTOR_ID,
+    sourceCreatedAt: null,
+    sourceUpdatedAt: null,
+  };
+}
+
+async function activeFeatureFacts(db: Kysely<DB>): Promise<Array<Selectable<IndexedFileFactsTable>>> {
+  return db
+    .selectFrom("indexed_file_facts")
+    .selectAll()
+    .where("fact_type", "=", "feature")
+    .where("deleted_at", "is", null)
+    .orderBy("indexed_file_id", "asc")
+    .execute();
+}
+
+async function featureRows(db: Kysely<DB>, normalizedName: string): Promise<Array<Selectable<SubEntitiesTable>>> {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "feature")
+    .where("normalized_name", "=", normalizedName)
+    .orderBy("valid_from", "asc")
+    .execute();
+}
+
+async function currentFeatureRows(
+  db: Kysely<DB>,
+  normalizedName: string,
+): Promise<Array<Selectable<SubEntitiesTable>>> {
+  return db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "feature")
+    .where("normalized_name", "=", normalizedName)
+    .where("valid_to", "is", null)
+    .execute();
+}
+
+async function currentEvidenceRefs(db: Kysely<DB>, subEntityId: string, kind: string): Promise<string[]> {
+  const rows = await db
+    .selectFrom("sub_entity_evidence")
+    .select("ref_id")
+    .where("sub_entity_id", "=", subEntityId)
+    .where("kind", "=", kind)
+    .orderBy("ref_id", "asc")
+    .execute();
+  return rows.map((row) => row.ref_id);
+}
+
+async function countFeatureSubEntities(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("sub_entities")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .where("kind", "=", "feature")
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function countEntitiesByType(db: Kysely<DB>, sourceType: string): Promise<number> {
+  const row = await db
+    .selectFrom("entities")
+    .select((eb) => eb.fn.count<number>("id").as("count"))
+    .where("source_type", "=", sourceType)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+function readFeatureRaw(raw: string | null): { featureId: string; corroborationKey: string } {
+  const parsed = JSON.parse(raw ?? "{}") as { featureId?: unknown; corroborationKey?: unknown };
+  if (typeof parsed.featureId !== "string" || typeof parsed.corroborationKey !== "string") {
+    throw new Error("invalid feature raw");
+  }
+  return { featureId: parsed.featureId, corroborationKey: parsed.corroborationKey };
+}

--- a/packages/server/src/connectors/smart-enrichment.test.ts
+++ b/packages/server/src/connectors/smart-enrichment.test.ts
@@ -1272,7 +1272,7 @@ describe("extractEntities prompt — v7 quality rules", () => {
       description: "AI services company. Sketch is one of our products.",
     });
 
-    expect(captured).toContain("Organization: Canvas Labs");
+    expect(captured).toContain("Background on the organization that operates this system (Canvas Labs)");
     expect(captured).toContain("AI services company. Sketch is one of our products.");
   });
 
@@ -1301,5 +1301,143 @@ describe("extractEntities prompt — v7 quality rules", () => {
     expect(productLine).toContain("injected known-products list");
     expect(captured).toContain("Known entities likely to appear in this file");
     expect(captured).toContain("Known Product (product)");
+  });
+});
+
+describe("smartEnrichFile — LLM leak gates", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    try {
+      await db.destroy();
+    } catch {
+      // already destroyed
+    }
+  });
+
+  function extractionGenerator(extraction: unknown): GeminiGenerator {
+    return {
+      generate: async () => "A short document summary.",
+      generateJSON: async <T>(_prompt: string, opts?: { label?: string }) =>
+        (opts?.label?.startsWith("extractEntities") ? extraction : {}) as T,
+    } as GeminiGenerator;
+  }
+
+  async function extractedNames(fileId: string): Promise<string[]> {
+    const rows = await db
+      .selectFrom("indexed_file_facts")
+      .select("subject_name")
+      .where("indexed_file_id", "=", fileId)
+      .where("fact_type", "=", "llm_extracted")
+      .execute();
+    return rows.map((row) => row.subject_name ?? "");
+  }
+
+  async function relationEndpointNames(fileId: string): Promise<string[]> {
+    const rows = await db
+      .selectFrom("indexed_file_facts")
+      .select("raw")
+      .where("indexed_file_id", "=", fileId)
+      .where("fact_type", "=", "llm_relation")
+      .execute();
+    return rows.flatMap((row) => {
+      const raw = JSON.parse(row.raw ?? "{}") as { source?: { name?: string }; target?: { name?: string } };
+      return [raw.source?.name, raw.target?.name].filter((name): name is string => Boolean(name));
+    });
+  }
+
+  it("drops a personal email-provider company — mention and relation — but keeps a real company", async () => {
+    const fileId = randomUUID();
+    const content = "Anoushka Srivastava emailed about the project. Oliver Wyman is the client.";
+    await seedFile(db, fileId, { content, contentHash: "hash-provider" });
+    const generator = extractionGenerator({
+      mentions: [
+        { mention: "Anoushka Srivastava", type: "person", variations: [], confidence: 0.95 },
+        { mention: "Gmail", type: "company", variations: [], confidence: 0.95 },
+        { mention: "Oliver Wyman", type: "company", variations: [], confidence: 0.95 },
+      ],
+      relations: [
+        {
+          type: "works_at",
+          source: { name: "Anoushka Srivastava", type: "person", variations: [] },
+          target: { name: "Gmail", type: "company", variations: [] },
+          confidence: 0.95,
+          context: content,
+        },
+        {
+          type: "engaged_with",
+          source: { name: "Anoushka Srivastava", type: "person", variations: [] },
+          target: { name: "Oliver Wyman", type: "company", variations: [] },
+          confidence: 0.95,
+          context: content,
+        },
+      ],
+    });
+
+    await smartEnrichFile(
+      { db, logger: createTestLogger(), generator, embeddingProvider: null },
+      smartFileContext(fileId, "hash-provider", { content }),
+    );
+
+    const names = await extractedNames(fileId);
+    expect(names).toContain("Oliver Wyman");
+    expect(names).toContain("Anoushka Srivastava");
+    expect(names).not.toContain("Gmail");
+
+    const endpoints = await relationEndpointNames(fileId);
+    expect(endpoints).toContain("Oliver Wyman");
+    expect(endpoints).not.toContain("Gmail");
+  });
+
+  it("drops a project mention that merely restates the email subject, keeps a body project", async () => {
+    const fileId = randomUUID();
+    const content = "Rajesh Chaudhary discussed the Branding and MVP Design Proposal. We also kicked off K8s Migration.";
+    await seedFile(db, fileId, { content, contentHash: "hash-subject" });
+    const generator = extractionGenerator({
+      mentions: [
+        { mention: "Rajesh Chaudhary", type: "person", variations: [], confidence: 0.95 },
+        { mention: "Branding and MVP Design Proposal", type: "project", variations: [], confidence: 0.95 },
+        { mention: "K8s Migration", type: "project", variations: [], confidence: 0.95 },
+      ],
+      relations: [],
+    });
+
+    await smartEnrichFile(
+      { db, logger: createTestLogger(), generator, embeddingProvider: null },
+      smartFileContext(fileId, "hash-subject", {
+        content,
+        fileName: "Re: Branding and MVP Design Proposal",
+      }),
+    );
+
+    const names = await extractedNames(fileId);
+    expect(names).toContain("K8s Migration");
+    expect(names).not.toContain("Branding and MVP Design Proposal");
+  });
+
+  it("does not over-match: companies that merely contain a provider word survive", async () => {
+    const fileId = randomUUID();
+    const content = "Live Nation and Proton Labs announced a partnership.";
+    await seedFile(db, fileId, { content, contentHash: "hash-substring" });
+    const generator = extractionGenerator({
+      mentions: [
+        { mention: "Live Nation", type: "company", variations: [], confidence: 0.95 },
+        { mention: "Proton Labs", type: "company", variations: [], confidence: 0.95 },
+      ],
+      relations: [],
+    });
+
+    await smartEnrichFile(
+      { db, logger: createTestLogger(), generator, embeddingProvider: null },
+      smartFileContext(fileId, "hash-substring", { content }),
+    );
+
+    const names = await extractedNames(fileId);
+    expect(names).toContain("Live Nation");
+    expect(names).toContain("Proton Labs");
   });
 });

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -9,12 +9,13 @@
  *
  * Falls back to deterministic enrichment when Gemini is unavailable.
  */
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import type { Logger } from "pino";
 import { isPg } from "../db/dialect";
 import { createEntityRepository } from "../db/repositories/entities";
+import { upsertFeatureFact } from "../db/repositories/features";
 import {
   type UpsertIndexedFileFactInput,
   buildIndexedFileFactKey,
@@ -40,6 +41,9 @@ import {
   cleanupRelationshipEvidenceForFacts,
   materializeUnmaterializedFacts,
 } from "../entities/materialize";
+import { normalizeEntityMatchName } from "../entities/materialize-deps";
+import { reconcileFeatureSubEntity } from "../entities/materialize-feature";
+import type { EntityRow, MaterializeDeps } from "../entities/materialize-types";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 import { type ProposeEntityType, proposeEntity } from "../entities/propose";
 import { isEmailProviderName, validateLearnedFact, validateLlmMention } from "../entities/validators";
@@ -102,6 +106,12 @@ function proposableEntityTypes(experimentalFlag = false, fileType?: string | nul
   return set;
 }
 
+function extractionValidTypes(experimentalFlag = false, fileType?: string | null): Set<string> {
+  const types = new Set<string>(proposableEntityTypes(experimentalFlag, fileType));
+  if (experimentalFlag) types.add("feature");
+  return types;
+}
+
 // ── Types ────────────────────────────────────────────────────────────────
 
 interface ExtractedMention {
@@ -109,6 +119,7 @@ interface ExtractedMention {
   type: string;
   variations: string[];
   confidence?: number;
+  parentProduct?: string;
 }
 
 interface ExtractedRelationEndpoint {
@@ -279,7 +290,7 @@ export async function extractEntities(
   participantBlock?: string,
   dumpDir?: string,
   experimentalFlag = false,
-  allowedTypes = proposableEntityTypes(experimentalFlag, file.fileType),
+  allowedTypes = extractionValidTypes(experimentalFlag, file.fileType),
 ): Promise<EntityExtractionResult> {
   const truncatedContent = file.content.slice(0, MAX_CONTENT_CHARS);
 
@@ -322,6 +333,18 @@ export async function extractEntities(
   const toolFocusLine = experimentalFlag
     ? "- **Tools**: third-party SaaS apps/platforms the org uses (e.g., Slack, Notion, Zoom, Figma, GitHub)\n"
     : "";
+  const featureFocusLine = experimentalFlag
+    ? '- **Features**: a feature is a named sub-capability, module, tab, or screen within a product (e.g., "CRM Analytics", "Push Notifications"). Emit it as type "feature" and set "parentProduct" to the product it belongs to. Never emit a feature as a product or project.\n'
+    : "";
+  const featureSchemaInstruction = experimentalFlag
+    ? '\nFor feature mentions, include "parentProduct" with the product the feature belongs to. Omit "parentProduct" for non-feature mentions.\n'
+    : "";
+  const mentionExamples = experimentalFlag
+    ? `    { "mention": "Project Atlas", "type": "project", "variations": ["Atlas", "the Atlas deal"], "confidence": 0.86 },
+    { "mention": "Sarah Chen", "type": "person", "variations": ["Sarah", "S. Chen"], "confidence": 0.95 },
+    { "mention": "CRM Analytics", "type": "feature", "parentProduct": "Canvas CRM", "variations": ["Analytics tab"], "confidence": 0.91 }`
+    : `    { "mention": "Project Atlas", "type": "project", "variations": ["Atlas", "the Atlas deal"], "confidence": 0.86 },
+    { "mention": "Sarah Chen", "type": "person", "variations": ["Sarah", "S. Chen"], "confidence": 0.95 }`;
   const relationshipTypesPrompt = `Valid relationship types:
 - "works_at": person -> company (the person is employed by the company)
 - "engaged_with": person -> company (the person is working with, for, or delivered to an external company without being employed by it — vendor, consultancy, or client-engagement context)
@@ -345,7 +368,7 @@ Extract entities that a business team would want to track and reference across d
 - **Companies**: external businesses, clients, partners, vendors
 - **Products**: named products or services your org builds or uses. When product entries appear in the Known entities section, treat that injected known-products list as the source of truth instead of inventing product names.
 - **Projects**: named umbrella engagements or programs with their own scope and timeline (e.g., "OW Tourism Dashboard", "Paid Member Migration Phase 2", "K8S Migration"). A project is the umbrella, NOT a single ticket, pull request, or one feature of a product.
-${toolFocusLine}
+${toolFocusLine}${featureFocusLine}
 
 DO NOT extract:
 - Email addresses, phone numbers, URLs, or other system identifiers — these are stored separately. If a person is identifiable by name, use the name (e.g., "Sarah Chen"); never use an email address as the mention.
@@ -380,6 +403,7 @@ Type disambiguation:
 - Any mention ending in "Pvt Ltd", "Private Limited", "Inc", "LLC", "Ltd", "GmbH", "Consulting", "Solutions", or "Technologies" is type "company", never "person", regardless of where it appears (including the participant block).
 
 For each entity, provide the primary name, type, name variations, and a confidence score in [0, 1] reflecting how directly grounded the mention is in the text.
+${featureSchemaInstruction}
 
 If email thread context is provided, use it only to resolve references in the current message. Do not extract an entity or relationship unless the current message refers to it directly or indirectly.
 
@@ -398,8 +422,7 @@ When a "Meeting participants" block is present above and lists attendees from mu
 Return one JSON object:
 {
   "mentions": [
-    { "mention": "Project Atlas", "type": "project", "variations": ["Atlas", "the Atlas deal"], "confidence": 0.86 },
-    { "mention": "Sarah Chen", "type": "person", "variations": ["Sarah", "S. Chen"], "confidence": 0.95 }
+${mentionExamples}
   ],
   "relations": [
     {
@@ -790,7 +813,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
   const { db, logger, generator, embeddingProvider } = deps;
   const entityRepo = createEntityRepository(db);
   const fileVersion = contentVersionOf(file);
-  const allowedTypes = proposableEntityTypes(deps.experimentalFlag, file.fileType);
+  const validExtractionTypes = extractionValidTypes(deps.experimentalFlag, file.fileType);
 
   const fileMeta = {
     fileId: file.id,
@@ -814,7 +837,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
       deps.participantBlock,
       deps.debugDumpDir,
       deps.experimentalFlag,
-      allowedTypes,
+      validExtractionTypes,
     );
   } catch (err) {
     logger.error({ ...fileMeta, stage: "extractEntities", err }, "smartEnrichFile: stage failed");
@@ -832,7 +855,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
   );
 
   await deps.ensureFresh?.();
-  const writtenLlmFactKeys = await reconcileLlmExtractionFacts(deps, file, extraction, allowedTypes);
+  const writtenLlmFactKeys = await reconcileLlmExtractionFacts(deps, file, extraction, validExtractionTypes);
   try {
     await deps.ensureFresh?.();
   } catch (err) {
@@ -842,7 +865,10 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
     throw err;
   }
 
-  const { matched, unmatched } = await matchEntities(db, extraction.mentions);
+  const matchableMentions = deps.experimentalFlag
+    ? extraction.mentions.filter((mention) => !isFeatureMention(mention))
+    : extraction.mentions;
+  const { matched, unmatched } = await matchEntities(db, matchableMentions);
   const allMatched = matched.map((m) => m.entity);
   logger.debug(
     { fileId: file.id, matchedCount: matched.length, unmatchedCount: unmatched.length },
@@ -978,7 +1004,7 @@ async function reconcileLlmExtractionFacts(
   deps: SmartEnrichmentDeps,
   file: FileContext,
   extraction: EntityExtractionResult,
-  allowedTypes: Set<ProposeEntityType>,
+  allowedTypes: Set<string>,
 ): Promise<string[]> {
   const { db } = deps;
   const factRepo = createIndexedFileFactRepository(db);
@@ -990,7 +1016,9 @@ async function reconcileLlmExtractionFacts(
   const contentHash = file.contentHash ?? `missing-content-hash:${file.id}`;
   const emittedMentionKeys: string[] = [];
   const emittedRelationKeys: string[] = [];
+  const emittedFeatureKeys: string[] = [];
   const writtenFactKeys: string[] = [];
+  let materializeDeps: MaterializeDeps | null = null;
 
   try {
     for (const rawMention of extraction.mentions) {
@@ -998,7 +1026,7 @@ async function reconcileLlmExtractionFacts(
         ...rawMention,
         type: coerceMentionType(rawMention.mention, rawMention.type, deps.experimentalFlag),
       };
-      if (!allowedTypes.has(mention.type as ProposeEntityType)) {
+      if (!allowedTypes.has(mention.type)) {
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention, entityType: mention.type },
           "Dropped LLM mention with unsupported type",
@@ -1006,10 +1034,7 @@ async function reconcileLlmExtractionFacts(
         continue;
       }
       if (mention.type === "company" && isEmailProviderName(mention.mention)) {
-        deps.logger.info(
-          { fileId: file.id, displayName: mention.mention },
-          "Dropped email-provider company mention",
-        );
+        deps.logger.info({ fileId: file.id, displayName: mention.mention }, "Dropped email-provider company mention");
         continue;
       }
       if (
@@ -1030,12 +1055,50 @@ async function reconcileLlmExtractionFacts(
         fileContent: file.content,
         resolutionContext: file.threadContext,
         source: "llm_extraction",
+        experimentalFlag: deps.experimentalFlag,
       });
       if (!validation.ok) {
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention, reason: validation.reason },
           "Dropped invalid LLM mention",
         );
+        continue;
+      }
+      if (mention.type === "feature") {
+        materializeDeps ??= await buildMaterializeDeps(db, { experimentalFlag: deps.experimentalFlag });
+        const parent = resolveFeatureParentProduct(materializeDeps, mention.parentProduct);
+        if (!parent) {
+          deps.logger.info(
+            { fileId: file.id, displayName: mention.mention, parentProduct: mention.parentProduct ?? null },
+            "Dropped LLM feature mention without a unique parent product",
+          );
+          continue;
+        }
+        const featureId = buildLlmFeatureId(file.id, mention.mention, parent.id);
+        const corroborationKey = buildLlmFeatureCorroborationKey(mention.mention, parent.id);
+        await deps.ensureFresh?.();
+        const result = await upsertFeatureFact(db, {
+          experimentalFlag: deps.experimentalFlag,
+          indexedFileId: file.id,
+          connectorConfigId: file.connectorConfigId,
+          createdByUserId: owner?.created_by ?? null,
+          contentHash,
+          source: "llm_extraction",
+          featureId,
+          featureName: mention.mention,
+          parentEntityId: parent.id,
+          status: "proposed",
+          evidence: { fileIds: [file.id], entityIds: [parent.id] },
+          corroborationKey,
+          promptVersion: LLM_EXTRACTION_PROMPT_VERSION,
+          model: "gemini",
+          confidence: typeof mention.confidence === "number" ? mention.confidence : 0.7,
+        });
+        if (result.emitted && result.factKey) {
+          emittedFeatureKeys.push(result.factKey);
+          writtenFactKeys.push(result.factKey);
+        }
+        await yieldToEventLoop();
         continue;
       }
       const input: UpsertIndexedFileFactInput = {
@@ -1088,6 +1151,11 @@ async function reconcileLlmExtractionFacts(
     }
 
     await deps.ensureFresh?.();
+    const featureCorroborationKeys = await collectStaleFeatureCorroborationKeys(
+      db,
+      file.id,
+      new Set(emittedFeatureKeys),
+    );
     const mentionReconcile = await factRepo.reconcileStaleFacts(
       { kind: "file", indexedFileId: file.id, source: "llm_extraction", factType: "llm_extracted" },
       new Set(emittedMentionKeys),
@@ -1096,11 +1164,21 @@ async function reconcileLlmExtractionFacts(
       { kind: "file", indexedFileId: file.id, source: "llm_extraction", factType: "llm_relation" },
       new Set(emittedRelationKeys),
     );
+    await factRepo.reconcileStaleFacts(
+      { kind: "file", indexedFileId: file.id, source: "llm_extraction", factType: "feature" },
+      new Set(emittedFeatureKeys),
+    );
     await cleanupRelationshipEvidenceForFacts(db, [
       ...mentionReconcile.tombstonedFactIds,
       ...relationReconcile.tombstonedFactIds,
     ]);
     await cleanupEmptyRelationships(db);
+    if (featureCorroborationKeys.length > 0) {
+      materializeDeps ??= await buildMaterializeDeps(db, { experimentalFlag: deps.experimentalFlag });
+      for (const corroborationKey of featureCorroborationKeys) {
+        await reconcileFeatureSubEntity(materializeDeps, corroborationKey);
+      }
+    }
 
     await deps.ensureFresh?.();
     await db
@@ -1121,17 +1199,87 @@ async function reconcileLlmExtractionFacts(
   }
 }
 
+function isFeatureMention(mention: ExtractedMention): boolean {
+  return mention.type.trim().toLowerCase() === "feature";
+}
+
+function resolveFeatureParentProduct(
+  deps: MaterializeDeps,
+  parentProduct: string | null | undefined,
+): EntityRow | null {
+  const normalized = normalizeEntityMatchName("product", parentProduct ?? "");
+  if (!normalized) return null;
+  const matches = [
+    ...deps.lookup.getByNormalizedName(normalized),
+    ...(deps.lookup.getByAlias?.(normalized) ?? []),
+  ].filter((entity) => entity.source_type === "product");
+  const unique = new Map(matches.map((entity) => [entity.id, entity]));
+  return unique.size === 1 ? [...unique.values()][0] : null;
+}
+
+function buildLlmFeatureId(indexedFileId: string, featureName: string, parentEntityId: string): string {
+  return `llm-feature:${indexedFileId}:${createHash("sha256")
+    .update([normalizeName(featureName), parentEntityId].join("\x1f"))
+    .digest("hex")}`;
+}
+
+function buildLlmFeatureCorroborationKey(featureName: string, parentEntityId: string): string {
+  return createHash("sha256")
+    .update([normalizeName(featureName), parentEntityId].join("\x1f"))
+    .digest("hex");
+}
+
+async function collectStaleFeatureCorroborationKeys(
+  db: Kysely<DB>,
+  indexedFileId: string,
+  seenFactKeys: Set<string>,
+): Promise<string[]> {
+  let query = db
+    .selectFrom("indexed_file_facts")
+    .select("raw")
+    .where("indexed_file_id", "=", indexedFileId)
+    .where("source", "=", "llm_extraction")
+    .where("fact_type", "=", "feature")
+    .where("deleted_at", "is", null);
+  if (seenFactKeys.size > 0) {
+    query = query.where("fact_key", "not in", [...seenFactKeys]);
+  }
+  const rows = await query.execute();
+  const keys = rows.map((row) => readFeatureCorroborationKey(row.raw)).filter((key): key is string => Boolean(key));
+  return [...new Set(keys)];
+}
+
+function readFeatureCorroborationKey(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { corroborationKey?: unknown };
+    return typeof parsed.corroborationKey === "string" && parsed.corroborationKey.length > 0
+      ? parsed.corroborationKey
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 async function tombstoneWrittenLlmFacts(deps: SmartEnrichmentDeps, factKeys: string[]): Promise<void> {
   const keys = [...new Set(factKeys)];
   if (keys.length === 0) return;
   const now = new Date().toISOString();
   const facts = await deps.db
     .selectFrom("indexed_file_facts")
-    .select(["id", "indexed_file_id"])
+    .select(["id", "indexed_file_id", "fact_type", "raw"])
     .where("fact_key", "in", keys)
     .where("deleted_at", "is", null)
     .execute();
   if (facts.length === 0) return;
+  const featureCorroborationKeys = [
+    ...new Set(
+      facts
+        .filter((fact) => fact.fact_type === "feature")
+        .map((fact) => readFeatureCorroborationKey(fact.raw))
+        .filter((key): key is string => Boolean(key)),
+    ),
+  ];
   await deps.db
     .updateTable("indexed_file_facts")
     .set({ deleted_at: now, materialized_at: null, updated_at: now })
@@ -1153,6 +1301,12 @@ async function tombstoneWrittenLlmFacts(deps: SmartEnrichmentDeps, factKeys: str
     .where("source", "=", "llm_extraction")
     .where("confidence", "!=", "EXTRACTED")
     .execute();
+  if (featureCorroborationKeys.length > 0) {
+    const materializeDeps = await buildMaterializeDeps(deps.db, { experimentalFlag: deps.experimentalFlag });
+    for (const corroborationKey of featureCorroborationKeys) {
+      await reconcileFeatureSubEntity(materializeDeps, corroborationKey);
+    }
+  }
 }
 
 /**
@@ -1178,7 +1332,7 @@ function buildRelationFactInput(input: {
   relation: ExtractedRelation;
   mentions: ExtractedMention[];
   experimentalFlag?: boolean;
-  allowedTypes: Set<ProposeEntityType>;
+  allowedTypes: Set<string>;
 }): UpsertIndexedFileFactInput | null {
   const relationType = normalizeRelationType(input.relation.type);
   if (!relationType || !isHighConfidenceRelation(input.relation.confidence)) return null;
@@ -1193,10 +1347,7 @@ function buildRelationFactInput(input: {
   );
   if (!sourceType || !targetType) return null;
   if (!normalizeRelationEndpointType(sourceType) || !normalizeRelationEndpointType(targetType)) return null;
-  if (
-    !input.allowedTypes.has(sourceType as ProposeEntityType) ||
-    !input.allowedTypes.has(targetType as ProposeEntityType)
-  ) {
+  if (!input.allowedTypes.has(sourceType) || !input.allowedTypes.has(targetType)) {
     return null;
   }
   if (

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -42,7 +42,7 @@ import {
 } from "../entities/materialize";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 import { type ProposeEntityType, proposeEntity } from "../entities/propose";
-import { validateLearnedFact, validateLlmMention } from "../entities/validators";
+import { isEmailProviderName, validateLearnedFact, validateLlmMention } from "../entities/validators";
 import { yieldToEventLoop } from "../lib/event-loop";
 import { STRUCTURAL_TASK_FILE_TYPES } from "./document-facts";
 import type { EmbeddingProvider } from "./embeddings/types";
@@ -284,7 +284,7 @@ export async function extractEntities(
   const truncatedContent = file.content.slice(0, MAX_CONTENT_CHARS);
 
   const orgSection = orgContext?.description
-    ? `\nOrganization: ${orgContext.orgName ?? "Unknown"}. ${orgContext.description}${orgContext.industry ? ` (Industry: ${orgContext.industry})` : ""}\n`
+    ? `\nBackground on the organization that operates this system (${orgContext.orgName ?? "Unknown"}${orgContext.industry ? `, industry: ${orgContext.industry}` : ""}). This is context for disambiguation only — do NOT extract an entity merely because it is named in this background. Extract only entities the document content below actually refers to:\n${orgContext.description}\n`
     : "";
   const disambiguationSection = orgContext?.disambiguationGuidance
     ? `\nProduct/disambiguation guidance:\n${orgContext.disambiguationGuidance}\n`
@@ -1005,6 +1005,23 @@ async function reconcileLlmExtractionFacts(
         );
         continue;
       }
+      if (mention.type === "company" && isEmailProviderName(mention.mention)) {
+        deps.logger.info(
+          { fileId: file.id, displayName: mention.mention },
+          "Dropped email-provider company mention",
+        );
+        continue;
+      }
+      if (
+        mention.type === "project" &&
+        normalizeDocumentTitle(mention.mention) === normalizeDocumentTitle(file.fileName)
+      ) {
+        deps.logger.info(
+          { fileId: file.id, displayName: mention.mention },
+          "Dropped project mention matching document title",
+        );
+        continue;
+      }
       if (mention.mention.length < MIN_ENTITY_NAME_LENGTH) continue;
       const validation = validateLlmMention({
         displayName: mention.mention,
@@ -1138,6 +1155,22 @@ async function tombstoneWrittenLlmFacts(deps: SmartEnrichmentDeps, factKeys: str
     .execute();
 }
 
+/**
+ * Normalize a document title for comparison against an extracted project name:
+ * strip leading reply/forward prefixes (`Re:`, `Fwd:`, `Fw:`, possibly repeated)
+ * then lowercase/collapse whitespace via {@link normalizeName}. Used to drop a
+ * `project` mention that is merely the email subject / file title restated.
+ */
+function normalizeDocumentTitle(title: string | null | undefined): string {
+  let current = title ?? "";
+  let previous: string;
+  do {
+    previous = current;
+    current = current.replace(/^\s*(re|fwd|fw)\s*:\s*/i, "");
+  } while (current !== previous);
+  return normalizeName(current);
+}
+
 function buildRelationFactInput(input: {
   file: FileContext;
   ownerUserId: string | null;
@@ -1163,6 +1196,12 @@ function buildRelationFactInput(input: {
   if (
     !input.allowedTypes.has(sourceType as ProposeEntityType) ||
     !input.allowedTypes.has(targetType as ProposeEntityType)
+  ) {
+    return null;
+  }
+  if (
+    (sourceType === "company" && isEmailProviderName(sourceName)) ||
+    (targetType === "company" && isEmailProviderName(targetName))
   ) {
     return null;
   }

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -238,11 +238,15 @@ export interface CommitmentSeed {
 export interface FeatureFactRaw {
   featureId: string;
   featureName: string;
+  corroborationKey?: string;
   parentProductRef?: { source: string; sourceId: string };
   parentEntityId?: string;
   status: "proposed" | "building" | "shipped" | "deprecated";
   dueAt?: string;
   evidence: { fileIds: string[]; entityIds: string[] };
+  promptVersion?: string;
+  model?: string;
+  confidence?: number;
 }
 
 export interface MilestoneFactRaw {

--- a/packages/server/src/db/repositories/features.integration.test.ts
+++ b/packages/server/src/db/repositories/features.integration.test.ts
@@ -295,6 +295,7 @@ async function seedEntity(db: Kysely<DB>, input: { id: string; name: string; typ
       metadata: null,
       source_ref_id: null,
       status: "confirmed",
+      provenance_tier: input.type === "product" ? "declared" : "inferred",
       hotness: 0,
       created_at: now,
       updated_at: now,

--- a/packages/server/src/db/repositories/features.ts
+++ b/packages/server/src/db/repositories/features.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import type { FeatureFactRaw } from "../../connectors/types";
 import type { DB } from "../schema";
-import { createIndexedFileFactRepository } from "./indexed-file-facts";
+import { buildIndexedFileFactKey, createIndexedFileFactRepository } from "./indexed-file-facts";
 
 export type FeatureStatus = "proposed" | "building" | "shipped" | "deprecated";
 
@@ -15,21 +15,28 @@ export interface UpsertFeatureFactInput {
   source: string;
   featureId: string;
   featureName: string;
+  corroborationKey?: string;
   parentProductRef?: { source: string; sourceId: string };
   parentEntityId?: string;
   status: FeatureStatus;
   dueAt?: string;
   evidence: { fileIds: string[]; entityIds: string[] };
   contextSnippet?: string | null;
+  promptVersion?: string;
+  model?: string;
+  confidence?: number;
 }
 
-export async function upsertFeatureFact(db: Kysely<DB>, input: UpsertFeatureFactInput): Promise<{ emitted: boolean }> {
+export async function upsertFeatureFact(
+  db: Kysely<DB>,
+  input: UpsertFeatureFactInput,
+): Promise<{ emitted: boolean; factKey?: string }> {
   const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
   const source = requireNonEmpty(input.source, "source");
   const featureId = requireNonEmpty(input.featureId, "featureId");
   if (!input.experimentalFlag) return { emitted: false };
 
-  await createIndexedFileFactRepository(db).upsertFact({
+  const factInput = {
     indexedFileId: input.indexedFileId ?? null,
     connectorConfigId,
     createdByUserId: input.createdByUserId ?? null,
@@ -43,19 +50,24 @@ export async function upsertFeatureFact(db: Kysely<DB>, input: UpsertFeatureFact
     subjectSourceId: featureId,
     contextSnippet: input.contextSnippet ?? null,
     raw: buildFeatureRaw(input, featureId),
-  });
-  return { emitted: true };
+  } as const;
+  await createIndexedFileFactRepository(db).upsertFact(factInput);
+  return { emitted: true, factKey: buildIndexedFileFactKey(factInput) };
 }
 
 function buildFeatureRaw(input: UpsertFeatureFactInput, featureId: string): FeatureFactRaw {
   return {
     featureId,
     featureName: input.featureName,
+    corroborationKey: input.corroborationKey,
     parentProductRef: input.parentProductRef,
     parentEntityId: input.parentEntityId,
     status: input.status,
     dueAt: input.dueAt,
     evidence: input.evidence,
+    promptVersion: input.promptVersion,
+    model: input.model,
+    confidence: input.confidence,
   };
 }
 

--- a/packages/server/src/db/repositories/sub-entities.ts
+++ b/packages/server/src/db/repositories/sub-entities.ts
@@ -37,6 +37,7 @@ export interface SupersedeSubEntityInput {
   metadata?: Record<string, unknown> | null;
   sourceFactId?: string | null;
   effectiveAt: string;
+  closeOnly?: boolean;
 }
 
 export interface ListCurrentByKindOptions {
@@ -204,6 +205,20 @@ async function supersedeInTransaction(
       .where("normalized_name", "=", normalized)
       .orderBy("valid_from", "asc")
       .execute();
+    if (input.closeOnly) {
+      const current = rows.find((row) => row.valid_to === null);
+      if (!current) return { subEntityId: "", created: false, superseded: false };
+      const closeValues = hasDomainStatus
+        ? { valid_to: effectiveAt, updated_at: now }
+        : { valid_to: effectiveAt, status: "superseded", updated_at: now };
+      const result = await trx
+        .updateTable("sub_entities")
+        .set(closeValues)
+        .where("id", "=", current.id)
+        .where("valid_to", "is", null)
+        .executeTakeFirst();
+      return { subEntityId: current.id, created: false, superseded: Number(result.numUpdatedRows ?? 0) > 0 };
+    }
     const existingAtTime = rows.find((row) => row.valid_from === effectiveAt && row.value_signature === incomingSig);
     if (existingAtTime) {
       await refreshSupersededRow(trx, existingAtTime.id, input, now);

--- a/packages/server/src/entities/materialize-feature.ts
+++ b/packages/server/src/entities/materialize-feature.ts
@@ -1,13 +1,22 @@
-import { createSubEntityRepository } from "../db/repositories/sub-entities";
+import { normalizeName } from "../connectors/name-normalize";
+import { type SubEntityRow, createSubEntityRepository } from "../db/repositories/sub-entities";
 import { type SubEntityParentInput, resolveParent } from "./materialize-commitment";
 import { readJsonObject } from "./materialize-json";
-import type { IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
+import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
 
 export async function materializeFeature(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
   if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readJsonObject(fact.raw);
   const feature = readFeature(raw);
   if (!feature) return { kind: "skipped", reason: "invalid_feature" };
+
+  if (isLlmFeatureSource(fact.source)) {
+    if (!feature.corroborationKey) return { kind: "skipped", reason: "invalid_feature" };
+    const result = await reconcileFeatureSubEntity(deps, feature.corroborationKey);
+    return result.materialized
+      ? { kind: "feature_materialized" }
+      : { kind: "deferred_below_threshold", reason: "feature_ungated" };
+  }
 
   const parent = resolveParent(deps, feature, ["product"]);
   if (!parent) return { kind: "skipped", reason: "missing_feature_parent" };
@@ -19,7 +28,7 @@ export async function materializeFeature(deps: MaterializeDeps, fact: IndexedFil
     dedupName: feature.featureName,
     displayName: feature.featureName,
     status: feature.status,
-    provenance: fact.source === "llm" ? "corroborated_llm" : "structural",
+    provenance: featureProvenance(fact.source),
     dueAt: feature.dueAt ?? null,
     ownerUserId: deps.resolveOwner(fact),
     sourceFactId: fact.id,
@@ -34,9 +43,45 @@ export async function materializeFeature(deps: MaterializeDeps, fact: IndexedFil
   return { kind: "feature_materialized" };
 }
 
+export async function reconcileFeatureSubEntity(
+  deps: MaterializeDeps,
+  corroborationKey: string,
+): Promise<{ support: number; materialized: boolean; subEntityId?: string }> {
+  if (!deps.experimentalFlag) return { support: 0, materialized: false };
+  const entries = await loadCorroboratingFeatureFacts(deps, corroborationKey);
+  const support = distinctIndexedFileCount(entries);
+  if (support >= deps.llmPromotionThreshold) {
+    const supported = resolveSupportedFeature(deps, entries);
+    if (!supported) {
+      await closeCurrentFeatureSubEntity(deps, corroborationKey, null);
+      return { support, materialized: false };
+    }
+    const repo = createSubEntityRepository(deps.db);
+    const result = await repo.upsertSubEntity({
+      parentEntityId: supported.parent.id,
+      kind: "feature",
+      dedupName: supported.feature.featureName,
+      displayName: supported.feature.featureName,
+      status: supported.feature.status,
+      provenance: "corroborated_llm",
+      dueAt: supported.feature.dueAt ?? null,
+      ownerUserId: deps.resolveOwner(supported.fact),
+      sourceFactId: supported.fact.id,
+      metadata: { corroborationKey },
+    });
+    await replaceCurrentEvidence(deps, result.subEntityId, evidenceForEntries(entries, supported.parent.id));
+    return { support, materialized: true, subEntityId: result.subEntityId };
+  }
+
+  const supported = resolveSupportedFeature(deps, entries);
+  await closeCurrentFeatureSubEntity(deps, corroborationKey, supported);
+  return { support, materialized: false };
+}
+
 interface FeatureInput extends SubEntityParentInput {
   featureId: string;
   featureName: string;
+  corroborationKey?: string;
   status: "proposed" | "building" | "shipped" | "deprecated";
   dueAt?: string;
   evidence: { fileIds: string[]; entityIds: string[] };
@@ -57,6 +102,7 @@ function readFeature(raw: Record<string, unknown>): FeatureInput | null {
   return {
     featureId: raw.featureId,
     featureName: raw.featureName,
+    corroborationKey: readOptionalString(raw.corroborationKey),
     parentRef: readParentProductRef(raw.parentProductRef),
     parentEntityId: readOptionalString(raw.parentEntityId),
     status: raw.status,
@@ -85,4 +131,143 @@ function isEvidence(value: unknown): value is { fileIds: string[]; entityIds: st
 
 function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function featureProvenance(source: string): string {
+  return isLlmFeatureSource(source) ? "corroborated_llm" : "structural";
+}
+
+function isLlmFeatureSource(source: string): boolean {
+  return source === "llm_extraction" || source === "llm";
+}
+
+async function loadCorroboratingFeatureFacts(
+  deps: MaterializeDeps,
+  corroborationKey: string,
+): Promise<Array<{ fact: IndexedFileFactRow; feature: FeatureInput }>> {
+  const rows = await deps.db
+    .selectFrom("indexed_file_facts")
+    .selectAll()
+    .where("fact_type", "=", "feature")
+    .where("deleted_at", "is", null)
+    .orderBy("updated_at", "desc")
+    .execute();
+  const out: Array<{ fact: IndexedFileFactRow; feature: FeatureInput }> = [];
+  for (const row of rows) {
+    if (!isLlmFeatureSource(row.source)) continue;
+    const feature = readFeature(readJsonObject(row.raw));
+    if (feature?.corroborationKey === corroborationKey) out.push({ fact: row, feature });
+  }
+  return out;
+}
+
+function distinctIndexedFileCount(entries: Array<{ fact: IndexedFileFactRow }>): number {
+  return new Set(entries.map((entry) => entry.fact.indexed_file_id).filter((id): id is string => Boolean(id))).size;
+}
+
+function resolveSupportedFeature(
+  deps: MaterializeDeps,
+  entries: Array<{ fact: IndexedFileFactRow; feature: FeatureInput }>,
+): { fact: IndexedFileFactRow; feature: FeatureInput; parent: EntityRow } | null {
+  for (const entry of entries) {
+    const parent = resolveParent(deps, entry.feature, ["product"]);
+    if (parent) return { ...entry, parent };
+  }
+  return null;
+}
+
+function evidenceForEntries(
+  entries: Array<{ fact: IndexedFileFactRow; feature: FeatureInput }>,
+  parentEntityId: string,
+): Array<{ kind: string; refId: string }> {
+  const factIds = entries.map((entry) => entry.fact.id);
+  const indexedFileIds = entries.map((entry) => entry.fact.indexed_file_id).filter((id): id is string => Boolean(id));
+  const fileIds = entries.flatMap((entry) => entry.feature.evidence.fileIds);
+  const entityIds = entries.flatMap((entry) => entry.feature.evidence.entityIds);
+  return [
+    ...[...new Set(factIds)].map((refId) => ({ kind: "fact", refId })),
+    ...[...new Set([...indexedFileIds, ...fileIds])].map((refId) => ({ kind: "file", refId })),
+    ...[...new Set([parentEntityId, ...entityIds])].map((refId) => ({ kind: "entity", refId })),
+  ];
+}
+
+async function replaceCurrentEvidence(
+  deps: MaterializeDeps,
+  subEntityId: string,
+  evidence: Array<{ kind: string; refId: string }>,
+): Promise<void> {
+  await deps.db.deleteFrom("sub_entity_evidence").where("sub_entity_id", "=", subEntityId).execute();
+  const repo = createSubEntityRepository(deps.db);
+  for (const edge of evidence) {
+    await repo.upsertSubEntityEvidence(subEntityId, edge.kind, edge.refId);
+  }
+}
+
+async function closeCurrentFeatureSubEntity(
+  deps: MaterializeDeps,
+  corroborationKey: string,
+  supported: { feature: FeatureInput; parent: EntityRow } | null,
+): Promise<void> {
+  const current = supported
+    ? await findCurrentFeatureByParentAndName(
+        deps,
+        supported.parent.id,
+        supported.feature.featureName,
+        corroborationKey,
+      )
+    : await findCurrentFeatureByCorroborationKey(deps, corroborationKey);
+  if (!current?.parent_entity_id) return;
+  const repo = createSubEntityRepository(deps.db);
+  await repo.supersedeSubEntity({
+    parentEntityId: current.parent_entity_id,
+    kind: "feature",
+    dedupName: current.display_name,
+    displayName: current.display_name,
+    provenance: current.provenance,
+    sourceFactId: current.source_fact_id,
+    effectiveAt: new Date().toISOString(),
+    closeOnly: true,
+  });
+  await deps.db.deleteFrom("sub_entity_evidence").where("sub_entity_id", "=", current.id).execute();
+}
+
+async function findCurrentFeatureByParentAndName(
+  deps: MaterializeDeps,
+  parentEntityId: string,
+  featureName: string,
+  corroborationKey: string,
+): Promise<SubEntityRow | undefined> {
+  const row = await deps.db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("parent_scope_key", "=", parentEntityId)
+    .where("kind", "=", "feature")
+    .where("normalized_name", "=", normalizeName(featureName))
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+  if (row && readMetadataCorroborationKey(row.metadata_json) === corroborationKey) return row;
+  return findCurrentFeatureByCorroborationKey(deps, corroborationKey);
+}
+
+async function findCurrentFeatureByCorroborationKey(
+  deps: MaterializeDeps,
+  corroborationKey: string,
+): Promise<SubEntityRow | undefined> {
+  const rows = await deps.db
+    .selectFrom("sub_entities")
+    .selectAll()
+    .where("kind", "=", "feature")
+    .where("valid_to", "is", null)
+    .execute();
+  return rows.find((row) => readMetadataCorroborationKey(row.metadata_json) === corroborationKey);
+}
+
+function readMetadataCorroborationKey(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { corroborationKey?: unknown };
+    return typeof parsed.corroborationKey === "string" ? parsed.corroborationKey : null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/server/src/entities/recreate.test.ts
+++ b/packages/server/src/entities/recreate.test.ts
@@ -198,6 +198,35 @@ describe("resetDerivedEntityData", () => {
     expect(file.embedding_status).toBe("done");
   });
 
+  it("preserves human-blessed tiers (declared, human_confirmed) and deletes derived ones", async () => {
+    const now = new Date().toISOString();
+    const seedEntity = async (id: string, tier: string) => {
+      await db
+        .insertInto("entities")
+        .values({
+          id,
+          name: id,
+          source_type: "project",
+          status: "confirmed",
+          provenance_tier: tier,
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+    };
+    await seedEntity("declared-product", "declared");
+    await seedEntity("approved-project", "human_confirmed");
+    await seedEntity("structural-project", "structural");
+    await seedEntity("inferred-guess", "inferred");
+
+    const summary = await resetDerivedEntityData(db, createTestLogger());
+
+    expect(summary.deleted.entities).toBe(2);
+    const survivors = await db.selectFrom("entities").select("id").orderBy("id", "asc").execute();
+    expect(survivors.map((row) => row.id)).toEqual(["approved-project", "declared-product"]);
+  });
+
   it("rejects while a connector is marked syncing", async () => {
     await seedGraph();
     await db.updateTable("connector_configs").set({ sync_status: "syncing" }).where("id", "=", "connector-1").execute();

--- a/packages/server/src/entities/recreate.ts
+++ b/packages/server/src/entities/recreate.ts
@@ -74,16 +74,26 @@ async function deleteTable(db: Kysely<DB>, table: string): Promise<number> {
   }
 }
 
+/**
+ * Reset preserves human-blessed entities: `declared` (added/declared via Your
+ * Org) and `human_confirmed` (approved from the review queue). Both encode an
+ * explicit operator decision that replay cannot reconstruct — approvals live in
+ * `entity_review_queue`, not in `indexed_file_facts`, so a deleted approved
+ * entity would never come back as approved. Only derived tiers (`structural`,
+ * `inferred`) are rebuilt from facts.
+ */
+const PRESERVED_RESET_TIERS = ["declared", "human_confirmed"];
+
 async function deleteRecreatableEntities(db: Kysely<DB>): Promise<number> {
   try {
     const before = await db
       .selectFrom("entities")
       .select(db.fn.countAll<number>().as("count"))
-      .where("provenance_tier", "!=", "declared")
+      .where("provenance_tier", "not in", PRESERVED_RESET_TIERS)
       .executeTakeFirst();
     const count = Number(before?.count ?? 0);
     if (count === 0) return 0;
-    await db.deleteFrom("entities").where("provenance_tier", "!=", "declared").execute();
+    await db.deleteFrom("entities").where("provenance_tier", "not in", PRESERVED_RESET_TIERS).execute();
     return count;
   } catch (err) {
     if (isMissingTableError(err)) return 0;

--- a/packages/server/src/entities/validators.ts
+++ b/packages/server/src/entities/validators.ts
@@ -11,6 +11,56 @@ export type LlmMentionValidationResult =
 
 export type LearnedFactValidationResult = { ok: true } | { ok: false; reason: "negation" | "hedge" | "placeholder" };
 
+/**
+ * Consumer webmail brands the LLM tends to mint as a "company" after seeing a
+ * personal email address (e.g. `anoushka@gmail.com` -> a `Gmail` company with a
+ * spurious `works_at` edge). The deterministic affiliation path already drops
+ * these via the personal/shared domain check, but the LLM extraction path has no
+ * domain to check — only the brand name — so it needs this name-based gate.
+ *
+ * Whole-name equality only (see {@link isEmailProviderName}); collision-prone
+ * bare words (`live`, `me`, `mac`, `msn`) are deliberately excluded so real
+ * companies like "Live Nation" survive.
+ */
+const EMAIL_PROVIDER_NAMES = new Set([
+  "gmail",
+  "googlemail",
+  "google mail",
+  "outlook",
+  "hotmail",
+  "yahoo",
+  "ymail",
+  "rocketmail",
+  "aol",
+  "icloud",
+  "proton",
+  "protonmail",
+  "proton mail",
+  "gmx",
+  "yandex",
+  "fastmail",
+  "zoho mail",
+  "qq",
+  "163",
+  "naver",
+  "hey",
+]);
+
+/**
+ * True when `name` is exactly a consumer email-provider brand (after lowercasing,
+ * collapsing whitespace, and stripping a trailing TLD like `.com`). Matches the
+ * whole name only — "Proton Labs" or "Live Nation" return false.
+ */
+export function isEmailProviderName(name: string): boolean {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/\.(com|net|org|co|io|me)$/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return EMAIL_PROVIDER_NAMES.has(normalized);
+}
+
 export function validateLlmMention(input: {
   displayName: string;
   entityType?: string;

--- a/packages/server/src/entities/validators.ts
+++ b/packages/server/src/entities/validators.ts
@@ -68,9 +68,12 @@ export function validateLlmMention(input: {
   fileContent: string;
   resolutionContext?: string | null;
   source: "llm_extraction" | "connector_extracted";
+  experimentalFlag?: boolean;
 }): LlmMentionValidationResult {
   if (input.source !== "llm_extraction") return { ok: true };
-  if (input.entityType?.trim().toLowerCase() === "feature") return { ok: false, reason: "type_removed" };
+  if (!input.experimentalFlag && input.entityType?.trim().toLowerCase() === "feature") {
+    return { ok: false, reason: "type_removed" };
+  }
 
   const content = normalizePresenceText(input.fileContent);
   const names = [input.displayName, ...(input.aliases ?? [])]


### PR DESCRIPTION
Stacked context-graph slice 21/27.

Base: `feat/context-graph-20-structural-spine`
Head: `feat/context-graph-21-feature-producer`

Adds the feature producer and supporting reset behavior.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`