### PR TITLE
fix: add structural noise gates

### DIFF
--- a/packages/server/src/connectors/clickup-workspace-scope.test.ts
+++ b/packages/server/src/connectors/clickup-workspace-scope.test.ts
@@ -95,7 +95,7 @@ describe("ClickUp workspace effective scope", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not seed reachable workspace members or entities when only another workspace's space is selected", async () => {
+  it("does not seed workspace members as people, and does not reach another workspace when only one space is selected", async () => {
     const fetchSpy = mockClickUpFetch();
     const { entitySeeds, personSeeds, items } = await collectClickUpSync({
       workspaces: [],
@@ -103,26 +103,17 @@ describe("ClickUp workspace effective scope", () => {
     });
 
     expect(items).toEqual([]);
-    expect(personSeeds).toEqual([
-      expect.objectContaining({
-        sourceId: "user:1",
-        name: "Alice A",
-        email: "alice@workspace-a.example",
-      }),
-    ]);
-    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_workspace").map((seed) => seed.sourceId)).toEqual([
-      "workspace-a",
-    ]);
-    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_space").map((seed) => seed.sourceId)).toEqual([
-      "space-a",
-    ]);
+    // Bare workspace membership is not an engagement signal — no phantom people.
+    expect(personSeeds).toEqual([]);
+    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_workspace")).toEqual([]);
+    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_space")).toEqual([]);
 
     const paths = pathsFrom(fetchSpy);
     expect(paths).not.toEqual(expect.arrayContaining(["/api/v2/space/space-b/folder"]));
     expect(paths).not.toEqual(expect.arrayContaining(["/api/v3/workspaces/workspace-b/docs"]));
   });
 
-  it("keeps unscoped sync seeding every reachable workspace", async () => {
+  it("processes every reachable workspace when unscoped, still without seeding members as people", async () => {
     const fetchSpy = mockClickUpFetch();
     const { entitySeeds, personSeeds, items } = await collectClickUpSync({
       workspaces: [],
@@ -130,19 +121,11 @@ describe("ClickUp workspace effective scope", () => {
     });
 
     expect(items).toEqual([]);
-    expect(personSeeds.map((seed) => seed.sourceId).sort()).toEqual(["user:1", "user:2"]);
-    expect(
-      entitySeeds
-        .filter((seed) => seed.sourceType === "clickup_workspace")
-        .map((seed) => seed.sourceId)
-        .sort(),
-    ).toEqual(["workspace-a", "workspace-b"]);
-    expect(
-      entitySeeds
-        .filter((seed) => seed.sourceType === "clickup_space")
-        .map((seed) => seed.sourceId)
-        .sort(),
-    ).toEqual(["space-a", "space-b"]);
+    // No tasks in these fixtures → no assignees → no people, even though both
+    // workspaces are fully processed (proven by the fetch paths below).
+    expect(personSeeds).toEqual([]);
+    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_workspace")).toEqual([]);
+    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_space")).toEqual([]);
 
     expect(pathsFrom(fetchSpy)).toEqual(
       expect.arrayContaining([
@@ -152,5 +135,48 @@ describe("ClickUp workspace effective scope", () => {
         "/api/v3/workspaces/workspace-b/docs",
       ]),
     );
+  });
+
+  it("seeds task assignees as people (engagement signal), keyed by assignee username", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const path = new URL(String(input)).pathname;
+      if (path === "/api/v2/team") {
+        return jsonResponse({
+          teams: [{ id: "workspace-a", name: "Workspace A", members: teams[0].members }],
+        });
+      }
+      if (path === "/api/v2/team/workspace-a/space") {
+        return jsonResponse({ spaces: [{ id: "space-a", name: "Space A" }] });
+      }
+      if (path === "/api/v2/space/space-a/folder") return jsonResponse({ folders: [] });
+      if (path === "/api/v2/space/space-a/list") {
+        return jsonResponse({ lists: [{ id: "list-a", name: "List A" }] });
+      }
+      if (path === "/api/v2/list/list-a/task") {
+        return jsonResponse({
+          tasks: [
+            {
+              id: "task-1",
+              name: "Do the thing",
+              status: { status: "open", type: "open" },
+              assignees: [{ id: 1, username: "Alice A", email: "alice@workspace-a.example" }],
+              tags: [],
+              url: "https://app.clickup.com/t/task-1",
+              list: { id: "list-a", name: "List A" },
+              space: { id: "space-a" },
+              date_updated: "1700000000000",
+            },
+          ],
+        });
+      }
+      if (path === "/api/v3/workspaces/workspace-a/docs") return jsonResponse({ docs: [] });
+      return new Response(JSON.stringify({ error: `unexpected path ${path}` }), { status: 404 });
+    });
+
+    const { personSeeds } = await collectClickUpSync({ workspaces: [], spaces: [] });
+
+    // The assignee is seeded (engagement), keyed by username — not by user:<id>.
+    expect(personSeeds).toEqual([expect.objectContaining({ sourceId: "assignee:Alice A", name: "Alice A" })]);
+    expect(personSeeds.every((seed) => !seed.sourceId.startsWith("user:"))).toBe(true);
   });
 });

--- a/packages/server/src/connectors/clickup-workspace-scope.test.ts
+++ b/packages/server/src/connectors/clickup-workspace-scope.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClickUpConnector } from "./clickup";
+import type { EntitySeed, PersonEntitySeed, SyncedItem } from "./types";
+
+const teams = [
+  {
+    id: "workspace-a",
+    name: "Workspace A",
+    members: [{ user: { id: 1, username: "Alice A", email: "alice@workspace-a.example" } }],
+  },
+  {
+    id: "workspace-b",
+    name: "Workspace B",
+    members: [{ user: { id: 2, username: "Bob B", email: "bob@workspace-b.example" } }],
+  },
+];
+
+const spacesByWorkspace = {
+  "workspace-a": [{ id: "space-a", name: "Space A" }],
+  "workspace-b": [{ id: "space-b", name: "Space B" }],
+};
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockClickUpFetch(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const path = new URL(String(input)).pathname;
+
+    if (path === "/api/v2/team") {
+      return jsonResponse({ teams });
+    }
+
+    const teamSpaceMatch = path.match(/^\/api\/v2\/team\/([^/]+)\/space$/);
+    if (teamSpaceMatch) {
+      return jsonResponse({
+        spaces: spacesByWorkspace[teamSpaceMatch[1] as keyof typeof spacesByWorkspace] ?? [],
+      });
+    }
+
+    const spaceFoldersMatch = path.match(/^\/api\/v2\/space\/([^/]+)\/folder$/);
+    if (spaceFoldersMatch) {
+      return jsonResponse({ folders: [] });
+    }
+
+    const spaceListsMatch = path.match(/^\/api\/v2\/space\/([^/]+)\/list$/);
+    if (spaceListsMatch) {
+      return jsonResponse({ lists: [] });
+    }
+
+    const docsMatch = path.match(/^\/api\/v3\/workspaces\/([^/]+)\/docs$/);
+    if (docsMatch) {
+      return jsonResponse({ docs: [] });
+    }
+
+    return new Response(JSON.stringify({ error: `unexpected path ${path}` }), { status: 404 });
+  });
+}
+
+async function collectClickUpSync(scopeConfig: Record<string, unknown>) {
+  const connector = createClickUpConnector();
+  const entitySeeds: EntitySeed[] = [];
+  const personSeeds: PersonEntitySeed[] = [];
+  const items: SyncedItem[] = [];
+
+  for await (const item of connector.sync({
+    credentials: { type: "api_key", api_key: "clickup-token" },
+    scopeConfig,
+    cursor: null,
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+    onEntitySeed: async (seed) => {
+      entitySeeds.push(seed);
+    },
+    onPersonSeed: async (seed) => {
+      personSeeds.push(seed);
+    },
+  })) {
+    items.push(item);
+  }
+
+  return { entitySeeds, personSeeds, items };
+}
+
+function pathsFrom(fetchSpy: ReturnType<typeof mockClickUpFetch>): string[] {
+  const calls = fetchSpy.mock.calls as Parameters<typeof fetch>[];
+  return calls.map((call) => new URL(String(call[0])).pathname);
+}
+
+describe("ClickUp workspace effective scope", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not seed reachable workspace members or entities when only another workspace's space is selected", async () => {
+    const fetchSpy = mockClickUpFetch();
+    const { entitySeeds, personSeeds, items } = await collectClickUpSync({
+      workspaces: [],
+      spaces: ["space-a"],
+    });
+
+    expect(items).toEqual([]);
+    expect(personSeeds).toEqual([
+      expect.objectContaining({
+        sourceId: "user:1",
+        name: "Alice A",
+        email: "alice@workspace-a.example",
+      }),
+    ]);
+    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_workspace").map((seed) => seed.sourceId)).toEqual([
+      "workspace-a",
+    ]);
+    expect(entitySeeds.filter((seed) => seed.sourceType === "clickup_space").map((seed) => seed.sourceId)).toEqual([
+      "space-a",
+    ]);
+
+    const paths = pathsFrom(fetchSpy);
+    expect(paths).not.toEqual(expect.arrayContaining(["/api/v2/space/space-b/folder"]));
+    expect(paths).not.toEqual(expect.arrayContaining(["/api/v3/workspaces/workspace-b/docs"]));
+  });
+
+  it("keeps unscoped sync seeding every reachable workspace", async () => {
+    const fetchSpy = mockClickUpFetch();
+    const { entitySeeds, personSeeds, items } = await collectClickUpSync({
+      workspaces: [],
+      spaces: [],
+    });
+
+    expect(items).toEqual([]);
+    expect(personSeeds.map((seed) => seed.sourceId).sort()).toEqual(["user:1", "user:2"]);
+    expect(
+      entitySeeds
+        .filter((seed) => seed.sourceType === "clickup_workspace")
+        .map((seed) => seed.sourceId)
+        .sort(),
+    ).toEqual(["workspace-a", "workspace-b"]);
+    expect(
+      entitySeeds
+        .filter((seed) => seed.sourceType === "clickup_space")
+        .map((seed) => seed.sourceId)
+        .sort(),
+    ).toEqual(["space-a", "space-b"]);
+
+    expect(pathsFrom(fetchSpy)).toEqual(
+      expect.arrayContaining([
+        "/api/v2/space/space-a/folder",
+        "/api/v2/space/space-b/folder",
+        "/api/v3/workspaces/workspace-a/docs",
+        "/api/v3/workspaces/workspace-b/docs",
+      ]),
+    );
+  });
+});

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -718,14 +718,6 @@ export function createClickUpConnector(): Connector {
           });
         }
 
-        // Workspace membership alone is not an engagement signal, so members are
-        // NOT seeded as person entities here — a shared workspace's full roster
-        // would otherwise mint hundreds of isolated "phantom" people (zero
-        // mentions, zero edges). People come from task assignees (seeded below,
-        // after traversal) and from text mentions. Member emails still feed the
-        // access scope for doc/space visibility.
-
-        // Workspace-level access scope (used for docs and public spaces)
         const workspaceScope: SyncedItem["accessScope"] = {
           scopeType: "workspace",
           providerScopeId: team.id,
@@ -740,8 +732,6 @@ export function createClickUpConnector(): Connector {
           }
           syncedAnyAllowedSpace = true;
 
-          // Build access scope for this space.
-          // Private spaces use space members; public spaces use all workspace members.
           let spaceScope: SyncedItem["accessScope"];
           if (space.private && space.members) {
             const memberEmails = extractMemberEmails(space.members);
@@ -936,14 +926,6 @@ export function createClickUpConnector(): Connector {
           }
         }
 
-        // Sync ClickUp Docs at workspace level.
-        // Docs are fetched per-workspace with no space-level filter, so they would leak
-        // across workspaces the user never selected. When workspaces are explicitly scoped,
-        // this team already passed the workspace filter above. When only spaces are selected
-        // (workspaces empty), sync docs only if this workspace contains a selected space;
-        // otherwise a workspace reachable by the token but never opted into would still have
-        // its docs ingested. With neither workspaces nor spaces selected, the connection is
-        // unscoped and every workspace's docs sync (unchanged behavior).
         const workspaceInDocScope =
           allowedWorkspaces.includes(team.id) ||
           (allowedWorkspaces.length === 0 && (allowedSpaces.length === 0 || syncedAnyAllowedSpace));

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -718,31 +718,12 @@ export function createClickUpConnector(): Connector {
           });
         }
 
-        // Seed workspace as top-level entity
-        if (!experimentalFlag && onEntitySeed) {
-          await onEntitySeed({
-            name: workspaceName,
-            sourceType: "clickup_workspace",
-            source: "clickup",
-            sourceId: team.id,
-            metadata: { memberCount: workspaceEmails.length },
-          });
-        }
-
-        // Seed workspace members as person entities
-        if (onPersonSeed) {
-          for (const member of team.members) {
-            if (member.user.username) {
-              await onPersonSeed({
-                name: member.user.username,
-                email: member.user.email,
-                subtype: "internal",
-                source: "clickup",
-                sourceId: `user:${member.user.id}`,
-              });
-            }
-          }
-        }
+        // Workspace membership alone is not an engagement signal, so members are
+        // NOT seeded as person entities here — a shared workspace's full roster
+        // would otherwise mint hundreds of isolated "phantom" people (zero
+        // mentions, zero edges). People come from task assignees (seeded below,
+        // after traversal) and from text mentions. Member emails still feed the
+        // access scope for doc/space visibility.
 
         // Workspace-level access scope (used for docs and public spaces)
         const workspaceScope: SyncedItem["accessScope"] = {
@@ -758,17 +739,6 @@ export function createClickUpConnector(): Connector {
             continue;
           }
           syncedAnyAllowedSpace = true;
-
-          // Seed space as entity with workspace context
-          if (!experimentalFlag && onEntitySeed) {
-            await onEntitySeed({
-              name: space.name,
-              sourceType: "clickup_space",
-              source: "clickup",
-              sourceId: space.id,
-              metadata: { private: space.private, workspaceName, workspaceId: team.id },
-            });
-          }
 
           // Build access scope for this space.
           // Private spaces use space members; public spaces use all workspace members.

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -744,10 +744,12 @@ export function createClickUpConnector(): Connector {
           spaces: ClickUpSpace[];
         };
 
+        let syncedAnyAllowedSpace = false;
         for (const space of spacesRes.spaces) {
           if (allowedSpaces.length > 0 && !allowedSpaces.includes(space.id)) {
             continue;
           }
+          syncedAnyAllowedSpace = true;
 
           // Seed space as entity with workspace context
           if (!experimentalFlag && onEntitySeed) {
@@ -956,8 +958,20 @@ export function createClickUpConnector(): Connector {
           }
         }
 
-        // Sync ClickUp Docs at workspace level
-        yield* fetchDocsFromWorkspace(team.id, token, logger, workspaceScope, cursor ?? undefined);
+        // Sync ClickUp Docs at workspace level.
+        // Docs are fetched per-workspace with no space-level filter, so they would leak
+        // across workspaces the user never selected. When workspaces are explicitly scoped,
+        // this team already passed the workspace filter above. When only spaces are selected
+        // (workspaces empty), sync docs only if this workspace contains a selected space;
+        // otherwise a workspace reachable by the token but never opted into would still have
+        // its docs ingested. With neither workspaces nor spaces selected, the connection is
+        // unscoped and every workspace's docs sync (unchanged behavior).
+        const workspaceInDocScope =
+          allowedWorkspaces.includes(team.id) ||
+          (allowedWorkspaces.length === 0 && (allowedSpaces.length === 0 || syncedAnyAllowedSpace));
+        if (workspaceInDocScope) {
+          yield* fetchDocsFromWorkspace(team.id, token, logger, workspaceScope, cursor ?? undefined);
+        }
       }
 
       // Seed assignees collected during task traversal as person entities

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -675,10 +675,22 @@ export function createClickUpConnector(): Connector {
       };
 
       for (const team of teamsRes.teams) {
-        // Workspace filter: skip workspaces not in scope
         if (allowedWorkspaces.length > 0 && !allowedWorkspaces.includes(team.id)) {
           continue;
         }
+
+        const spacesRes = (await clickupRequest(`/team/${team.id}/space`, token, logger)) as {
+          spaces: ClickUpSpace[];
+        };
+        const workspaceContainsAllowedSpace = spacesRes.spaces.some((space) => allowedSpaces.includes(space.id));
+        const workspaceInScope =
+          (allowedWorkspaces.length === 0 && allowedSpaces.length === 0) ||
+          allowedWorkspaces.includes(team.id) ||
+          (allowedWorkspaces.length === 0 && allowedSpaces.length > 0 && workspaceContainsAllowedSpace);
+        if (!workspaceInScope) {
+          continue;
+        }
+
         const workspaceName = team.name.trim();
         const workspaceEmails = extractMemberEmails(team.members);
         logger.info(
@@ -738,10 +750,6 @@ export function createClickUpConnector(): Connector {
           providerScopeId: team.id,
           label: workspaceName,
           memberEmails: workspaceEmails,
-        };
-
-        const spacesRes = (await clickupRequest(`/team/${team.id}/space`, token, logger)) as {
-          spaces: ClickUpSpace[];
         };
 
         let syncedAnyAllowedSpace = false;

--- a/packages/server/src/db/repositories/entity-domains.ts
+++ b/packages/server/src/db/repositories/entity-domains.ts
@@ -131,12 +131,58 @@ export function normalizeWebsiteDomain(value: string | null | undefined): string
 }
 
 /**
- * Propose a company display name from a raw domain. `habuild.in` → `Habuild`,
- * `oliver-wyman.com` → `Oliver Wyman`. The result is a hint for the candidate
- * row — ECR-05 will route this through `proposeEntity` for real review.
+ * Multi-label public suffixes where the registrable label sits one further left
+ * than a single-label TLD. Hand-maintained (no public-suffix-list dependency);
+ * covers the ccTLD shapes that show up in this data. `x.co.in` → SLD `x`, not
+ * `co`.
+ */
+const COMPOUND_TLD_SUFFIXES: ReadonlySet<string> = new Set([
+  "co.in",
+  "co.uk",
+  "co.jp",
+  "co.nz",
+  "co.kr",
+  "co.za",
+  "com.au",
+  "com.br",
+  "com.sg",
+  "com.mx",
+  "com.tr",
+  "ac.in",
+  "ac.uk",
+  "ac.jp",
+  "org.in",
+  "org.uk",
+  "net.in",
+  "gov.in",
+  "gov.uk",
+  "edu.in",
+  "bank.in",
+]);
+
+/**
+ * Propose a company display name from a raw domain. Uses the registrable
+ * second-level label (the one left of the public suffix), NOT the leftmost
+ * label, so a subdomain host does not become the name: `habuild.in` → `Habuild`,
+ * `oliver-wyman.com` → `Oliver Wyman`, `support.aws.com` → `Aws`,
+ * `xwf.google.com` → `Google`, `x.co.in` → `X`. The result is a hint for the
+ * candidate row — ECR-05 will route this through `proposeEntity` for real review.
  */
 export function proposeCompanyNameFromDomain(domain: string): string {
-  const base = domain.split(".")[0] ?? domain;
+  const normalized = domain.trim().toLowerCase().replace(/\.+$/, "");
+  const labels = normalized.split(".").filter((s) => s.length > 0);
+  let base: string;
+  if (labels.length <= 1) {
+    base = labels[0] ?? normalized;
+  } else {
+    const suffixLen = COMPOUND_TLD_SUFFIXES.has(labels.slice(-2).join(".")) ? 2 : 1;
+    const sldIndex = labels.length - 1 - suffixLen;
+    // The input is nothing but a public suffix (e.g. `co.in`) — there is no
+    // registrable label to name a company after, so refuse rather than mint a
+    // bogus "Co" candidate. An empty name is skipped by the promotion sweep.
+    if (sldIndex < 0) return "";
+    base = labels[sldIndex];
+  }
   return base
     .split(/[-_]/)
     .filter((s) => s.length > 0)

--- a/packages/server/src/entities/domain-promotion.ts
+++ b/packages/server/src/entities/domain-promotion.ts
@@ -4,7 +4,9 @@ import { createEntityRepository, whereLiveEntity } from "../db/repositories/enti
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
 import type { DB, EntitiesTable } from "../db/schema";
+import { isPersonalOrSharedDomain, isWellKnownNonClientDomain } from "./personal-domains";
 import { type Entity, type EntityLookup, proposeEntity } from "./propose";
+import { isEmailProviderName } from "./validators";
 
 export const DOMAIN_PROMOTION_THRESHOLD = 1;
 
@@ -194,6 +196,18 @@ export async function sweepDomainPromotions(db: Kysely<DB>, logger: Logger): Pro
     const domain = candidate.domain;
     const proposedName = candidate.proposed_company_name ?? candidate.name;
     if (!domain || !proposedName) continue;
+    // Belt-and-suspenders: never mint or link a company for a consumer webmail /
+    // shared domain, even if a stale domain_observation candidate slipped through
+    // upstream. Guards both the domain (independent of the DB seed) and the
+    // provider brand name ("Gmail").
+    if (isPersonalOrSharedDomain(domain) || isEmailProviderName(proposedName)) {
+      logger.info({ domain, proposedName }, "Skipping personal/shared domain promotion");
+      continue;
+    }
+    if (isWellKnownNonClientDomain(domain)) {
+      logger.info({ domain, proposedName }, "Skipping well-known non-client (vendor/infra) domain promotion");
+      continue;
+    }
     const observedPeople = parseStringArray(candidate.observed_person_entity_ids);
     const evidenceFiles = parseStringArray(candidate.evidence_file_ids);
 

--- a/packages/server/src/entities/personal-domains.test.ts
+++ b/packages/server/src/entities/personal-domains.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { proposeCompanyNameFromDomain } from "../db/repositories/entity-domains";
+import { isPersonalOrSharedDomain, isWellKnownNonClientDomain } from "./personal-domains";
+
+describe("isPersonalOrSharedDomain — subdomain, label-boundary matching", () => {
+  it("matches a subdomain of a listed shared domain, on label boundaries", () => {
+    expect(isPersonalOrSharedDomain("linear.app")).toBe(true);
+    expect(isPersonalOrSharedDomain("oauthapp.linear.app")).toBe(true);
+    expect(isPersonalOrSharedDomain("foo.linear.app")).toBe(true);
+    // Webmail subdomain too.
+    expect(isPersonalOrSharedDomain("mail.gmail.com")).toBe(true);
+  });
+
+  it("does NOT match a same-suffix domain that only shares a substring (boundary safety)", () => {
+    expect(isPersonalOrSharedDomain("notlinear.app")).toBe(false);
+    expect(isPersonalOrSharedDomain("mygmail.com")).toBe(false);
+    // A real corporate domain is never a subdomain of the sets.
+    expect(isPersonalOrSharedDomain("habuild.in")).toBe(false);
+    expect(isPersonalOrSharedDomain("oliverwyman.com")).toBe(false);
+  });
+
+  it("normalizes case / whitespace / trailing dot, and tolerates empties", () => {
+    expect(isPersonalOrSharedDomain("  GMAIL.com. ")).toBe(true);
+    expect(isPersonalOrSharedDomain(null)).toBe(false);
+    expect(isPersonalOrSharedDomain("")).toBe(false);
+  });
+});
+
+describe("isWellKnownNonClientDomain — vendor/infra suppression (sweep only)", () => {
+  it("matches vendor domains and their notification subdomains", () => {
+    expect(isWellKnownNonClientDomain("fireflies.ai")).toBe(true);
+    expect(isWellKnownNonClientDomain("support.aws.com")).toBe(true);
+    expect(isWellKnownNonClientDomain("xwf.google.com")).toBe(true);
+    expect(isWellKnownNonClientDomain("stripe.com")).toBe(true);
+  });
+
+  it("leaves real corporate domains alone", () => {
+    expect(isWellKnownNonClientDomain("habuild.in")).toBe(false);
+    expect(isWellKnownNonClientDomain("oliverwyman.com")).toBe(false);
+    expect(isWellKnownNonClientDomain(null)).toBe(false);
+  });
+});
+
+describe("proposeCompanyNameFromDomain — registrable second-level label", () => {
+  it("uses the label left of the public suffix, not the leftmost subdomain", () => {
+    expect(proposeCompanyNameFromDomain("support.aws.com")).toBe("Aws");
+    expect(proposeCompanyNameFromDomain("xwf.google.com")).toBe("Google");
+    expect(proposeCompanyNameFromDomain("oauthapp.linear.app")).toBe("Linear");
+  });
+
+  it("handles compound ccTLD suffixes (SLD, not the suffix label)", () => {
+    expect(proposeCompanyNameFromDomain("x.co.in")).toBe("X");
+    expect(proposeCompanyNameFromDomain("icici.bank.in")).toBe("Icici");
+    expect(proposeCompanyNameFromDomain("wilp.bits-pilani.ac.in")).toBe("Bits Pilani");
+  });
+
+  it("keeps simple corporate domains unchanged", () => {
+    expect(proposeCompanyNameFromDomain("habuild.in")).toBe("Habuild");
+    expect(proposeCompanyNameFromDomain("oliver-wyman.com")).toBe("Oliver Wyman");
+    expect(proposeCompanyNameFromDomain("a.b.co.uk")).toBe("B");
+  });
+
+  it("refuses a bare public suffix (no registrable label) instead of minting a junk name", () => {
+    // `co.in` is nothing but a compound public suffix — must NOT become "Co".
+    expect(proposeCompanyNameFromDomain("co.in")).toBe("");
+    expect(proposeCompanyNameFromDomain("co.uk.")).toBe("");
+    // A single label (degenerate, not a real email domain) title-cases as-is.
+    expect(proposeCompanyNameFromDomain("internal")).toBe("Internal");
+  });
+});

--- a/packages/server/src/entities/personal-domains.ts
+++ b/packages/server/src/entities/personal-domains.ts
@@ -1,0 +1,127 @@
+/**
+ * Canonical personal / shared email-provider domains, as CODE — the runtime
+ * source of truth for "never promote this domain to a company".
+ *
+ * Background: the domain-promotion pipeline only skips personal providers when
+ * `isPersonalOrShared(domain)` says so, and that check historically read solely
+ * from `entity_domains` seed rows planted once by migration
+ * `064-entity-domains-seed`. Any rebuild/purge that clears `entity_domains`
+ * silently removed the guard, letting `gmail.com` mint a "Gmail" company. Keeping
+ * the list in code makes the guard independent of mutable DB state; the DB seed
+ * becomes a secondary, operator-visible copy.
+ *
+ * This list is the superset. Migration 064 carries an inline copy for the
+ * initial seed and must be kept aligned with this file when either changes.
+ */
+
+export const PERSONAL_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  "gmail.com",
+  "googlemail.com",
+  "outlook.com",
+  "hotmail.com",
+  "live.com",
+  "msn.com",
+  "yahoo.com",
+  "ymail.com",
+  "rocketmail.com",
+  "aol.com",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "proton.me",
+  "protonmail.com",
+  "pm.me",
+  "gmx.com",
+  "gmx.net",
+  "mail.com",
+  "zoho.com",
+  "yandex.com",
+  "fastmail.com",
+  "hey.com",
+  "tutanota.com",
+  "qq.com",
+  "163.com",
+  "126.com",
+  "naver.com",
+]);
+
+export const SHARED_DOMAINS: ReadonlySet<string> = new Set([
+  "googlegroups.com",
+  "slack.com",
+  "discord.com",
+  "intercom.io",
+  "hubspot.com",
+  "salesforce.com",
+  "atlassian.net",
+  "notion.so",
+  "linear.app",
+  "clickup.com",
+  "zoom.us",
+]);
+
+/**
+ * Well-known SaaS / infra / notification-sender domains that are noise in a
+ * typical org's client graph, not companies to promote (our own connector,
+ * calendar/billing/notification senders, mega-consumer brands). Deliberately
+ * kept SEPARATE from {@link SHARED_DOMAINS} — this set is consulted only by the
+ * domain-promotion sweep, so it never widens the personal/shared guard that
+ * affiliation and engagement callers read. Hard-coding the mega brands
+ * (google/microsoft/amazon/…) is a single-deployment judgement call: if a tenant
+ * ever has one of these as a real client, drop it from this one constant.
+ */
+export const WELL_KNOWN_NON_CLIENT_DOMAINS: ReadonlySet<string> = new Set([
+  "fireflies.ai",
+  "calendly.com",
+  "docusign.com",
+  "stripe.com",
+  "aws.com",
+  "amazonaws.com",
+  "google.com",
+  "microsoft.com",
+  "amazon.com",
+  "apple.com",
+  "zomato.com",
+]);
+
+/**
+ * True when `domain` — or any of its parent domains, on label boundaries — is in
+ * `set`. `foo.linear.app` matches `linear.app`; `notlinear.app` does not. Skips
+ * the bare TLD (checks suffixes down to the registrable pair only).
+ */
+function domainOrParentInSet(domain: string, set: ReadonlySet<string>): boolean {
+  const labels = domain.split(".").filter(Boolean);
+  for (let i = 0; i <= labels.length - 2; i++) {
+    if (set.has(labels.slice(i).join("."))) return true;
+  }
+  return false;
+}
+
+function normalizeDomain(domain: string): string {
+  return domain.trim().toLowerCase().replace(/\.+$/, "");
+}
+
+/**
+ * True when `domain` is a known consumer webmail provider or a shared
+ * SaaS/tooling domain — either way, not a company's corporate domain and never a
+ * valid promotion target. Matches on label boundaries, so subdomains of a listed
+ * domain (`oauthapp.linear.app`) are also caught. Case-insensitive; trims
+ * surrounding whitespace and trailing dots.
+ */
+export function isPersonalOrSharedDomain(domain: string | null | undefined): boolean {
+  if (!domain) return false;
+  const normalized = normalizeDomain(domain);
+  if (!normalized) return false;
+  return domainOrParentInSet(normalized, PERSONAL_EMAIL_DOMAINS) || domainOrParentInSet(normalized, SHARED_DOMAINS);
+}
+
+/**
+ * True when `domain` (or a parent, on label boundaries) is a well-known
+ * non-client SaaS/infra/notification domain. Used ONLY by the domain-promotion
+ * sweep to suppress vendor-noise company creation.
+ */
+export function isWellKnownNonClientDomain(domain: string | null | undefined): boolean {
+  if (!domain) return false;
+  const normalized = normalizeDomain(domain);
+  if (!normalized) return false;
+  return domainOrParentInSet(normalized, WELL_KNOWN_NON_CLIENT_DOMAINS);
+}


### PR DESCRIPTION
Stacked context-graph slice 23/27.

Base: `feat/context-graph-22-feature-lifecycle-noise`
Head: `feat/context-graph-23-structural-noise-gates`

Folds in the ClickUp phantom-member fix and domain-promotion junk/vendor gates: 87ed2076 and fc2b6d0e, with required ClickUp scope prerequisites.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`