### PR TITLE
feat: add name embedding dedup

### DIFF
--- a/packages/server/scripts/backfill-trunk-name-embeddings.ts
+++ b/packages/server/scripts/backfill-trunk-name-embeddings.ts
@@ -1,0 +1,40 @@
+import { loadConfig, validateConfig } from "../src/config";
+import { reconcileMissingNameEmbeddings } from "../src/connectors/embeddings/trunk-name-embeddings";
+import {
+  createEnrichmentEmbeddingProvider,
+  resolveOpenRouterEnrichmentConfig,
+} from "../src/connectors/enrichment-providers";
+import { createDatabase } from "../src/db";
+import { runMigrations } from "../src/db/migrate";
+import { createSettingsRepository } from "../src/db/repositories/settings";
+import { createLogger } from "../src/logger";
+
+async function main() {
+  const config = loadConfig();
+  validateConfig(config);
+  const logger = createLogger(config);
+  const db = await createDatabase(config);
+
+  try {
+    await runMigrations(db, { quiet: true });
+    const settings = await createSettingsRepository(db, config.ENCRYPTION_KEY).get();
+    const openRouterConfig = resolveOpenRouterEnrichmentConfig(settings, config.OPENROUTER_API_KEY);
+    const provider = createEnrichmentEmbeddingProvider({
+      geminiApiKey: settings?.gemini_api_key,
+      geminiMaxRpm: config.GEMINI_MAX_RPM,
+      geminiMaxRetries: config.GEMINI_MAX_RETRIES,
+      logger,
+      ...openRouterConfig,
+    });
+
+    await reconcileMissingNameEmbeddings(db, provider);
+    logger.info({ provider: provider?.name ?? null }, "trunk name embedding backfill complete");
+  } finally {
+    await db.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/server/scripts/eval-dedup-adjudication.ts
+++ b/packages/server/scripts/eval-dedup-adjudication.ts
@@ -1,10 +1,10 @@
 /**
  * Behavioral eval for PR-F8 dedup adjudication.
  *
- * Runs live extraction plus the focused dedup pass with a fixed known set:
- * {OW Tourism Recovery Dashboard, Maaden Dashboard, Maaden Sites}. Prints each
- * project/product mention's extracted name, chosen handle, and final canonical
- * name. Writes NOTHING to the database; it only reads the configured Gemini key.
+ * Runs live extraction plus the focused dedup pass with fixed and retrieved
+ * known sets. Prints each project/product mention's extracted name, chosen
+ * handle, and final canonical name. Writes NOTHING to the production database;
+ * it only reads the configured Gemini key and uses an in-memory eval database.
  *
  * LEADS ON THE NO-OVER-MERGE CHECK: tourism short forms may resolve to the
  * tourism dashboard, Maaden Dashboard must not collapse into Maaden Sites,
@@ -15,8 +15,22 @@
  */
 import Database from "better-sqlite3";
 import { Kysely, SqliteDialect } from "kysely";
+import type { Config } from "../src/config";
+import { createGeminiEmbeddingProvider } from "../src/connectors/embeddings/gemini";
+import {
+  reconcileMissingNameEmbeddings,
+  retrieveNameDedupCandidates,
+} from "../src/connectors/embeddings/trunk-name-embeddings";
+import type { EmbeddingProvider } from "../src/connectors/embeddings/types";
 import { createGeminiGenerator } from "../src/connectors/gemini-generate";
-import { adjudicateKnownMatches, extractEntities } from "../src/connectors/smart-enrichment";
+import {
+  adjudicateKnownMatches,
+  extractEntities,
+  mergeKnownEntities,
+  projectProductMentionNames,
+} from "../src/connectors/smart-enrichment";
+import { createDatabase } from "../src/db";
+import { runMigrations } from "../src/db/migrate";
 import type { DB } from "../src/db/schema";
 
 const DB_PATH = "/Users/hkalra/projects/claude/sketch/data/sketch.db";
@@ -38,6 +52,12 @@ type EvalMention = {
   finalName: string;
   matchesKnown?: string;
 };
+
+interface EvalDeps {
+  generator: ReturnType<typeof createGeminiGenerator>;
+  retrievalDb: Kysely<DB>;
+  embeddingProvider: EmbeddingProvider;
+}
 
 const CASES: Array<{
   label: string;
@@ -77,6 +97,115 @@ Oliver Wyman, or the Maaden mining workstreams.`,
   },
 ];
 
+function evalFile(label: string, content: string) {
+  return {
+    id: `eval-${label}`,
+    fileName: `${label}.txt`,
+    content,
+    threadContext: null,
+    contentCategory: "document",
+    fileType: "document",
+    source: "eval",
+    sourcePath: "/",
+    contentHash: null,
+    connectorConfigId: "eval",
+    sourceCreatedAt: null,
+    sourceUpdatedAt: null,
+  };
+}
+
+function mentionSummaries(
+  mentions: Array<{ mention: string; type: string; matchesKnown?: string }>,
+  rewrites: Map<string, string>,
+): EvalMention[] {
+  return mentions
+    .filter((m) => m.type === "project" || m.type === "product")
+    .map((m) => ({
+      original: m.mention,
+      finalName: rewrites.get(m.mention) ?? m.mention,
+      matchesKnown: m.matchesKnown,
+    }));
+}
+
+async function seedProject(db: Kysely<DB>, id: string, name: string): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: "project",
+      subtype: null,
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+}
+
+async function createRetrievalDb(embeddingProvider: EmbeddingProvider): Promise<Kysely<DB>> {
+  const db = await createDatabase({ DB_TYPE: "sqlite", SQLITE_PATH: ":memory:" } as Config);
+  await runMigrations(db, { quiet: true });
+  await seedProject(db, "eval-tourism", TOURISM);
+  await seedProject(db, "eval-maaden-dashboard", MAADEN_DASHBOARD);
+  await seedProject(db, "eval-maaden-sites", MAADEN_SITES);
+  await reconcileMissingNameEmbeddings(db, embeddingProvider);
+  return db;
+}
+
+async function runKnownCase(
+  deps: EvalDeps,
+  label: string,
+  content: string,
+  known = KNOWN,
+  anchorNames = ANCHOR_NAMES,
+): Promise<EvalMention[]> {
+  const file = evalFile(label, content);
+  const result = await extractEntities(deps.generator, file, null, known, undefined, undefined, EXPERIMENTAL);
+  const rewrites = await adjudicateKnownMatches(deps.generator, result.mentions, known, {
+    fileId: file.id,
+    anchorNames,
+  });
+  return mentionSummaries(result.mentions, rewrites);
+}
+
+async function runRetrievedCase(
+  deps: EvalDeps,
+  label: string,
+  content: string,
+  provider: EmbeddingProvider,
+  known = [] as typeof KNOWN,
+  anchorNames = ANCHOR_NAMES,
+): Promise<EvalMention[]> {
+  const file = evalFile(label, content);
+  const result = await extractEntities(deps.generator, file, null, known, undefined, undefined, EXPERIMENTAL);
+  const retrieved = await retrieveNameDedupCandidates(
+    deps.retrievalDb,
+    provider,
+    projectProductMentionNames(result.mentions),
+  );
+  const widened = mergeKnownEntities(known, retrieved);
+  const rewrites = await adjudicateKnownMatches(deps.generator, result.mentions, widened, {
+    fileId: file.id,
+    anchorNames,
+  });
+  return mentionSummaries(result.mentions, rewrites);
+}
+
+function printMentions(label: string, mentions: EvalMention[]): void {
+  console.log(`${"#".repeat(70)}\n# ${label}`);
+  console.log("#".repeat(70));
+  for (const mention of mentions) {
+    console.log(
+      `  [project/product] extracted="${mention.original}"  handle=${mention.matchesKnown ?? "none"}  final="${mention.finalName}"`,
+    );
+  }
+}
+
 async function main() {
   const sqliteDb = new Database(DB_PATH, { readonly: true });
   const db = new Kysely<DB>({ dialect: new SqliteDialect({ database: sqliteDb }) });
@@ -88,46 +217,17 @@ async function main() {
     .executeTakeFirstOrThrow();
   if (!settings.gemini_api_key) throw new Error("no gemini_api_key in settings");
   const generator = createGeminiGenerator(settings.gemini_api_key);
+  const embeddingProvider = createGeminiEmbeddingProvider(settings.gemini_api_key);
+  const retrievalDb = await createRetrievalDb(embeddingProvider);
+  const deps = { generator, retrievalDb, embeddingProvider };
 
   console.log(`Known set: ${KNOWN.map((k, i) => `[K${i + 1}] ${k.name}`).join("  ")}\n`);
 
   let pass = true;
   for (const c of CASES) {
-    const file = {
-      id: `eval-${c.label}`,
-      fileName: `${c.label}.txt`,
-      content: c.content,
-      threadContext: null,
-      contentCategory: "document",
-      fileType: "document",
-      source: "eval",
-      sourcePath: "/",
-      contentHash: null,
-      connectorConfigId: "eval",
-      sourceCreatedAt: null,
-      sourceUpdatedAt: null,
-    };
-
-    const result = await extractEntities(generator, file, null, KNOWN, undefined, undefined, EXPERIMENTAL);
-    const rewrites = await adjudicateKnownMatches(generator, result.mentions, KNOWN, {
-      fileId: file.id,
-      anchorNames: ANCHOR_NAMES,
-    });
-
-    console.log(`${"#".repeat(70)}\n# ${c.label}`);
-    console.log("#".repeat(70));
-    const mentions = result.mentions
-      .filter((m) => m.type === "project" || m.type === "product")
-      .map((m) => ({
-        original: m.mention,
-        finalName: rewrites.get(m.mention) ?? m.mention,
-        matchesKnown: m.matchesKnown,
-      }));
-
+    const mentions = await runKnownCase(deps, c.label, c.content);
+    printMentions(c.label, mentions);
     for (const mention of mentions) {
-      console.log(
-        `  [project/product] extracted="${mention.original}"  handle=${mention.matchesKnown ?? "none"}  final="${mention.finalName}"`,
-      );
       if (!c.isOverMerge(mention)) continue;
       pass = false;
       console.log("  FALSE MERGE detected");
@@ -138,7 +238,82 @@ async function main() {
     console.log("");
   }
 
-  console.log(pass ? "RESULT: PASS (no over-merge)" : "RESULT: FAIL (over-merge detected)");
+  const crossFileContent = `Weekly delivery notes.
+The tourism dashboard team reviewed destination arrivals, hotel occupancy, and
+aviation capacity. The next sprint for the tourism dashboard focuses on arrivals
+data quality and occupancy drilldowns.`;
+  const crossFileWithRetrieval = await runRetrievedCase(
+    deps,
+    "cross-file fold-in with retrieval",
+    crossFileContent,
+    embeddingProvider,
+    [],
+    [],
+  );
+  printMentions("cross-file fold-in with retrieval", crossFileWithRetrieval);
+  const folded = crossFileWithRetrieval.some((mention) => mention.finalName === TOURISM);
+  if (!folded) {
+    pass = false;
+    console.log("  F9 retrieval did not fold the short tourism mention");
+  }
+
+  const emptyProvider: EmbeddingProvider = {
+    name: "empty",
+    dimensions: 3072,
+    supportsImages: false,
+    embedTexts: async () => [],
+  };
+  const crossFileControl = await runRetrievedCase(
+    deps,
+    "cross-file false-green control",
+    crossFileContent,
+    emptyProvider,
+    [],
+    [],
+  );
+  printMentions("cross-file false-green control", crossFileControl);
+  if (crossFileControl.some((mention) => mention.finalName === TOURISM)) {
+    pass = false;
+    console.log("  pure F8 control folded without retrieval");
+  }
+
+  const maadenRetrieval = await runRetrievedCase(
+    deps,
+    "maaden retrieval over-merge guard",
+    `Maaden Dashboard notes.
+The Maaden Dashboard tracks mining output, ore-grade trends, and haul-truck
+utilization for the Maaden operating team.`,
+    embeddingProvider,
+    [],
+    ["Maaden"],
+  );
+  printMentions("maaden retrieval over-merge guard", maadenRetrieval);
+  if (
+    maadenRetrieval.some(
+      (mention) => mention.original.toLowerCase().includes("dashboard") && mention.finalName === MAADEN_SITES,
+    )
+  ) {
+    pass = false;
+    console.log("  Maaden Dashboard folded into Maaden Sites");
+  }
+
+  const throwingProvider: EmbeddingProvider = {
+    name: "throwing",
+    dimensions: 3072,
+    supportsImages: false,
+    embedTexts: async () => {
+      throw new Error("embedding unavailable");
+    },
+  };
+  const failOpen = await runRetrievedCase(deps, "retrieval fail-open", crossFileContent, throwingProvider, [], []);
+  printMentions("retrieval fail-open", failOpen);
+  if (failOpen.some((mention) => mention.finalName === TOURISM)) {
+    pass = false;
+    console.log("  fail-open provider unexpectedly folded the short tourism mention");
+  }
+
+  console.log(pass ? "RESULT: PASS" : "RESULT: FAIL");
+  await retrievalDb.destroy();
   await db.destroy();
   if (!pass) process.exit(1);
 }

--- a/packages/server/scripts/eval-dedup-adjudication.ts
+++ b/packages/server/scripts/eval-dedup-adjudication.ts
@@ -122,7 +122,7 @@ function mentionSummaries(
     .filter((m) => m.type === "project" || m.type === "product")
     .map((m) => ({
       original: m.mention,
-      finalName: rewrites.get(m.mention) ?? m.mention,
+      finalName: rewrites.get(`${m.type}:${m.mention}`) ?? m.mention,
       matchesKnown: m.matchesKnown,
     }));
 }

--- a/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
+++ b/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as dbIndex from "../../db/index";
 import { EMBEDDING_DIMENSIONS } from "../../db/index";
 import type { DB } from "../../db/schema";
-import { reconcileMissingNameEmbeddings } from "./trunk-name-embeddings";
+import { reconcileMissingNameEmbeddings, retrieveNameDedupCandidates } from "./trunk-name-embeddings";
 import type { EmbeddingProvider } from "./types";
 
 function vector(value: number): number[] {
@@ -14,12 +14,12 @@ function vector(value: number): number[] {
   return embedding;
 }
 
-function makeProvider(): EmbeddingProvider & { embedTexts: ReturnType<typeof vi.fn> } {
+function makeProvider(embeddings?: number[][]): EmbeddingProvider & { embedTexts: ReturnType<typeof vi.fn> } {
   return {
     name: "test",
     dimensions: EMBEDDING_DIMENSIONS,
     supportsImages: false,
-    embedTexts: vi.fn(async (texts: string[]) => texts.map((_text, index) => vector(index + 1))),
+    embedTexts: vi.fn(async (texts: string[]) => embeddings ?? texts.map((_text, index) => vector(index + 1))),
   };
 }
 
@@ -79,6 +79,18 @@ async function insertReview(
     INSERT INTO entity_review_queue (id, proposed_name, entity_type, status)
     VALUES (${row.id}, ${row.name}, ${row.type}, ${row.status ?? "pending"})
   `.execute(db);
+}
+
+async function insertEntityEmbedding(db: Kysely<DB>, id: string, embedding: number[]): Promise<void> {
+  await sql`INSERT INTO entity_name_embeddings (entity_id, embedding) VALUES (${id}, ${JSON.stringify(embedding)})`.execute(
+    db,
+  );
+}
+
+async function insertReviewEmbedding(db: Kysely<DB>, id: string, embedding: number[]): Promise<void> {
+  await sql`INSERT INTO entity_review_queue_embeddings (review_id, embedding) VALUES (${id}, ${JSON.stringify(
+    embedding,
+  )})`.execute(db);
 }
 
 async function entityEmbeddingIds(db: Kysely<DB>): Promise<string[]> {
@@ -153,5 +165,61 @@ describe("trunk name embedding reconcile", () => {
 
     expect(provider.embedTexts).not.toHaveBeenCalled();
     expect(await entityEmbeddingIds(db)).toEqual([]);
+  });
+
+  it("retrieves type-correct candidates above the similarity threshold", async () => {
+    await insertEntity(db, { id: "entity-project", name: "Project Atlas", type: "project" });
+    await insertEntity(db, { id: "entity-product", name: "Product Atlas", type: "product" });
+    await insertReview(db, { id: "review-project", name: "Review Atlas", type: "project" });
+    await insertReview(db, { id: "review-far", name: "Far Atlas", type: "project" });
+    await insertEntityEmbedding(db, "entity-project", vector(0.95));
+    await insertEntityEmbedding(db, "entity-product", vector(0.96));
+    await insertReviewEmbedding(db, "review-project", vector(0.9));
+    await insertReviewEmbedding(db, "review-far", vector(0.1));
+    const provider = makeProvider([vector(1)]);
+
+    const candidates = await retrieveNameDedupCandidates(db, provider, [{ name: "Atlas Project", type: "project" }], {
+      topK: 10,
+    });
+
+    expect(provider.embedTexts).toHaveBeenCalledOnce();
+    expect(provider.embedTexts).toHaveBeenCalledWith(["Atlas Project"]);
+    expect(candidates).toEqual([
+      { name: "Project Atlas", type: "project", entityId: "entity-project" },
+      { name: "Review Atlas", type: "project", reviewId: "review-project" },
+    ]);
+  });
+
+  it("overfetches so wrong-type and orphan nearest rows do not hide usable candidates", async () => {
+    for (let index = 0; index < 3; index++) {
+      await insertEntity(db, { id: `wrong-${index}`, name: `Wrong ${index}`, type: "product" });
+      await insertEntityEmbedding(db, `wrong-${index}`, vector(1));
+      await insertEntityEmbedding(db, `orphan-${index}`, vector(1));
+    }
+    for (let index = 0; index < 3; index++) {
+      await insertEntity(db, { id: `usable-${index}`, name: `Usable ${index}`, type: "project" });
+      await insertEntityEmbedding(db, `usable-${index}`, vector(0.95 - index * 0.01));
+    }
+    const provider = makeProvider([vector(1)]);
+
+    const candidates = await retrieveNameDedupCandidates(db, provider, [{ name: "Usable Project", type: "project" }], {
+      topK: 3,
+    });
+
+    expect(candidates.map((candidate) => candidate.name).sort()).toEqual(["Usable 0", "Usable 1", "Usable 2"]);
+  });
+
+  it("fails open when retrieval has no provider or the provider throws", async () => {
+    await insertEntity(db, { id: "entity-project", name: "Project Atlas", type: "project" });
+    await insertEntityEmbedding(db, "entity-project", vector(1));
+    const throwingProvider = makeProvider();
+    throwingProvider.embedTexts.mockRejectedValueOnce(new Error("embedding unavailable"));
+
+    await expect(retrieveNameDedupCandidates(db, null, [{ name: "Atlas Project", type: "project" }])).resolves.toEqual(
+      [],
+    );
+    await expect(
+      retrieveNameDedupCandidates(db, throwingProvider, [{ name: "Atlas Project", type: "project" }]),
+    ).resolves.toEqual([]);
   });
 });

--- a/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
+++ b/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
@@ -1,0 +1,157 @@
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect, sql } from "kysely";
+import * as sqliteVec from "sqlite-vec";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as dbIndex from "../../db/index";
+import { EMBEDDING_DIMENSIONS } from "../../db/index";
+import type { DB } from "../../db/schema";
+import { reconcileMissingNameEmbeddings } from "./trunk-name-embeddings";
+import type { EmbeddingProvider } from "./types";
+
+function vector(value: number): number[] {
+  const embedding = new Array(EMBEDDING_DIMENSIONS).fill(0);
+  embedding[0] = value;
+  return embedding;
+}
+
+function makeProvider(): EmbeddingProvider & { embedTexts: ReturnType<typeof vi.fn> } {
+  return {
+    name: "test",
+    dimensions: EMBEDDING_DIMENSIONS,
+    supportsImages: false,
+    embedTexts: vi.fn(async (texts: string[]) => texts.map((_text, index) => vector(index + 1))),
+  };
+}
+
+async function createDb(): Promise<Kysely<DB>> {
+  const raw = new Database(":memory:");
+  sqliteVec.load(raw);
+  const db = new Kysely<DB>({ dialect: new SqliteDialect({ database: raw }) });
+  await sql`
+    CREATE TABLE entities (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      source_type TEXT NOT NULL,
+      deleted_at TEXT,
+      merged_into_entity_id TEXT
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE entity_review_queue (
+      id TEXT PRIMARY KEY,
+      proposed_name TEXT NOT NULL,
+      entity_type TEXT NOT NULL,
+      status TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`
+    CREATE VIRTUAL TABLE entity_name_embeddings USING vec0(
+      entity_id TEXT PRIMARY KEY,
+      embedding float[${sql.lit(EMBEDDING_DIMENSIONS)}]
+    )
+  `.execute(db);
+  await sql`
+    CREATE VIRTUAL TABLE entity_review_queue_embeddings USING vec0(
+      review_id TEXT PRIMARY KEY,
+      embedding float[${sql.lit(EMBEDDING_DIMENSIONS)}]
+    )
+  `.execute(db);
+  return db;
+}
+
+async function insertEntity(
+  db: Kysely<DB>,
+  row: { id: string; name: string; type: string; deleted?: boolean; mergedInto?: string | null },
+): Promise<void> {
+  await sql`
+    INSERT INTO entities (id, name, source_type, deleted_at, merged_into_entity_id)
+    VALUES (${row.id}, ${row.name}, ${row.type}, ${row.deleted ? "2026-06-30T00:00:00.000Z" : null}, ${
+      row.mergedInto ?? null
+    })
+  `.execute(db);
+}
+
+async function insertReview(
+  db: Kysely<DB>,
+  row: { id: string; name: string; type: string; status?: string },
+): Promise<void> {
+  await sql`
+    INSERT INTO entity_review_queue (id, proposed_name, entity_type, status)
+    VALUES (${row.id}, ${row.name}, ${row.type}, ${row.status ?? "pending"})
+  `.execute(db);
+}
+
+async function entityEmbeddingIds(db: Kysely<DB>): Promise<string[]> {
+  const rows = await sql<{ entity_id: string }>`
+    SELECT entity_id FROM entity_name_embeddings ORDER BY entity_id ASC
+  `.execute(db);
+  return rows.rows.map((row) => row.entity_id);
+}
+
+async function reviewEmbeddingIds(db: Kysely<DB>): Promise<string[]> {
+  const rows = await sql<{ review_id: string }>`
+    SELECT review_id FROM entity_review_queue_embeddings ORDER BY review_id ASC
+  `.execute(db);
+  return rows.rows.map((row) => row.review_id);
+}
+
+describe("trunk name embedding reconcile", () => {
+  let db: Kysely<DB>;
+  let vecSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    db = await createDb();
+    vecSpy = vi.spyOn(dbIndex, "isSqliteVecAvailable").mockReturnValue(true);
+  });
+
+  afterEach(async () => {
+    vecSpy.mockRestore();
+    await db.destroy();
+  });
+
+  it("embeds only missing live project/product entities and pending project/product reviews", async () => {
+    await insertEntity(db, { id: "entity-project", name: "Project Atlas", type: "project" });
+    await insertEntity(db, { id: "entity-product", name: "Product OS", type: "product" });
+    await insertEntity(db, { id: "entity-person", name: "Sarah Chen", type: "person" });
+    await insertEntity(db, { id: "entity-deleted", name: "Deleted Project", type: "project", deleted: true });
+    await insertEntity(db, { id: "entity-existing", name: "Embedded Project", type: "project" });
+    await insertReview(db, { id: "review-project", name: "Review Project", type: "project" });
+    await insertReview(db, { id: "review-product", name: "Review Product", type: "product" });
+    await insertReview(db, { id: "review-team", name: "Review Team", type: "team" });
+    await insertReview(db, { id: "review-confirmed", name: "Confirmed Project", type: "project", status: "confirmed" });
+    await insertReview(db, { id: "review-existing", name: "Embedded Review", type: "project" });
+    await sql`INSERT INTO entity_name_embeddings (entity_id, embedding) VALUES (${"entity-existing"}, ${JSON.stringify(
+      vector(0.5),
+    )})`.execute(db);
+    await sql`INSERT INTO entity_review_queue_embeddings (review_id, embedding) VALUES (${"review-existing"}, ${JSON.stringify(
+      vector(0.6),
+    )})`.execute(db);
+    const provider = makeProvider();
+
+    await reconcileMissingNameEmbeddings(db, provider);
+
+    const embeddedNames = provider.embedTexts.mock.calls.flatMap((call) => call[0]).sort();
+    expect(embeddedNames).toEqual(["Product OS", "Project Atlas", "Review Product", "Review Project"].sort());
+    expect(await entityEmbeddingIds(db)).toEqual(["entity-existing", "entity-product", "entity-project"]);
+    expect(await reviewEmbeddingIds(db)).toEqual(["review-existing", "review-product", "review-project"]);
+  });
+
+  it("fails open when provider is absent", async () => {
+    await insertEntity(db, { id: "entity-project", name: "Project Atlas", type: "project" });
+
+    await expect(reconcileMissingNameEmbeddings(db, null)).resolves.toBeUndefined();
+
+    expect(await entityEmbeddingIds(db)).toEqual([]);
+  });
+
+  it("fails open when sqlite vec storage is unavailable", async () => {
+    vecSpy.mockReturnValue(false);
+    await insertEntity(db, { id: "entity-project", name: "Project Atlas", type: "project" });
+    const provider = makeProvider();
+
+    await expect(reconcileMissingNameEmbeddings(db, provider)).resolves.toBeUndefined();
+
+    expect(provider.embedTexts).not.toHaveBeenCalled();
+    expect(await entityEmbeddingIds(db)).toEqual([]);
+  });
+});

--- a/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
+++ b/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
@@ -8,9 +8,15 @@ import type { DB } from "../../db/schema";
 import { reconcileMissingNameEmbeddings, retrieveNameDedupCandidates } from "./trunk-name-embeddings";
 import type { EmbeddingProvider } from "./types";
 
-function vector(value: number): number[] {
+/**
+ * Unit vector whose cosine similarity to the base query vector (vector(1) =
+ * [1, 0, ...]) equals `cosine`. The dedup vec0 tables use distance_metric=cosine,
+ * so a stored vector(c) retrieved against a vector(1) query scores similarity c.
+ */
+function vector(cosine: number): number[] {
   const embedding = new Array(EMBEDDING_DIMENSIONS).fill(0);
-  embedding[0] = value;
+  embedding[0] = cosine;
+  embedding[1] = Math.sqrt(Math.max(0, 1 - cosine * cosine));
   return embedding;
 }
 
@@ -19,7 +25,7 @@ function makeProvider(embeddings?: number[][]): EmbeddingProvider & { embedTexts
     name: "test",
     dimensions: EMBEDDING_DIMENSIONS,
     supportsImages: false,
-    embedTexts: vi.fn(async (texts: string[]) => embeddings ?? texts.map((_text, index) => vector(index + 1))),
+    embedTexts: vi.fn(async (texts: string[]) => embeddings ?? texts.map(() => vector(1))),
   };
 }
 
@@ -47,13 +53,13 @@ async function createDb(): Promise<Kysely<DB>> {
   await sql`
     CREATE VIRTUAL TABLE entity_name_embeddings USING vec0(
       entity_id TEXT PRIMARY KEY,
-      embedding float[${sql.lit(EMBEDDING_DIMENSIONS)}]
+      embedding float[${sql.lit(EMBEDDING_DIMENSIONS)}] distance_metric=cosine
     )
   `.execute(db);
   await sql`
     CREATE VIRTUAL TABLE entity_review_queue_embeddings USING vec0(
       review_id TEXT PRIMARY KEY,
-      embedding float[${sql.lit(EMBEDDING_DIMENSIONS)}]
+      embedding float[${sql.lit(EMBEDDING_DIMENSIONS)}] distance_metric=cosine
     )
   `.execute(db);
   return db;

--- a/packages/server/src/connectors/embeddings/trunk-name-embeddings.ts
+++ b/packages/server/src/connectors/embeddings/trunk-name-embeddings.ts
@@ -2,14 +2,22 @@ import { type Kysely, sql } from "kysely";
 import pino from "pino";
 import { isPg } from "../../db/dialect";
 import * as dbIndex from "../../db/index";
+import { EMBEDDING_DIMENSIONS } from "../../db/index";
 import type { DB } from "../../db/schema";
+import type { KnownEntityForPrompt } from "../file-scope-context";
 import type { EmbeddingProvider } from "./types";
 
 export type NameDedupEntityType = "project" | "product";
 export type NameEmbeddingKind = "entity" | "review";
+export type NameDedupQuery = { name: string; type: NameDedupEntityType };
 
 export interface ReconcileMissingNameEmbeddingsOptions {
   types?: NameDedupEntityType[];
+}
+
+export interface RetrieveNameDedupCandidatesOptions {
+  topK?: number;
+  minCosine?: number;
 }
 
 type MissingNameRow = {
@@ -18,8 +26,19 @@ type MissingNameRow = {
   type: string;
 };
 
+type RetrievedNameRow = {
+  entityId: string | null;
+  reviewId: string | null;
+  name: string;
+  type: string;
+  similarity: number;
+};
+
 const NAME_EMBEDDING_BATCH_SIZE = 64;
 const NAME_EMBEDDING_TYPES: NameDedupEntityType[] = ["project", "product"];
+export const NAME_DEDUP_COSINE_THRESHOLD = 0.62;
+export const NAME_DEDUP_TOP_K = 10;
+export const NAME_DEDUP_OVERFETCH = 4;
 const logger = pino({ level: process.env.NODE_ENV === "test" ? "silent" : "warn" });
 
 function storageAvailable(db: Kysely<DB>): boolean {
@@ -143,5 +162,169 @@ export async function deleteNameEmbedding(db: Kysely<DB>, kind: NameEmbeddingKin
     await db.deleteFrom("entity_review_queue_embeddings").where("review_id", "=", id).execute();
   } catch (err) {
     logger.warn({ err, kind }, "name embedding delete failed open");
+  }
+}
+
+function candidateKey(row: RetrievedNameRow): string {
+  return `${row.type}:${row.name.toLowerCase()}`;
+}
+
+function toKnownEntity(row: RetrievedNameRow): KnownEntityForPrompt {
+  const entity: KnownEntityForPrompt = { name: row.name, type: row.type };
+  if (row.entityId) entity.entityId = row.entityId;
+  if (row.reviewId) entity.reviewId = row.reviewId;
+  return entity;
+}
+
+async function retrieveEntityRows(
+  db: Kysely<DB>,
+  query: NameDedupQuery,
+  embeddingJson: string,
+  vecLimit: number,
+): Promise<RetrievedNameRow[]> {
+  if (isPg(db)) {
+    const dims = EMBEDDING_DIMENSIONS;
+    const result = await sql<RetrievedNameRow>`
+      SELECT
+        e.id as "entityId",
+        NULL::text as "reviewId",
+        e.name,
+        e.source_type as type,
+        (1 - ranked.distance) as similarity
+      FROM (
+        SELECT
+          entity_id,
+          (embedding::halfvec(${sql.lit(dims)}) <=> ${embeddingJson}::halfvec(${sql.lit(dims)})) as distance
+        FROM entity_name_embeddings
+        ORDER BY embedding::halfvec(${sql.lit(dims)}) <=> ${embeddingJson}::halfvec(${sql.lit(dims)})
+        LIMIT ${vecLimit}
+      ) ranked
+      INNER JOIN entities e ON e.id = ranked.entity_id
+      WHERE e.source_type = ${query.type}
+        AND e.deleted_at IS NULL
+        AND e.merged_into_entity_id IS NULL
+      ORDER BY ranked.distance ASC
+    `.execute(db);
+    return result.rows;
+  }
+
+  const result = await sql<RetrievedNameRow>`
+    SELECT
+      e.id as entityId,
+      NULL as reviewId,
+      e.name,
+      e.source_type as type,
+      (1 - ranked.distance) as similarity
+    FROM (
+      SELECT entity_id, distance
+      FROM entity_name_embeddings
+      WHERE embedding MATCH ${embeddingJson}
+        AND k = ${vecLimit}
+      ORDER BY distance ASC
+    ) ranked
+    INNER JOIN entities e ON e.id = ranked.entity_id
+    WHERE e.source_type = ${query.type}
+      AND e.deleted_at IS NULL
+      AND e.merged_into_entity_id IS NULL
+    ORDER BY ranked.distance ASC
+  `.execute(db);
+  return result.rows;
+}
+
+async function retrieveReviewRows(
+  db: Kysely<DB>,
+  query: NameDedupQuery,
+  embeddingJson: string,
+  vecLimit: number,
+): Promise<RetrievedNameRow[]> {
+  if (isPg(db)) {
+    const dims = EMBEDDING_DIMENSIONS;
+    const result = await sql<RetrievedNameRow>`
+      SELECT
+        NULL::text as "entityId",
+        q.id as "reviewId",
+        q.proposed_name as name,
+        q.entity_type as type,
+        (1 - ranked.distance) as similarity
+      FROM (
+        SELECT
+          review_id,
+          (embedding::halfvec(${sql.lit(dims)}) <=> ${embeddingJson}::halfvec(${sql.lit(dims)})) as distance
+        FROM entity_review_queue_embeddings
+        ORDER BY embedding::halfvec(${sql.lit(dims)}) <=> ${embeddingJson}::halfvec(${sql.lit(dims)})
+        LIMIT ${vecLimit}
+      ) ranked
+      INNER JOIN entity_review_queue q ON q.id = ranked.review_id
+      WHERE q.entity_type = ${query.type}
+        AND q.status = 'pending'
+      ORDER BY ranked.distance ASC
+    `.execute(db);
+    return result.rows;
+  }
+
+  const result = await sql<RetrievedNameRow>`
+    SELECT
+      NULL as entityId,
+      q.id as reviewId,
+      q.proposed_name as name,
+      q.entity_type as type,
+      (1 - ranked.distance) as similarity
+    FROM (
+      SELECT review_id, distance
+      FROM entity_review_queue_embeddings
+      WHERE embedding MATCH ${embeddingJson}
+        AND k = ${vecLimit}
+      ORDER BY distance ASC
+    ) ranked
+    INNER JOIN entity_review_queue q ON q.id = ranked.review_id
+    WHERE q.entity_type = ${query.type}
+      AND q.status = 'pending'
+    ORDER BY ranked.distance ASC
+  `.execute(db);
+  return result.rows;
+}
+
+export async function retrieveNameDedupCandidates(
+  db: Kysely<DB>,
+  provider: EmbeddingProvider | null | undefined,
+  queries: NameDedupQuery[],
+  opts: RetrieveNameDedupCandidatesOptions = {},
+): Promise<KnownEntityForPrompt[]> {
+  if (!provider || !storageAvailable(db) || queries.length === 0) return [];
+
+  try {
+    const topK = opts.topK ?? NAME_DEDUP_TOP_K;
+    const minCosine = opts.minCosine ?? NAME_DEDUP_COSINE_THRESHOLD;
+    const vecLimit = Math.max(1, topK * NAME_DEDUP_OVERFETCH);
+    const embeddings = await provider.embedTexts(queries.map((query) => query.name));
+    const bestByKey = new Map<string, RetrievedNameRow>();
+
+    for (let index = 0; index < queries.length; index++) {
+      const embedding = embeddings[index];
+      if (!embedding) continue;
+      const embeddingJson = JSON.stringify(embedding);
+      const rows = [
+        ...(await retrieveEntityRows(db, queries[index], embeddingJson, vecLimit)),
+        ...(await retrieveReviewRows(db, queries[index], embeddingJson, vecLimit)),
+      ]
+        .filter((row) => row.similarity >= minCosine)
+        .sort((left, right) => right.similarity - left.similarity)
+        .slice(0, topK);
+
+      for (const row of rows) {
+        const key = candidateKey(row);
+        const existing = bestByKey.get(key);
+        if (!existing || row.similarity > existing.similarity) {
+          bestByKey.set(key, row);
+        }
+      }
+    }
+
+    return Array.from(bestByKey.values())
+      .sort((left, right) => right.similarity - left.similarity)
+      .map(toKnownEntity);
+  } catch (err) {
+    logger.warn({ err, stage: "retrieveNameDedupCandidates" }, "name dedup retrieval failed open");
+    return [];
   }
 }

--- a/packages/server/src/connectors/embeddings/trunk-name-embeddings.ts
+++ b/packages/server/src/connectors/embeddings/trunk-name-embeddings.ts
@@ -1,0 +1,147 @@
+import { type Kysely, sql } from "kysely";
+import pino from "pino";
+import { isPg } from "../../db/dialect";
+import * as dbIndex from "../../db/index";
+import type { DB } from "../../db/schema";
+import type { EmbeddingProvider } from "./types";
+
+export type NameDedupEntityType = "project" | "product";
+export type NameEmbeddingKind = "entity" | "review";
+
+export interface ReconcileMissingNameEmbeddingsOptions {
+  types?: NameDedupEntityType[];
+}
+
+type MissingNameRow = {
+  id: string;
+  name: string;
+  type: string;
+};
+
+const NAME_EMBEDDING_BATCH_SIZE = 64;
+const NAME_EMBEDDING_TYPES: NameDedupEntityType[] = ["project", "product"];
+const logger = pino({ level: process.env.NODE_ENV === "test" ? "silent" : "warn" });
+
+function storageAvailable(db: Kysely<DB>): boolean {
+  return isPg(db) || dbIndex.isSqliteVecAvailable();
+}
+
+function requestedTypes(types: NameDedupEntityType[] | undefined): NameDedupEntityType[] {
+  const requested = types ?? NAME_EMBEDDING_TYPES;
+  return NAME_EMBEDDING_TYPES.filter((type) => requested.includes(type));
+}
+
+async function missingEntityRows(db: Kysely<DB>, types: NameDedupEntityType[]): Promise<MissingNameRow[]> {
+  if (types.length === 0) return [];
+  return db
+    .selectFrom("entities")
+    .select(["id", "name", "source_type as type"])
+    .where("source_type", "in", types)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .where(
+      sql<boolean>`NOT EXISTS (
+        SELECT 1 FROM entity_name_embeddings
+        WHERE entity_name_embeddings.entity_id = entities.id
+      )`,
+    )
+    .orderBy("id", "asc")
+    .execute();
+}
+
+async function missingReviewRows(db: Kysely<DB>, types: NameDedupEntityType[]): Promise<MissingNameRow[]> {
+  if (types.length === 0) return [];
+  return db
+    .selectFrom("entity_review_queue")
+    .select(["id", "proposed_name as name", "entity_type as type"])
+    .where("entity_type", "in", types)
+    .where("status", "=", "pending")
+    .where(
+      sql<boolean>`NOT EXISTS (
+        SELECT 1 FROM entity_review_queue_embeddings
+        WHERE entity_review_queue_embeddings.review_id = entity_review_queue.id
+      )`,
+    )
+    .orderBy("id", "asc")
+    .execute();
+}
+
+async function insertNameEmbedding(
+  db: Kysely<DB>,
+  kind: NameEmbeddingKind,
+  id: string,
+  embedding: number[],
+): Promise<void> {
+  const vector = JSON.stringify(embedding);
+  if (isPg(db)) {
+    if (kind === "entity") {
+      await sql`INSERT INTO entity_name_embeddings (entity_id, embedding)
+        VALUES (${id}, ${vector}::vector)
+        ON CONFLICT (entity_id) DO NOTHING`.execute(db);
+      return;
+    }
+
+    await sql`INSERT INTO entity_review_queue_embeddings (review_id, embedding)
+      VALUES (${id}, ${vector}::vector)
+      ON CONFLICT (review_id) DO NOTHING`.execute(db);
+    return;
+  }
+
+  if (kind === "entity") {
+    await sql`INSERT OR IGNORE INTO entity_name_embeddings (entity_id, embedding)
+      VALUES (${id}, ${vector})`.execute(db);
+    return;
+  }
+
+  await sql`INSERT OR IGNORE INTO entity_review_queue_embeddings (review_id, embedding)
+    VALUES (${id}, ${vector})`.execute(db);
+}
+
+async function embedMissingRows(
+  db: Kysely<DB>,
+  provider: EmbeddingProvider,
+  kind: NameEmbeddingKind,
+  rows: MissingNameRow[],
+): Promise<void> {
+  for (let start = 0; start < rows.length; start += NAME_EMBEDDING_BATCH_SIZE) {
+    const batch = rows.slice(start, start + NAME_EMBEDDING_BATCH_SIZE);
+    const embeddings = await provider.embedTexts(batch.map((row) => row.name));
+    for (let index = 0; index < batch.length; index++) {
+      const embedding = embeddings[index];
+      if (!embedding) continue;
+      await insertNameEmbedding(db, kind, batch[index].id, embedding);
+    }
+  }
+}
+
+export async function reconcileMissingNameEmbeddings(
+  db: Kysely<DB>,
+  provider: EmbeddingProvider | null | undefined,
+  opts: ReconcileMissingNameEmbeddingsOptions = {},
+): Promise<void> {
+  if (!provider || !storageAvailable(db)) return;
+
+  try {
+    const types = requestedTypes(opts.types);
+    const [entities, reviews] = await Promise.all([missingEntityRows(db, types), missingReviewRows(db, types)]);
+    await embedMissingRows(db, provider, "entity", entities);
+    await embedMissingRows(db, provider, "review", reviews);
+  } catch (err) {
+    logger.warn({ err, stage: "reconcileMissingNameEmbeddings" }, "name embedding reconcile failed open");
+  }
+}
+
+export async function deleteNameEmbedding(db: Kysely<DB>, kind: NameEmbeddingKind, id: string): Promise<void> {
+  if (!storageAvailable(db)) return;
+
+  try {
+    if (kind === "entity") {
+      await db.deleteFrom("entity_name_embeddings").where("entity_id", "=", id).execute();
+      return;
+    }
+
+    await db.deleteFrom("entity_review_queue_embeddings").where("review_id", "=", id).execute();
+  } catch (err) {
+    logger.warn({ err, kind }, "name embedding delete failed open");
+  }
+}

--- a/packages/server/src/connectors/smart-enrichment.test.ts
+++ b/packages/server/src/connectors/smart-enrichment.test.ts
@@ -20,6 +20,8 @@ import {
   extractEntities,
   handleCandidates,
   hasDistinctiveOverlap,
+  mergeKnownEntities,
+  projectProductMentionNames,
   smartEnrichFile,
 } from "./smart-enrichment";
 
@@ -1586,6 +1588,37 @@ describe("dedup adjudication", () => {
     } catch {}
   });
 
+  it("builds unique project/product retrieval queries and merges retrieved known entities without replacing existing", () => {
+    expect(
+      projectProductMentionNames([
+        { mention: "Tourism Dashboard", type: "project" },
+        { mention: "tourism dashboard", type: "project" },
+        { mention: "Insight OS", type: "product" },
+        { mention: "Maaden", type: "company" },
+      ]),
+    ).toEqual([
+      { name: "Tourism Dashboard", type: "project" },
+      { name: "Insight OS", type: "product" },
+    ]);
+
+    const merged = mergeKnownEntities(
+      [
+        { name: "Tourism Dashboard", type: "project", entityId: "existing" },
+        { name: "Maaden", type: "company", entityId: "company" },
+      ],
+      [
+        { name: "tourism dashboard", type: "project", reviewId: "retrieved-duplicate" },
+        { name: "Maaden Sites", type: "project", reviewId: "retrieved-new" },
+      ],
+    );
+
+    expect(merged).toEqual([
+      { name: "Tourism Dashboard", type: "project", entityId: "existing" },
+      { name: "Maaden", type: "company", entityId: "company" },
+      { name: "Maaden Sites", type: "project", reviewId: "retrieved-new" },
+    ]);
+  });
+
   it("canonicalizes a dedup hit across mentions, relation endpoints, and feature parents", async () => {
     const fileId = randomUUID();
     const canonical = "[OW x Canvasx] Tourism Recovery Dashboard";
@@ -1693,6 +1726,36 @@ describe("dedup adjudication", () => {
     expect(rewrites.size).toBe(0);
     expect(mentions[0].mention).toBe("War Dashboard");
     expect((mentions[0] as { matchesKnown?: string }).matchesKnown).toBeUndefined();
+  });
+
+  it("rejects a retrieved Maaden Sites candidate for a Maaden Dashboard mention even when the LLM picks it", async () => {
+    expect(hasDistinctiveOverlap("Maaden Dashboard", "Maaden Sites", ["Maaden"])).toBe(false);
+    const mentions = [{ mention: "Maaden Dashboard", type: "project", variations: [], confidence: 0.94 }];
+    const generator = {
+      generate: async () => "",
+      generateJSON: async <T>(_prompt: string, opts?: { label?: string }) => {
+        if (opts?.label?.startsWith("dedupAdjudicate:")) {
+          return [{ mention: "M1", matchesKnown: "K1" }] as T;
+        }
+        return {} as T;
+      },
+    } as GeminiGenerator;
+
+    const rewrites = await adjudicateKnownMatches(
+      generator,
+      mentions,
+      [{ name: "Maaden Sites", type: "project", reviewId: "retrieved-maaden-sites" }],
+      { fileId: "f-maaden-overmerge", logger: createTestLogger(), anchorNames: ["Maaden"] },
+    );
+
+    expect(rewrites.size).toBe(0);
+    expect(mentions[0]).toEqual({
+      mention: "Maaden Dashboard",
+      type: "project",
+      variations: [],
+      confidence: 0.94,
+      matchesKnown: undefined,
+    });
   });
 
   it("clears stale matchesKnown and fails open when the dedup generator throws", async () => {

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -55,6 +55,11 @@ import {
 } from "../entities/validators";
 import { yieldToEventLoop } from "../lib/event-loop";
 import { STRUCTURAL_TASK_FILE_TYPES } from "./document-facts";
+import {
+  type NameDedupEntityType,
+  reconcileMissingNameEmbeddings,
+  retrieveNameDedupCandidates,
+} from "./embeddings/trunk-name-embeddings";
 import type { EmbeddingProvider } from "./embeddings/types";
 import { isGenericEngagementName } from "./engagement-name-filter";
 import { isCodeShapedFeatureName } from "./feature-name-filter";
@@ -491,6 +496,37 @@ type DedupAdjudicationRow = {
 function isProjectOrProductMention(mention: ExtractedMention): boolean {
   const type = mention.type.trim().toLowerCase();
   return type === "project" || type === "product";
+}
+
+export function projectProductMentionNames(mentions: Array<Pick<ExtractedMention, "mention" | "type">>) {
+  const seen = new Set<string>();
+  const queries: Array<{ name: string; type: NameDedupEntityType }> = [];
+  for (const mention of mentions) {
+    const name = mention.mention.trim();
+    const type = mention.type.trim().toLowerCase();
+    if (!name) continue;
+    if (type !== "project" && type !== "product") continue;
+    const key = `${type}:${name.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    queries.push({ name, type });
+  }
+  return queries;
+}
+
+export function mergeKnownEntities(
+  existing: KnownEntityForPrompt[],
+  retrieved: KnownEntityForPrompt[],
+): KnownEntityForPrompt[] {
+  const byKey = new Map<string, KnownEntityForPrompt>();
+  for (const entity of existing) {
+    byKey.set(`${entity.type}:${entity.name.toLowerCase()}`, entity);
+  }
+  for (const entity of retrieved) {
+    const key = `${entity.type}:${entity.name.toLowerCase()}`;
+    if (!byKey.has(key)) byKey.set(key, entity);
+  }
+  return Array.from(byKey.values());
 }
 
 function normalizeDedupRejectionKey(entityId: string, mentionName: string): string {
@@ -1106,14 +1142,21 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
   );
 
   if (deps.experimentalFlag) {
-    const rejectedKnownMatchPairs = await listRejectedKnownMatchPairs(db, deps.knownEntities);
-    const canonicalRewriteMap = await adjudicateKnownMatches(generator, extraction.mentions, deps.knownEntities, {
+    if (deps.embeddingProvider) {
+      await reconcileMissingNameEmbeddings(db, deps.embeddingProvider);
+    }
+    const retrievedKnown = deps.embeddingProvider
+      ? await retrieveNameDedupCandidates(db, deps.embeddingProvider, projectProductMentionNames(extraction.mentions))
+      : [];
+    const widenedKnown = mergeKnownEntities(deps.knownEntities ?? [], retrievedKnown);
+    const rejectedKnownMatchPairs = await listRejectedKnownMatchPairs(db, widenedKnown);
+    const canonicalRewriteMap = await adjudicateKnownMatches(generator, extraction.mentions, widenedKnown, {
       fileId: file.id,
       debugDumpDir: deps.debugDumpDir,
       logger,
       rejectedKnownMatchPairs,
     });
-    resolveKnownMatches(extraction.mentions, deps.knownEntities);
+    resolveKnownMatches(extraction.mentions, widenedKnown);
     applyCanonicalRewriteMap(extraction, canonicalRewriteMap);
   }
 

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -14,6 +14,10 @@ export const EMBEDDING_DIMENSIONS = 3072;
  */
 export let sqliteVecAvailable = false;
 
+export function isSqliteVecAvailable(): boolean {
+  return sqliteVecAvailable;
+}
+
 export async function createDatabase(config: Config): Promise<Kysely<DB>> {
   if (config.DB_TYPE === "postgres") {
     const { Pool } = await import("pg");
@@ -42,8 +46,15 @@ export async function createDatabase(config: Config): Promise<Kysely<DB>> {
     // Create vec0 virtual tables. These live outside Kysely migrations because
     // they require the sqlite-vec extension to be loaded first. Drop and recreate
     // if dimensions changed.
-    for (const table of ["chunk_embeddings", "file_embeddings"] as const) {
-      const pk = table === "chunk_embeddings" ? "chunk_id" : "indexed_file_id";
+    const PK_BY_TABLE = {
+      chunk_embeddings: "chunk_id",
+      file_embeddings: "indexed_file_id",
+      entity_name_embeddings: "entity_id",
+      entity_review_queue_embeddings: "review_id",
+    } as const;
+
+    for (const table of Object.keys(PK_BY_TABLE) as Array<keyof typeof PK_BY_TABLE>) {
+      const pk = PK_BY_TABLE[table];
       const existingDef = sqlite.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name=?").get(table) as
         | { sql: string }
         | undefined;

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -53,8 +53,18 @@ export async function createDatabase(config: Config): Promise<Kysely<DB>> {
       entity_review_queue_embeddings: "review_id",
     } as const;
 
+    /**
+     * Trunk-name dedup tables use explicit cosine distance so a `1 - distance`
+     * conversion yields true cosine similarity, matching the Postgres halfvec
+     * `<=>` path and making the dedup similarity threshold portable. The
+     * chunk/file tables keep the default L2 metric — their score is only a soft
+     * ranking signal blended with FTS, so changing it would shift existing search.
+     */
+    const COSINE_TABLES = new Set<keyof typeof PK_BY_TABLE>(["entity_name_embeddings", "entity_review_queue_embeddings"]);
+
     for (const table of Object.keys(PK_BY_TABLE) as Array<keyof typeof PK_BY_TABLE>) {
       const pk = PK_BY_TABLE[table];
+      const metric = COSINE_TABLES.has(table) ? " distance_metric=cosine" : "";
       const existingDef = sqlite.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name=?").get(table) as
         | { sql: string }
         | undefined;
@@ -76,7 +86,7 @@ export async function createDatabase(config: Config): Promise<Kysely<DB>> {
       sqlite.exec(`
         CREATE VIRTUAL TABLE IF NOT EXISTS ${table} USING vec0(
           ${pk} TEXT PRIMARY KEY,
-          embedding float[${EMBEDDING_DIMENSIONS}]
+          embedding float[${EMBEDDING_DIMENSIONS}]${metric}
         )
       `);
     }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -130,6 +130,7 @@ import * as m127 from "./migrations/127-work-cycles-connector";
 import * as m128 from "./migrations/128-work-cycles-connector-key";
 import * as m129 from "./migrations/129-container-name-qualification";
 import * as m130 from "./migrations/130-entity-provenance-tier";
+import * as m131 from "./migrations/131-trunk-name-embeddings";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -264,6 +265,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "128-work-cycles-connector-key": m128,
           "129-container-name-qualification": m129,
           "130-entity-provenance-tier": m130,
+          "131-trunk-name-embeddings": m131,
         };
       },
     },

--- a/packages/server/src/db/migrations/131-trunk-name-embeddings.integration.test.ts
+++ b/packages/server/src/db/migrations/131-trunk-name-embeddings.integration.test.ts
@@ -1,0 +1,57 @@
+import { type Kysely, sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+
+async function columnInfo(db: Kysely<DB>, tableName: string, columnName: string) {
+  const result = await sql<{ column_name: string; data_type: string; udt_name: string }>`
+    SELECT column_name, data_type, udt_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = ${tableName}
+      AND column_name = ${columnName}
+  `.execute(db);
+  return result.rows;
+}
+
+async function indexNames(db: Kysely<DB>, tableName: string): Promise<string[]> {
+  const result = await sql<{ indexname: string }>`
+    SELECT indexname
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = ${tableName}
+  `.execute(db);
+  return result.rows.map((row) => row.indexname);
+}
+
+describe("117-trunk-name-embeddings migration", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestPgDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("creates entity_name_embeddings with a text primary key and vector embedding", async () => {
+    expect(await columnInfo(db, "entity_name_embeddings", "entity_id")).toEqual([
+      expect.objectContaining({ column_name: "entity_id", data_type: "text" }),
+    ]);
+    expect(await columnInfo(db, "entity_name_embeddings", "embedding")).toEqual([
+      expect.objectContaining({ column_name: "embedding", data_type: "USER-DEFINED", udt_name: "vector" }),
+    ]);
+    expect(await indexNames(db, "entity_name_embeddings")).toContain("idx_entity_name_embeddings_hnsw");
+  });
+
+  it("creates entity_review_queue_embeddings with a text primary key and vector embedding", async () => {
+    expect(await columnInfo(db, "entity_review_queue_embeddings", "review_id")).toEqual([
+      expect.objectContaining({ column_name: "review_id", data_type: "text" }),
+    ]);
+    expect(await columnInfo(db, "entity_review_queue_embeddings", "embedding")).toEqual([
+      expect.objectContaining({ column_name: "embedding", data_type: "USER-DEFINED", udt_name: "vector" }),
+    ]);
+    expect(await indexNames(db, "entity_review_queue_embeddings")).toContain("idx_review_queue_embeddings_hnsw");
+  });
+});

--- a/packages/server/src/db/migrations/131-trunk-name-embeddings.ts
+++ b/packages/server/src/db/migrations/131-trunk-name-embeddings.ts
@@ -1,0 +1,29 @@
+import { type Kysely, sql } from "kysely";
+import { isPg } from "../dialect";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (!isPg(db)) return;
+
+  await sql`CREATE TABLE entity_name_embeddings (
+    entity_id TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+    embedding vector(3072) NOT NULL
+  )`.execute(db);
+
+  await sql`CREATE INDEX idx_entity_name_embeddings_hnsw ON entity_name_embeddings
+    USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)`.execute(db);
+
+  await sql`CREATE TABLE entity_review_queue_embeddings (
+    review_id TEXT PRIMARY KEY REFERENCES entity_review_queue(id) ON DELETE CASCADE,
+    embedding vector(3072) NOT NULL
+  )`.execute(db);
+
+  await sql`CREATE INDEX idx_review_queue_embeddings_hnsw ON entity_review_queue_embeddings
+    USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  if (!isPg(db)) return;
+
+  await sql`DROP TABLE IF EXISTS entity_review_queue_embeddings`.execute(db);
+  await sql`DROP TABLE IF EXISTS entity_name_embeddings`.execute(db);
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 126;
+const EXPECTED_MIGRATION_COUNT = 127;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -159,6 +159,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[123]).toBe("128-work-cycles-connector-key");
     expect(names[124]).toBe("129-container-name-qualification");
     expect(names[125]).toBe("130-entity-provenance-tier");
+    expect(names[126]).toBe("131-trunk-name-embeddings");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 126;
+const EXPECTED_MIGRATION_COUNT = 127;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -182,6 +182,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[123]).toBe("128-work-cycles-connector-key");
     expect(names[124]).toBe("129-container-name-qualification");
     expect(names[125]).toBe("130-entity-provenance-tier");
+    expect(names[126]).toBe("131-trunk-name-embeddings");
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Kysely, RawBuilder, Selectable } from "kysely";
 import { sql } from "kysely";
+import { deleteNameEmbedding } from "../../connectors/embeddings/trunk-name-embeddings";
 import { normalizeName } from "../../connectors/name-normalize";
 import { normalizeEntityMatchName } from "../../entities/match-normalize";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../../entities/profile-facts";
@@ -562,11 +563,17 @@ export function createEntityRepository(db: Kysely<DB>) {
       }>,
     ) {
       const entityId = await resolveLiveEntityId(db, id);
+      const existing = updates.name
+        ? await db.selectFrom("entities").select("name").where("id", "=", entityId).executeTakeFirst()
+        : undefined;
       await db
         .updateTable("entities")
         .set({ ...updates, updated_at: new Date().toISOString() })
         .where("id", "=", entityId)
         .execute();
+      if (existing && updates.name && existing.name !== updates.name) {
+        await deleteNameEmbedding(db, "entity", entityId);
+      }
     },
 
     /**
@@ -1211,6 +1218,9 @@ export function createEntityRepository(db: Kysely<DB>) {
         }
 
         await db.updateTable("entities").set(updates).where("id", "=", existing.id).execute();
+        if (existing.name !== data.name) {
+          await deleteNameEmbedding(db, "entity", existing.id);
+        }
 
         await db
           .updateTable("entity_source_refs")

--- a/packages/server/src/db/repositories/entity-review.ts
+++ b/packages/server/src/db/repositories/entity-review.ts
@@ -8,6 +8,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { type Kysely, type Selectable, sql } from "kysely";
+import { deleteNameEmbedding } from "../../connectors/embeddings/trunk-name-embeddings";
 import { normalizeName } from "../../connectors/name-normalize";
 import { isPg } from "../dialect";
 import type { DB, EntityAliasRejectionsTable, EntityReviewEvidenceTable, EntityReviewQueueTable } from "../schema";
@@ -281,6 +282,9 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
           })
           .where("id", "=", existing.id)
           .execute();
+        if (existing.proposed_name !== input.proposedName) {
+          await deleteNameEmbedding(db, "review", existing.id);
+        }
       }
 
       const refreshed = await db

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -193,6 +193,16 @@ export interface FileEmbeddingsTable {
   embedding: string;
 }
 
+export interface EntityNameEmbeddingsTable {
+  entity_id: string;
+  embedding: string;
+}
+
+export interface EntityReviewQueueEmbeddingsTable {
+  review_id: string;
+  embedding: string;
+}
+
 export interface DocumentChunksTable {
   id: string;
   indexed_file_id: string;
@@ -1033,6 +1043,8 @@ export interface DB {
   document_timeframes: DocumentTimeframesTable;
   chunk_embeddings: ChunkEmbeddingsTable;
   file_embeddings: FileEmbeddingsTable;
+  entity_name_embeddings: EntityNameEmbeddingsTable;
+  entity_review_queue_embeddings: EntityReviewQueueEmbeddingsTable;
   user_provider_identities: UserProviderIdentitiesTable;
   file_access: FileAccessTable;
   file_share_emails: FileShareEmailsTable;


### PR DESCRIPTION
Stacked context-graph slice 25/27.

Base: `feat/context-graph-24-dedup-adjudication-noise`
Head: `feat/context-graph-25-name-embedding-dedup`

Adds trunk/name embedding support for dedup.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`