### PR TITLE
feat: extend dedup context to people and companies

### DIFF
--- a/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
+++ b/packages/server/src/connectors/embeddings/trunk-name-embeddings.test.ts
@@ -5,7 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as dbIndex from "../../db/index";
 import { EMBEDDING_DIMENSIONS } from "../../db/index";
 import type { DB } from "../../db/schema";
-import { reconcileMissingNameEmbeddings, retrieveNameDedupCandidates } from "./trunk-name-embeddings";
+import {
+  reconcileMissingNameEmbeddings,
+  retrieveEntityNameCandidates,
+  retrieveNameDedupCandidates,
+} from "./trunk-name-embeddings";
 import type { EmbeddingProvider } from "./types";
 
 /**
@@ -127,14 +131,17 @@ describe("trunk name embedding reconcile", () => {
     await db.destroy();
   });
 
-  it("embeds only missing live project/product entities and pending project/product reviews", async () => {
+  it("embeds person and company entity rows but keeps review rows project/product only", async () => {
     await insertEntity(db, { id: "entity-project", name: "Project Atlas", type: "project" });
     await insertEntity(db, { id: "entity-product", name: "Product OS", type: "product" });
     await insertEntity(db, { id: "entity-person", name: "Sarah Chen", type: "person" });
+    await insertEntity(db, { id: "entity-company", name: "Sarah Chen Co", type: "company" });
     await insertEntity(db, { id: "entity-deleted", name: "Deleted Project", type: "project", deleted: true });
     await insertEntity(db, { id: "entity-existing", name: "Embedded Project", type: "project" });
     await insertReview(db, { id: "review-project", name: "Review Project", type: "project" });
     await insertReview(db, { id: "review-product", name: "Review Product", type: "product" });
+    await insertReview(db, { id: "review-person", name: "Review Person", type: "person" });
+    await insertReview(db, { id: "review-company", name: "Review Company", type: "company" });
     await insertReview(db, { id: "review-team", name: "Review Team", type: "team" });
     await insertReview(db, { id: "review-confirmed", name: "Confirmed Project", type: "project", status: "confirmed" });
     await insertReview(db, { id: "review-existing", name: "Embedded Review", type: "project" });
@@ -149,9 +156,22 @@ describe("trunk name embedding reconcile", () => {
     await reconcileMissingNameEmbeddings(db, provider);
 
     const embeddedNames = provider.embedTexts.mock.calls.flatMap((call) => call[0]).sort();
-    expect(embeddedNames).toEqual(["Product OS", "Project Atlas", "Review Product", "Review Project"].sort());
-    expect(await entityEmbeddingIds(db)).toEqual(["entity-existing", "entity-product", "entity-project"]);
+    expect(embeddedNames).toEqual(
+      ["Product OS", "Project Atlas", "Review Product", "Review Project", "Sarah Chen", "Sarah Chen Co"].sort(),
+    );
+    expect(await entityEmbeddingIds(db)).toEqual([
+      "entity-company",
+      "entity-existing",
+      "entity-person",
+      "entity-product",
+      "entity-project",
+    ]);
     expect(await reviewEmbeddingIds(db)).toEqual(["review-existing", "review-product", "review-project"]);
+
+    const candidates = await retrieveEntityNameCandidates(db, provider, { name: "Sarah Chen", type: "person" });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({ entityId: "entity-person", name: "Sarah Chen", type: "person" });
+    expect(candidates[0].similarity).toBeCloseTo(1);
   });
 
   it("fails open when provider is absent", async () => {

--- a/packages/server/src/connectors/embeddings/trunk-name-embeddings.ts
+++ b/packages/server/src/connectors/embeddings/trunk-name-embeddings.ts
@@ -7,7 +7,7 @@ import type { DB } from "../../db/schema";
 import type { KnownEntityForPrompt } from "../file-scope-context";
 import type { EmbeddingProvider } from "./types";
 
-export type NameDedupEntityType = "project" | "product";
+export type NameDedupEntityType = "project" | "product" | "person" | "company";
 export type NameEmbeddingKind = "entity" | "review";
 export type NameDedupQuery = { name: string; type: NameDedupEntityType };
 
@@ -35,7 +35,8 @@ type RetrievedNameRow = {
 };
 
 const NAME_EMBEDDING_BATCH_SIZE = 64;
-const NAME_EMBEDDING_TYPES: NameDedupEntityType[] = ["project", "product"];
+const NAME_EMBEDDING_TYPES: NameDedupEntityType[] = ["project", "product", "person", "company"];
+const REVIEW_NAME_EMBEDDING_TYPES: NameDedupEntityType[] = ["project", "product"];
 export const NAME_DEDUP_COSINE_THRESHOLD = 0.62;
 export const NAME_DEDUP_TOP_K = 10;
 export const NAME_DEDUP_OVERFETCH = 4;
@@ -45,9 +46,12 @@ function storageAvailable(db: Kysely<DB>): boolean {
   return isPg(db) || dbIndex.isSqliteVecAvailable();
 }
 
-function requestedTypes(types: NameDedupEntityType[] | undefined): NameDedupEntityType[] {
-  const requested = types ?? NAME_EMBEDDING_TYPES;
-  return NAME_EMBEDDING_TYPES.filter((type) => requested.includes(type));
+function requestedTypes(
+  types: NameDedupEntityType[] | undefined,
+  allowedTypes: NameDedupEntityType[] = NAME_EMBEDDING_TYPES,
+): NameDedupEntityType[] {
+  const requested = types ?? allowedTypes;
+  return allowedTypes.filter((type) => requested.includes(type));
 }
 
 async function missingEntityRows(db: Kysely<DB>, types: NameDedupEntityType[]): Promise<MissingNameRow[]> {
@@ -141,8 +145,12 @@ export async function reconcileMissingNameEmbeddings(
   if (!provider || !storageAvailable(db)) return;
 
   try {
-    const types = requestedTypes(opts.types);
-    const [entities, reviews] = await Promise.all([missingEntityRows(db, types), missingReviewRows(db, types)]);
+    const entityTypes = requestedTypes(opts.types);
+    const reviewTypes = requestedTypes(opts.types, REVIEW_NAME_EMBEDDING_TYPES);
+    const [entities, reviews] = await Promise.all([
+      missingEntityRows(db, entityTypes),
+      missingReviewRows(db, reviewTypes),
+    ]);
     await embedMissingRows(db, provider, "entity", entities);
     await embedMissingRows(db, provider, "review", reviews);
   } catch (err) {
@@ -282,6 +290,32 @@ async function retrieveReviewRows(
     ORDER BY ranked.distance ASC
   `.execute(db);
   return result.rows;
+}
+
+export async function retrieveEntityNameCandidates(
+  db: Kysely<DB>,
+  provider: EmbeddingProvider | null | undefined,
+  query: NameDedupQuery,
+  opts: RetrieveNameDedupCandidatesOptions = {},
+): Promise<Array<{ entityId: string; name: string; type: string; similarity: number }>> {
+  if (!provider || !storageAvailable(db)) return [];
+
+  try {
+    const topK = opts.topK ?? NAME_DEDUP_TOP_K;
+    const minCosine = opts.minCosine ?? NAME_DEDUP_COSINE_THRESHOLD;
+    const vecLimit = Math.max(1, topK * NAME_DEDUP_OVERFETCH);
+    const [embedding] = await provider.embedTexts([query.name]);
+    if (!embedding) return [];
+    return (await retrieveEntityRows(db, query, JSON.stringify(embedding), vecLimit))
+      .filter((row): row is RetrievedNameRow & { entityId: string } => row.entityId !== null)
+      .filter((row) => row.similarity >= minCosine)
+      .sort((left, right) => right.similarity - left.similarity)
+      .slice(0, topK)
+      .map((row) => ({ entityId: row.entityId, name: row.name, type: row.type, similarity: row.similarity }));
+  } catch (err) {
+    logger.warn({ err, stage: "retrieveEntityNameCandidates" }, "entity name retrieval failed open");
+    return [];
+  }
 }
 
 export async function retrieveNameDedupCandidates(

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -250,6 +250,7 @@ async function emitAndMaterializeDocumentFactsFromStoredFile(
   if (result.changed) {
     await materializeUnmaterializedFacts(deps.db, deps.logger, {
       experimentalFlag: deps.experimentalFlag,
+      embeddingProvider: deps.embeddingProvider,
       factTypes: ["llm_task"],
     });
   }
@@ -642,7 +643,10 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
               );
               await ensureFileFresh(db, file.id, fileVersion);
               if (floor.emitted > 0) {
-                await materializeUnmaterializedFacts(db, logger, { experimentalFlag: deps.experimentalFlag });
+                await materializeUnmaterializedFacts(db, logger, {
+                  experimentalFlag: deps.experimentalFlag,
+                  embeddingProvider: deps.embeddingProvider,
+                });
               }
               await resetSummaryRetry(db, file.id, fileVersion);
             } catch (err) {
@@ -934,7 +938,10 @@ async function enrichTextDocument(
       );
       await ensureFileFresh(db, file.id, fileVersion);
       if (floor.emitted > 0) {
-        await materializeUnmaterializedFacts(db, logger, { experimentalFlag: deps.experimentalFlag });
+        await materializeUnmaterializedFacts(db, logger, {
+          experimentalFlag: deps.experimentalFlag,
+          embeddingProvider,
+        });
       }
       await resetSummaryRetry(db, file.id, fileVersion);
       usedSmartEnrichment = true;

--- a/packages/server/src/connectors/file-scope-context.test.ts
+++ b/packages/server/src/connectors/file-scope-context.test.ts
@@ -183,6 +183,35 @@ async function seedMention(
     .execute();
 }
 
+async function seedRelationship(
+  db: Kysely<DB>,
+  args: {
+    sourceEntityId: string;
+    targetEntityId: string;
+    relationshipType?: string;
+    confidence?: string;
+    confidenceScore?: number;
+    source?: string;
+    validFrom?: string;
+    validTo?: string | null;
+  },
+): Promise<void> {
+  await db
+    .insertInto("entity_relationships")
+    .values({
+      id: randomUUID(),
+      source_entity_id: args.sourceEntityId,
+      target_entity_id: args.targetEntityId,
+      relationship_type: args.relationshipType ?? "contributes_to",
+      confidence: args.confidence ?? "INFERRED",
+      confidence_score: args.confidenceScore ?? 0.9,
+      source: args.source ?? "test",
+      valid_from: args.validFrom ?? "",
+      valid_to: args.validTo ?? null,
+    })
+    .execute();
+}
+
 async function seedReviewProposal(
   db: Kysely<DB>,
   args: {
@@ -521,9 +550,10 @@ describe("file-scope-context", () => {
 
     const promptFile = "file-baseline-overlap";
     const coMentionFile = "file-baseline-comention";
-    const recentDate = new Date(Date.UTC(2026, 4, 25)).toISOString();
-    await seedFile(db, promptFile, recentDate);
-    await seedFile(db, coMentionFile, recentDate);
+    const promptDate = new Date(Date.UTC(2026, 4, 25)).toISOString();
+    const staleOverlapDate = new Date(Date.UTC(2025, 4, 26)).toISOString();
+    await seedFile(db, promptFile, promptDate);
+    await seedFile(db, coMentionFile, staleOverlapDate);
     await seedAttendeeFact(db, {
       fileId: promptFile,
       name: "Anchor Person",
@@ -646,6 +676,155 @@ describe("file-scope-context", () => {
     });
     expect(personAnchored.map((entry) => entry.name)).not.toContain("Alice Internal");
     expect(personAnchored.map((entry) => entry.name)).not.toContain("Ambiguous Project");
+  });
+
+  it("prefers person contributes_to initiatives by tier before co-occurrence backfill", async () => {
+    const now = Date.UTC(2026, 4, 26);
+    const recentDate = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const promptFile = "file-person-contributes-prompt";
+    const evidenceFile = "file-person-contributes-evidence";
+    await seedFile(db, promptFile, recentDate);
+    await seedFile(db, evidenceFile, recentDate);
+
+    await seedEntity(db, { id: "person-contributes", name: "Contributing Person", sourceType: "person", hotness: 5 });
+    await seedContactPoint(db, { entityId: "person-contributes", email: "contributor@internal.test" });
+    await seedEntity(db, { id: "project-structural", name: "Structural Project", sourceType: "project", hotness: 1 });
+    await seedEntity(db, { id: "product-comention", name: "Co Mention Product", sourceType: "product", hotness: 1 });
+    await seedEntity(db, { id: "project-adjacent", name: "Adjacent Project", sourceType: "project", hotness: 1 });
+    await seedEntity(db, { id: "project-manual", name: "Manual Decoy Project", sourceType: "project", hotness: 1 });
+
+    await seedAttendeeFact(db, {
+      fileId: promptFile,
+      name: "Contributor",
+      email: "contributor@internal.test",
+    });
+    await seedMention(db, { entityId: "person-contributes", fileId: evidenceFile });
+    await seedMention(db, { entityId: "project-adjacent", fileId: evidenceFile });
+    await seedRelationship(db, {
+      sourceEntityId: "person-contributes",
+      targetEntityId: "project-structural",
+      source: "structural_assignee",
+      confidenceScore: 0.7,
+    });
+    await seedRelationship(db, {
+      sourceEntityId: "person-contributes",
+      targetEntityId: "product-comention",
+      source: "co_mention",
+      confidenceScore: 0.99,
+    });
+    await seedRelationship(db, {
+      sourceEntityId: "person-contributes",
+      targetEntityId: "project-manual",
+      source: "manual",
+      confidenceScore: 1,
+    });
+
+    const known = await buildFileScopedKnownEntities(
+      { db, now: () => now, experimentalFlag: true },
+      promptFile,
+      [],
+      "",
+    );
+
+    const initiatives = known
+      .filter((entry) => entry.type === "project" || entry.type === "product")
+      .map((entry) => entry.name);
+    expect(initiatives).toEqual(["Structural Project", "Co Mention Product", "Adjacent Project"]);
+    expect(initiatives).not.toContain("Manual Decoy Project");
+  });
+
+  it("preserves person co-occurrence recall when no contributes_to edges exist", async () => {
+    const now = Date.UTC(2026, 4, 26);
+    const recentDate = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const promptFile = "file-person-recall-prompt";
+    const evidenceFile = "file-person-recall-evidence";
+    await seedFile(db, promptFile, recentDate);
+    await seedFile(db, evidenceFile, recentDate);
+
+    await seedEntity(db, { id: "person-recall", name: "Recall Person", sourceType: "person", hotness: 5 });
+    await seedContactPoint(db, { entityId: "person-recall", email: "recall@internal.test" });
+    await seedEntity(db, { id: "project-recall", name: "Recall Project", sourceType: "project", hotness: 1 });
+    await seedAttendeeFact(db, { fileId: promptFile, name: "Recall", email: "recall@internal.test" });
+    await seedMention(db, { entityId: "person-recall", fileId: evidenceFile });
+    await seedMention(db, { entityId: "project-recall", fileId: evidenceFile });
+
+    const known = await buildFileScopedKnownEntities(
+      { db, now: () => now, experimentalFlag: true },
+      promptFile,
+      [],
+      "",
+    );
+
+    expect(known.find((entry) => entry.name === "Recall Project")).toMatchObject({
+      name: "Recall Project",
+      type: "project",
+      entityId: "project-recall",
+      mentionCount: 1,
+      recentlyActive: true,
+    });
+  });
+
+  it("boosts overflow contributes_to baseline entries without wasting cap on injected entities", async () => {
+    const now = Date.UTC(2026, 4, 26);
+    const recentDate = new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const promptFile = "file-person-baseline-overflow-prompt";
+    const coMentionFile = "file-person-baseline-comention";
+    const overflowSeenFile = "file-person-baseline-overflow-seen";
+    const injectedSeenFile = "file-person-baseline-injected-seen";
+    await seedFile(db, promptFile, recentDate);
+    await seedFile(db, coMentionFile, recentDate);
+    await seedFile(db, overflowSeenFile, recentDate);
+    await seedFile(db, injectedSeenFile, recentDate);
+
+    await seedEntity(db, { id: "person-baseline-overflow", name: "Overflow Person", sourceType: "person", hotness: 5 });
+    await seedContactPoint(db, { entityId: "person-baseline-overflow", email: "overflow@internal.test" });
+    await seedEntity(db, {
+      id: "project-cooccur-baseline",
+      name: "Cooccur Baseline Project",
+      sourceType: "project",
+      hotness: 10,
+    });
+    await seedAttendeeFact(db, { fileId: promptFile, name: "Overflow", email: "overflow@internal.test" });
+    await seedMention(db, { entityId: "person-baseline-overflow", fileId: coMentionFile });
+    await seedMention(db, { entityId: "project-cooccur-baseline", fileId: coMentionFile });
+
+    for (let i = 0; i <= PER_ANCHOR_INITIATIVE_CAP; i++) {
+      const isOverflow = i === PER_ANCHOR_INITIATIVE_CAP;
+      const entityId = isOverflow ? "project-overflow-baseline" : `project-injected-baseline-${i}`;
+      const name = isOverflow ? "Overflow Baseline Project" : `Injected Baseline Project ${i}`;
+      await seedEntity(db, {
+        id: entityId,
+        name,
+        sourceType: "project",
+        hotness: i === 0 ? 100 : 10,
+      });
+      await seedRelationship(db, {
+        sourceEntityId: "person-baseline-overflow",
+        targetEntityId: entityId,
+        source: "structural_assignee",
+        confidenceScore: 1 - i * 0.01,
+      });
+    }
+
+    await seedMention(db, { entityId: "project-overflow-baseline", fileId: overflowSeenFile });
+    await seedMention(db, { entityId: "project-injected-baseline-0", fileId: injectedSeenFile });
+
+    const known = await buildFileScopedKnownEntities(
+      { db, now: () => now, experimentalFlag: true },
+      promptFile,
+      [
+        { id: "project-injected-baseline-0", name: "Injected Baseline Project 0", type: "project", hotness: 100 },
+        { id: "project-overflow-baseline", name: "Overflow Baseline Project", type: "project", hotness: 10 },
+        { id: "project-cooccur-baseline", name: "Cooccur Baseline Project", type: "project", hotness: 10 },
+      ],
+      "",
+      { baselineRelevanceCap: 1 },
+    );
+
+    const names = known.map((entry) => entry.name);
+    expect(names).toContain("Overflow Baseline Project");
+    expect(names).not.toContain("Cooccur Baseline Project");
+    expect(known.filter((entry) => entry.name === "Injected Baseline Project 0")).toHaveLength(1);
   });
 
   it("skips hub person anchors before adjacency while retaining low-degree person adjacency", async () => {

--- a/packages/server/src/connectors/file-scope-context.ts
+++ b/packages/server/src/connectors/file-scope-context.ts
@@ -52,6 +52,8 @@ export const HUB_PERSON_DEGREE_CAP = 30;
 export const BASELINE_ALWAYS_INCLUDE_CAP = 50;
 export const PENDING_PROPOSAL_MIN_OCCURRENCE = 1;
 const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
+const STRUCTURAL_ASSIGNEE_SOURCE = "structural_assignee";
+const CO_MENTION_SOURCE = "co_mention";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 export interface FileScopeDeps {
@@ -60,6 +62,7 @@ export interface FileScopeDeps {
   now?: () => number;
   experimentalFlag?: boolean;
   loadAdjacencyForAnchor?: (deps: FileScopeDeps, anchorId: string) => Promise<AdjacencyEntry[]>;
+  loadContributesToForAnchor?: (deps: FileScopeDeps, anchorId: string) => Promise<ContributesToEntry[]>;
   loadPendingProposalsForAnchor?: (deps: FileScopeDeps, anchorId: string) => Promise<PendingProposalEntry[]>;
 }
 
@@ -92,6 +95,13 @@ export interface PendingProposalEntry {
   score: number;
 }
 
+export interface ContributesToEntry {
+  id: string;
+  name: string;
+  sourceType: string;
+  tier: number;
+}
+
 export interface KnownEntityForPrompt {
   id?: string;
   entityId?: string;
@@ -107,10 +117,18 @@ export interface KnownEntityForPrompt {
 
 interface BaselineScore {
   entity: KnownEntityForPrompt;
-  anchorOverlap: number;
+  overlap: number;
   recency: number;
   hotness: number;
   score: number;
+}
+
+interface AnchorScopedEntry {
+  id: string;
+  name: string;
+  sourceType: string;
+  mentionCount?: number;
+  recentlyActive?: boolean;
 }
 
 export interface BuildFileScopedKnownEntitiesOptions {
@@ -249,6 +267,59 @@ export async function adjacencyForAnchor(deps: FileScopeDeps, anchorId: string):
     .sort((a, b) => b.score - a.score);
 }
 
+export async function contributesToForAnchor(deps: FileScopeDeps, anchorId: string): Promise<ContributesToEntry[]> {
+  const hiddenTypes = Array.from(HIDDEN_ENTITY_SOURCE_TYPES);
+  const rows = await deps.db
+    .selectFrom("entity_relationships as rel")
+    .innerJoin("entities as t", "t.id", "rel.target_entity_id")
+    .select((eb) => [
+      eb.ref("t.id").as("id"),
+      eb.ref("t.name").as("name"),
+      eb.ref("t.source_type").as("source_type"),
+      eb.ref("rel.source").as("edge_source"),
+      eb.ref("rel.confidence_score").as("confidence_score"),
+      eb.ref("rel.valid_from").as("valid_from"),
+    ])
+    .where("rel.source_entity_id", "=", anchorId)
+    .where("rel.relationship_type", "=", "contributes_to")
+    .where("rel.valid_to", "is", null)
+    .where("rel.source", "in", [STRUCTURAL_ASSIGNEE_SOURCE, CO_MENTION_SOURCE])
+    .where("t.source_type", "in", ["project", "product"])
+    .where("t.source_type", "not in", hiddenTypes.length > 0 ? hiddenTypes : [""])
+    .where(whereLiveEntity("t"))
+    .execute();
+
+  return rows
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      sourceType: row.source_type,
+      tier: row.edge_source === STRUCTURAL_ASSIGNEE_SOURCE ? 0 : 1,
+      confidenceScore: Number(row.confidence_score),
+      validFromTime: new Date(row.valid_from).getTime(),
+    }))
+    .sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier - b.tier;
+      if (b.confidenceScore !== a.confidenceScore) return b.confidenceScore - a.confidenceScore;
+      const aValidFrom = Number.isNaN(a.validFromTime) ? 0 : a.validFromTime;
+      const bValidFrom = Number.isNaN(b.validFromTime) ? 0 : b.validFromTime;
+      return bValidFrom - aValidFrom;
+    })
+    .map(({ confidenceScore, validFromTime, ...entry }) => entry);
+}
+
+function tieredFill<T extends { id: string }>(primary: T[], backfill: T[], cap: number): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const entry of [...primary, ...backfill]) {
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    out.push(entry);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
 function isPendingProposalType(value: string): value is PendingProposalEntry["type"] {
   return value === "project" || value === "product";
 }
@@ -310,7 +381,9 @@ export async function buildFileScopedKnownEntities(
     if (!byKey.has(k)) byKey.set(k, { name: a.name, type: a.sourceType, entityId: a.id });
   }
 
-  for (const anchor of [...anchors.companies, ...anchors.persons]) {
+  const contributesToTargetIds = new Set<string>();
+
+  for (const anchor of anchors.companies) {
     const adj = await (deps.loadAdjacencyForAnchor ?? adjacencyForAnchor)(deps, anchor.id);
     const initiatives = adj
       .filter((x) => x.sourceType === "project" || x.sourceType === "product")
@@ -329,7 +402,39 @@ export async function buildFileScopedKnownEntities(
     }
   }
 
-  for (const b of await rankBaselineKnownEntities(deps, baseline, anchors, fileContent ?? "", opts)) {
+  for (const anchor of anchors.persons) {
+    const contributesTo = await (deps.loadContributesToForAnchor ?? contributesToForAnchor)(deps, anchor.id);
+    for (const entry of contributesTo) contributesToTargetIds.add(entry.id);
+
+    const adj = await (deps.loadAdjacencyForAnchor ?? adjacencyForAnchor)(deps, anchor.id);
+    const adjacencyInitiatives = adj.filter((x) => x.sourceType === "project" || x.sourceType === "product");
+    const initiatives = tieredFill<AnchorScopedEntry>(contributesTo, adjacencyInitiatives, PER_ANCHOR_INITIATIVE_CAP);
+    const teams = adj.filter((x) => x.sourceType === "team").slice(0, PER_ANCHOR_TEAM_CAP);
+    for (const x of [...initiatives, ...teams]) {
+      const k = keyOf(x.name, x.sourceType);
+      if (byKey.has(k)) continue;
+      byKey.set(k, {
+        name: x.name,
+        type: x.sourceType,
+        entityId: x.id,
+        mentionCount: x.mentionCount,
+        recentlyActive: x.recentlyActive,
+      });
+    }
+  }
+
+  const alreadyInjectedIds = new Set(
+    Array.from(byKey.values()).flatMap((entry) => (entry.entityId ? [entry.entityId] : [])),
+  );
+  for (const b of await rankBaselineKnownEntities(
+    deps,
+    baseline,
+    anchors,
+    fileContent ?? "",
+    contributesToTargetIds,
+    alreadyInjectedIds,
+    opts,
+  )) {
     const k = keyOf(b.name, b.type);
     if (byKey.has(k)) continue;
     byKey.set(k, stripPromptInternalFields(b));
@@ -423,10 +528,12 @@ async function rankBaselineKnownEntities(
   baseline: KnownEntityForPrompt[],
   anchors: FileAnchors,
   fileContent: string,
+  contributesToTargetIds: Set<string>,
+  alreadyInjectedIds: Set<string>,
   opts: BuildFileScopedKnownEntitiesOptions,
 ): Promise<KnownEntityForPrompt[]> {
   const legacy = baseline.filter((entity) => !entity.id);
-  const scoredCandidates = baseline.filter((entity) => entity.id);
+  const scoredCandidates = baseline.filter((entity) => entity.id && !alreadyInjectedIds.has(entity.id));
   if (scoredCandidates.length === 0) return legacy;
 
   const cap = opts.baselineRelevanceCap ?? BASELINE_RELEVANCE_CAP;
@@ -443,7 +550,7 @@ async function rankBaselineKnownEntities(
   const candidates = scoredCandidates.filter((entity) => !alwaysIds.has(entity.id));
   const candidateIds = candidates.flatMap((entity) => (entity.id ? [entity.id] : []));
   const anchorIds = [...anchors.companies.map((anchor) => anchor.id), ...anchors.persons.map((anchor) => anchor.id)];
-  const [lastSeenById, overlapIds] = await Promise.all([
+  const [lastSeenById, coOccurOverlapIds] = await Promise.all([
     loadBaselineLastSeen(deps, candidateIds),
     loadBaselineAnchorOverlap(deps, candidateIds, anchorIds),
   ]);
@@ -454,14 +561,19 @@ async function rankBaselineKnownEntities(
     const lastSeen = entity.id ? lastSeenById.get(entity.id) : undefined;
     const ageDays = lastSeen === undefined ? Number.POSITIVE_INFINITY : Math.max(0, (now - lastSeen) / DAY_MS);
     const recency = ageDays <= BASELINE_RECENCY_WINDOW_DAYS ? Math.exp(-ageDays / BASELINE_RECENCY_WINDOW_DAYS) : 0;
-    const anchorOverlap = entity.id && overlapIds.has(entity.id) ? 1 : 0;
+    let overlap = 0;
+    if (entity.id && contributesToTargetIds.has(entity.id)) {
+      overlap = 0.6;
+    } else if (entity.id && coOccurOverlapIds.has(entity.id)) {
+      overlap = 0.4;
+    }
     const hotness = Number(entity.hotness ?? 0) / maxHotness;
     return {
       entity,
-      anchorOverlap,
+      overlap,
       recency,
       hotness,
-      score: 0.5 * anchorOverlap + 0.3 * recency + 0.2 * hotness,
+      score: overlap + 0.3 * recency + 0.2 * hotness,
     };
   });
 

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -1515,7 +1515,10 @@ async function reconcileLlmExtractionFacts(
       .execute();
 
     await deps.ensureFresh?.();
-    await materializeUnmaterializedFacts(db, deps.logger, { experimentalFlag: deps.experimentalFlag });
+    await materializeUnmaterializedFacts(db, deps.logger, {
+      experimentalFlag: deps.experimentalFlag,
+      embeddingProvider: deps.embeddingProvider,
+    });
     return writtenFactKeys;
   } catch (err) {
     if (isStaleEnrichmentError(err)) {

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -1,5 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
+import { type NameDedupEntityType, retrieveEntityNameCandidates } from "../connectors/embeddings/trunk-name-embeddings";
+import type { EmbeddingProvider } from "../connectors/embeddings/types";
 import { createEntityRepository, whereLiveEntity } from "../db/repositories/entities";
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
 import { createEntityReviewRepo } from "../db/repositories/entity-review";
@@ -19,7 +21,7 @@ import {
   findTokenSetMatches,
   removeFromCandidatePool,
 } from "./name-dedup";
-import type { Entity, EntityLookup, ProposeEntityType } from "./propose";
+import type { Entity, EntityLookup, ProposeEntityType, RankedCandidate } from "./propose";
 import { canUseEntityAsMatchTarget } from "./provenance";
 
 export { normalizeEntityMatchName } from "./match-normalize";
@@ -199,6 +201,10 @@ async function findLlmExtractedThirdPartyMention(
   return null;
 }
 
+function isNameDedupEntityType(entityType: ProposeEntityType): entityType is NameDedupEntityType {
+  return entityType === "project" || entityType === "product" || entityType === "person" || entityType === "company";
+}
+
 export function registerEntity(index: LookupIndex, entity: EntityRow): void {
   const existingPersonScopeKeys = index.personScopeKeysByEntityId.get(entity.id);
   unregisterEntity(index, entity.id);
@@ -320,6 +326,7 @@ export interface BuildMaterializeDepsOptions {
   structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
+  embeddingProvider?: EmbeddingProvider | null;
 }
 
 export async function buildMaterializeDeps(
@@ -349,6 +356,7 @@ export async function buildMaterializeDeps(
   const structuralAutoBirthTypes = new Set(opts.structuralAutoBirthTypes ?? configuredStructuralAutoBirthTypes);
   const birthGateDryRun = opts.birthGateDryRun ?? configuredBirthGateDryRun;
   const experimentalFlag = opts.experimentalFlag ?? configuredExperimentalFlag;
+  const embeddingProvider = opts.embeddingProvider ?? null;
 
   const lookup: EntityLookup = {
     getByNormalizedName: (n) => index.byNormalizedName.get(n) ?? [],
@@ -389,6 +397,25 @@ export async function buildMaterializeDeps(
     getPersonScopeKeys: (entityId) => index.personScopeKeysByEntityId.get(entityId) ?? [],
     findLlmExtractedThirdPartyMention: (name) => findLlmExtractedThirdPartyMention(db, name),
   };
+  if (embeddingProvider && experimentalFlag) {
+    lookup.retrieveEmbeddingCandidates = async (entityType, name): Promise<RankedCandidate[]> => {
+      if (!isNameDedupEntityType(entityType)) return [];
+      try {
+        const pool = index.entitiesByType.get(entityType) ?? [];
+        const entitiesById = new Map(pool.map((entity) => [entity.id, entity]));
+        const rows = await retrieveEntityNameCandidates(db, embeddingProvider, { name, type: entityType });
+        const candidates: RankedCandidate[] = [];
+        for (const row of rows) {
+          const entity = entitiesById.get(row.entityId);
+          if (entity) candidates.push({ entity, score: row.similarity, reason: "embedding" });
+        }
+        return candidates;
+      } catch (err) {
+        opts.logger?.warn({ err, entityType }, "embedding lookup failed open");
+        return [];
+      }
+    };
+  }
 
   const fileToConnector = new Map<string, string>();
   const connectorOwners = new Map<string, string>();
@@ -414,6 +441,7 @@ export async function buildMaterializeDeps(
     structuralAutoBirthTypes,
     birthGateDryRun,
     experimentalFlag,
+    embeddingProvider,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),
     onEntityResolved: (entity: Entity) => refreshResolvedEntityIndex(db, index, entity),
     getIndexedFileSourceTime: (indexedFileId: string) =>

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -182,6 +182,7 @@ export async function replaySourceFacts(
     structuralAutoBirthTypes: opts.structuralAutoBirthTypes,
     birthGateDryRun: opts.birthGateDryRun,
     experimentalFlag: opts.experimentalFlag,
+    embeddingProvider: opts.embeddingProvider,
   });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));
   const facts = (await db.selectFrom("indexed_file_facts").selectAll().where("deleted_at", "is", null).execute())
@@ -256,6 +257,7 @@ async function materializeUnmaterializedFactsInner(
     structuralAutoBirthTypes: opts.structuralAutoBirthTypes,
     birthGateDryRun: opts.birthGateDryRun,
     experimentalFlag: opts.experimentalFlag,
+    embeddingProvider: opts.embeddingProvider,
   });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));
   let factsQuery = db

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -1,5 +1,6 @@
 import type { Kysely, Selectable } from "kysely";
 import type { Logger } from "pino";
+import type { EmbeddingProvider } from "../connectors/embeddings/types";
 import type { createEntityRepository } from "../db/repositories/entities";
 import type { EntityDomainsRepository } from "../db/repositories/entity-domains";
 import type { createEntityReviewRepo } from "../db/repositories/entity-review";
@@ -65,6 +66,7 @@ export interface MaterializeDeps {
   structuralAutoBirthTypes: Set<ProposeEntityType>;
   birthGateDryRun: boolean;
   experimentalFlag: boolean;
+  embeddingProvider: EmbeddingProvider | null;
 }
 
 export type MaterializeResult =
@@ -98,6 +100,7 @@ export interface ReplaySourceFactsOptions {
   structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
+  embeddingProvider?: EmbeddingProvider | null;
 }
 
 export interface MaterializeProgress {
@@ -115,6 +118,7 @@ export interface MaterializeUnmaterializedOptions {
   structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
   experimentalFlag?: boolean;
+  embeddingProvider?: EmbeddingProvider | null;
   factTypes?: IndexedFileFactType[];
   /**
    * Fires before processing each fact with `completed = index, total = facts.length`

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddingProvider } from "../connectors/embeddings/types";
 import { normalizeName } from "../connectors/name-normalize";
 import { createEntityRepository } from "../db/repositories/entities";
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
@@ -47,6 +48,15 @@ function readEmail(e: Entity): string | null {
   } catch {
     return null;
   }
+}
+
+function makeEmbeddingProvider(): EmbeddingProvider & { embedTexts: ReturnType<typeof vi.fn> } {
+  return {
+    name: "test",
+    dimensions: 2,
+    supportsImages: false,
+    embedTexts: vi.fn(async () => [[1, 0]]),
+  };
 }
 
 async function insertTestFile(db: Kysely<DB>, id: string): Promise<void> {
@@ -1618,5 +1628,151 @@ describe("proposeEntity", () => {
 
     expect(apiResult).toEqual({ kind: "suppressed", reason: "third_party_vendor_collision" });
     expect(baseResult.kind).toBe("created");
+  });
+
+  it("32. embedding fallback queues unresolved person proposals including skipFuzzy", async () => {
+    const entityRepo = createEntityRepository(db);
+    const husnu = await entityRepo.upsertEntity({
+      name: "Husnu Ozyegin",
+      sourceType: "person",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const oliver = await entityRepo.upsertEntity({
+      name: "Oliver Wyman",
+      sourceType: "person",
+      subtype: "external",
+      status: "confirmed",
+    });
+    const entities = await db.selectFrom("entities").selectAll().execute();
+    const retrieveEmbeddingCandidates = vi.fn(async (_entityType: string, name: string) => {
+      if (name === "HO") return [{ entity: husnu, score: 0.91, reason: "embedding" as const }];
+      if (name === "OW") return [{ entity: oliver, score: 0.92, reason: "embedding" as const }];
+      return [];
+    });
+    const deps = {
+      entityRepo,
+      reviewRepo: createEntityReviewRepo(db),
+      lookup: {
+        ...makeLookup(() => entities),
+        retrieveEmbeddingCandidates,
+      },
+      readEmail,
+    };
+
+    const normal = await proposeEntity(deps, {
+      name: "HO",
+      entityType: "person",
+      subtype: "external",
+      source: "llm_extraction",
+      sourceId: "person:ho",
+      evidence: [],
+      triggeredByUserId: "user-1",
+    });
+    const skipFuzzy = await proposeEntity(deps, {
+      name: "OW",
+      entityType: "person",
+      subtype: "external",
+      source: "llm_extraction",
+      sourceId: "person:ow",
+      evidence: [],
+      triggeredByUserId: "user-1",
+      skipFuzzy: true,
+    });
+
+    expect(normal.kind).toBe("queued");
+    expect(skipFuzzy.kind).toBe("queued");
+    if (normal.kind !== "queued" || skipFuzzy.kind !== "queued") throw new Error("unreachable");
+    expect(normal.candidateEntityId).toBe(husnu.id);
+    expect(skipFuzzy.candidateEntityId).toBe(oliver.id);
+    expect(retrieveEmbeddingCandidates).toHaveBeenCalledTimes(2);
+    expect(retrieveEmbeddingCandidates.mock.calls.map((call) => call[0])).toEqual(["person", "person"]);
+
+    const queue = await db.selectFrom("entity_review_queue").selectAll().orderBy("proposed_name", "asc").execute();
+    expect(queue.map((row) => [row.proposed_name, row.candidate_entity_id, row.candidate_reason])).toEqual([
+      ["HO", husnu.id, "embedding"],
+      ["OW", oliver.id, "embedding"],
+    ]);
+    const persons = await fetchPersonEntities(db);
+    expect(persons.map((person) => person.name).sort()).toEqual(["Husnu Ozyegin", "Oliver Wyman"]);
+  });
+
+  it("33. deterministic email and project paths do not call embedding fallback", async () => {
+    const entityRepo = createEntityRepository(db);
+    const bob = await entityRepo.upsertPersonEntity({
+      name: "Bob Chen",
+      email: "bob@acme.com",
+      subtype: "external",
+      source: "seed",
+      sourceId: "seed:bob",
+    });
+    const entities = await db.selectFrom("entities").selectAll().execute();
+    const retrieveEmbeddingCandidates = vi.fn(async () => []);
+    const deps = {
+      entityRepo,
+      reviewRepo: createEntityReviewRepo(db),
+      lookup: {
+        ...makeLookup(() => entities),
+        retrieveEmbeddingCandidates,
+      },
+      readEmail,
+    };
+
+    const linked = await proposeEntity(deps, {
+      name: "Robert Chen",
+      email: "bob@acme.com",
+      entityType: "person",
+      subtype: "external",
+      source: "fireflies",
+      sourceId: "fireflies:bob",
+      evidence: [],
+      triggeredByUserId: "user-1",
+    });
+    const project = await proposeEntity(deps, {
+      name: "Project Phoenix",
+      entityType: "project",
+      subtype: "external",
+      source: "llm_extraction",
+      sourceId: "project:phoenix",
+      evidence: [],
+      triggeredByUserId: "user-1",
+    });
+
+    expect(linked.kind).toBe("linked");
+    if (linked.kind !== "linked") throw new Error("unreachable");
+    expect(linked.entity.id).toBe(bob.id);
+    expect(project.kind).toBe("created");
+    expect(retrieveEmbeddingCandidates).not.toHaveBeenCalled();
+  });
+
+  it("34. materialize deps leave embedding lookup off without provider or experimental flag", async () => {
+    const provider = makeEmbeddingProvider();
+    const withoutProvider = await buildMaterializeDeps(db, { experimentalFlag: true });
+    const flagOff = await buildMaterializeDeps(db, { experimentalFlag: false, embeddingProvider: provider });
+
+    expect(withoutProvider.lookup.retrieveEmbeddingCandidates).toBeUndefined();
+    expect(flagOff.lookup.retrieveEmbeddingCandidates).toBeUndefined();
+
+    const result = await proposeEntity(
+      {
+        entityRepo: flagOff.entityRepo,
+        reviewRepo: flagOff.reviewRepo,
+        lookup: flagOff.lookup,
+        readEmail: flagOff.readEmail,
+        onEntityResolved: flagOff.onEntityResolved,
+      },
+      {
+        name: "No Provider Person",
+        entityType: "person",
+        subtype: "external",
+        source: "llm_extraction",
+        sourceId: "person:no-provider",
+        evidence: [],
+        triggeredByUserId: "user-1",
+      },
+    );
+
+    expect(result.kind).toBe("created");
+    expect(provider.embedTexts).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/entities/propose.ts
+++ b/packages/server/src/entities/propose.ts
@@ -42,7 +42,8 @@ export type CandidateReason =
   | "strict-normalized"
   | "token-set"
   | "minhash"
-  | "adjacency";
+  | "adjacency"
+  | "embedding";
 
 export interface ProposeInput {
   name: string;
@@ -120,6 +121,7 @@ export type EntityLookup = {
     score: number;
     reason: Extract<CandidateReason, "strict-normalized" | "token-set" | "minhash">;
   }>;
+  retrieveEmbeddingCandidates?(entityType: ProposeEntityType, name: string): Promise<RankedCandidate[]>;
   /** Company ids associated with a normalized corporate domain. */
   getCompanyIdsByDomain?(domain: string): string[];
   getPersonScopeKeys?(entityId: string): string[];
@@ -142,7 +144,7 @@ export interface ProposeDeps {
   onEntityResolved?: (entity: Entity) => void | Promise<void>;
 }
 
-interface RankedCandidate {
+export interface RankedCandidate {
   entity: Entity;
   score: number;
   reason: CandidateReason;
@@ -507,6 +509,29 @@ async function birthGateOrCreate(
   return { kind: "created", entity };
 }
 
+async function embeddingCandidatesThenCreate(
+  deps: ProposeDeps,
+  input: ProposeInput,
+  normalized: string,
+  createReason: "skipFuzzy" | "ranked_empty",
+): Promise<ProposeResult> {
+  if ((input.entityType === "person" || input.entityType === "company") && deps.lookup.retrieveEmbeddingCandidates) {
+    try {
+      const retrieved = await deps.lookup.retrieveEmbeddingCandidates(input.entityType, input.name);
+      const ranked: RankedCandidate[] = [];
+      for (const candidate of retrieved) {
+        if (!isEligibleMatchTarget(input, candidate.entity)) continue;
+        if (await deps.reviewRepo.isRejected(candidate.entity.id, normalized)) continue;
+        ranked.push(candidate);
+      }
+      if (ranked.length > 0) return queueProposal(deps, input, normalized, ranked, "embedding");
+    } catch (err) {
+      deps.logger?.warn({ err, entityType: input.entityType }, "embedding candidate retrieval failed open");
+    }
+  }
+  return birthGateOrCreate(deps, input, normalized, createReason);
+}
+
 async function decideScopedPersonCandidates(
   deps: ProposeDeps,
   input: ProposeInput,
@@ -748,7 +773,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
   }
 
   if (input.skipFuzzy) {
-    return birthGateOrCreate(deps, input, normalized, "skipFuzzy");
+    return embeddingCandidatesThenCreate(deps, input, normalized, "skipFuzzy");
   }
 
   // 4) Fuzzy-rank against same-type entities.
@@ -767,7 +792,7 @@ export async function proposeEntity(deps: ProposeDeps, input: ProposeInput): Pro
 
   // 6) Decide.
   if (ranked.length === 0) {
-    return birthGateOrCreate(deps, input, normalized, "ranked_empty");
+    return embeddingCandidatesThenCreate(deps, input, normalized, "ranked_empty");
   }
   if (input.entityType === "person") return decideScopedPersonCandidates(deps, input, normalized, ranked);
   return queueProposal(deps, input, normalized, ranked, ranked[0].reason);


### PR DESCRIPTION
Stacked context-graph slice 26/27.

Base: `feat/context-graph-25-name-embedding-dedup`
Head: `feat/context-graph-26-person-company-dedup-context`

Extends embedding dedup and context handling to people and companies.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`