### PR TITLE
fix: harden GA cleanup

### DIFF
--- a/packages/server/scripts/eval-dedup-adjudication.ts
+++ b/packages/server/scripts/eval-dedup-adjudication.ts
@@ -34,7 +34,6 @@ import { runMigrations } from "../src/db/migrate";
 import type { DB } from "../src/db/schema";
 
 const DB_PATH = "/Users/hkalra/projects/claude/sketch/data/sketch.db";
-const EXPERIMENTAL = true;
 const TOURISM = "OW Tourism Recovery Dashboard";
 const MAADEN_DASHBOARD = "Maaden Dashboard";
 const MAADEN_SITES = "Maaden Sites";

--- a/packages/server/scripts/probe-extraction.ts
+++ b/packages/server/scripts/probe-extraction.ts
@@ -19,7 +19,6 @@ import { parseOrgContext } from "../src/db/repositories/settings";
 import type { DB } from "../src/db/schema";
 
 const DB_PATH = "/Users/hkalra/projects/claude/sketch/data/sketch.db";
-const EXPERIMENTAL = true;
 
 async function main() {
   const fileIds = process.argv.slice(2);
@@ -73,12 +72,7 @@ async function main() {
       continue;
     }
 
-    const knownEntities = await buildFileScopedKnownEntities(
-      { db, experimentalFlag: EXPERIMENTAL } as never,
-      file.id,
-      [],
-      file.content,
-    );
+    const knownEntities = await buildFileScopedKnownEntities({ db } as never, file.id, [], file.content);
     const participantBlock = await buildParticipantBlock({ db } as never, {
       fileId: file.id,
       fileContent: file.content,

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -330,7 +330,6 @@ export function buildSystemContext(params: {
   indexedSources?: Array<{ source: string; fileCount: number }>;
   agentInstructions?: string | null;
   visionAnalysisEnabled?: boolean;
-  experimentalFlag?: boolean;
 }): string {
   const sections: string[] = [];
 
@@ -499,11 +498,7 @@ export function buildSystemContext(params: {
       "- **SearchEntities** — find projects, people, teams, companies, and products across connected sources. " +
         "Pass multiple name variations to maximize matches. Returns entity IDs.",
       "- **GetEntityContext** — get a cross-source timeline of mentions for an entity (from SearchEntities).",
-      ...(params.experimentalFlag
-        ? [
-            "- **ListTasks** — list current tracker-owned tasks by project entity or assignee entity, including status, source, priority, and due date.",
-          ]
-        : []),
+      "- **ListTasks** — list current tracker-owned tasks by project entity or assignee entity, including status, source, priority, and due date.",
       "",
       'Recency questions ("latest", "most recent", "last X"):',
       '- Always pass `sortBy: "recency"`. Default `limit` becomes 3 (small disambiguation set).',

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -236,7 +236,6 @@ export interface RunAgentParams {
   agentInstructions?: string | null;
   agentAllowedTools?: string[] | null;
   agentOutputWriter?: AgentOutputWriter;
-  experimentalFlag?: boolean;
   conversationRepo?: ReturnType<typeof createConversationRepository>;
   conversationContext?: {
     conversationId: number;
@@ -333,7 +332,6 @@ export async function runAgent(params: RunAgentParams): Promise<RunAgentResult> 
     indexedSources,
     agentInstructions: params.agentInstructions,
     visionAnalysisEnabled: visualAnalysisAllowed,
-    experimentalFlag: params.experimentalFlag,
   });
 
   const sdkBuiltInTools = params.agentAllowedTools
@@ -437,7 +435,6 @@ export async function runAgent(params: RunAgentParams): Promise<RunAgentResult> 
     agentInstructions: params.agentInstructions,
     agentAllowedTools: params.agentAllowedTools,
     agentOutputWriter: params.agentOutputWriter,
-    experimentalFlag: params.experimentalFlag,
     originOrgContextEnabled: params.claudeConfigDir !== undefined,
   });
 

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -78,7 +78,7 @@ export function createSketchMcpServer(deps: SketchMcpDeps) {
         ]
       : []),
     ...createSearchTools(deps),
-    ...(deps.experimentalFlag ? [createListTasksTool(deps)] : []),
+    createListTasksTool(deps),
   ];
 
   return createSdkMcpServer({ name: "sketch", tools });

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -141,7 +141,6 @@ export interface SketchMcpDeps {
   agentInstructions?: string | null;
   agentAllowedTools?: string[] | null;
   agentOutputWriter?: AgentOutputWriter;
-  experimentalFlag?: boolean;
   originOrgContextEnabled?: boolean;
   publicMcp?: {
     userEmails?: string[];

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -683,9 +683,8 @@ const DAILY_BRIEF_INSTRUCTIONS = [
 const DURABLE_TASKS_INSTRUCTION =
   "- The runtime context may include openDurableTasks: tasks that already exist with the shown status. Render those as-is and only create todos for genuinely new work; do not duplicate an existing task.";
 
-function buildInstructions(opts?: { experimentalFlag?: boolean }): string {
-  if (opts?.experimentalFlag) return `${DAILY_BRIEF_INSTRUCTIONS}\n${DURABLE_TASKS_INSTRUCTION}`;
-  return DAILY_BRIEF_INSTRUCTIONS;
+function buildInstructions(): string {
+  return `${DAILY_BRIEF_INSTRUCTIONS}\n${DURABLE_TASKS_INSTRUCTION}`;
 }
 
 function parseTodaysMeetings(value: unknown): TodaysMeeting[] {
@@ -879,7 +878,6 @@ function dropCompletedTodos(output: FormattedPriorOutput | null): FormattedPrior
 }
 
 async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Record<string, unknown>> {
-  if (!args.config.EXPERIMENTAL_FLAG) return {};
   const taskRepo = createTaskRepository(args.db);
   const userEmails = await args.users.getAllEmailsForUser(args.userId);
   const openDurableTasks = await taskRepo.loadOpenDurableTasksForBrief({
@@ -904,7 +902,6 @@ async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Rec
 }
 
 async function onOutputSaved(args: AgentOutputSavedArgs): Promise<void> {
-  if (!args.config.EXPERIMENTAL_FLAG) return;
   const taskRepo = createTaskRepository(args.db);
   for (const item of args.items) {
     if (item.sectionKey !== "todos") continue;

--- a/packages/server/src/agents/service.test.ts
+++ b/packages/server/src/agents/service.test.ts
@@ -25,7 +25,7 @@ describe("Daily Brief durable-task hooks", () => {
     await db.destroy();
   });
 
-  it("with the flag on, surfaces open durable tasks, scrubs completed prior todos, and promotes emitted todos", async () => {
+  it("surfaces open durable tasks, scrubs completed prior todos, and promotes emitted todos", async () => {
     const users = createUserRepository(db);
     const user = await users.create({ name: "Daily Brief User", email: "brief-owner@example.com" });
     await seedIndexedFile(db, "brief-file-1", user.id);
@@ -45,7 +45,7 @@ describe("Daily Brief durable-task hooks", () => {
     });
 
     const before = await countTasks(db);
-    const run = await runAndCapture(db, user.id, true, OUTPUT_DATE, [
+    const run = await runAndCapture(db, user.id, OUTPUT_DATE, [
       briefItem({ title: "Brand new follow-up", knowledgeRefs: { entityIds: [], fileIds: ["brief-file-1"] } }),
     ]);
     const after = await countTasks(db);
@@ -58,30 +58,11 @@ describe("Daily Brief durable-task hooks", () => {
     expect(run.instructions).toContain("openDurableTasks");
     expect(after).toBeGreaterThan(before);
   });
-
-  it("with the flag off, omits durable tasks, leaves prior todos intact, and promotes nothing", async () => {
-    const users = createUserRepository(db);
-    const user = await users.create({ name: "Daily Brief User", email: "brief-owner-2@example.com" });
-    await seedIndexedFile(db, "brief-file-2", user.id);
-    await seedCompletedOutput(db, user.id, OUTPUT_DATE);
-
-    const before = await countTasks(db);
-    const run = await runAndCapture(db, user.id, false, OUTPUT_DATE, [
-      briefItem({ title: "Flag-off emitted todo", knowledgeRefs: { entityIds: [], fileIds: ["brief-file-2"] } }),
-    ]);
-    const after = await countTasks(db);
-
-    expect(run.context).not.toHaveProperty("openDurableTasks");
-    expect(priorTitles(run.context.sameDayPreviousOutput)).toEqual(["Completed prior todo", "Open prior todo"]);
-    expect(run.instructions).not.toContain("openDurableTasks");
-    expect(after).toBe(before);
-  });
 });
 
 async function runAndCapture(
   db: Kysely<DB>,
   userId: string,
-  experimentalFlag: boolean,
   outputDate: string,
   items: AgentOutputItemInput[],
 ): Promise<{ context: Record<string, unknown>; instructions: string }> {
@@ -89,7 +70,7 @@ async function runAndCapture(
   const capturedParams: RunAgentParams[] = [];
   const service = new AgentRunService({
     db,
-    config: createTestConfig({ EXPERIMENTAL_FLAG: experimentalFlag }),
+    config: createTestConfig(),
     logger: createTestLogger(),
     users: createUserRepository(db),
     settings: createSettingsRepository(db),

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -1745,7 +1745,7 @@ export class AgentRunService {
         currentUserId: user.id,
         userRepo: this.deps.users,
         maxTurns: 35,
-        agentInstructions: def.buildInstructions({ experimentalFlag: this.deps.config.EXPERIMENTAL_FLAG }),
+        agentInstructions: def.buildInstructions(),
         agentAllowedTools: def.allowedTools,
         agentOutputWriter: writer,
       });

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -128,10 +128,8 @@ export interface AgentDefinition {
    * Fully static instruction string. Per-user values (enabled sections, item cap,
    * focus) are NOT interpolated here; they flow through the runtime context in the
    * user message so this string stays byte-identical across users for prompt-cache reuse.
-   * `opts.experimentalFlag` may add gated guidance; when the flag is off the string
-   * stays static and cache-shared.
    */
-  buildInstructions(opts?: { experimentalFlag?: boolean }): string;
+  buildInstructions(): string;
   /** Derive display refs, source URLs, and canonical action labels from indexed data. */
   enrichItems(db: Kysely<DB>, items: AgentOutputItemInput[]): Promise<AgentOutputItemInput[]>;
   /** Optional per-definition runtime context appended to the agent run JSON. */
@@ -152,8 +150,7 @@ export interface AgentDefinition {
   toApiItem(item: AgentStoredItem): AgentApiItem;
   /**
    * Optional: add or override runtime-context fields before serialization. Returns a
-   * partial object merged over the engine-built context. Used for experimental,
-   * definition-specific data (e.g. open durable tasks for the daily brief).
+   * partial object merged over the engine-built context.
    */
   augmentRuntimeContext?(args: AgentRuntimeContextArgs): Promise<Record<string, unknown>>;
   /** Optional: side effects to run after an output is persisted (e.g. task promotion). */

--- a/packages/server/src/api/api-tokens.test.ts
+++ b/packages/server/src/api/api-tokens.test.ts
@@ -45,7 +45,7 @@ async function setupSession(email: string) {
 describe("API token routes", () => {
   it("creates and lists only the caller's own tokens", async () => {
     const { cookie } = await setupSession("alice@example.com");
-    const app = createApp(db, createTestConfig({ BASE_URL: "https://sketch.test", EXPERIMENTAL_FLAG: false }), {
+    const app = createApp(db, createTestConfig({ BASE_URL: "https://sketch.test" }), {
       logger: createTestLogger(),
     });
 
@@ -79,7 +79,7 @@ describe("API token routes", () => {
       tokenHash: hashApiToken(plaintext),
       prefix: getApiTokenDisplayPrefix(plaintext),
     });
-    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    const app = createApp(db, createTestConfig({}), { logger: createTestLogger() });
 
     const res = await app.request(`/api/api-tokens/${row.id}`, {
       method: "DELETE",

--- a/packages/server/src/api/connectors-authz.test.ts
+++ b/packages/server/src/api/connectors-authz.test.ts
@@ -1362,14 +1362,14 @@ describe("Connectors API — authorization", () => {
   });
 
   describe("OAuth /api/oauth/zoho — admin-only flow", () => {
-    it("is available without EXPERIMENTAL_FLAG", async () => {
+    it("is available", async () => {
       const res = await app.request("/api/oauth/zoho/status", {
         headers: { Cookie: adminCookie },
       });
       expect(res.status).toBe(200);
     });
 
-    it("shows existing Zoho configs and files without EXPERIMENTAL_FLAG", async () => {
+    it("shows existing Zoho configs and files", async () => {
       const cfg = await insertConfig(db, { connectorType: "zoho_crm", createdBy: adminId });
       await createConnectorRepository(db).upsertFile({
         source: "zoho_crm",

--- a/packages/server/src/api/connectors-hierarchy-scope.test.ts
+++ b/packages/server/src/api/connectors-hierarchy-scope.test.ts
@@ -1,7 +1,7 @@
 /**
  * PR-2a coverage for the connector hierarchy mapping: the PATCH /:id/scope merge
  * (a partial scope update must preserve sibling keys it does not touch) and the
- * flag-gated exposure of a connector's declared `hierarchyLevels` on the GET routes.
+ * exposure of a connector's declared `hierarchyLevels` on the GET routes.
  */
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -90,10 +90,10 @@ describe("Connectors API — hierarchy mapping scope", () => {
     expect(stored.hierarchyMapping).toEqual({ space: "team", folder: "project" });
   });
 
-  it("exposes hierarchyLevels on GET only when EXPERIMENTAL_FLAG is on", async () => {
+  it("exposes hierarchyLevels on GET", async () => {
     const adminId = await seedAdmin(db);
 
-    const onApp = createApp(db, { ...createTestConfig(), EXPERIMENTAL_FLAG: true }, { logger });
+    const onApp = createApp(db, { ...createTestConfig() }, { logger });
     const onCookie = await login(onApp);
     const id = await insertClickUp(db, adminId);
     const onRes = await onApp.request(`/api/connectors/${id}`, { headers: { Cookie: onCookie } });
@@ -105,11 +105,5 @@ describe("Connectors API — hierarchy mapping scope", () => {
       "folder",
       "list",
     ]);
-
-    const offApp = createApp(db, { ...createTestConfig(), EXPERIMENTAL_FLAG: false }, { logger });
-    const offCookie = await login(offApp);
-    const offRes = await offApp.request(`/api/connectors/${id}`, { headers: { Cookie: offCookie } });
-    const offBody = await offRes.json();
-    expect(offBody.connector.hierarchyLevels).toBeUndefined();
   });
 });

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -312,7 +312,6 @@ export function connectorRoutes(
       | "CO_MENTION_CONTRIBUTES_TO_THRESHOLD"
       | "GEMINI_MAX_RPM"
       | "GEMINI_MAX_RETRIES"
-      | "EXPERIMENTAL_FLAG"
       | "ENCRYPTION_KEY"
       | "CONNECTOR_CREDENTIAL_SOURCE"
       | "CANVAS_CREDENTIAL_PRIVATE_KEY_PEM"
@@ -532,7 +531,7 @@ export function connectorRoutes(
           fileCount,
           perUserAuth: meta.perUserAuth,
           requiresOAuthClientSetup: meta.requiresOAuthClientSetup,
-          hierarchyLevels: appConfig?.EXPERIMENTAL_FLAG ? (meta.hierarchyLevels ?? null) : undefined,
+          hierarchyLevels: meta.hierarchyLevels ?? null,
           ...permissionFields(permissions),
         };
       }),
@@ -1800,7 +1799,7 @@ export function connectorRoutes(
         fileCount,
         perUserAuth: meta.perUserAuth,
         requiresOAuthClientSetup: meta.requiresOAuthClientSetup,
-        hierarchyLevels: appConfig?.EXPERIMENTAL_FLAG ? (meta.hierarchyLevels ?? null) : undefined,
+        hierarchyLevels: meta.hierarchyLevels ?? null,
         ...permissionFields(permissions),
       },
     });
@@ -2354,7 +2353,6 @@ export function connectorRoutes(
       geminiApiKey: settings?.gemini_api_key,
       geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
       geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
-      experimentalFlag: appConfig?.EXPERIMENTAL_FLAG,
       fileIds: [fileId],
       debugDumpDir,
     }).catch((err) => {

--- a/packages/server/src/api/entities.test.ts
+++ b/packages/server/src/api/entities.test.ts
@@ -1222,7 +1222,7 @@ describe("Entity drawer routes", () => {
   let memberCookie: string;
   let memberEmail: string;
 
-  const flaggedConfig = createTestConfig({ EXPERIMENTAL_FLAG: true });
+  const config = createTestConfig({});
 
   beforeEach(async () => {
     if (isRecreateActive()) endRecreateLock();
@@ -1231,7 +1231,7 @@ describe("Entity drawer routes", () => {
     adminId = admin.id;
     const member = await seedMember(db);
     memberEmail = member.email;
-    app = createApp(db, flaggedConfig, { logger });
+    app = createApp(db, config, { logger });
     adminCookie = await login(app);
     memberCookie = await loginAs(app, memberEmail);
   });
@@ -1767,8 +1767,8 @@ describe("Entity drawer routes", () => {
     expect(body.totalCount).toBe(2);
   });
 
-  it("GET /api/entities/:id/relations works without EXPERIMENTAL_FLAG (Files is GA)", async () => {
-    const offConfig = createTestConfig({ EXPERIMENTAL_FLAG: false });
+  it("GET /api/entities/:id/relations works", async () => {
+    const offConfig = createTestConfig({});
     const offApp = createApp(db, offConfig, { logger });
     await seedEntity("e1", "Sarah", "person");
     const offCookie = await login(offApp);

--- a/packages/server/src/api/entities.ts
+++ b/packages/server/src/api/entities.ts
@@ -17,6 +17,6 @@ export function entityRoutes(db: Kysely<DB>, deps: EntityRoutesDeps) {
   routes.route("/", createEntityMergeRoutes(db));
   routes.route("/", createEntityBindingRoutes(db));
   routes.route("/", createEntityProfileRoutes(db, deps));
-  if (deps.config.EXPERIMENTAL_FLAG) routes.route("/", createTaskRoutes(db));
+  routes.route("/", createTaskRoutes(db));
   return routes;
 }

--- a/packages/server/src/api/entities/maintenance-routes.ts
+++ b/packages/server/src/api/entities/maintenance-routes.ts
@@ -422,7 +422,7 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
   /**
    * POST /api/entities/resets
    * Delete entities by category, optionally clearing related fact flags and
-   * rebuilding the entity graph via materialize+deterministic linking.
+   * rebuilding the entity graph via materialize and relationship sweeps.
    *
    * Body: {
    *   categories: ("manual" | "connectors" | "ai")[],

--- a/packages/server/src/api/entities/maintenance-routes.ts
+++ b/packages/server/src/api/entities/maintenance-routes.ts
@@ -202,7 +202,6 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
           llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
           featureAutoMintThreshold: config.FEATURE_AUTO_MINT_THRESHOLD,
           coMentionContributesToThreshold: config.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
-          experimentalFlag: config.EXPERIMENTAL_FLAG,
           onProgress: (progress) => {
             job.progress = progress;
           },
@@ -374,7 +373,6 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
           missingFileIds: resolved.missingFileIds,
           runAfter,
           lockAlreadyHeld,
-          experimentalFlag: config.EXPERIMENTAL_FLAG,
           llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
           featureAutoMintThreshold: config.FEATURE_AUTO_MINT_THRESHOLD,
           coMentionContributesToThreshold: config.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
@@ -589,7 +587,6 @@ export function createEntityMaintenanceRoutes(db: Kysely<DB>, deps: EntityRoutes
           llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
           featureAutoMintThreshold: config.FEATURE_AUTO_MINT_THRESHOLD,
           coMentionContributesToThreshold: config.CO_MENTION_CONTRIBUTES_TO_THRESHOLD,
-          experimentalFlag: config.EXPERIMENTAL_FLAG,
           materializeFactTypes: factTypes.length > 0 ? factTypes : undefined,
           onProgress: (progress) => {
             job.progress = progress;

--- a/packages/server/src/api/mcp-servers.isolated.test.ts
+++ b/packages/server/src/api/mcp-servers.isolated.test.ts
@@ -1429,7 +1429,7 @@ describe("MCP Servers API", () => {
   // --- PATCH /api/mcp-servers/:id/connections/:connectionId/access ---
 
   describe("PATCH /api/mcp-servers/:id/connections/:connectionId/access", () => {
-    it("is mounted when experimental features are disabled", async () => {
+    it("is mounted", async () => {
       await seedAdmin(db);
       const repo = createMcpServerRepository(db);
       const server = await repo.create({
@@ -1454,7 +1454,7 @@ describe("MCP Servers API", () => {
       const { createProvider } = await import("../integrations/factory");
       vi.mocked(createProvider).mockReturnValue(mockProvider);
 
-      const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: false }));
+      const app = createApp(db, createTestConfig({}));
       const memberCookie = await getMemberCookie(db);
 
       const res = await app.request(
@@ -1500,7 +1500,7 @@ describe("MCP Servers API", () => {
       const { createProvider } = await import("../integrations/factory");
       vi.mocked(createProvider).mockReturnValue(mockProvider);
 
-      const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }));
+      const app = createApp(db, createTestConfig({}));
       const memberCookie = await getMemberCookie(db);
 
       const res = await app.request(
@@ -1552,7 +1552,7 @@ describe("MCP Servers API", () => {
       const { createProvider } = await import("../integrations/factory");
       vi.mocked(createProvider).mockReturnValue(mockProvider);
 
-      const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }));
+      const app = createApp(db, createTestConfig({}));
       const memberCookie = await getMemberCookie(db);
 
       const res = await app.request(`/api/mcp-servers/${server.id}/connections/pd-1/access`, {

--- a/packages/server/src/api/products.test.ts
+++ b/packages/server/src/api/products.test.ts
@@ -13,6 +13,7 @@ import { createTestConfig, createTestDb, createTestLogger } from "../test-utils"
 
 const PASSWORD = "testpassword123";
 const ADMIN_EMAIL = "admin@test.com";
+const MEMBER_EMAIL = "member@test.com";
 const CONNECTOR_ID = "connector-1";
 const PRODUCT_BIRTH_GATE_TYPES: Set<ProposeEntityType> = new Set(["project", "product", "team"]);
 const PRODUCT_LIVE_TYPES: Set<ProposeEntityType> = new Set(["product"]);
@@ -28,17 +29,24 @@ async function seedAdmin(db: Kysely<DB>): Promise<{ id: string }> {
     passwordHash: await hashPassword(PASSWORD),
     authRole: "admin",
   });
+  await users.create({
+    name: "member",
+    email: MEMBER_EMAIL,
+    emailVerified: true,
+    passwordHash: await hashPassword(PASSWORD),
+    authRole: "member",
+  });
   await settings.update({ onboardingCompletedAt: new Date().toISOString() });
   const admin = await users.findByEmail(ADMIN_EMAIL);
   if (!admin) throw new Error("admin missing");
   return { id: admin.id };
 }
 
-async function login(app: ReturnType<typeof createApp>): Promise<string> {
+async function login(app: ReturnType<typeof createApp>, email = ADMIN_EMAIL): Promise<string> {
   const res = await app.request("/api/auth/login", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email: ADMIN_EMAIL, password: PASSWORD }),
+    body: JSON.stringify({ email, password: PASSWORD }),
   });
   return res.headers.get("set-cookie") ?? "";
 }
@@ -120,6 +128,7 @@ describe("declared products API", () => {
   let db: Kysely<DB>;
   let app: ReturnType<typeof createApp>;
   let cookie: string;
+  let memberCookie: string;
   let adminId: string;
 
   beforeEach(async () => {
@@ -128,10 +137,22 @@ describe("declared products API", () => {
     adminId = admin.id;
     app = createApp(db, createTestConfig({}), { logger: createTestLogger() });
     cookie = await login(app);
+    memberCookie = await login(app, MEMBER_EMAIL);
   });
 
   afterEach(async () => {
     await db.destroy();
+  });
+
+  it("rejects product declarations from non-admin members", async () => {
+    const res = await app.request("/api/products", {
+      method: "POST",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Canvas Copilot" }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await countProducts(db)).toBe(0);
   });
 
   it("declares a new product immediately as a single declared entity", async () => {

--- a/packages/server/src/api/products.test.ts
+++ b/packages/server/src/api/products.test.ts
@@ -126,7 +126,7 @@ describe("declared products API", () => {
     db = await createTestDb();
     const admin = await seedAdmin(db);
     adminId = admin.id;
-    app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    app = createApp(db, createTestConfig({}), { logger: createTestLogger() });
     cookie = await login(app);
   });
 

--- a/packages/server/src/api/products.ts
+++ b/packages/server/src/api/products.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
 import { z } from "zod";
+import { denyIfNotAdmin } from "./auth-helpers";
 import { createEntityRepository } from "../db/repositories/entities";
 import type { DB } from "../db/schema";
 
@@ -24,6 +25,9 @@ export function productRoutes(db: Kysely<DB>) {
   const repo = createEntityRepository(db);
 
   routes.post("/", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
     const parsed = declareProductBodySchema.safeParse(await c.req.json());
     if (!parsed.success) {
       return c.json({ error: { code: "BAD_REQUEST", message: "name is required" } }, 400);

--- a/packages/server/src/api/products.ts
+++ b/packages/server/src/api/products.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
 import { z } from "zod";
-import { denyIfNotAdmin } from "./auth-helpers";
 import { createEntityRepository } from "../db/repositories/entities";
 import type { DB } from "../db/schema";
+import { denyIfNotAdmin } from "./auth-helpers";
 
 const declareProductBodySchema = z.object({
   name: z.string().trim().min(1),

--- a/packages/server/src/api/settings.ts
+++ b/packages/server/src/api/settings.ts
@@ -52,7 +52,7 @@ export function settingsRoutes(
   settings: SettingsRepo,
   db?: Kysely<DB>,
   logger?: Logger,
-  config?: Pick<Config, "GEMINI_MAX_RPM" | "GEMINI_MAX_RETRIES" | "OPENROUTER_API_KEY" | "EXPERIMENTAL_FLAG">,
+  config?: Pick<Config, "GEMINI_MAX_RPM" | "GEMINI_MAX_RETRIES" | "OPENROUTER_API_KEY">,
 ) {
   const routes = new Hono();
 
@@ -170,7 +170,6 @@ export function settingsRoutes(
       geminiApiKey: row?.gemini_api_key,
       geminiMaxRpm: config?.GEMINI_MAX_RPM,
       geminiMaxRetries: config?.GEMINI_MAX_RETRIES,
-      experimentalFlag: config?.EXPERIMENTAL_FLAG,
     }).catch((err) => {
       logger.error({ err }, "Manual enrichment run failed");
     });

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -91,7 +91,6 @@ type UserRepo = ReturnType<typeof createUserRepository>;
 
 interface SetupDeps {
   managedUrl?: string;
-  experimentalFlag?: boolean;
   onSlackTokensUpdated?: (tokens?: { botToken: string; appToken: string }) => Promise<void>;
   onLlmSettingsUpdated?: () => Promise<void>;
   userRepo?: UserRepo;
@@ -192,7 +191,6 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       slackConnected: hasSlack,
       llmConnected: hasLlm,
       llmProvider,
-      experimentalFlag: deps.experimentalFlag ?? false,
       ...(deps.managedUrl ? { managedUrl: deps.managedUrl } : {}),
     });
   });

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -103,17 +103,10 @@ export async function createServer(config: Config, options?: CreateServerOptions
     llmPromotionThreshold: config.LLM_PROMOTION_THRESHOLD,
     llmTaskCorroborationThreshold: config.LLM_TASK_CORROBORATION_THRESHOLD,
     featureAutoMintThreshold: config.FEATURE_AUTO_MINT_THRESHOLD,
-    birthGateTypes: config.EXPERIMENTAL_FLAG
-      ? new Set<ProposeEntityType>(["project", "product", "team"])
-      : new Set<ProposeEntityType>(),
-    birthGateLiveTypes: config.EXPERIMENTAL_FLAG
-      ? new Set<ProposeEntityType>(["product", "project"])
-      : new Set<ProposeEntityType>(),
-    structuralAutoBirthTypes: config.EXPERIMENTAL_FLAG
-      ? new Set<ProposeEntityType>(["project"])
-      : new Set<ProposeEntityType>(),
+    birthGateTypes: new Set<ProposeEntityType>(["project", "product", "team"]),
+    birthGateLiveTypes: new Set<ProposeEntityType>(["product", "project"]),
+    structuralAutoBirthTypes: new Set<ProposeEntityType>(["project"]),
     birthGateDryRun: config.BIRTH_GATE_DRY_RUN,
-    experimentalFlag: config.EXPERIMENTAL_FLAG,
   });
 
   // Migration 039 backfills the legacy admin-owned Fireflies row to a real user id.
@@ -210,7 +203,6 @@ export async function createServer(config: Config, options?: CreateServerOptions
       settingsEncryptionKey: params.settingsEncryptionKey ?? config.ENCRYPTION_KEY,
       localDeviceInvoker: params.localDeviceInvoker ?? localDeviceGateway,
       localClaudeSessionService: params.localClaudeSessionService ?? localClaudeSessionService,
-      experimentalFlag: params.experimentalFlag ?? config.EXPERIMENTAL_FLAG,
       ...(Object.keys(resolvedAgentEnv).length > 0
         ? {
             agentEnv: resolvedAgentEnv,

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -24,10 +24,6 @@ export const configSchema = z.object({
   MAX_UPLOAD_SIZE_MB: z.coerce.number().default(50),
 
   // Feature flags
-  EXPERIMENTAL_FLAG: z
-    .enum(["true", "false", "1", "0"])
-    .default("false")
-    .transform((v) => v === "true" || v === "1"),
   BIRTH_GATE_DRY_RUN: z
     .enum(["true", "false", "1", "0"])
     .default("true")

--- a/packages/server/src/connectors/clickup-hierarchy-mapping.test.ts
+++ b/packages/server/src/connectors/clickup-hierarchy-mapping.test.ts
@@ -94,7 +94,6 @@ async function collectClickUpSync(
     scopeConfig: hierarchyMapping ? { hierarchyMapping } : {},
     cursor: null,
     logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
-    experimentalFlag: true,
     onEntitySeed: async (seed) => {
       seeds.push(seed);
     },
@@ -208,7 +207,6 @@ describe("ClickUp hierarchy mapping", () => {
       },
       item: items[0] as SyncedItem,
       indexedFileId: "indexed-task",
-      experimentalFlag: true,
     });
 
     expect(emittedFacts).toEqual(
@@ -232,6 +230,30 @@ describe("ClickUp hierarchy mapping", () => {
     );
     expect(emittedFacts).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ subjectSourceId: "folder-delivery" })]),
+    );
+  });
+
+  it("uses stored hierarchy mapping without emitting legacy flat seeds", async () => {
+    const { seeds } = await collectClickUpSync(
+      {
+        team: { id: "workspace-mapped", name: "Mapped Workspace", members: [] },
+        spaces: [{ id: "space-mapped", name: "Mapped Space" }],
+        foldersBySpace: { "space-mapped": [] },
+        listsByFolder: {},
+        folderlessListsBySpace: { "space-mapped": [{ id: "list-mapped", name: "Mapped List" }] },
+        tasksByList: { "list-mapped": [] },
+      },
+      { workspace: "team", space: "project", list: "ignore" },
+    );
+
+    expect(seeds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceType: "team", sourceId: "workspace-mapped", name: "Mapped Workspace" }),
+        expect.objectContaining({ sourceType: "project", sourceId: "space-mapped", name: "Mapped Space" }),
+      ]),
+    );
+    expect(seeds.map((seed) => seed.sourceType)).not.toEqual(
+      expect.arrayContaining(["clickup_workspace", "clickup_space"]),
     );
   });
 

--- a/packages/server/src/connectors/clickup-project-seeding.test.ts
+++ b/packages/server/src/connectors/clickup-project-seeding.test.ts
@@ -192,7 +192,6 @@ async function syncRecordedClickUpPayload(db: Kysely<DB>, syncRunId: string): Pr
       factContext,
       item,
       indexedFileId: itemResult.indexedFileId,
-      experimentalFlag: true,
     });
   }
 
@@ -212,10 +211,10 @@ describe("ClickUp project entity seeding", () => {
     await db.destroy();
   });
 
-  it("seeds folder-with-lists and folderless-list projects and links folderless tasks to the list project", async () => {
+  it("seeds folder projects from the default hierarchy and leaves folderless tasks unparented", async () => {
     await syncRecordedClickUpPayload(db, "sync-run-1");
 
-    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     expect(summary.entitiesCreated).toBe(2);
     const projects = await db
@@ -235,9 +234,9 @@ describe("ClickUp project entity seeding", () => {
       },
       {
         id: expect.any(String),
-        name: "Delivery Customer Rollout",
-        aliases: '["Customer Rollout"]',
-        source_id: "cu-list-flat-1",
+        name: "Delivery No Active Work",
+        aliases: '["No Active Work"]',
+        source_id: "cu-folder-empty",
       },
     ]);
     const legacyFolders = await db
@@ -251,22 +250,19 @@ describe("ClickUp project entity seeding", () => {
       .select("id")
       .where("provider_file_id", "=", "cu-task-flat-1")
       .executeTakeFirstOrThrow();
-    const flatProject = projects.find((project) => project.source_id === "cu-list-flat-1");
-    expect(flatProject).toBeDefined();
     const flatProjectMention = await db
       .selectFrom("entity_mentions")
       .selectAll()
       .where("indexed_file_id", "=", flatTask.id)
-      .where("entity_id", "=", flatProject?.id ?? "")
       .where("source", "=", "clickup_parent_entity")
-      .executeTakeFirstOrThrow();
-    expect(flatProjectMention.context_snippet).toBe("In list: Customer Rollout");
+      .executeTakeFirst();
+    expect(flatProjectMention).toBeUndefined();
     const flatTaskRow = await db
       .selectFrom("tasks")
       .select(["parent_name"])
       .where("source_task_id", "=", "cu-task-flat-1")
       .executeTakeFirstOrThrow();
-    expect(flatTaskRow.parent_name).toBe("Delivery Customer Rollout");
+    expect(flatTaskRow.parent_name).toBeNull();
   });
 
   it("re-syncs the same ClickUp tree without duplicate project entities or entity churn", async () => {
@@ -307,13 +303,7 @@ describe("ClickUp project entity seeding", () => {
       .execute();
     expect(secondProjects).toEqual(firstProjects);
     const reviews = await db.selectFrom("entity_review_queue").selectAll().execute();
-    expect(reviews).toHaveLength(1);
-    expect(reviews[0]).toMatchObject({
-      proposed_name: "Delivery",
-      entity_type: "project",
-      seed_source: "clickup",
-      seed_source_id: "cu-space-1",
-    });
+    expect(reviews).toHaveLength(0);
   });
 
   it("migrates legacy ClickUp folder rows and tombstones only folder facts before reset replay", async () => {

--- a/packages/server/src/connectors/clickup.test.ts
+++ b/packages/server/src/connectors/clickup.test.ts
@@ -75,7 +75,7 @@ describe("detectSprintCycle", () => {
 });
 
 describe("resolveListCycle", () => {
-  it("keeps legacy sprint detection for flag-off and computed-default states", () => {
+  it("uses heuristic sprint detection only when no valid hierarchy mapping is stored", () => {
     expect(
       resolveListCycle({
         list: sprintList,
@@ -83,9 +83,8 @@ describe("resolveListCycle", () => {
         workspaceName: "Workspace",
         workspaceId: "workspace",
         storedMapping: { space: "project", list: "ignore" },
-        experimentalFlag: false,
       }),
-    ).toMatchObject({ externalRef: sprintList.id, scopeRef: { source: "clickup", sourceId: sprintsEnabledSpace.id } });
+    ).toBeNull();
 
     for (const storedMapping of [undefined, {}, { nope: "project" }, { list: "bogus" }]) {
       expect(
@@ -95,7 +94,6 @@ describe("resolveListCycle", () => {
           workspaceName: "Workspace",
           workspaceId: "workspace",
           storedMapping,
-          experimentalFlag: true,
         }),
       ).toMatchObject({ externalRef: sprintList.id });
     }
@@ -109,7 +107,6 @@ describe("resolveListCycle", () => {
         workspaceName: "Workspace",
         workspaceId: "workspace",
         storedMapping: { space: "project", list: "project" },
-        experimentalFlag: true,
       }),
     ).toBeNull();
 
@@ -120,7 +117,6 @@ describe("resolveListCycle", () => {
         workspaceName: "Workspace",
         workspaceId: "workspace",
         storedMapping: { space: "project", list: "sprint" },
-        experimentalFlag: true,
       }),
     ).toMatchObject({
       externalRef: sprintList.id,
@@ -138,7 +134,6 @@ describe("resolveListCycle", () => {
         workspaceName: "Workspace",
         workspaceId: "workspace",
         storedMapping: { space: "project", list: "sprint" },
-        experimentalFlag: true,
       }),
     ).toBeNull();
 
@@ -149,7 +144,6 @@ describe("resolveListCycle", () => {
         workspaceName: "Workspace",
         workspaceId: "workspace",
         storedMapping: { workspace: "team", space: "ignore", list: "sprint" },
-        experimentalFlag: true,
         logger: { warn: vi.fn() },
       }),
     ).toBeNull();
@@ -162,7 +156,6 @@ describe("resolveListCycle", () => {
         workspaceName: "Workspace",
         workspaceId: "workspace",
         storedMapping: { space: "project", folder: "ignore", list: "sprint" },
-        experimentalFlag: true,
       }),
     ).toMatchObject({ scopeRef: { source: "clickup", sourceId: sprintsEnabledSpace.id } });
 
@@ -174,7 +167,6 @@ describe("resolveListCycle", () => {
         workspaceName: "Workspace",
         workspaceId: "workspace",
         storedMapping: { folder: "project", list: "sprint" },
-        experimentalFlag: true,
       }),
     ).toMatchObject({ scopeRef: { source: "clickup", sourceId: "folder-design" } });
   });

--- a/packages/server/src/connectors/clickup.ts
+++ b/packages/server/src/connectors/clickup.ts
@@ -312,10 +312,9 @@ export function resolveListCycle(params: {
   workspaceName: string;
   workspaceId: string;
   storedMapping: unknown;
-  experimentalFlag: boolean;
   logger?: Pick<Logger, "warn">;
 }): SyncedTaskCycle | null {
-  if (!params.experimentalFlag || !hasStoredHierarchyMapping(params.storedMapping)) {
+  if (!hasStoredHierarchyMapping(params.storedMapping)) {
     return detectSprintCycle(params.list, params.space, params.folder);
   }
 
@@ -482,30 +481,6 @@ function taskToSyncedItem(
   };
 }
 
-function clickupProjectSeed(params: {
-  node: ClickUpFolder | ClickUpList;
-  workspaceName: string;
-  workspaceId: string;
-  spaceName: string;
-  spaceId: string;
-}): EntitySeed {
-  const name = qualifyContainerName(params.node.name, params.spaceName);
-  return {
-    name,
-    sourceType: "project",
-    source: "clickup",
-    sourceId: params.node.id,
-    aliases: name === params.node.name ? undefined : [params.node.name],
-    metadata: {
-      workspaceName: params.workspaceName,
-      workspaceId: params.workspaceId,
-      spaceName: params.spaceName,
-      spaceId: params.spaceId,
-      path: `${params.workspaceName} / ${params.spaceName} / ${params.node.name}`,
-    },
-  };
-}
-
 function clickupHierarchySeed(params: {
   node: { id: string; name: string };
   sourceType: "team" | "project";
@@ -656,7 +631,7 @@ export function createClickUpConnector(): Connector {
       await clickupRequest("/user", token, pino({ level: "silent" }));
     },
 
-    async *sync({ credentials, scopeConfig, cursor, logger, onEntitySeed, onPersonSeed, experimentalFlag = false }) {
+    async *sync({ credentials, scopeConfig, cursor, logger, onEntitySeed, onPersonSeed }) {
       const token = getAccessToken(credentials);
       const allowedWorkspaces = (scopeConfig.workspaces as string[] | undefined) ?? [];
       const allowedSpaces = (scopeConfig.spaces as string[] | undefined) ?? [];
@@ -698,15 +673,13 @@ export function createClickUpConnector(): Connector {
           "Workspace members resolved",
         );
 
-        const workspaceMapping = experimentalFlag
-          ? resolveHierarchyMapping(
-              CLICKUP_HIERARCHY_LEVELS,
-              hasStoredMapping ? storedHierarchyMapping : computeStructureAwareDefault(CLICKUP_HIERARCHY_LEVELS),
-              { logger },
-            )
-          : undefined;
+        const workspaceMapping = resolveHierarchyMapping(
+          CLICKUP_HIERARCHY_LEVELS,
+          hasStoredMapping ? storedHierarchyMapping : computeStructureAwareDefault(CLICKUP_HIERARCHY_LEVELS),
+          { logger },
+        );
 
-        if (experimentalFlag && workspaceMapping) {
+        if (workspaceMapping) {
           await maybeSeedMappedClickUpNode({
             onEntitySeed,
             mapping: workspaceMapping,
@@ -757,40 +730,33 @@ export function createClickUpConnector(): Connector {
             folders: ClickUpFolder[];
           };
 
-          // Folderless lists are fetched up-front only on the experimental path, where the
-          // structure-aware default mapping needs to know whether the space has any. When the
-          // flag is off they are fetched after the folder loop (the original order) so a failure
-          // there cannot block folder-list tasks that have already been traversed.
           let hierarchyMapping: HierarchyMapping | undefined;
-          let folderlessLists: ClickUpList[] = [];
-          if (experimentalFlag) {
-            const folderlessListsRes = (await clickupRequest(`/space/${space.id}/list`, token, logger)) as {
-              lists: ClickUpList[];
-            };
-            folderlessLists = folderlessListsRes.lists;
-            hierarchyMapping = resolveHierarchyMapping(
-              CLICKUP_HIERARCHY_LEVELS,
-              hasStoredMapping
-                ? storedHierarchyMapping
-                : computeStructureAwareDefault(CLICKUP_HIERARCHY_LEVELS, {
-                    hasFolders: foldersRes.folders.length > 0,
-                    hasFolderlessLists: folderlessLists.length > 0,
-                  }),
-              { logger },
-            );
-            if (hierarchyMapping) {
-              await maybeSeedMappedClickUpNode({
-                onEntitySeed,
-                mapping: hierarchyMapping,
-                levelKey: "space",
-                node: space,
-                workspaceName,
-                workspaceId: team.id,
-                spaceName: space.name,
-                spaceId: space.id,
-                parentPath: [workspaceName],
-              });
-            }
+          const folderlessListsRes = (await clickupRequest(`/space/${space.id}/list`, token, logger)) as {
+            lists: ClickUpList[];
+          };
+          const folderlessLists = folderlessListsRes.lists;
+          hierarchyMapping = resolveHierarchyMapping(
+            CLICKUP_HIERARCHY_LEVELS,
+            hasStoredMapping
+              ? storedHierarchyMapping
+              : computeStructureAwareDefault(CLICKUP_HIERARCHY_LEVELS, {
+                  hasFolders: foldersRes.folders.length > 0,
+                  hasFolderlessLists: folderlessLists.length > 0,
+                }),
+            { logger },
+          );
+          if (hierarchyMapping) {
+            await maybeSeedMappedClickUpNode({
+              onEntitySeed,
+              mapping: hierarchyMapping,
+              levelKey: "space",
+              node: space,
+              workspaceName,
+              workspaceId: team.id,
+              spaceName: space.name,
+              spaceId: space.id,
+              parentPath: [workspaceName],
+            });
           }
 
           for (const folder of foldersRes.folders) {
@@ -798,18 +764,7 @@ export function createClickUpConnector(): Connector {
               lists: ClickUpList[];
             };
             const lists = listsRes.lists;
-            if (!experimentalFlag && onEntitySeed && lists.length > 0) {
-              await onEntitySeed(
-                clickupProjectSeed({
-                  node: folder,
-                  workspaceName,
-                  workspaceId: team.id,
-                  spaceName: space.name,
-                  spaceId: space.id,
-                }),
-              );
-            }
-            if (experimentalFlag && hierarchyMapping) {
+            if (hierarchyMapping) {
               await maybeSeedMappedClickUpNode({
                 onEntitySeed,
                 mapping: hierarchyMapping,
@@ -823,7 +778,7 @@ export function createClickUpConnector(): Connector {
               });
             }
             for (const list of lists) {
-              if (experimentalFlag && hierarchyMapping) {
+              if (hierarchyMapping) {
                 await maybeSeedMappedClickUpNode({
                   onEntitySeed,
                   mapping: hierarchyMapping,
@@ -843,7 +798,6 @@ export function createClickUpConnector(): Connector {
                 workspaceName,
                 workspaceId: team.id,
                 storedMapping: storedHierarchyMapping,
-                experimentalFlag,
                 logger,
               });
               yield* fetchTasksFromList(
@@ -866,25 +820,8 @@ export function createClickUpConnector(): Connector {
             }
           }
 
-          if (!experimentalFlag) {
-            const folderlessListsRes = (await clickupRequest(`/space/${space.id}/list`, token, logger)) as {
-              lists: ClickUpList[];
-            };
-            folderlessLists = folderlessListsRes.lists;
-          }
           for (const list of folderlessLists) {
-            if (!experimentalFlag && onEntitySeed) {
-              await onEntitySeed(
-                clickupProjectSeed({
-                  node: list,
-                  workspaceName,
-                  workspaceId: team.id,
-                  spaceName: space.name,
-                  spaceId: space.id,
-                }),
-              );
-            }
-            if (experimentalFlag && hierarchyMapping) {
+            if (hierarchyMapping) {
               await maybeSeedMappedClickUpNode({
                 onEntitySeed,
                 mapping: hierarchyMapping,
@@ -903,7 +840,6 @@ export function createClickUpConnector(): Connector {
               workspaceName,
               workspaceId: team.id,
               storedMapping: storedHierarchyMapping,
-              experimentalFlag,
               logger,
             });
             yield* fetchTasksFromList(

--- a/packages/server/src/connectors/document-facts.isolated.test.ts
+++ b/packages/server/src/connectors/document-facts.isolated.test.ts
@@ -82,7 +82,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -112,7 +111,6 @@ describe("document-derived facts", () => {
           { source: "linear", sourceId: "a-project" },
         ],
       },
-      experimentalFlag: true,
       contentChanged: true,
       generator: fakeGenerator,
     });
@@ -124,7 +122,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
     const enrichFacts = await activeLlmTaskFacts(db);
@@ -142,7 +139,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -166,7 +162,6 @@ describe("document-derived facts", () => {
       factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-1" },
       indexedFileId: FILE_ID,
       item: { ...baseSyncedItem(), fileType: "issue" },
-      experimentalFlag: true,
       contentChanged: true,
       generator: fakeGenerator,
     });
@@ -187,7 +182,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID_2],
     });
 
@@ -222,7 +216,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -254,7 +247,6 @@ describe("document-derived facts", () => {
           { source: "linear", sourceId: "project-a" },
         ],
       },
-      experimentalFlag: true,
       contentChanged: true,
       generator: fakeGenerator,
     });
@@ -265,7 +257,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
     const enrichRaw = JSON.parse((await activeLlmTaskFacts(db))[0].raw ?? "{}");
@@ -284,7 +275,6 @@ describe("document-derived facts", () => {
         logger: createTestLogger(),
         embeddingProvider: null,
         generator: fakeGenerator,
-        experimentalFlag: true,
         fileIds: [FILE_ID],
       });
     }
@@ -301,7 +291,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
     expect(extractMock).toHaveBeenLastCalledWith(expect.objectContaining({ priorTitles: [] }));
@@ -311,7 +300,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -327,7 +315,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
     expect(await activeTasks(db)).toHaveLength(1);
@@ -339,7 +326,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
     expect(await activeTasks(db)).toHaveLength(1);
@@ -351,7 +337,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -387,7 +372,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -397,7 +381,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -421,7 +404,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
     extractMock.mockResolvedValueOnce([taskCandidate]);
@@ -430,7 +412,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID_2],
     });
 
@@ -440,7 +421,6 @@ describe("document-derived facts", () => {
       logger: createTestLogger(),
       embeddingProvider: null,
       generator: fakeGenerator,
-      experimentalFlag: true,
       fileIds: [FILE_ID],
     });
 
@@ -468,7 +448,7 @@ describe("document-derived facts", () => {
         attendees: [],
         parentRefs: [],
       },
-      { experimentalFlag: true, contentChanged: false, generator: fakeGenerator },
+      { contentChanged: false, generator: fakeGenerator },
     );
     expect(skipped.changed).toBe(false);
 
@@ -486,7 +466,7 @@ describe("document-derived facts", () => {
         attendees: [],
         parentRefs: [],
       },
-      { experimentalFlag: true, contentChanged: true, generator: fakeGenerator },
+      { contentChanged: true, generator: fakeGenerator },
     );
     expect(emitted.changed).toBe(true);
   });

--- a/packages/server/src/connectors/document-facts.test.ts
+++ b/packages/server/src/connectors/document-facts.test.ts
@@ -43,7 +43,6 @@ describe("document-derived llm_task extraction", () => {
     const generator = fakeGenerator(generateJSON);
 
     const result = await emitDocumentDerivedFacts(db, baseContext(), {
-      experimentalFlag: true,
       contentChanged: true,
       generator,
     });
@@ -52,7 +51,7 @@ describe("document-derived llm_task extraction", () => {
     expect(generateJSONCalls).toEqual([
       {
         prompt: expect.stringContaining("Source date: 2025-04-25"),
-        opts: { maxTokens: 2048, label: "extractLlmTask", dumpDir: undefined },
+        opts: { maxTokens: 8192, label: "extractLlmTask", dumpDir: undefined },
       },
     ]);
     expect(await activeLlmTaskFacts(db)).toHaveLength(1);
@@ -65,7 +64,6 @@ describe("document-derived llm_task extraction", () => {
     });
 
     const result = await emitDocumentDerivedFacts(db, baseContext(), {
-      experimentalFlag: true,
       contentChanged: true,
       generator,
       logger,
@@ -81,7 +79,6 @@ describe("document-derived llm_task extraction", () => {
 
   it("skips gracefully when no generator is available", async () => {
     const result = await emitDocumentDerivedFacts(db, baseContext(), {
-      experimentalFlag: true,
       contentChanged: true,
     });
 
@@ -100,7 +97,7 @@ describe("document-derived llm_task extraction", () => {
       const result = await emitDocumentDerivedFacts(
         db,
         { ...baseContext(), fileType },
-        { experimentalFlag: true, contentChanged: true, generator },
+        { contentChanged: true, generator },
       );
 
       expect(result.changed).toBe(false);
@@ -116,7 +113,7 @@ describe("document-derived llm_task extraction", () => {
       const result = await emitDocumentDerivedFacts(
         db,
         { ...baseContext(), fileType },
-        { experimentalFlag: true, contentChanged: true, generator },
+        { contentChanged: true, generator },
       );
 
       expect(result.changed).toBe(true);

--- a/packages/server/src/connectors/document-facts.ts
+++ b/packages/server/src/connectors/document-facts.ts
@@ -34,7 +34,6 @@ export interface DocumentFactContext {
 }
 
 export interface EmitDocumentDerivedFactsOptions {
-  experimentalFlag?: boolean;
   contentChanged?: boolean;
   generator?: GeminiGenerator;
   dumpDir?: string;
@@ -64,12 +63,12 @@ export function sortDocumentParentRefs(parentRefs: DocumentFactParentRef[]): Doc
 export async function emitDocumentDerivedFacts(
   db: Kysely<DB>,
   ctx: DocumentFactContext,
-  { experimentalFlag = false, contentChanged = false, generator, dumpDir, logger }: EmitDocumentDerivedFactsOptions,
+  { contentChanged = false, generator, dumpDir, logger }: EmitDocumentDerivedFactsOptions,
 ): Promise<EmitDocumentDerivedFactsResult> {
   const emittedFactKeys = new Set<string>();
   const factRepo = createIndexedFileFactRepository(db);
 
-  if (!(experimentalFlag && ctx.contentCategory === "document" && ctx.content)) {
+  if (!(ctx.contentCategory === "document" && ctx.content)) {
     return { emittedFactKeys, tombstonedFactIds: [], changed: false };
   }
 
@@ -120,7 +119,6 @@ export async function emitDocumentDerivedFacts(
 
   for (const candidate of candidates) {
     const result = await upsertLlmTaskFact(db, {
-      experimentalFlag,
       indexedFileId: ctx.indexedFileId,
       connectorConfigId,
       createdByUserId: ctx.createdByUserId,

--- a/packages/server/src/connectors/engagement-floor.ts
+++ b/packages/server/src/connectors/engagement-floor.ts
@@ -43,9 +43,9 @@ import {
 } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
 import { isRoleAccountEmail } from "../entities/affiliations";
-import { isEmailProviderName } from "../entities/validators";
 import { cleanupEmptyRelationships, cleanupRelationshipEvidenceForFacts } from "../entities/materialize";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
+import { isEmailProviderName } from "../entities/validators";
 import { yieldToEventLoop } from "../lib/event-loop";
 import { parseActionItemOwners } from "./participant-block";
 

--- a/packages/server/src/connectors/enrichment.test.ts
+++ b/packages/server/src/connectors/enrichment.test.ts
@@ -14,11 +14,10 @@ import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEntityRepository } from "../db/repositories/entities";
-import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
 import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
 import type { EmbeddingProvider } from "./embeddings/types";
-import { clearEnrichmentData, isEnrichmentActive, matchesAsWord, runEnrichment } from "./enrichment";
+import { clearEnrichmentData, isEnrichmentActive, runEnrichment } from "./enrichment";
 import type { GeminiGenerator } from "./gemini-generate";
 
 /** Insert the minimum rows needed to have an indexed file ready for enrichment. */
@@ -700,7 +699,7 @@ describe("runEnrichment — claim semantics", () => {
     expect(await getStatus(fileId)).toBe("done");
   });
 
-  it("deterministic relinking preserves LLM extraction mentions", async () => {
+  it("no-key enrichment preserves existing LLM extraction mentions", async () => {
     const fileId = randomUUID();
     await seedFile(db, fileId, "Jane Doe discussed the launch plan.");
     await setStatus(fileId, "pending");
@@ -715,25 +714,6 @@ describe("runEnrichment — claim semantics", () => {
       confidence: "INFERRED",
       source: "llm_extraction",
       relation: "mentioned",
-    });
-    await createIndexedFileFactRepository(db).upsertFact({
-      indexedFileId: fileId,
-      connectorConfigId: "conn-1",
-      contentHash: "hash",
-      source: "llm_extraction",
-      factType: "llm_extracted",
-      relation: "mentioned",
-      subjectName: "Jane Doe",
-      subjectSource: "llm_extraction",
-      subjectSourceId: `${fileId}:hash:Jane Doe`,
-      raw: {
-        contentHash: "hash",
-        promptVersion: "llm-extraction-v1",
-        model: "gemini",
-        mention: "Jane Doe",
-        type: "person",
-        variations: [],
-      },
     });
 
     await runEnrichment({ db, logger: createTestLogger(), embeddingProvider: null, fileIds: [fileId] });
@@ -744,23 +724,17 @@ describe("runEnrichment — claim semantics", () => {
       .where("indexed_file_id", "=", fileId)
       .execute();
     expect(mentions).toContainEqual({ source: "llm_extraction", confidence: "INFERRED", relation: "mentioned" });
+    expect(mentions.some((mention) => mention.source === "deterministic_substring")).toBe(false);
   });
 
-  it("deterministic relinking removes legacy llm_extraction mentions without backing facts", async () => {
+  it("no-key enrichment does not create deterministic substring mentions", async () => {
     const fileId = randomUUID();
     await seedFile(db, fileId, "Jane Doe discussed the launch plan.");
     await setStatus(fileId, "pending");
-    const entity = await createEntityRepository(db).upsertEntity({
+    await createEntityRepository(db).upsertEntity({
       name: "Jane Doe",
       sourceType: "person",
       status: "confirmed",
-    });
-    await createEntityRepository(db).createMention({
-      entityId: entity.id,
-      indexedFileId: fileId,
-      confidence: "INFERRED",
-      source: "llm_extraction",
-      relation: "mentioned",
     });
 
     await runEnrichment({ db, logger: createTestLogger(), embeddingProvider: null, fileIds: [fileId] });
@@ -770,41 +744,7 @@ describe("runEnrichment — claim semantics", () => {
       .select(["source", "confidence", "relation"])
       .where("indexed_file_id", "=", fileId)
       .execute();
-    expect(mentions).not.toContainEqual({ source: "llm_extraction", confidence: "INFERRED", relation: "mentioned" });
-    expect(mentions).toContainEqual({
-      source: "deterministic_substring",
-      confidence: "INFERRED",
-      relation: "mentioned",
-    });
-  });
-});
-
-describe("matchesAsWord — word-boundary entity name matching", () => {
-  it("does NOT match a name embedded inside a longer word", () => {
-    // The bug that motivated this helper: "Anshu" inside "Himanshu" was
-    // creating false-positive entity_mentions on every "Himanshu" doc.
-    expect(matchesAsWord("himanshu kalra is here", "anshu")).toBe(false);
-    expect(matchesAsWord("estimated 5 days", "tim")).toBe(false);
-    expect(matchesAsWord("donate to charity", "don")).toBe(false);
-  });
-
-  it("matches at word boundaries", () => {
-    expect(matchesAsWord("anshu is on the call", "anshu")).toBe(true);
-    expect(matchesAsWord("called anshu yesterday", "anshu")).toBe(true);
-    expect(matchesAsWord("anshu, please review", "anshu")).toBe(true);
-    expect(matchesAsWord("hello, anshu!", "anshu")).toBe(true);
-  });
-
-  it("matches multi-word names exactly", () => {
-    expect(matchesAsWord("himanshu kalra reviewed it", "himanshu kalra")).toBe(true);
-    expect(matchesAsWord("met with himanshu kalra today", "himanshu kalra")).toBe(true);
-    expect(matchesAsWord("himanshu and kalra are different people", "himanshu kalra")).toBe(false);
-  });
-
-  it("escapes regex metacharacters in names", () => {
-    // Names with regex-special chars must not be treated as patterns.
-    expect(matchesAsWord("invoiced o.brien yesterday", "o.brien")).toBe(true);
-    expect(matchesAsWord("invoiced oXbrien yesterday", "o.brien")).toBe(false);
+    expect(mentions).toEqual([]);
   });
 });
 

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -241,7 +241,6 @@ async function emitAndMaterializeDocumentFactsFromStoredFile(
 ): Promise<void> {
   const context = await buildStoredDocumentFactContext(deps.db, file);
   const result = await emitDocumentDerivedFacts(deps.db, context, {
-    experimentalFlag: deps.experimentalFlag,
     contentChanged: true,
     generator: generator ?? undefined,
     dumpDir: deps.debugDumpDir,
@@ -249,7 +248,6 @@ async function emitAndMaterializeDocumentFactsFromStoredFile(
   });
   if (result.changed) {
     await materializeUnmaterializedFacts(deps.db, deps.logger, {
-      experimentalFlag: deps.experimentalFlag,
       embeddingProvider: deps.embeddingProvider,
       factTypes: ["llm_task"],
     });
@@ -330,10 +328,7 @@ async function markEmbeddingFailure(
   await query.execute();
 }
 
-export async function loadBaselineKnownEntities(
-  db: Kysely<DB>,
-  opts: { experimentalFlag?: boolean } = {},
-): Promise<KnownEntityForPrompt[]> {
+export async function loadBaselineKnownEntities(db: Kysely<DB>): Promise<KnownEntityForPrompt[]> {
   const baseEntities = await db
     .selectFrom("entities")
     .select(["id", "name", "source_type", "aliases", "metadata", "hotness"])
@@ -347,18 +342,16 @@ export async function loadBaselineKnownEntities(
     )
     .where(whereLiveEntity())
     .execute();
-  const projectEntities = opts.experimentalFlag
-    ? await db
-        .selectFrom("entities")
-        .select(["id", "name", "source_type", "aliases", "metadata", "hotness"])
-        .where("source_type", "=", "project")
-        .where("status", "=", "confirmed")
-        .where(whereLiveEntity())
-        .orderBy("hotness", "desc")
-        .orderBy("name", "asc")
-        .limit(PROJECT_BASELINE_LIMIT)
-        .execute()
-    : [];
+  const projectEntities = await db
+    .selectFrom("entities")
+    .select(["id", "name", "source_type", "aliases", "metadata", "hotness"])
+    .where("source_type", "=", "project")
+    .where("status", "=", "confirmed")
+    .where(whereLiveEntity())
+    .orderBy("hotness", "desc")
+    .orderBy("name", "asc")
+    .limit(PROJECT_BASELINE_LIMIT)
+    .execute();
   const entities = [...baseEntities, ...projectEntities];
   return entities.map((entity) => ({
     id: entity.id,
@@ -380,7 +373,6 @@ export interface EnrichmentDeps {
   geminiApiKey?: string | null;
   geminiMaxRpm?: number;
   geminiMaxRetries?: number;
-  experimentalFlag?: boolean;
   /** Download image from Google Drive by provider file ID. Returns buffer + mime type. */
   downloadImage?: (providerFileId: string, connectorConfigId: string) => Promise<{ buffer: Buffer; mimeType: string }>;
   /** If set, only enrich these specific file IDs (ignoring pending status). */
@@ -465,7 +457,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
   }
 
   try {
-    deps.knownEntities = await loadBaselineKnownEntities(db, { experimentalFlag: deps.experimentalFlag });
+    deps.knownEntities = await loadBaselineKnownEntities(db);
   } catch {
     // entities table may not exist yet — ignore
   }
@@ -594,7 +586,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
               const generator = getGenerator();
               if (!generator) throw new Error("Enrichment generator unavailable");
               const knownEntities = await buildFileScopedKnownEntities(
-                { db, logger, experimentalFlag: deps.experimentalFlag },
+                { db, logger },
                 file.id,
                 deps.knownEntities ?? [],
                 file.content,
@@ -612,7 +604,6 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
                   orgContext: deps.orgContext,
                   knownEntities,
                   participantBlock,
-                  experimentalFlag: deps.experimentalFlag,
                   debugDumpDir: deps.debugDumpDir,
                   ensureFresh: () => ensureFileFresh(db, file.id, fileVersion),
                 },
@@ -644,7 +635,6 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
               await ensureFileFresh(db, file.id, fileVersion);
               if (floor.emitted > 0) {
                 await materializeUnmaterializedFacts(db, logger, {
-                  experimentalFlag: deps.experimentalFlag,
                   embeddingProvider: deps.embeddingProvider,
                 });
               }
@@ -892,7 +882,7 @@ async function enrichTextDocument(
   if (!summaryAlreadyResolved && generator && wordCount >= minWordsForSummary) {
     try {
       const knownEntities = await buildFileScopedKnownEntities(
-        { db, logger, experimentalFlag: deps.experimentalFlag },
+        { db, logger },
         file.id,
         deps.knownEntities ?? [],
         file.content,
@@ -909,7 +899,6 @@ async function enrichTextDocument(
           participantBlock,
           debugDumpDir: deps.debugDumpDir,
           ensureFresh: () => ensureFileFresh(db, file.id, fileVersion),
-          experimentalFlag: deps.experimentalFlag,
         },
         {
           id: file.id,
@@ -939,7 +928,6 @@ async function enrichTextDocument(
       await ensureFileFresh(db, file.id, fileVersion);
       if (floor.emitted > 0) {
         await materializeUnmaterializedFacts(db, logger, {
-          experimentalFlag: deps.experimentalFlag,
           embeddingProvider,
         });
       }

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -4,11 +4,10 @@
  * Runs after sync completes. For each file with embedding_status = 'pending':
  * 1. Chunk text content
  * 2. Extract timeframes (deterministic regex-based)
- * 3. Link entities deterministically (substring match entity names against content)
+ * 3. Extract AI-grounded summaries and entity facts when available
  * 4. Generate embeddings (text chunks or images)
  * 5. Store everything in DB
  *
- * No LLM calls — all extraction is deterministic.
  * Images are downloaded temporarily from Google Drive, embedded, then discarded.
  */
 import { randomUUID } from "node:crypto";
@@ -21,10 +20,8 @@ import { PERSON_PARTICIPANT_FACT_TYPES } from "../db/repositories/indexed-file-f
 import { parseOrgContext } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
-import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 import { PRODUCT_MATCH_TARGET_PROVENANCE_TIERS } from "../entities/provenance";
 import { yieldToEventLoop } from "../lib/event-loop";
-import type { Chunk } from "./chunking";
 import { chunkText } from "./chunking";
 import { type DocumentFactContext, emitDocumentDerivedFacts, sortDocumentParentRefs } from "./document-facts";
 import { ensureEmailThreadSummary, rebuildEmailThreadSummary } from "./email/thread-summary";
@@ -41,10 +38,6 @@ export const MAX_FILES_PER_RUN = 5000;
 export const SCHEDULED_ENRICHMENT_MAX_FILES_PER_RUN = 50;
 export const SCHEDULED_ENRICHMENT_TIME_BUDGET_MS = 5 * 60 * 1000;
 
-/** Minimum entity name length for substring matching (avoids false positives). */
-const MIN_ENTITY_NAME_LENGTH = 3;
-
-const DETERMINISTIC_LINK_BATCH_SIZE = 500;
 const PROJECT_BASELINE_LIMIT = 200;
 const ENRICHMENT_BACKOFF_MS = [
   30 * 60 * 1000,
@@ -66,12 +59,6 @@ class StaleEnrichmentError extends Error {
     this.name = "StaleEnrichmentError";
   }
 }
-
-type DeterministicEntity = {
-  id: string;
-  name: string;
-  aliases: string | null;
-};
 
 type FileContentVersion = {
   contentHash: string | null;
@@ -824,17 +811,13 @@ async function enrichTextDocument(
   const { db, logger, embeddingProvider } = deps;
   const fileVersion = contentVersionOf(file);
 
-  // For structured data (CSV/sheets), only extract timeframes + link entities — no chunking, no embedding
+  // For structured data (CSV/sheets), only extract timeframes — no chunking, summary, or embedding
   if (isStructured) {
     const timeframes = extractDatesFromText(file.content);
     await withFreshFileWriteLock(db, file.id, fileVersion, async (trx) => {
       await clearFileTimeframes(trx, file.id);
       await storeTimeframes(trx, file.id, timeframes);
     });
-
-    await linkEntitiesDeterministic(db, file.id, file.content, [], undefined, () =>
-      ensureFileFresh(db, file.id, fileVersion),
-    );
 
     logger.debug({ fileId: file.id, fileName: file.file_name }, "Structured file enriched (no chunking/embedding)");
     return;
@@ -863,7 +846,7 @@ async function enrichTextDocument(
     await storeTimeframes(trx, file.id, timeframes);
   });
 
-  // 4. Entity linking — AI-powered when Gemini available, deterministic fallback
+  // 4. Summary and entity extraction — AI-powered when Gemini is available
   // Skip LLM calls for tiny content; mail and calendar items use a lower threshold because the payload is often short.
   const wordCount = file.content.split(/\s+/).filter(Boolean).length;
   let usedSmartEnrichment = false;
@@ -936,14 +919,11 @@ async function enrichTextDocument(
     } catch (err) {
       if (err instanceof StaleEnrichmentError) throw err;
       smartEnrichmentFailed = true;
-      logger.warn({ err, fileId: file.id }, "Smart enrichment failed, falling back to deterministic");
+      logger.warn({ err, fileId: file.id }, "Smart enrichment failed");
     }
   }
 
   if (!summaryAlreadyResolved && !usedSmartEnrichment) {
-    await linkEntitiesDeterministic(db, file.id, file.content, chunks, undefined, () =>
-      ensureFileFresh(db, file.id, fileVersion),
-    );
     const summaryQuery = db
       .updateTable("indexed_files")
       .set(
@@ -1063,194 +1043,6 @@ async function enrichImage(
   });
 
   // buffer is garbage collected — nothing stored on disk
-}
-
-/**
- * Deterministic entity linking: substring-match entity names/aliases
- * against document content, create mentions for matches.
- */
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * Word-boundary substring match. Plain `String.includes` falsely matches
- * short names inside longer words — "Anshu" inside "Himanshu", "Tim" inside
- * "estimated", "Don" inside "donate". `\b` ensures the candidate sits at
- * an ASCII word boundary. JS `\b` is ASCII-only; names with non-ASCII
- * letters (accents, Devanagari, etc.) would need `\p{L}` boundaries — out
- * of scope for this fix, which targets the dominant false-positive class.
- */
-export function matchesAsWord(content: string, name: string): boolean {
-  if (!name || !content) return false;
-  return new RegExp(`\\b${escapeRegex(name)}\\b`).test(content);
-}
-
-export async function linkEntitiesByDeterministicMatch(db: Kysely<DB>, logger: Logger): Promise<EnrichmentResult> {
-  const result: EnrichmentResult = { filesProcessed: 0, filesSkipped: 0, filesFailed: 0, errors: [] };
-  const allEntities = await createEntityRepository(db).getEntitiesByStatus("confirmed", {
-    excludeSourceTypes: Array.from(HIDDEN_ENTITY_SOURCE_TYPES),
-  });
-  let lastFileId: string | null = null;
-
-  while (true) {
-    let query = db
-      .selectFrom("indexed_files")
-      .select(["id", "content"])
-      .where("is_archived", "=", 0)
-      .where("content", "is not", null)
-      .orderBy("id", "asc")
-      .limit(DETERMINISTIC_LINK_BATCH_SIZE);
-    if (lastFileId) {
-      query = query.where("id", ">", lastFileId);
-    }
-    const files = await query.execute();
-    if (files.length === 0) break;
-    lastFileId = files[files.length - 1].id;
-
-    const fileIds = files.map((file) => file.id);
-    const chunkRows = await db
-      .selectFrom("document_chunks")
-      .select(["indexed_file_id", "chunk_index", "content", "token_count"])
-      .where("indexed_file_id", "in", fileIds)
-      .orderBy("indexed_file_id", "asc")
-      .orderBy("chunk_index", "asc")
-      .execute();
-    const chunksByFile = new Map<string, Chunk[]>();
-    for (const chunk of chunkRows) {
-      const chunks = chunksByFile.get(chunk.indexed_file_id) ?? [];
-      chunks.push({
-        index: chunk.chunk_index,
-        content: chunk.content,
-        tokenCount: chunk.token_count ?? 0,
-      });
-      chunksByFile.set(chunk.indexed_file_id, chunks);
-    }
-
-    for (const file of files) {
-      try {
-        await linkEntitiesDeterministic(db, file.id, file.content ?? "", chunksByFile.get(file.id) ?? [], allEntities);
-        result.filesProcessed++;
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.warn({ err, fileId: file.id }, "Deterministic entity linking failed");
-        result.errors.push({ fileId: file.id, error: message });
-        result.filesFailed++;
-      }
-    }
-  }
-
-  return result;
-}
-
-async function linkEntitiesDeterministic(
-  db: Kysely<DB>,
-  fileId: string,
-  content: string,
-  chunks: Chunk[],
-  allEntities?: DeterministicEntity[],
-  ensureFresh?: () => Promise<void>,
-): Promise<void> {
-  const entityRepo = createEntityRepository(db);
-
-  await ensureFresh?.();
-  await db
-    .deleteFrom("entity_mentions")
-    .where("indexed_file_id", "=", fileId)
-    .where("source", "=", "deterministic_substring")
-    .where("confidence", "!=", "EXTRACTED")
-    .execute();
-
-  await deleteStaleLegacyDeterministicMentions(db, fileId);
-
-  const entities =
-    allEntities ??
-    (await entityRepo.getEntitiesByStatus("confirmed", {
-      excludeSourceTypes: Array.from(HIDDEN_ENTITY_SOURCE_TYPES),
-    }));
-  const contentLower = content.toLowerCase();
-
-  for (const entity of entities) {
-    const names: string[] = [entity.name];
-    try {
-      const aliases = JSON.parse(entity.aliases || "[]") as string[];
-      names.push(...aliases);
-    } catch {
-      /* skip bad JSON */
-    }
-
-    // Check if any name/alias appears in content (skip very short names).
-    // Word-boundary match avoids "anshu" inside "himanshu" false positives.
-    const matchedName = names.find((name) => {
-      const nameLower = name.toLowerCase();
-      if (nameLower.length < MIN_ENTITY_NAME_LENGTH) return false;
-      return matchesAsWord(contentLower, nameLower);
-    });
-
-    if (matchedName) {
-      const nameLower = matchedName.toLowerCase();
-      const chunkIndex = chunks.findIndex((c) => matchesAsWord(c.content.toLowerCase(), nameLower));
-
-      await ensureFresh?.();
-      await entityRepo.createMention({
-        entityId: entity.id,
-        indexedFileId: fileId,
-        chunkIndex: chunkIndex >= 0 ? chunkIndex : null,
-        contextSnippet: chunkIndex >= 0 ? chunks[chunkIndex].content.slice(0, 300) : null,
-        confidence: "INFERRED",
-        source: "deterministic_substring",
-        relation: "mentioned",
-      });
-      await entityRepo.updateHotness(entity.id);
-      await yieldToEventLoop();
-    }
-  }
-}
-
-function normalizeDeterministicName(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, " ");
-}
-
-function entityNames(entity: { name: string; aliases: string | null }): string[] {
-  const names = [entity.name];
-  try {
-    const aliases = JSON.parse(entity.aliases || "[]") as string[];
-    names.push(...aliases.filter((alias) => typeof alias === "string"));
-  } catch {}
-  return names;
-}
-
-async function deleteStaleLegacyDeterministicMentions(db: Kysely<DB>, fileId: string): Promise<void> {
-  const activeFactRows = await db
-    .selectFrom("indexed_file_facts")
-    .select("subject_name")
-    .where("indexed_file_id", "=", fileId)
-    .where("source", "=", "llm_extraction")
-    .where("fact_type", "=", "llm_extracted")
-    .where("deleted_at", "is", null)
-    .execute();
-  const activeLlmNames = new Set(
-    activeFactRows
-      .map((row) => row.subject_name)
-      .filter((name): name is string => Boolean(name))
-      .map(normalizeDeterministicName),
-  );
-
-  const legacyMentions = await db
-    .selectFrom("entity_mentions")
-    .innerJoin("entities", "entities.id", "entity_mentions.entity_id")
-    .select(["entity_mentions.id as id", "entities.name as name", "entities.aliases as aliases"])
-    .where("entity_mentions.indexed_file_id", "=", fileId)
-    .where("entity_mentions.source", "=", "llm_extraction")
-    .where("entity_mentions.confidence", "!=", "EXTRACTED")
-    .where(whereLiveEntity())
-    .execute();
-  const staleIds = legacyMentions
-    .filter((mention) => entityNames(mention).every((name) => !activeLlmNames.has(normalizeDeterministicName(name))))
-    .map((mention) => mention.id);
-
-  if (staleIds.length === 0) return;
-  await db.deleteFrom("entity_mentions").where("id", "in", staleIds).execute();
 }
 
 async function storeTimeframes(

--- a/packages/server/src/connectors/file-scope-context.test.ts
+++ b/packages/server/src/connectors/file-scope-context.test.ts
@@ -474,7 +474,7 @@ describe("file-scope-context", () => {
     ]);
 
     const known = await buildFileScopedKnownEntities(
-      { db, experimentalFlag: true, loadAdjacencyForAnchor, loadPendingProposalsForAnchor },
+      { db, loadAdjacencyForAnchor, loadPendingProposalsForAnchor },
       "file-pending-build",
       [{ name: "Tourism Dashboard", type: "project", description: "confirmed" }],
     );
@@ -658,15 +658,8 @@ describe("file-scope-context", () => {
     await seedMention(db, { entityId: "person-ambiguous-a", fileId: ambiguousEvidenceFile });
     await seedMention(db, { entityId: "project-ambiguous", fileId: ambiguousEvidenceFile });
 
-    const companyOnly = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, [], "");
-    const personAnchored = await buildFileScopedKnownEntities(
-      { db, now: () => now, experimentalFlag: true },
-      promptFile,
-      [],
-      "",
-    );
+    const personAnchored = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, [], "");
 
-    expect(companyOnly).toEqual([]);
     expect(personAnchored.find((entry) => entry.name === "Internal Atlas")).toMatchObject({
       name: "Internal Atlas",
       type: "project",
@@ -859,7 +852,7 @@ describe("file-scope-context", () => {
       return adjacencyForAnchor(deps, anchorId);
     });
     const known = await buildFileScopedKnownEntities(
-      { db, now: () => now, experimentalFlag: true, loadAdjacencyForAnchor },
+      { db, now: () => now, loadAdjacencyForAnchor },
       promptFile,
       [],
       "",
@@ -871,11 +864,11 @@ describe("file-scope-context", () => {
     expect(known.map((entry) => entry.name).some((name) => name.startsWith("Hub Project"))).toBe(false);
   });
 
-  it("keeps company-only ranking unchanged with flag off and bounds project baseline expansion with flag on", async () => {
+  it("keeps anchored ranking and bounds project baseline expansion", async () => {
     const now = Date.UTC(2026, 4, 26);
     const recentDate = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
-    const promptFile = "file-flag-off-parity";
-    const coMentionFile = "file-flag-off-parity-evidence";
+    const promptFile = "file-ranking-parity";
+    const coMentionFile = "file-ranking-parity-evidence";
     await seedFile(db, promptFile, recentDate);
     await seedFile(db, coMentionFile, recentDate);
     await seedEntity(db, { id: "ent-parity-company", name: "Parity Co", sourceType: "company", hotness: 10 });
@@ -895,14 +888,8 @@ describe("file-scope-context", () => {
       { id: "baseline-cold", name: "Cold Product", type: "product", hotness: 1 },
       { id: "ent-parity-product", name: "Parity Product", type: "product", hotness: 10 },
     ];
-    const legacyFlagOmitted = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, baseline, "");
-    const explicitFlagOff = await buildFileScopedKnownEntities(
-      { db, now: () => now, experimentalFlag: false },
-      promptFile,
-      baseline,
-      "",
-    );
-    expect(explicitFlagOff).toEqual(legacyFlagOmitted);
+    const anchoredKnown = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, baseline, "");
+    expect(anchoredKnown.map((entry) => entry.name)).toContain("Parity Product");
 
     for (let i = 0; i < 80; i++) {
       await seedEntity(db, {
@@ -912,16 +899,14 @@ describe("file-scope-context", () => {
         hotness: i,
       });
     }
-    const baselineFlagOff = await loadBaselineKnownEntities(db, { experimentalFlag: false });
-    const baselineFlagOn = await loadBaselineKnownEntities(db, { experimentalFlag: true });
-    expect(baselineFlagOff.map((entry) => entry.type)).not.toContain("project");
-    expect(baselineFlagOn.map((entry) => entry.name)).toContain("Bounded Project 79");
+    const baselineKnown = await loadBaselineKnownEntities(db);
+    expect(baselineKnown.map((entry) => entry.name)).toContain("Bounded Project 79");
 
     const content = Array.from({ length: 80 }, (_, i) => `Bounded Project ${i}`).join("\n");
     const known = await buildFileScopedKnownEntities(
-      { db, now: () => now, experimentalFlag: true },
+      { db, now: () => now },
       "file-baseline-bound",
-      baselineFlagOn,
+      baselineKnown,
       content,
     );
     expect(known.filter((entry) => entry.type === "project").length).toBeLessThanOrEqual(

--- a/packages/server/src/connectors/file-scope-context.test.ts
+++ b/packages/server/src/connectors/file-scope-context.test.ts
@@ -712,12 +712,7 @@ describe("file-scope-context", () => {
       confidenceScore: 1,
     });
 
-    const known = await buildFileScopedKnownEntities(
-      { db, now: () => now, experimentalFlag: true },
-      promptFile,
-      [],
-      "",
-    );
+    const known = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, [], "");
 
     const initiatives = known
       .filter((entry) => entry.type === "project" || entry.type === "product")
@@ -741,12 +736,7 @@ describe("file-scope-context", () => {
     await seedMention(db, { entityId: "person-recall", fileId: evidenceFile });
     await seedMention(db, { entityId: "project-recall", fileId: evidenceFile });
 
-    const known = await buildFileScopedKnownEntities(
-      { db, now: () => now, experimentalFlag: true },
-      promptFile,
-      [],
-      "",
-    );
+    const known = await buildFileScopedKnownEntities({ db, now: () => now }, promptFile, [], "");
 
     expect(known.find((entry) => entry.name === "Recall Project")).toMatchObject({
       name: "Recall Project",
@@ -803,7 +793,7 @@ describe("file-scope-context", () => {
     await seedMention(db, { entityId: "project-injected-baseline-0", fileId: injectedSeenFile });
 
     const known = await buildFileScopedKnownEntities(
-      { db, now: () => now, experimentalFlag: true },
+      { db, now: () => now },
       promptFile,
       [
         { id: "project-injected-baseline-0", name: "Injected Baseline Project 0", type: "project", hotness: 100 },

--- a/packages/server/src/connectors/file-scope-context.ts
+++ b/packages/server/src/connectors/file-scope-context.ts
@@ -60,7 +60,6 @@ export interface FileScopeDeps {
   db: Kysely<DB>;
   logger?: Logger;
   now?: () => number;
-  experimentalFlag?: boolean;
   loadAdjacencyForAnchor?: (deps: FileScopeDeps, anchorId: string) => Promise<AdjacencyEntry[]>;
   loadContributesToForAnchor?: (deps: FileScopeDeps, anchorId: string) => Promise<ContributesToEntry[]>;
   loadPendingProposalsForAnchor?: (deps: FileScopeDeps, anchorId: string) => Promise<PendingProposalEntry[]>;
@@ -154,6 +153,7 @@ export async function resolveFileAnchors(deps: FileScopeDeps, fileId: string): P
   for (const row of attendees) {
     const email = row.subject_email;
     if (!email) continue;
+    if (!email.includes("@")) continue;
     participantEmails.push(email);
     const domain = domainsRepo.normalizeEmailDomain(email);
     if (!domain) continue;
@@ -173,7 +173,6 @@ export async function resolveFileAnchors(deps: FileScopeDeps, fileId: string): P
   const companies = Array.from(companyMap.values())
     .sort((a, b) => b.hotness - a.hotness)
     .slice(0, MAX_ANCHORS_PER_SIDE);
-  if (!deps.experimentalFlag) return { companies, persons: [] };
 
   const entityRepo = createEntityRepository(deps.db);
   const personsByEmail = await entityRepo.getPersonEntitiesByEmails(participantEmails);
@@ -440,14 +439,12 @@ export async function buildFileScopedKnownEntities(
     byKey.set(k, stripPromptInternalFields(b));
   }
 
-  if (deps.experimentalFlag) {
-    for (const anchor of [...anchors.companies, ...anchors.persons]) {
-      const pendingProposals = await (deps.loadPendingProposalsForAnchor ?? pendingProposalsForAnchor)(deps, anchor.id);
-      for (const proposal of pendingProposals.slice(0, PER_ANCHOR_INITIATIVE_CAP)) {
-        const k = keyOf(proposal.name, proposal.type);
-        if (byKey.has(k)) continue;
-        byKey.set(k, { name: proposal.name, type: proposal.type, reviewId: proposal.id });
-      }
+  for (const anchor of [...anchors.companies, ...anchors.persons]) {
+    const pendingProposals = await (deps.loadPendingProposalsForAnchor ?? pendingProposalsForAnchor)(deps, anchor.id);
+    for (const proposal of pendingProposals.slice(0, PER_ANCHOR_INITIATIVE_CAP)) {
+      const k = keyOf(proposal.name, proposal.type);
+      if (byKey.has(k)) continue;
+      byKey.set(k, { name: proposal.name, type: proposal.type, reviewId: proposal.id });
     }
   }
 
@@ -537,15 +534,13 @@ async function rankBaselineKnownEntities(
   if (scoredCandidates.length === 0) return legacy;
 
   const cap = opts.baselineRelevanceCap ?? BASELINE_RELEVANCE_CAP;
-  const alwaysInclude = deps.experimentalFlag
-    ? scoredCandidates
-        .filter((entity) => hasVerbatimMention(fileContent, entity))
-        .sort((a, b) => {
-          const hotness = Number(b.hotness ?? 0) - Number(a.hotness ?? 0);
-          return hotness !== 0 ? hotness : a.name.localeCompare(b.name);
-        })
-        .slice(0, BASELINE_ALWAYS_INCLUDE_CAP)
-    : scoredCandidates.filter((entity) => hasVerbatimMention(fileContent, entity));
+  const alwaysInclude = scoredCandidates
+    .filter((entity) => hasVerbatimMention(fileContent, entity))
+    .sort((a, b) => {
+      const hotness = Number(b.hotness ?? 0) - Number(a.hotness ?? 0);
+      return hotness !== 0 ? hotness : a.name.localeCompare(b.name);
+    })
+    .slice(0, BASELINE_ALWAYS_INCLUDE_CAP);
   const alwaysIds = new Set(alwaysInclude.map((entity) => entity.id));
   const candidates = scoredCandidates.filter((entity) => !alwaysIds.has(entity.id));
   const candidateIds = candidates.flatMap((entity) => (entity.id ? [entity.id] : []));

--- a/packages/server/src/connectors/linear-project-seeding.test.ts
+++ b/packages/server/src/connectors/linear-project-seeding.test.ts
@@ -184,7 +184,6 @@ async function syncRecordedLinearPayload(db: Kysely<DB>, syncRunId: string): Pro
       factContext,
       item,
       indexedFileId: itemResult.indexedFileId,
-      experimentalFlag: true,
     });
   }
 
@@ -212,7 +211,7 @@ describe("Linear project entity seeding", () => {
   it("materializes one Linear project seed with a bare project source ref", async () => {
     await syncRecordedLinearPayload(db, "sync-run-1");
 
-    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     expect(summary.entitiesCreated).toBe(1);
     const projects = await db.selectFrom("entities").selectAll().where("source_type", "=", "project").execute();

--- a/packages/server/src/connectors/post-sync.isolated.test.ts
+++ b/packages/server/src/connectors/post-sync.isolated.test.ts
@@ -63,7 +63,6 @@ describe("runPostSyncGraphPipeline", () => {
       });
 
       expect(materializeUnmaterializedFacts).toHaveBeenCalledTimes(1);
-      expect(reconcileStructuralAssigneeContributesTo).not.toHaveBeenCalled();
       expect(sweepCoMentionContributesTo).toHaveBeenCalledTimes(1);
       expect(sweepCoMentionContributesTo).toHaveBeenCalledWith(db, expect.anything(), {
         scope: { kind: "files", indexedFileIds: ["file-1", "file-2"] },
@@ -74,7 +73,7 @@ describe("runPostSyncGraphPipeline", () => {
     }
   });
 
-  it("runs the structural assignee producer for affected files before the co-mention sweep when experimental", async () => {
+  it("runs the structural assignee producer for affected files before the co-mention sweep", async () => {
     const { sweepCoMentionContributesTo } = await import("../entities/co-mention-sweep");
     const db = await createTestDb();
     const logger = createTestLogger();
@@ -84,7 +83,6 @@ describe("runPostSyncGraphPipeline", () => {
         db,
         syncLogger: logger,
         affectedIndexedFileIds: ["file-1", "file-2"],
-        experimentalFlag: true,
         coMentionContributesToThreshold: 4,
       });
 
@@ -137,7 +135,6 @@ describe("runPostSyncGraphPipeline", () => {
         db,
         syncLogger: logger,
         affectedIndexedFileIds: [],
-        experimentalFlag: true,
       });
 
       expect(reconcileStructuralAssigneeContributesTo).toHaveBeenCalledTimes(1);
@@ -205,7 +202,6 @@ describe("runPostSyncGraphPipeline", () => {
         affectedIndexedFileIds: [],
         connectorConfigId: "connector-a",
         syncRunId: "sync-new",
-        experimentalFlag: true,
         runCycleReconcile: false,
       });
       await expect(loadCycle(db, cycle.cycleId)).resolves.toMatchObject({ state: "active", deleted_at: null });
@@ -217,7 +213,6 @@ describe("runPostSyncGraphPipeline", () => {
         affectedIndexedFileIds: [],
         connectorConfigId: "connector-a",
         syncRunId: "sync-new",
-        experimentalFlag: true,
         runCycleReconcile: true,
       });
       await expect(loadCycle(db, cycle.cycleId)).resolves.toMatchObject({
@@ -225,36 +220,6 @@ describe("runPostSyncGraphPipeline", () => {
         deleted_at: expect.any(String),
       });
       await expect(openMemberships(db, cycle.cycleId)).resolves.toBe(0);
-    } finally {
-      await db.destroy();
-    }
-  });
-
-  it("does not close pre-existing cycles when the experimental flag is off", async () => {
-    const db = await createTestDb();
-    const logger = createTestLogger();
-
-    try {
-      await seedConnector(db, "connector-a");
-      const cycle = await upsertWorkCycle(db, {
-        connectorConfigId: "connector-a",
-        source: "clickup",
-        externalRef: "sprint-flag-off",
-        name: "Sprint Flag Off",
-        lastSeenSyncRunId: "sync-old",
-      });
-
-      await runPostSyncGraphPipeline({
-        db,
-        syncLogger: logger,
-        affectedIndexedFileIds: [],
-        connectorConfigId: "connector-a",
-        syncRunId: "sync-new",
-        experimentalFlag: false,
-        runCycleReconcile: true,
-      });
-
-      await expect(loadCycle(db, cycle.cycleId)).resolves.toMatchObject({ state: "active", deleted_at: null });
     } finally {
       await db.destroy();
     }
@@ -288,7 +253,6 @@ describe("runPostSyncGraphPipeline", () => {
         affectedIndexedFileIds: [],
         connectorConfigId: "connector-a",
         syncRunId: "sync-new",
-        experimentalFlag: true,
         runCycleReconcile: true,
       });
 

--- a/packages/server/src/connectors/post-sync.ts
+++ b/packages/server/src/connectors/post-sync.ts
@@ -18,7 +18,6 @@ export interface PostSyncGraphPipelineParams {
   source?: string;
   syncRunId?: string;
   connectorConfigId?: string;
-  experimentalFlag?: boolean;
   runCycleReconcile?: boolean;
 }
 
@@ -31,7 +30,6 @@ export async function runPostSyncGraphPipeline({
   source,
   syncRunId,
   connectorConfigId,
-  experimentalFlag,
   runCycleReconcile,
 }: PostSyncGraphPipelineParams): Promise<void> {
   const materializeSummary = await materializeUnmaterializedFacts(db, syncLogger);
@@ -44,27 +42,25 @@ export async function runPostSyncGraphPipeline({
   if (reanchoredTasks.count > 0 || expiredTasks > 0) {
     syncLogger.info({ reanchoredTasks: reanchoredTasks.count, expiredTasks }, "Post-sync task sweep complete");
   }
-  if (experimentalFlag) {
-    if (affectedIndexedFileIds.length > 0) {
-      await reconcileStructuralAssigneeContributesTo(
-        db,
-        syncLogger.child({ component: "structural-assignee-producer" }),
-        {
-          scope: { kind: "files", indexedFileIds: affectedIndexedFileIds },
-        },
-      );
-    }
-    if (reanchoredTasks.taskIds.length > 0) {
-      await reconcileStructuralAssigneeContributesTo(
-        db,
-        syncLogger.child({ component: "structural-assignee-producer" }),
-        {
-          scope: { kind: "tasks", taskIds: reanchoredTasks.taskIds },
-        },
-      );
-    }
+  if (affectedIndexedFileIds.length > 0) {
+    await reconcileStructuralAssigneeContributesTo(
+      db,
+      syncLogger.child({ component: "structural-assignee-producer" }),
+      {
+        scope: { kind: "files", indexedFileIds: affectedIndexedFileIds },
+      },
+    );
   }
-  if (experimentalFlag && runCycleReconcile && connectorConfigId && syncRunId) {
+  if (reanchoredTasks.taskIds.length > 0) {
+    await reconcileStructuralAssigneeContributesTo(
+      db,
+      syncLogger.child({ component: "structural-assignee-producer" }),
+      {
+        scope: { kind: "tasks", taskIds: reanchoredTasks.taskIds },
+      },
+    );
+  }
+  if (runCycleReconcile && connectorConfigId && syncRunId) {
     const closedWorkCycles = await reconcileWorkCycles(db, {
       connectorConfigId,
       syncRunId,

--- a/packages/server/src/connectors/smart-enrichment-feature-producer.integration.test.ts
+++ b/packages/server/src/connectors/smart-enrichment-feature-producer.integration.test.ts
@@ -3,7 +3,6 @@ import type { Kysely, Selectable } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createEntityRepository } from "../db/repositories/entities";
 import { upsertFeatureFact } from "../db/repositories/features";
-import { buildIndexedFileFactKey } from "../db/repositories/indexed-file-facts";
 import type { DB, IndexedFileFactsTable, SubEntitiesTable } from "../db/schema";
 import { buildMaterializeDeps, materializeFromFact } from "../entities/materialize";
 import { createTestLogger, createTestPgDb } from "../test-utils";
@@ -12,7 +11,6 @@ import { smartEnrichFile } from "./smart-enrichment";
 
 const USER_ID = "feature-producer-user";
 const CONNECTOR_ID = "feature-producer-connector";
-const PROMPT_VERSION = "llm-extraction-v11";
 let db: Kysely<DB>;
 
 type Mention = {
@@ -60,7 +58,7 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
       },
     ]);
     for (const file of files) {
-      await smartEnrichFile(deps(generator, true), fileContext(file));
+      await smartEnrichFile(deps(generator), fileContext(file));
     }
 
     const feature = await currentFeatureRows(db, "crm analytics");
@@ -96,7 +94,7 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
     expect(new Set(raws.map((raw) => raw.corroborationKey)).size).toBe(1);
   }, 30000);
 
-  it("defers unresolved and ambiguous parents while keeping flag-off fact keys unchanged", async () => {
+  it("defers unresolved and ambiguous parents", async () => {
     const missingParentFile = {
       id: `feature-missing-parent-${randomUUID()}`,
       hash: "hash-feature-missing-parent",
@@ -114,7 +112,6 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
             confidence: 0.94,
           },
         ]),
-        true,
       ),
       fileContext(missingParentFile),
     );
@@ -146,75 +143,12 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
             confidence: 0.93,
           },
         ]),
-        true,
       ),
       fileContext(ambiguousFile),
     );
     featureFacts = await activeFeatureFacts(db);
     expect(featureFacts).toHaveLength(2);
     expect(await countFeatureSubEntities(db)).toBe(0);
-
-    const flagOffFile = {
-      id: `feature-flag-off-${randomUUID()}`,
-      hash: "hash-feature-flag-off",
-      content: "CRM Analytics is discussed as a product candidate.",
-    };
-    await seedFile(db, flagOffFile);
-    let capturedPrompt = "";
-    await smartEnrichFile(
-      deps(
-        generatorWithMentions(
-          [{ mention: "CRM Analytics", type: "product", variations: [], confidence: 0.95 }],
-          (prompt) => {
-            capturedPrompt = prompt;
-          },
-        ),
-        false,
-      ),
-      fileContext(flagOffFile),
-    );
-
-    expect(capturedPrompt).not.toContain('"feature"');
-    expect(capturedPrompt).not.toContain("parentProduct");
-    const fact = await db
-      .selectFrom("indexed_file_facts")
-      .selectAll()
-      .where("indexed_file_id", "=", flagOffFile.id)
-      .where("fact_type", "=", "llm_extracted")
-      .where("subject_name", "=", "CRM Analytics")
-      .executeTakeFirstOrThrow();
-    expect(fact.fact_key).toBe(
-      buildIndexedFileFactKey({
-        indexedFileId: flagOffFile.id,
-        connectorConfigId: CONNECTOR_ID,
-        createdByUserId: USER_ID,
-        contentHash: flagOffFile.hash,
-        source: "llm_extraction",
-        factType: "llm_extracted",
-        relation: "mentioned",
-        subjectName: "CRM Analytics",
-        subjectSource: "llm_extraction",
-        subjectSourceId: `${flagOffFile.id}:${flagOffFile.hash}:${PROMPT_VERSION}:CRM Analytics`,
-        contextSnippet: null,
-        raw: {
-          contentHash: flagOffFile.hash,
-          promptVersion: PROMPT_VERSION,
-          model: "gemini",
-          mention: "CRM Analytics",
-          type: "product",
-          variations: [],
-          confidence: 0.95,
-        },
-      }),
-    );
-    await expect(
-      db
-        .selectFrom("indexed_file_facts")
-        .selectAll()
-        .where("indexed_file_id", "=", flagOffFile.id)
-        .where("fact_type", "=", "feature")
-        .execute(),
-    ).resolves.toEqual([]);
   }, 30000);
 
   it("filters code-shaped feature names in the producer and materializer", async () => {
@@ -251,7 +185,6 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
             confidence: 0.92,
           },
         ]),
-        true,
       ),
       fileContext(file),
     );
@@ -263,7 +196,6 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
     await expect(currentFeatureRows(db, "questionrequestdto")).resolves.toHaveLength(0);
 
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: file.id,
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -281,10 +213,7 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
       .where("subject_source_id", "=", "feature-stored-noise")
       .executeTakeFirstOrThrow();
     await expect(
-      materializeFromFact(
-        await buildMaterializeDeps(db, { experimentalFlag: true, featureAutoMintThreshold: 1 }),
-        storedNoiseFact,
-      ),
+      materializeFromFact(await buildMaterializeDeps(db, { featureAutoMintThreshold: 1 }), storedNoiseFact),
     ).resolves.toEqual({ kind: "deferred_below_threshold", reason: "noise_rejected" });
     await expect(currentFeatureRows(db, "answerresponsedto")).resolves.toHaveLength(0);
     await expect(currentFeatureRows(db, "paylater")).resolves.toEqual([
@@ -316,13 +245,13 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
         confidence: 0.94,
       },
     ]);
-    await smartEnrichFile(deps(featureGenerator, true), fileContext(firstFile));
+    await smartEnrichFile(deps(featureGenerator), fileContext(firstFile));
     expect(await activeFeatureFacts(db)).toHaveLength(1);
     let current = await currentFeatureRows(db, "usage dashboards");
     expect(current).toHaveLength(1);
     expect(current[0]).toMatchObject({ parent_entity_id: product.id, provenance: "corroborated_llm" });
 
-    await smartEnrichFile(deps(featureGenerator, true), fileContext(secondFile));
+    await smartEnrichFile(deps(featureGenerator), fileContext(secondFile));
     current = await currentFeatureRows(db, "usage dashboards");
     expect(current).toHaveLength(1);
     expect(current[0]).toMatchObject({ parent_entity_id: product.id, provenance: "corroborated_llm" });
@@ -334,7 +263,7 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
       content: "Canvas CRM release notes cover cleanup work without that dashboard module.",
     };
     await updateFileContent(db, updatedSecondFile);
-    await smartEnrichFile(deps(generatorWithMentions([]), true), fileContext(updatedSecondFile));
+    await smartEnrichFile(deps(generatorWithMentions([])), fileContext(updatedSecondFile));
 
     const secondFact = await db
       .selectFrom("indexed_file_facts")
@@ -353,7 +282,7 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
       content: "Canvas CRM release notes cover cleanup work without that dashboard module.",
     };
     await updateFileContent(db, updatedFirstFile);
-    await smartEnrichFile(deps(generatorWithMentions([]), true), fileContext(updatedFirstFile));
+    await smartEnrichFile(deps(generatorWithMentions([])), fileContext(updatedFirstFile));
 
     current = await currentFeatureRows(db, "usage dashboards");
     expect(current).toHaveLength(0);
@@ -364,13 +293,12 @@ describe("smartEnrichFile LLM feature producer postgres", () => {
   }, 30000);
 });
 
-function deps(generator: GeminiGenerator, experimentalFlag: boolean) {
+function deps(generator: GeminiGenerator) {
   return {
     db,
     logger: createTestLogger(),
     generator,
     embeddingProvider: null,
-    experimentalFlag,
   };
 }
 

--- a/packages/server/src/connectors/smart-enrichment.test.ts
+++ b/packages/server/src/connectors/smart-enrichment.test.ts
@@ -554,7 +554,7 @@ describe("smartEnrichFile — LLM extraction facts", () => {
     } as GeminiGenerator;
 
     await smartEnrichFile(
-      { db, logger: createTestLogger(), generator, embeddingProvider: null, experimentalFlag: true },
+      { db, logger: createTestLogger(), generator, embeddingProvider: null },
       {
         id: fileId,
         fileName: `${fileId}.txt`,
@@ -1161,7 +1161,7 @@ describe("extractEntities prompt — v6 entity type removal", () => {
     }
   });
 
-  it("renders supported entity types without removed feature guidance", async () => {
+  it("renders supported entity types with feature guidance", async () => {
     let capturedPrompt = "";
     const generator = {
       generate: async () => "",
@@ -1191,10 +1191,9 @@ describe("extractEntities prompt — v6 entity type removal", () => {
     expect(capturedPrompt).toContain("Prefer extracting from the top down");
     expect(capturedPrompt).toContain('"engaged_with"');
     expect(capturedPrompt).toContain("without being employed by it");
-    expect(capturedPrompt).toContain('Valid types: "person", "project", "company", "product"');
-    expect(capturedPrompt).not.toContain("Features");
-    expect(capturedPrompt).not.toContain('"feature"');
-    expect(capturedPrompt).not.toContain("feature -> project | product");
+    expect(capturedPrompt).toContain('Valid types: "person", "project", "company", "product", "tool", "feature"');
+    expect(capturedPrompt).toContain("Features");
+    expect(capturedPrompt).toContain('"feature"');
   });
 
   it("ignores feature mentions and feature endpoint relations emitted by the model", async () => {
@@ -1664,7 +1663,6 @@ describe("dedup adjudication", () => {
         logger: createTestLogger(),
         generator,
         embeddingProvider: null,
-        experimentalFlag: true,
         knownEntities: [{ name: canonical, type: "project" }],
       },
       smartFileContext(fileId, "hash-dedup-hit", { content }),

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -7,7 +7,7 @@
  * 3. Generate grounded file summaries (using matched entity definitions as context)
  * 4. Extract and append new facts to entity definitions
  *
- * Falls back to deterministic enrichment when Gemini is unavailable.
+ * When Gemini is unavailable, callers skip AI extraction and mark summaries accordingly.
  */
 import { createHash, randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -130,13 +130,12 @@ const GENERIC_DEDUP_TOKENS = new Set([
  * structural seeding. The LLM may still *match* a mention to an existing team
  * (see `MATCHABLE_ENTITY_TYPES`), but never create one.
  */
-const BASE_PROPOSABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product"];
+const BASE_PROPOSABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product", "tool"];
 const MATCHABLE_ENTITY_TYPES: ProposeEntityType[] = ["person", "project", "company", "product", "team", "deal"];
 const SPINE_TYPES_FROM_STRUCTURE = new Set<ProposeEntityType>(["project", "team"]);
 
-function proposableEntityTypes(experimentalFlag = false, fileType?: string | null): Set<ProposeEntityType> {
+function proposableEntityTypes(fileType?: string | null): Set<ProposeEntityType> {
   const types = [...BASE_PROPOSABLE_ENTITY_TYPES];
-  if (experimentalFlag) types.push("tool");
   let set = new Set(types);
   if (fileType && STRUCTURAL_TASK_FILE_TYPES.has(fileType.toLowerCase())) {
     set = new Set([...set].filter((type) => !SPINE_TYPES_FROM_STRUCTURE.has(type)));
@@ -144,9 +143,9 @@ function proposableEntityTypes(experimentalFlag = false, fileType?: string | nul
   return set;
 }
 
-function extractionValidTypes(experimentalFlag = false, fileType?: string | null): Set<string> {
-  const types = new Set<string>(proposableEntityTypes(experimentalFlag, fileType));
-  if (experimentalFlag) types.add("feature");
+function extractionValidTypes(fileType?: string | null): Set<string> {
+  const types = new Set<string>(proposableEntityTypes(fileType));
+  types.add("feature");
   return types;
 }
 
@@ -210,7 +209,6 @@ interface SmartEnrichmentDeps {
    * attendee metadata. Caller (enrichment.ts) builds via `buildParticipantBlock`.
    */
   participantBlock?: string;
-  experimentalFlag?: boolean;
   /**
    * When set, every LLM call inside this run writes a dump file (prompt + raw
    * response + token usage) under this directory. Set only by the per-file
@@ -328,8 +326,7 @@ export async function extractEntities(
   knownEntities?: KnownEntityForPrompt[],
   participantBlock?: string,
   dumpDir?: string,
-  experimentalFlag = false,
-  allowedTypes = extractionValidTypes(experimentalFlag, file.fileType),
+  allowedTypes = extractionValidTypes(file.fileType),
 ): Promise<EntityExtractionResult> {
   const truncatedContent = file.content.slice(0, MAX_CONTENT_CHARS);
 
@@ -351,24 +348,16 @@ export async function extractEntities(
     : "";
   const validTypes = [...allowedTypes];
   const validTypesPrompt = validTypes.map((type) => `"${type}"`).join(", ");
-  const toolFocusLine = experimentalFlag
-    ? "- **Tools**: third-party SaaS apps/platforms the org uses (e.g., Slack, Notion, Zoom, Figma, GitHub)\n"
-    : "";
-  const featureFocusLine = experimentalFlag
-    ? '- **Features**: a feature is a named sub-capability, module, tab, or screen within a product (e.g., "CRM Analytics", "Push Notifications"). Emit it as type "feature" and set "parentProduct" to the product it belongs to. A feature\'s parentProduct must be a product or project name, never a domain, URL, or email. Never emit a feature as a product or project.\n'
-    : "";
-  const featureNoiseLine = experimentalFlag
-    ? "- Do not emit class names, DTOs, code symbols, table names, or column names as features.\n"
-    : "";
-  const featureSchemaInstruction = experimentalFlag
-    ? '\nFor feature mentions, include "parentProduct" with the product the feature belongs to. Omit "parentProduct" for non-feature mentions.\n'
-    : "";
-  const mentionExamples = experimentalFlag
-    ? `    { "mention": "Project Atlas", "type": "project", "variations": ["Atlas", "the Atlas deal"], "confidence": 0.86 },
+  const toolFocusLine =
+    "- **Tools**: third-party SaaS apps/platforms the org uses (e.g., Slack, Notion, Zoom, Figma, GitHub)\n";
+  const featureFocusLine =
+    '- **Features**: a feature is a named sub-capability, module, tab, or screen within a product (e.g., "CRM Analytics", "Push Notifications"). Emit it as type "feature" and set "parentProduct" to the product it belongs to. A feature\'s parentProduct must be a product or project name, never a domain, URL, or email. Never emit a feature as a product or project.\n';
+  const featureNoiseLine = "- Do not emit class names, DTOs, code symbols, table names, or column names as features.\n";
+  const featureSchemaInstruction =
+    '\nFor feature mentions, include "parentProduct" with the product the feature belongs to. Omit "parentProduct" for non-feature mentions.\n';
+  const mentionExamples = `    { "mention": "Project Atlas", "type": "project", "variations": ["Atlas", "the Atlas deal"], "confidence": 0.86 },
     { "mention": "Sarah Chen", "type": "person", "variations": ["Sarah", "S. Chen"], "confidence": 0.95 },
-    { "mention": "CRM Analytics", "type": "feature", "parentProduct": "Canvas CRM", "variations": ["Analytics tab"], "confidence": 0.91 }`
-    : `    { "mention": "Project Atlas", "type": "project", "variations": ["Atlas", "the Atlas deal"], "confidence": 0.86 },
-    { "mention": "Sarah Chen", "type": "person", "variations": ["Sarah", "S. Chen"], "confidence": 0.95 }`;
+    { "mention": "CRM Analytics", "type": "feature", "parentProduct": "Canvas CRM", "variations": ["Analytics tab"], "confidence": 0.91 }`;
   const relationshipTypesPrompt = `Valid relationship types:
 - "works_at": person -> company (the person is employed by the company)
 - "engaged_with": person -> company (the person is working with, for, or delivered to an external company without being employed by it — vendor, consultancy, or client-engagement context)
@@ -808,7 +797,7 @@ export async function handleCandidates(
   deps: SmartEnrichmentDeps,
   fileId: string,
   unmatched: ExtractedMention[],
-  allowedTypes = proposableEntityTypes(deps.experimentalFlag),
+  allowedTypes = proposableEntityTypes(),
 ): Promise<MatchedEntity[]> {
   const { db, logger } = deps;
   const entityRepo = createEntityRepository(db);
@@ -817,7 +806,7 @@ export async function handleCandidates(
   for (const rawMention of unmatched) {
     const mention = {
       ...rawMention,
-      type: coerceMentionType(rawMention.mention, rawMention.type, deps.experimentalFlag),
+      type: coerceMentionType(rawMention.mention, rawMention.type),
     };
     if (!allowedTypes.has(mention.type as ProposeEntityType)) continue;
     if (mention.mention.length < MIN_ENTITY_NAME_LENGTH) continue;
@@ -1100,7 +1089,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
   const { db, logger, generator, embeddingProvider } = deps;
   const entityRepo = createEntityRepository(db);
   const fileVersion = contentVersionOf(file);
-  const validExtractionTypes = extractionValidTypes(deps.experimentalFlag, file.fileType);
+  const validExtractionTypes = extractionValidTypes(file.fileType);
 
   const fileMeta = {
     fileId: file.id,
@@ -1123,7 +1112,6 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
       deps.knownEntities,
       deps.participantBlock,
       deps.debugDumpDir,
-      deps.experimentalFlag,
       validExtractionTypes,
     );
   } catch (err) {
@@ -1141,24 +1129,22 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
     "smartEnrichFile: stage done",
   );
 
-  if (deps.experimentalFlag) {
-    if (deps.embeddingProvider) {
-      await reconcileMissingNameEmbeddings(db, deps.embeddingProvider);
-    }
-    const retrievedKnown = deps.embeddingProvider
-      ? await retrieveNameDedupCandidates(db, deps.embeddingProvider, projectProductMentionNames(extraction.mentions))
-      : [];
-    const widenedKnown = mergeKnownEntities(deps.knownEntities ?? [], retrievedKnown);
-    const rejectedKnownMatchPairs = await listRejectedKnownMatchPairs(db, widenedKnown);
-    const canonicalRewriteMap = await adjudicateKnownMatches(generator, extraction.mentions, widenedKnown, {
-      fileId: file.id,
-      debugDumpDir: deps.debugDumpDir,
-      logger,
-      rejectedKnownMatchPairs,
-    });
-    resolveKnownMatches(extraction.mentions, widenedKnown);
-    applyCanonicalRewriteMap(extraction, canonicalRewriteMap);
+  if (deps.embeddingProvider) {
+    await reconcileMissingNameEmbeddings(db, deps.embeddingProvider);
   }
+  const retrievedKnown = deps.embeddingProvider
+    ? await retrieveNameDedupCandidates(db, deps.embeddingProvider, projectProductMentionNames(extraction.mentions))
+    : [];
+  const widenedKnown = mergeKnownEntities(deps.knownEntities ?? [], retrievedKnown);
+  const rejectedKnownMatchPairs = await listRejectedKnownMatchPairs(db, widenedKnown);
+  const canonicalRewriteMap = await adjudicateKnownMatches(generator, extraction.mentions, widenedKnown, {
+    fileId: file.id,
+    debugDumpDir: deps.debugDumpDir,
+    logger,
+    rejectedKnownMatchPairs,
+  });
+  resolveKnownMatches(extraction.mentions, widenedKnown);
+  applyCanonicalRewriteMap(extraction, canonicalRewriteMap);
 
   await deps.ensureFresh?.();
   const writtenLlmFactKeys = await reconcileLlmExtractionFacts(deps, file, extraction, validExtractionTypes);
@@ -1171,9 +1157,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
     throw err;
   }
 
-  const matchableMentions = deps.experimentalFlag
-    ? extraction.mentions.filter((mention) => !isFeatureMention(mention))
-    : extraction.mentions;
+  const matchableMentions = extraction.mentions.filter((mention) => !isFeatureMention(mention));
   const { matched, unmatched } = await matchEntities(db, matchableMentions);
   const allMatched = matched.map((m) => m.entity);
   logger.debug(
@@ -1330,7 +1314,7 @@ async function reconcileLlmExtractionFacts(
     for (const rawMention of extraction.mentions) {
       const mention = {
         ...rawMention,
-        type: coerceMentionType(rawMention.mention, rawMention.type, deps.experimentalFlag),
+        type: coerceMentionType(rawMention.mention, rawMention.type),
       };
       if (!allowedTypes.has(mention.type)) {
         deps.logger.info(
@@ -1368,7 +1352,6 @@ async function reconcileLlmExtractionFacts(
         fileContent: file.content,
         resolutionContext: file.threadContext,
         source: "llm_extraction",
-        experimentalFlag: deps.experimentalFlag,
       });
       if (!validation.ok) {
         deps.logger.info(
@@ -1404,7 +1387,6 @@ async function reconcileLlmExtractionFacts(
         const corroborationKey = buildLlmFeatureCorroborationKey(mention.mention, parentProductName);
         await deps.ensureFresh?.();
         const result = await upsertFeatureFact(db, {
-          experimentalFlag: deps.experimentalFlag,
           indexedFileId: file.id,
           connectorConfigId: file.connectorConfigId,
           createdByUserId: owner?.created_by ?? null,
@@ -1464,7 +1446,6 @@ async function reconcileLlmExtractionFacts(
         contentHash,
         relation,
         mentions: extraction.mentions,
-        experimentalFlag: deps.experimentalFlag,
         allowedTypes,
       });
       if (!input) continue;
@@ -1500,7 +1481,7 @@ async function reconcileLlmExtractionFacts(
     ]);
     await cleanupEmptyRelationships(db);
     if (featureCorroborationKeys.length > 0) {
-      materializeDeps ??= await buildMaterializeDeps(db, { experimentalFlag: deps.experimentalFlag });
+      materializeDeps ??= await buildMaterializeDeps(db);
       for (const corroborationKey of featureCorroborationKeys) {
         await reconcileFeatureSubEntity(materializeDeps, corroborationKey);
       }
@@ -1516,7 +1497,6 @@ async function reconcileLlmExtractionFacts(
 
     await deps.ensureFresh?.();
     await materializeUnmaterializedFacts(db, deps.logger, {
-      experimentalFlag: deps.experimentalFlag,
       embeddingProvider: deps.embeddingProvider,
     });
     return writtenFactKeys;
@@ -1617,7 +1597,7 @@ async function tombstoneWrittenLlmFacts(deps: SmartEnrichmentDeps, factKeys: str
     .where("confidence", "!=", "EXTRACTED")
     .execute();
   if (featureCorroborationKeys.length > 0) {
-    const materializeDeps = await buildMaterializeDeps(deps.db, { experimentalFlag: deps.experimentalFlag });
+    const materializeDeps = await buildMaterializeDeps(deps.db);
     for (const corroborationKey of featureCorroborationKeys) {
       await reconcileFeatureSubEntity(materializeDeps, corroborationKey);
     }
@@ -1646,7 +1626,6 @@ function buildRelationFactInput(input: {
   contentHash: string;
   relation: ExtractedRelation;
   mentions: ExtractedMention[];
-  experimentalFlag?: boolean;
   allowedTypes: Set<string>;
 }): UpsertIndexedFileFactInput | null {
   const relationType = normalizeRelationType(input.relation.type);
@@ -1654,12 +1633,8 @@ function buildRelationFactInput(input: {
   const sourceName = input.relation.source.name?.trim();
   const targetName = input.relation.target.name?.trim();
   if (!sourceName || !targetName) return null;
-  const sourceType = normalizeMentionType(
-    coerceMentionType(sourceName, input.relation.source.type, input.experimentalFlag),
-  );
-  const targetType = normalizeMentionType(
-    coerceMentionType(targetName, input.relation.target.type, input.experimentalFlag),
-  );
+  const sourceType = normalizeMentionType(coerceMentionType(sourceName, input.relation.source.type));
+  const targetType = normalizeMentionType(coerceMentionType(targetName, input.relation.target.type));
   if (!sourceType || !targetType) return null;
   if (!normalizeRelationEndpointType(sourceType) || !normalizeRelationEndpointType(targetType)) return null;
   if (!input.allowedTypes.has(sourceType) || !input.allowedTypes.has(targetType)) {

--- a/packages/server/src/connectors/sync-facts.test.ts
+++ b/packages/server/src/connectors/sync-facts.test.ts
@@ -183,7 +183,6 @@ describe("emitFactsForSyncedItem", () => {
   it("keeps unchanged LLM task facts seen in the current sync run", async () => {
     const factRepo = createIndexedFileFactRepository(db);
     await upsertLlmTaskFact(db, {
-      experimentalFlag: true,
       indexedFileId: "file-1",
       connectorConfigId: "connector-1",
       createdByUserId: "user-1",
@@ -212,7 +211,6 @@ describe("emitFactsForSyncedItem", () => {
       },
       item: baseItem,
       indexedFileId: "file-1",
-      experimentalFlag: true,
       contentChanged: false,
     });
 

--- a/packages/server/src/connectors/sync-facts.ts
+++ b/packages/server/src/connectors/sync-facts.ts
@@ -25,7 +25,6 @@ interface EmitFactsForSyncedItemParams {
   item: SyncedItem;
   indexedFileId: string;
   emitCorrespondentFacts?: boolean;
-  experimentalFlag?: boolean;
   contentChanged?: boolean;
   generator?: GeminiGenerator;
 }
@@ -39,7 +38,6 @@ export async function emitFactsForSyncedItem({
   item,
   indexedFileId,
   emitCorrespondentFacts = false,
-  experimentalFlag = false,
   contentChanged = false,
   generator,
 }: EmitFactsForSyncedItemParams): Promise<void> {
@@ -204,7 +202,7 @@ export async function emitFactsForSyncedItem({
     }
   }
 
-  if (experimentalFlag && item.task) {
+  if (item.task) {
     await factRepo.upsertFact({
       ...factContext,
       indexedFileId,
@@ -223,7 +221,6 @@ export async function emitFactsForSyncedItem({
   if (item.commitments && item.commitments.length > 0 && db) {
     for (const commitment of item.commitments) {
       await upsertCommitmentFact(db, {
-        experimentalFlag,
         indexedFileId,
         connectorConfigId: factContext.connectorConfigId,
         createdByUserId: factContext.createdByUserId,
@@ -244,7 +241,6 @@ export async function emitFactsForSyncedItem({
 
   if (item.decisions && db) {
     await upsertDecisionFactsForFile(db, {
-      experimentalFlag,
       indexedFileId,
       connectorConfigId: factContext.connectorConfigId,
       createdByUserId: factContext.createdByUserId,
@@ -275,7 +271,7 @@ export async function emitFactsForSyncedItem({
           item.parentEntities?.map((parent) => ({ source: parent.source, sourceId: parent.sourceId })) ?? [],
         ),
       },
-      { experimentalFlag, contentChanged, generator },
+      { contentChanged, generator },
     );
   }
 

--- a/packages/server/src/connectors/sync.isolated.test.ts
+++ b/packages/server/src/connectors/sync.isolated.test.ts
@@ -1530,7 +1530,7 @@ describe("runConnectorSync — ACL sync on unchanged items", () => {
       .selectFrom("entity_mentions")
       .select(db.fn.countAll<number>().as("count"))
       .executeTakeFirstOrThrow();
-    expect(Number(mentionsBefore.count)).toBe(100);
+    expect(Number(mentionsBefore.count)).toBe(10);
 
     async function* mockGen() {
       yield {
@@ -1591,7 +1591,7 @@ describe("runConnectorSync — ACL sync on unchanged items", () => {
       .selectFrom("entity_mentions")
       .select(db.fn.countAll<number>().as("count"))
       .executeTakeFirstOrThrow();
-    expect(Number(mentionsAfter.count)).toBe(100);
+    expect(Number(mentionsAfter.count)).toBe(10);
   });
 
   it("force override processes the large reconcile and tombstones facts", async () => {

--- a/packages/server/src/connectors/sync.isolated.test.ts
+++ b/packages/server/src/connectors/sync.isolated.test.ts
@@ -1530,7 +1530,7 @@ describe("runConnectorSync — ACL sync on unchanged items", () => {
       .selectFrom("entity_mentions")
       .select(db.fn.countAll<number>().as("count"))
       .executeTakeFirstOrThrow();
-    expect(Number(mentionsBefore.count)).toBe(10);
+    expect(Number(mentionsBefore.count)).toBe(100);
 
     async function* mockGen() {
       yield {
@@ -1591,7 +1591,7 @@ describe("runConnectorSync — ACL sync on unchanged items", () => {
       .selectFrom("entity_mentions")
       .select(db.fn.countAll<number>().as("count"))
       .executeTakeFirstOrThrow();
-    expect(Number(mentionsAfter.count)).toBe(10);
+    expect(Number(mentionsAfter.count)).toBe(100);
   });
 
   it("force override processes the large reconcile and tombstones facts", async () => {

--- a/packages/server/src/connectors/sync.ts
+++ b/packages/server/src/connectors/sync.ts
@@ -130,7 +130,6 @@ export async function runConnectorSync(
       | "MICROSOFT_CLIENT_ID"
       | "MICROSOFT_CLIENT_SECRET"
       | "MICROSOFT_TENANT"
-      | "EXPERIMENTAL_FLAG"
     >
   >,
 ): Promise<SyncResult> {
@@ -258,7 +257,6 @@ export async function runConnectorSync(
       logger: syncLogger,
       ownerEmail,
       resolveNameToEmail,
-      experimentalFlag: appConfig?.EXPERIMENTAL_FLAG ?? false,
       onEntitySeed: async (seed) => {
         await factRepo.upsertFact({
           ...factContext,
@@ -337,7 +335,6 @@ export async function runConnectorSync(
           item,
           indexedFileId: itemResult.indexedFileId,
           emitCorrespondentFacts: connector.emitsCorrespondentFacts ?? false,
-          experimentalFlag: appConfig?.EXPERIMENTAL_FLAG ?? false,
           contentChanged: itemResult.kind !== "unchanged",
           generator: llmTaskGenerator,
         });
@@ -400,7 +397,6 @@ export async function runConnectorSync(
       source: connectorType,
       syncRunId,
       connectorConfigId: config.id,
-      experimentalFlag: appConfig?.EXPERIMENTAL_FLAG ?? false,
       runCycleReconcile: syncReconciled,
     });
 
@@ -524,7 +520,6 @@ export interface SyncSchedulerDeps {
       | "CANVAS_CREDENTIAL_PRIVATE_KEY_PEM"
       | "CANVAS_CREDENTIAL_PRIVATE_KEY_PATH"
       | "CANVAS_CREDENTIAL_PUBLIC_KEY_ID"
-      | "EXPERIMENTAL_FLAG"
       | "OUTLOOK_INITIAL_LOOKBACK_DAYS"
       | "OUTLOOK_MAX_INFLIGHT"
       | "TEAMS_INITIAL_LOOKBACK_DAYS"
@@ -682,7 +677,6 @@ export async function runScheduledEnrichment(db: Kysely<DB>, logger: Logger, dep
       geminiApiKey: settings?.gemini_api_key,
       geminiMaxRpm: deps?.appConfig?.GEMINI_MAX_RPM,
       geminiMaxRetries: deps?.appConfig?.GEMINI_MAX_RETRIES,
-      experimentalFlag: deps?.appConfig?.EXPERIMENTAL_FLAG,
       downloadImage: deps?.downloadImage,
       maxFilesPerRun: SCHEDULED_ENRICHMENT_MAX_FILES_PER_RUN,
       timeBudgetMs: SCHEDULED_ENRICHMENT_TIME_BUDGET_MS,

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -469,7 +469,6 @@ export interface Connector {
      * Optional — connectors that don't need it leave it unset.
      */
     resolveNameToEmail?: NameResolver;
-    experimentalFlag?: boolean;
     onEntitySeed?: EntitySeedCallback;
     onPersonSeed?: PersonEntitySeedCallback;
     onEmailSuppressed?: (record: SuppressedEmailRecord) => Promise<void>;

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -60,7 +60,10 @@ export async function createDatabase(config: Config): Promise<Kysely<DB>> {
      * chunk/file tables keep the default L2 metric — their score is only a soft
      * ranking signal blended with FTS, so changing it would shift existing search.
      */
-    const COSINE_TABLES = new Set<keyof typeof PK_BY_TABLE>(["entity_name_embeddings", "entity_review_queue_embeddings"]);
+    const COSINE_TABLES = new Set<keyof typeof PK_BY_TABLE>([
+      "entity_name_embeddings",
+      "entity_review_queue_embeddings",
+    ]);
 
     for (const table of Object.keys(PK_BY_TABLE) as Array<keyof typeof PK_BY_TABLE>) {
       const pk = PK_BY_TABLE[table];

--- a/packages/server/src/db/repositories/commitments.integration.test.ts
+++ b/packages/server/src/db/repositories/commitments.integration.test.ts
@@ -57,7 +57,6 @@ describe("commitment sub-entities postgres", () => {
       const project = await seedProject(freshDb, { id: "commitment-pg-project", name: "Commitment PG Project" });
 
       await upsertCommitmentFact(freshDb, {
-        experimentalFlag: true,
         connectorConfigId: CONNECTOR_ID,
         createdByUserId: USER_ID,
         lastSeenSyncRunId: "sync-1",
@@ -68,11 +67,10 @@ describe("commitment sub-entities postgres", () => {
         status: "open",
         evidence: { fileIds: [], entityIds: [project.id] },
       });
-      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), {});
       await expect(markCommitmentDone(freshDb, "pg-survives")).resolves.toBe(true);
 
       await upsertCommitmentFact(freshDb, {
-        experimentalFlag: true,
         connectorConfigId: CONNECTOR_ID,
         createdByUserId: USER_ID,
         lastSeenSyncRunId: "sync-2",
@@ -87,7 +85,7 @@ describe("commitment sub-entities postgres", () => {
         { kind: "connector", connectorConfigId: CONNECTOR_ID, syncRunId: "sync-2" },
         null,
       );
-      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), {});
 
       const rows = await freshDb
         .selectFrom("sub_entities")
@@ -100,7 +98,6 @@ describe("commitment sub-entities postgres", () => {
       expect(rows[0]).toMatchObject({ status: "done", status_authority: "local", parent_scope_key: project.id });
 
       await upsertCommitmentFact(freshDb, {
-        experimentalFlag: true,
         connectorConfigId: CONNECTOR_ID,
         createdByUserId: USER_ID,
         lastSeenSyncRunId: "sync-3",
@@ -111,9 +108,8 @@ describe("commitment sub-entities postgres", () => {
         status: "open",
         evidence: { fileIds: [], entityIds: [project.id] },
       });
-      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), {});
       await upsertCommitmentFact(freshDb, {
-        experimentalFlag: true,
         connectorConfigId: CONNECTOR_ID,
         createdByUserId: USER_ID,
         lastSeenSyncRunId: "sync-4",
@@ -124,7 +120,7 @@ describe("commitment sub-entities postgres", () => {
         status: "dropped",
         evidence: { fileIds: [], entityIds: [project.id] },
       });
-      await materializeUnmaterializedFacts(freshDb, createTestLogger(), { experimentalFlag: true });
+      await materializeUnmaterializedFacts(freshDb, createTestLogger(), {});
       const external = await freshDb
         .selectFrom("sub_entities")
         .selectAll()
@@ -159,7 +155,6 @@ async function seedBase(db: Kysely<DB>): Promise<void> {
 
 async function seedCommitment(db: Kysely<DB>, commitmentId: string): Promise<void> {
   await upsertCommitmentFact(db, {
-    experimentalFlag: true,
     connectorConfigId: CONNECTOR_ID,
     createdByUserId: USER_ID,
     lastSeenSyncRunId: "sync-prior",

--- a/packages/server/src/db/repositories/commitments.test.ts
+++ b/packages/server/src/db/repositories/commitments.test.ts
@@ -1,6 +1,6 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildMaterializeDeps, materializeFromFact, materializeUnmaterializedFacts } from "../../entities/materialize";
+import { materializeUnmaterializedFacts } from "../../entities/materialize";
 import { createTestDb, createTestLogger } from "../../test-utils";
 import type { DB } from "../schema";
 import { listOpenCommitments, markCommitmentDone, upsertCommitmentFact } from "./commitments";
@@ -29,21 +29,6 @@ describe("commitment sub-entities", () => {
     await seedProject(db, { id: TEST_ACCOUNT_ENTITY_ID, name: "Test Account" });
 
     await upsertCommitmentFact(db, {
-      experimentalFlag: false,
-      connectorConfigId: CONNECTOR_ID,
-      createdByUserId: USER_ID,
-      lastSeenSyncRunId: "sync-off",
-      source: "linear",
-      commitmentId: "flag-off",
-      parentRef: { source: "linear", sourceId: `${project.id}-source` },
-      title: "Flag-off commitment",
-      evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
-    });
-    expect(await countRows(db, "indexed_file_facts", "commitment")).toBe(0);
-    expect(await countRows(db, "sub_entities", "commitment")).toBe(0);
-
-    await upsertCommitmentFact(db, {
-      experimentalFlag: true,
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
       lastSeenSyncRunId: "sync-1",
@@ -55,16 +40,7 @@ describe("commitment sub-entities", () => {
       dueAt: "2026-07-01T00:00:00.000Z",
       evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
     });
-    const fact = await db
-      .selectFrom("indexed_file_facts")
-      .selectAll()
-      .where("subject_source_id", "=", "commitment-1")
-      .executeTakeFirstOrThrow();
-    const offResult = await materializeFromFact(await buildMaterializeDeps(db, { experimentalFlag: false }), fact);
-    expect(offResult).toEqual({ kind: "skipped", reason: "experimental_off" });
-    expect(await countRows(db, "sub_entities", "commitment")).toBe(0);
-
-    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    const summary = await materializeUnmaterializedFacts(db, createTestLogger(), {});
     expect(summary).toMatchObject({
       factsRead: 1,
       entitiesCreated: 0,
@@ -90,6 +66,11 @@ describe("commitment sub-entities", () => {
       created_by_user_id: USER_ID,
     });
     expect(row?.valid_to).toBeNull();
+    const fact = await db
+      .selectFrom("indexed_file_facts")
+      .select("id")
+      .where("subject_source_id", "=", "commitment-1")
+      .executeTakeFirstOrThrow();
     const rawAfterMaterialize = JSON.parse(
       (await db.selectFrom("indexed_file_facts").select("raw").where("id", "=", fact.id).executeTakeFirstOrThrow())
         .raw ?? "{}",
@@ -105,7 +86,6 @@ describe("commitment sub-entities", () => {
     expect(row).toMatchObject({ status: "done", status_authority: "local" });
 
     await upsertCommitmentFact(db, {
-      experimentalFlag: true,
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
       lastSeenSyncRunId: "sync-2",
@@ -121,7 +101,7 @@ describe("commitment sub-entities", () => {
       { kind: "connector", connectorConfigId: CONNECTOR_ID, syncRunId: "sync-2" },
       null,
     );
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     row = await currentCommitmentRow(db, "Send the follow-up");
     expect(row).toMatchObject({ status: "done", status_authority: "local", valid_to: null });
     const rawAfterDone = JSON.parse(
@@ -136,7 +116,6 @@ describe("commitment sub-entities", () => {
     expect(rawAfterDone.status).toBe("open");
 
     await upsertCommitmentFact(db, {
-      experimentalFlag: true,
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
       lastSeenSyncRunId: "sync-3",
@@ -147,9 +126,8 @@ describe("commitment sub-entities", () => {
       status: "open",
       evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     await upsertCommitmentFact(db, {
-      experimentalFlag: true,
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
       lastSeenSyncRunId: "sync-4",
@@ -160,7 +138,7 @@ describe("commitment sub-entities", () => {
       status: "dropped",
       evidence: { fileIds: ["commitment-file-1"], entityIds: [project.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     expect(await currentCommitmentRow(db, "Update the rollout note")).toMatchObject({
       status: "dropped",
       status_authority: "external",
@@ -178,7 +156,7 @@ describe("commitment sub-entities", () => {
     await seedCommitmentFact(db, "commitment-global-1", null, "Send Update");
     await seedCommitmentFact(db, "commitment-global-2", null, "send update");
 
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const rows = await db
       .selectFrom("sub_entities")
@@ -206,7 +184,7 @@ describe("commitment sub-entities", () => {
     const project = await seedProject(db, { id: "commitment-project", name: "Commitment Project" });
     await seedCommitmentFact(db, "commitment-1", project.id, "Send the follow-up");
 
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const subEntities = await createSubEntityRepository(db).listOpenSubEntities({
       parentEntityId: project.id,
@@ -309,7 +287,6 @@ async function seedCommitmentFact(
   title: string,
 ): Promise<void> {
   await upsertCommitmentFact(db, {
-    experimentalFlag: true,
     indexedFileId: "commitment-file-1",
     connectorConfigId: CONNECTOR_ID,
     createdByUserId: USER_ID,

--- a/packages/server/src/db/repositories/commitments.ts
+++ b/packages/server/src/db/repositories/commitments.ts
@@ -16,7 +16,6 @@ export interface CommitmentFactRaw extends CommitmentSeed {
 }
 
 export interface UpsertCommitmentFactInput {
-  experimentalFlag?: boolean;
   indexedFileId?: string | null;
   connectorConfigId: string;
   createdByUserId?: string | null;
@@ -65,7 +64,6 @@ export async function upsertCommitmentFact(
   const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
   const source = requireNonEmpty(input.source, "source");
   const commitmentId = requireNonEmpty(input.commitmentId, "commitmentId");
-  if (!input.experimentalFlag) return { emitted: false };
 
   await createIndexedFileFactRepository(db).upsertFact({
     indexedFileId: input.indexedFileId ?? null,

--- a/packages/server/src/db/repositories/decisions.integration.test.ts
+++ b/packages/server/src/db/repositories/decisions.integration.test.ts
@@ -28,7 +28,6 @@ describe("decision sub-entity supersession postgres", () => {
 
     await expect(
       upsertDecisionFact(db, {
-        experimentalFlag: false,
         indexedFileId: "decision-file-forward",
         connectorConfigId: CONNECTOR_ID,
         createdByUserId: USER_ID,
@@ -39,11 +38,9 @@ describe("decision sub-entity supersession postgres", () => {
         decidedAt: "2026-06-22T09:00:00.000Z",
         evidence: { fileIds: ["decision-file-forward"], entityIds: [project.id, TEST_ACCOUNT_ENTITY_ID] },
       }),
-    ).resolves.toEqual({ emitted: false });
-    expect(await countDecisionRows(db)).toBe(0);
+    ).resolves.toEqual({ emitted: true, factKey: expect.any(String), decisionId: expect.any(String) });
 
     await upsertDecisionFactsForFile(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-forward",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -58,10 +55,9 @@ describe("decision sub-entity supersession postgres", () => {
         },
       ],
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     await upsertDecisionFactsForFile(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-forward",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -76,7 +72,7 @@ describe("decision sub-entity supersession postgres", () => {
         },
       ],
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     let rows = await decisionRows(db, project.id, "pricing tier");
     expect(rows).toHaveLength(2);
@@ -93,7 +89,6 @@ describe("decision sub-entity supersession postgres", () => {
     });
 
     await upsertDecisionFactsForFile(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-forward",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -108,7 +103,7 @@ describe("decision sub-entity supersession postgres", () => {
         },
       ],
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     rows = await decisionRows(db, project.id, "pricing tier");
     expect(rows).toHaveLength(2);
@@ -122,7 +117,6 @@ describe("decision sub-entity supersession postgres", () => {
     await seedFile(db, "decision-file-order", "2026-06-22T10:00:00.000Z");
 
     await upsertDecisionFact(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-order",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -133,10 +127,9 @@ describe("decision sub-entity supersession postgres", () => {
       decidedAt: "2026-06-22T12:00:00.000Z",
       evidence: { fileIds: ["decision-file-order"], entityIds: [project.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     await upsertDecisionFact(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-order",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -147,7 +140,7 @@ describe("decision sub-entity supersession postgres", () => {
       decidedAt: "2026-06-22T10:00:00.000Z",
       evidence: { fileIds: ["decision-file-order"], entityIds: [project.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const asOf = await createSubEntityRepository(db).getSubEntitiesAsOf({
       parentEntityId: project.id,
@@ -184,7 +177,6 @@ describe("decision sub-entity supersession postgres", () => {
     await seedFile(db, "decision-file-b1", "2026-06-22T09:10:00.000Z");
 
     await upsertDecisionFact(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-a1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -196,7 +188,6 @@ describe("decision sub-entity supersession postgres", () => {
       evidence: { fileIds: ["decision-file-a1"], entityIds: [projectA.id] },
     });
     await upsertDecisionFact(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-a2",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -208,7 +199,6 @@ describe("decision sub-entity supersession postgres", () => {
       evidence: { fileIds: ["decision-file-a2"], entityIds: [projectA.id] },
     });
     await upsertDecisionFact(db, {
-      experimentalFlag: true,
       indexedFileId: "decision-file-b1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -219,7 +209,7 @@ describe("decision sub-entity supersession postgres", () => {
       decidedAt: "2026-06-22T09:10:00.000Z",
       evidence: { fileIds: ["decision-file-b1"], entityIds: [projectB.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const projectARows = await decisionRows(db, projectA.id, "support model");
     const projectBRows = await decisionRows(db, projectB.id, "support model");

--- a/packages/server/src/db/repositories/decisions.ts
+++ b/packages/server/src/db/repositories/decisions.ts
@@ -13,7 +13,6 @@ export interface DecisionFactRaw extends DecisionSeed {
 }
 
 export interface UpsertDecisionFactInput {
-  experimentalFlag?: boolean;
   indexedFileId: string;
   connectorConfigId: string;
   createdByUserId?: string | null;
@@ -34,7 +33,6 @@ export interface UpsertDecisionFactInput {
 }
 
 export interface UpsertDecisionFactsForFileInput {
-  experimentalFlag?: boolean;
   indexedFileId: string;
   connectorConfigId: string;
   createdByUserId?: string | null;
@@ -69,7 +67,6 @@ export async function upsertDecisionFact(
     input.decisionId ?? buildDecisionId(input.indexedFileId, input.topic, input.statement),
     "decisionId",
   );
-  if (!input.experimentalFlag) return { emitted: false };
 
   const raw: DecisionFactRaw = {
     decisionId,
@@ -109,11 +106,9 @@ export async function upsertDecisionFactsForFile(
   requireNonEmpty(input.connectorConfigId, "connectorConfigId");
   requireNonEmpty(input.source, "source");
   const emittedKeys = new Set<string>();
-  if (!input.experimentalFlag) return { emitted: false, factKeys: emittedKeys };
 
   for (const decision of input.decisions) {
     const result = await upsertDecisionFact(db, {
-      experimentalFlag: input.experimentalFlag,
       indexedFileId: input.indexedFileId,
       connectorConfigId: input.connectorConfigId,
       createdByUserId: input.createdByUserId,
@@ -149,9 +144,8 @@ export function buildDecisionId(indexedFileId: string, topic: string, statement:
 
 export async function listCurrentDecisions(
   db: Kysely<DB>,
-  opts: { experimentalFlag?: boolean; parentEntityId: string },
+  opts: { parentEntityId: string },
 ): Promise<CurrentDecision[]> {
-  if (!opts.experimentalFlag) return [];
   const rows = await createSubEntityRepository(db).listCurrentByKind({
     parentEntityId: opts.parentEntityId,
     kind: "decision",
@@ -161,9 +155,8 @@ export async function listCurrentDecisions(
 
 export async function getDecisionsAsOf(
   db: Kysely<DB>,
-  opts: { experimentalFlag?: boolean; parentEntityId: string; at: string },
+  opts: { parentEntityId: string; at: string },
 ): Promise<CurrentDecision[]> {
-  if (!opts.experimentalFlag) return [];
   const rows = await createSubEntityRepository(db).getSubEntitiesAsOf({
     parentEntityId: opts.parentEntityId,
     kind: "decision",

--- a/packages/server/src/db/repositories/entity-domains.test.ts
+++ b/packages/server/src/db/repositories/entity-domains.test.ts
@@ -121,6 +121,32 @@ describe("entity domains repository", () => {
     ]);
   });
 
+  it("isPersonalOrShared recognizes providers from the code constant even with no seed row", async () => {
+    db = await createTestDb();
+    const domainsRepo = createEntityDomainsRepository(db);
+    // Simulate a rebuild/purge that wiped the migration-064 personal seed.
+    await db.deleteFrom("entity_domains").execute();
+
+    expect(await domainsRepo.isPersonalOrShared("gmail.com")).toBe(true);
+    expect(await domainsRepo.isPersonalOrShared("ICLOUD.COM")).toBe(true);
+    expect(await domainsRepo.isPersonalOrShared("acme.com")).toBe(false);
+
+    // A poisoned corporate row must not flip a known provider back to false.
+    await db
+      .insertInto("entity_domains")
+      .values({
+        id: "d-poison",
+        entity_id: null,
+        domain: "gmail.com",
+        kind: "corporate",
+        is_primary: 0,
+        confidence: 0.9,
+        source: "observed",
+      })
+      .execute();
+    expect(await domainsRepo.isPersonalOrShared("gmail.com")).toBe(true);
+  });
+
   it("does not reassign manually or automatically owned domains to CRM Accounts", async () => {
     db = await createTestDb();
     await seedCompany("acme", "Acme Corp");

--- a/packages/server/src/db/repositories/entity-domains.ts
+++ b/packages/server/src/db/repositories/entity-domains.ts
@@ -3,6 +3,7 @@ import { isIP } from "node:net";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import { normalizeEntityMatchName } from "../../entities/match-normalize";
+import { isPersonalOrSharedDomain } from "../../entities/personal-domains";
 import { isPg } from "../dialect";
 import type { DB, EntitiesTable } from "../schema";
 import { whereLiveEntity } from "./entities";
@@ -271,6 +272,10 @@ export function createEntityDomainsRepository(db: Kysely<DB>) {
     normalizeWebsiteDomain,
 
     async isPersonalOrShared(domain: string): Promise<boolean> {
+      // The code constant wins over any DB row: a poisoned `corporate` row for
+      // gmail.com must never flip this to false. It also keeps the guard alive
+      // when the migration-064 seed has been cleared by a rebuild.
+      if (isPersonalOrSharedDomain(domain)) return true;
       const row = await db.selectFrom("entity_domains").select("kind").where("domain", "=", domain).executeTakeFirst();
       if (!row) return false;
       return row.kind === "personal" || row.kind === "shared";

--- a/packages/server/src/db/repositories/features.integration.test.ts
+++ b/packages/server/src/db/repositories/features.integration.test.ts
@@ -21,13 +21,43 @@ describe("feature sub-entities postgres", () => {
     db = undefined;
   });
 
+  it("materializes feature facts with default materialization dependencies", async () => {
+    db = await createTestPgDb();
+    await seedBase(db);
+    const product = await seedEntity(db, {
+      id: "feature-default-product",
+      name: "Feature Default Product",
+      type: "product",
+    });
+
+    await upsertFeatureFact(db, {
+      indexedFileId: "feature-file-1",
+      connectorConfigId: CONNECTOR_ID,
+      createdByUserId: USER_ID,
+      source: "linear",
+      featureId: "feature-default-materialize",
+      featureName: "Default Feature",
+      parentEntityId: product.id,
+      status: "building",
+      evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
+    });
+    const fact = await featureFact(db, "feature-default-materialize");
+
+    await expect(materializeFromFact(await buildMaterializeDeps(db, {}), fact)).resolves.toEqual({
+      kind: "feature_materialized",
+    });
+    await expect(featureRow(db, "default feature")).resolves.toMatchObject({
+      parent_entity_id: product.id,
+      valid_to: null,
+    });
+  }, 30000);
+
   it("materializes features under an existing product by product ref and product entity id", async () => {
     db = await createTestPgDb();
     await seedBase(db);
     const product = await seedEntity(db, { id: "feature-product-ref", name: "Feature Product", type: "product" });
 
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -41,7 +71,6 @@ describe("feature sub-entities postgres", () => {
       evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
     });
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -55,7 +84,7 @@ describe("feature sub-entities postgres", () => {
     });
 
     const beforeProducts = await countEntitiesByType(db, "product");
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     await expect(featureRow(db, "inline comments")).resolves.toMatchObject({
       kind: "feature",
@@ -96,7 +125,6 @@ describe("feature sub-entities postgres", () => {
     });
 
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -108,12 +136,11 @@ describe("feature sub-entities postgres", () => {
       status: "building",
       evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     const row = await featureRow(db, "usage dashboards");
     await expect(createSubEntityRepository(db).markSubEntityStatus(row.id, "shipped")).resolves.toBe(true);
 
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -125,7 +152,7 @@ describe("feature sub-entities postgres", () => {
       status: "deprecated",
       evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     await expect(featureRow(db, "usage dashboards")).resolves.toMatchObject({
       status: "shipped",
@@ -134,14 +161,17 @@ describe("feature sub-entities postgres", () => {
     });
   }, 30000);
 
-  it("materializes LLM features by parent name under products or projects and stays disabled when the flag is off", async () => {
+  it("materializes LLM features by parent name under products or projects", async () => {
     db = await createTestPgDb();
     await seedBase(db);
     const project = await seedEntity(db, { id: "feature-project-parent", name: "Feature Project", type: "project" });
-    const product = await seedEntity(db, { id: "feature-product-off", name: "Feature Product Off", type: "product" });
+    const product = await seedEntity(db, {
+      id: "feature-product-default",
+      name: "Feature Product Default",
+      type: "product",
+    });
 
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -162,10 +192,7 @@ describe("feature sub-entities postgres", () => {
     expect(raw.parentProductName).toBe("Feature Project");
     expect(raw.parentEntityId).toBeUndefined();
     await expect(
-      materializeFromFact(
-        await buildMaterializeDeps(db, { experimentalFlag: true, featureAutoMintThreshold: 1 }),
-        projectFact,
-      ),
+      materializeFromFact(await buildMaterializeDeps(db, { featureAutoMintThreshold: 1 }), projectFact),
     ).resolves.toEqual({ kind: "feature_materialized" });
     await expect(featureRow(db, "project by name feature")).resolves.toMatchObject({
       parent_entity_id: project.id,
@@ -175,40 +202,41 @@ describe("feature sub-entities postgres", () => {
 
     await expect(
       upsertFeatureFact(db, {
-        experimentalFlag: false,
         indexedFileId: "feature-file-1",
         connectorConfigId: CONNECTOR_ID,
         createdByUserId: USER_ID,
         source: "linear",
-        featureId: "feature-emit-off",
-        featureName: "Flag-off feature",
+        featureId: "feature-emit-default",
+        featureName: "Default emitted feature",
         parentEntityId: product.id,
         status: "building",
         evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
       }),
-    ).resolves.toEqual({ emitted: false });
+    ).resolves.toEqual({ emitted: true, factKey: expect.any(String) });
 
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
       source: "linear",
-      featureId: "feature-materialize-off",
-      featureName: "Materialize-off feature",
+      featureId: "feature-materialize-default",
+      featureName: "Default materialized feature",
       parentEntityId: product.id,
       status: "building",
       evidence: { fileIds: ["feature-file-1"], entityIds: [product.id] },
     });
-    const flagOffFact = await db
+    const directFact = await db
       .selectFrom("indexed_file_facts")
       .selectAll()
-      .where("subject_source_id", "=", "feature-materialize-off")
+      .where("subject_source_id", "=", "feature-materialize-default")
       .executeTakeFirstOrThrow();
-    await expect(
-      materializeFromFact(await buildMaterializeDeps(db, { experimentalFlag: false }), flagOffFact),
-    ).resolves.toEqual({ kind: "skipped", reason: "experimental_off" });
-    await expect(countFeatureRows(db)).resolves.toBe(1);
+    await expect(materializeFromFact(await buildMaterializeDeps(db, {}), directFact)).resolves.toEqual({
+      kind: "feature_materialized",
+    });
+    await expect(featureRow(db, "default materialized feature")).resolves.toMatchObject({
+      parent_entity_id: product.id,
+      valid_to: null,
+    });
   }, 30000);
 
   it("defers LLM features until parent approval and rejects inferred or ambiguous parents", async () => {
@@ -216,7 +244,6 @@ describe("feature sub-entities postgres", () => {
     await seedBase(db);
 
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -230,10 +257,7 @@ describe("feature sub-entities postgres", () => {
     });
     const deferredFact = await featureFact(db, "feature-defer-product");
     await expect(
-      materializeFromFact(
-        await buildMaterializeDeps(db, { experimentalFlag: true, featureAutoMintThreshold: 1 }),
-        deferredFact,
-      ),
+      materializeFromFact(await buildMaterializeDeps(db, { featureAutoMintThreshold: 1 }), deferredFact),
     ).resolves.toEqual({ kind: "deferred_below_threshold", reason: "feature_parent_absent" });
     await expect(countFeatureRows(db)).resolves.toBe(0);
     await expect(db.selectFrom("entity_mentions").selectAll().execute()).resolves.toEqual([]);
@@ -251,7 +275,6 @@ describe("feature sub-entities postgres", () => {
       provenanceTier: "human_confirmed",
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       featureAutoMintThreshold: 1,
       factTypes: ["feature"],
     });
@@ -268,7 +291,6 @@ describe("feature sub-entities postgres", () => {
       provenanceTier: "structural",
     });
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -281,7 +303,6 @@ describe("feature sub-entities postgres", () => {
       evidence: { fileIds: ["feature-file-1"], entityIds: [] },
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       featureAutoMintThreshold: 1,
       factTypes: ["feature"],
     });
@@ -298,7 +319,6 @@ describe("feature sub-entities postgres", () => {
       provenanceTier: "inferred",
     });
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -312,7 +332,7 @@ describe("feature sub-entities postgres", () => {
     });
     await expect(
       materializeFromFact(
-        await buildMaterializeDeps(db, { experimentalFlag: true, featureAutoMintThreshold: 1 }),
+        await buildMaterializeDeps(db, { featureAutoMintThreshold: 1 }),
         await featureFact(db, "feature-inferred-product"),
       ),
     ).resolves.toEqual({ kind: "deferred_below_threshold", reason: "feature_parent_absent" });
@@ -333,7 +353,6 @@ describe("feature sub-entities postgres", () => {
       provenanceTier: "structural",
     });
     await upsertFeatureFact(db, {
-      experimentalFlag: true,
       indexedFileId: "feature-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -347,7 +366,7 @@ describe("feature sub-entities postgres", () => {
     });
     await expect(
       materializeFromFact(
-        await buildMaterializeDeps(db, { experimentalFlag: true, featureAutoMintThreshold: 1 }),
+        await buildMaterializeDeps(db, { featureAutoMintThreshold: 1 }),
         await featureFact(db, "feature-ambiguous-parent"),
       ),
     ).resolves.toEqual({ kind: "deferred_below_threshold", reason: "feature_parent_absent" });
@@ -363,7 +382,7 @@ describe("feature sub-entities postgres", () => {
     const person = await seedEntity(db, { id: "resolver-person", name: "Resolver Person", type: "person" });
     const product = await seedEntity(db, { id: "resolver-product", name: "Resolver Product", type: "product" });
     const team = await seedEntity(db, { id: "resolver-team", name: "Resolver Team", type: "team" });
-    const deps = await buildMaterializeDeps(db, { experimentalFlag: true });
+    const deps = await buildMaterializeDeps(db, {});
 
     expect(resolveParent(deps, resolverInput(project.id), ["project", "person"])?.id).toBe(project.id);
     expect(resolveParent(deps, resolverInput(person.id), ["project", "person"])?.id).toBe(person.id);

--- a/packages/server/src/db/repositories/features.ts
+++ b/packages/server/src/db/repositories/features.ts
@@ -6,7 +6,6 @@ import { buildIndexedFileFactKey, createIndexedFileFactRepository } from "./inde
 export type FeatureStatus = "proposed" | "building" | "shipped" | "deprecated";
 
 export interface UpsertFeatureFactInput {
-  experimentalFlag?: boolean;
   indexedFileId?: string | null;
   connectorConfigId: string;
   createdByUserId?: string | null;
@@ -35,7 +34,6 @@ export async function upsertFeatureFact(
   const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
   const source = requireNonEmpty(input.source, "source");
   const featureId = requireNonEmpty(input.featureId, "featureId");
-  if (!input.experimentalFlag) return { emitted: false };
 
   const factInput = {
     indexedFileId: input.indexedFileId ?? null,

--- a/packages/server/src/db/repositories/indexed-file-facts.ts
+++ b/packages/server/src/db/repositories/indexed-file-facts.ts
@@ -532,7 +532,6 @@ function validateRaw(input: UpsertIndexedFileFactInput): string | null {
 }
 
 export interface UpsertLlmTaskFactInput {
-  experimentalFlag?: boolean;
   indexedFileId: string;
   connectorConfigId: string;
   createdByUserId?: string | null;
@@ -558,7 +557,6 @@ export async function upsertLlmTaskFact(
     input.candidateId ?? buildLlmTaskCandidateId(input.indexedFileId, input.candidate.title),
     "candidateId",
   );
-  if (!input.experimentalFlag) return { emitted: false };
 
   const raw: LlmTaskFactRaw = {
     candidateId,

--- a/packages/server/src/db/repositories/milestones.integration.test.ts
+++ b/packages/server/src/db/repositories/milestones.integration.test.ts
@@ -27,7 +27,6 @@ describe("milestone sub-entity supersession postgres", () => {
     await seedFile(db, "milestone-file-slip-2", "2026-06-15T09:00:00.000Z");
 
     await upsertMilestoneFact(db, {
-      experimentalFlag: true,
       indexedFileId: "milestone-file-slip-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -40,10 +39,9 @@ describe("milestone sub-entity supersession postgres", () => {
       observedAt: "2026-06-01T09:00:00.000Z",
       evidence: { fileIds: ["milestone-file-slip-1"], entityIds: [project.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     await upsertMilestoneFact(db, {
-      experimentalFlag: true,
       indexedFileId: "milestone-file-slip-2",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: USER_ID,
@@ -56,7 +54,7 @@ describe("milestone sub-entity supersession postgres", () => {
       observedAt: "2026-06-15T09:00:00.000Z",
       evidence: { fileIds: ["milestone-file-slip-2"], entityIds: [project.id] },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const rows = await milestoneRows(db, project.id, "public beta");
     expect(rows).toHaveLength(2);
@@ -270,7 +268,6 @@ async function emitMilestone(
   input: { fileId: string; status: "planned" | "hit" | "missed"; dueAt: string; observedAt: string },
 ): Promise<void> {
   await upsertMilestoneFact(db, {
-    experimentalFlag: true,
     indexedFileId: input.fileId,
     connectorConfigId: CONNECTOR_ID,
     createdByUserId: USER_ID,
@@ -283,7 +280,7 @@ async function emitMilestone(
     observedAt: input.observedAt,
     evidence: { fileIds: [input.fileId], entityIds: [projectId] },
   });
-  await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+  await materializeUnmaterializedFacts(db, createTestLogger(), {});
 }
 
 async function milestoneRows(db: Kysely<DB>, parentEntityId: string, normalizedName: string) {

--- a/packages/server/src/db/repositories/milestones.ts
+++ b/packages/server/src/db/repositories/milestones.ts
@@ -7,7 +7,6 @@ import { type SubEntityRow, createSubEntityRepository } from "./sub-entities";
 export type MilestoneStatus = "planned" | "hit" | "missed";
 
 export interface UpsertMilestoneFactInput {
-  experimentalFlag?: boolean;
   indexedFileId?: string | null;
   connectorConfigId: string;
   createdByUserId?: string | null;
@@ -32,7 +31,6 @@ export async function upsertMilestoneFact(
   const connectorConfigId = requireNonEmpty(input.connectorConfigId, "connectorConfigId");
   const source = requireNonEmpty(input.source, "source");
   const milestoneId = requireNonEmpty(input.milestoneId, "milestoneId");
-  if (!input.experimentalFlag) return { emitted: false };
 
   await createIndexedFileFactRepository(db).upsertFact({
     indexedFileId: input.indexedFileId ?? null,
@@ -52,11 +50,7 @@ export async function upsertMilestoneFact(
   return { emitted: true };
 }
 
-export async function listCurrentMilestones(
-  db: Kysely<DB>,
-  opts: { experimentalFlag?: boolean; parentEntityId: string },
-): Promise<SubEntityRow[]> {
-  if (!opts.experimentalFlag) return [];
+export async function listCurrentMilestones(db: Kysely<DB>, opts: { parentEntityId: string }): Promise<SubEntityRow[]> {
   return createSubEntityRepository(db).listCurrentByKind({
     parentEntityId: opts.parentEntityId,
     kind: "milestone",

--- a/packages/server/src/db/repositories/tasks.integration.test.ts
+++ b/packages/server/src/db/repositories/tasks.integration.test.ts
@@ -151,7 +151,6 @@ describe("createTaskRepository postgres", () => {
       corroborationKey: "send pricing deck|global",
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
 
@@ -200,7 +199,6 @@ describe("createTaskRepository postgres", () => {
       entityIds: ["pg-llm-project"],
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
 
@@ -313,7 +311,6 @@ async function seedPgLlmFact(input: {
   entityIds?: string[];
 }): Promise<void> {
   await upsertLlmTaskFact(input.db, {
-    experimentalFlag: true,
     indexedFileId: input.fileId,
     connectorConfigId: input.connectorConfigId,
     createdByUserId: input.ownerUserId,

--- a/packages/server/src/db/repositories/work-cycles.integration.test.ts
+++ b/packages/server/src/db/repositories/work-cycles.integration.test.ts
@@ -19,7 +19,7 @@ describe("work cycle sink postgres", () => {
     db = undefined;
   });
 
-  it("promotes sprint cycles only when flagged and preserves task materialization for non-sprints", async () => {
+  it("promotes sprint cycles and preserves task materialization for non-sprints", async () => {
     db = await createTestPgDb();
     await seedBase(db);
     const scope = await seedProject(db, {
@@ -27,10 +27,10 @@ describe("work cycle sink postgres", () => {
       name: "Work Cycle Scope",
       sourceId: "scope-folder",
     });
-    await seedFile(db, "work-cycle-file-flag");
+    await seedFile(db, "work-cycle-file-sprint");
 
     await emitStructuralTaskFact(db, {
-      fileId: "work-cycle-file-flag",
+      fileId: "work-cycle-file-sprint",
       sourceTaskId: "work-cycle-task-sprint",
       title: "Finish sprint scope",
       cycle: {
@@ -42,25 +42,7 @@ describe("work cycle sink postgres", () => {
       },
       syncRunId: "sync-1",
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: false });
-    expect(await tableCount(db, "tasks")).toBe(0);
-    expect(await tableCount(db, "work_cycles")).toBe(0);
-    expect(await tableCount(db, "task_cycle_memberships")).toBe(0);
-
-    await emitStructuralTaskFact(db, {
-      fileId: "work-cycle-file-flag",
-      sourceTaskId: "work-cycle-task-sprint",
-      title: "Finish sprint scope",
-      cycle: {
-        source: "linear",
-        externalRef: "sprint-23",
-        name: "Sprint 23",
-        scopeRef: { source: "linear", sourceId: "scope-folder" },
-        isSprint: true,
-      },
-      syncRunId: "sync-1",
-    });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const cycle = await db.selectFrom("work_cycles").selectAll().executeTakeFirstOrThrow();
     expect(cycle).toMatchObject({
@@ -78,7 +60,7 @@ describe("work cycle sink postgres", () => {
     expect(await openMembershipCount(db, "work-cycle-task-sprint")).toBe(1);
 
     await emitStructuralTaskFact(db, {
-      fileId: "work-cycle-file-flag",
+      fileId: "work-cycle-file-sprint",
       sourceTaskId: "work-cycle-task-sprint",
       title: "Finish sprint scope",
       cycle: {
@@ -90,7 +72,7 @@ describe("work cycle sink postgres", () => {
       },
       syncRunId: "sync-1",
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     expect(await tableCount(db, "work_cycles")).toBe(1);
     expect(await openMembershipCount(db, "work-cycle-task-sprint")).toBe(1);
 
@@ -108,7 +90,7 @@ describe("work cycle sink postgres", () => {
       },
       syncRunId: "sync-1",
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     const nonSprintTask = await db
       .selectFrom("tasks")
       .select(["title", "source_task_id", "status"])

--- a/packages/server/src/entities/affiliations.test.ts
+++ b/packages/server/src/entities/affiliations.test.ts
@@ -1,6 +1,6 @@
 /**
- * ELP-02 affiliation inference — three load-bearing tests covering distinct
- * failure modes:
+ * ELP-02 affiliation inference — load-bearing tests covering distinct failure
+ * modes:
  *
  * 1. Personal/shared seed domains block `works_at` inference. If this breaks,
  *    we silently declare "57 people work at gmail.com".
@@ -10,6 +10,10 @@
  * 3. Recreate (reset → replay → sweep) rebuilds the same `works_at` edges
  *    that live sync produces. If this breaks, recreate silently loses
  *    affiliation data and recreate parity is no longer a reliable backfill.
+ *
+ * Plus code-constant guard tests: the personal-provider guard must hold even
+ * when the migration-064 domain seed has been wiped by a rebuild, and the
+ * promotion sweep must refuse a personal-provider candidate outright.
  */
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -138,6 +142,72 @@ describe("ELP-02: affiliation inference", () => {
       .executeTakeFirst();
     expect(gmailRow?.kind).toBe("personal");
     expect(gmailRow?.entity_id).toBeNull();
+  });
+
+  it("blocks personal-provider affiliation even when the domain seed is wiped (code-constant guard)", async () => {
+    const domainsRepo = createEntityDomainsRepository(db);
+    const entityRepo = createEntityRepository(db);
+    // Simulate a rebuild/purge that dropped the migration-064 personal seed.
+    // The code constant must still recognize gmail.com as a personal provider.
+    await db.deleteFrom("entity_domains").execute();
+    const fileId = await seedFile(db, "f-wiped");
+    const person = await entityRepo.upsertPersonEntity({
+      name: "Casey Consumer",
+      email: "casey@gmail.com",
+      subtype: "external",
+      source: "fireflies",
+      sourceId: "person-gmail-wiped",
+    });
+
+    await inferAffiliationFromEmail(
+      { db, domainsRepo },
+      { personEntityId: person.id, email: "casey@gmail.com", evidenceFileId: fileId },
+    );
+
+    const observations = await db
+      .selectFrom("entity_candidates")
+      .selectAll()
+      .where("type", "=", "domain_observation")
+      .execute();
+    expect(observations).toHaveLength(0);
+    const rels = await db.selectFrom("entity_relationships").selectAll().execute();
+    expect(rels).toHaveLength(0);
+  });
+
+  it("domain-promotion sweep refuses to mint a company for a personal provider (backstop)", async () => {
+    const domainsRepo = createEntityDomainsRepository(db);
+    const entityRepo = createEntityRepository(db);
+    await db.deleteFrom("entity_domains").execute();
+    const fileId = await seedFile(db, "f-poison");
+    const person = await entityRepo.upsertPersonEntity({
+      name: "Dana Doe",
+      email: "dana@gmail.com",
+      subtype: "external",
+      source: "fireflies",
+      sourceId: "person-gmail-poison",
+    });
+    // Inject a domain_observation candidate directly, as if a prior unguarded run
+    // had accumulated it, and confirm the sweep's own backstop refuses it.
+    await domainsRepo.upsertDomainObservation({
+      domain: "gmail.com",
+      proposedCompanyName: "Gmail",
+      observedPersonEntityId: person.id,
+      evidenceFileId: fileId,
+      firstObservedByUserId: ADMIN_ID,
+    });
+
+    const result = await sweepDomainPromotions(db, createTestLogger());
+    expect(result.promoted).toBe(0);
+    expect(result.linkedExisting).toBe(0);
+
+    const companies = await db.selectFrom("entities").selectAll().where("source_type", "=", "company").execute();
+    expect(companies).toHaveLength(0);
+    const candidate = await db
+      .selectFrom("entity_candidates")
+      .selectAll()
+      .where("domain", "=", "gmail.com")
+      .executeTakeFirstOrThrow();
+    expect(candidate.promoted_entity_id).toBeNull();
   });
 
   it("a single demo prospect promotes the company immediately (threshold=1) with a works_at edge", async () => {

--- a/packages/server/src/entities/feature-queue-policy.integration.test.ts
+++ b/packages/server/src/entities/feature-queue-policy.integration.test.ts
@@ -33,7 +33,6 @@ describe("feature lifecycle queue policy postgres", () => {
     await upsertStructuralProject(db, "queue-file-1", "Referral Service", "linear-project-referral");
 
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmPromotionThreshold: 2,
       birthGateTypes: BIRTH_GATE_TYPES,
       birthGateLiveTypes: LIVE_TYPES,

--- a/packages/server/src/entities/graph.ts
+++ b/packages/server/src/entities/graph.ts
@@ -69,8 +69,7 @@ export function normalizeRelationEndpointType(raw: unknown): RelationEndpointTyp
   return (RELATION_ENDPOINT_TYPES as readonly string[]).includes(type) ? (type as RelationEndpointType) : null;
 }
 
-export function coerceMentionType(name: string, type: string, experimentalFlag = false): string {
-  if (!experimentalFlag) return type;
+export function coerceMentionType(name: string, type: string): string {
   return TOOL_NAME_DENYLIST.has(name.trim().toLowerCase()) ? "tool" : type;
 }
 

--- a/packages/server/src/entities/materialize-birth-gate.test.ts
+++ b/packages/server/src/entities/materialize-birth-gate.test.ts
@@ -249,7 +249,7 @@ describe("A1 birth gate", () => {
     });
   });
 
-  it("auto-creates product mentions with the gate off (EXPERIMENTAL_FLAG invisible)", async () => {
+  it("auto-creates product mentions with the birth gate dry run off", async () => {
     await seedConnector(db);
     await seedFile(db, "file-1");
     await upsertLlmMention(db, "file-1", "Canvas Copilot", "product");

--- a/packages/server/src/entities/materialize-commitment.ts
+++ b/packages/server/src/entities/materialize-commitment.ts
@@ -8,7 +8,6 @@ export async function materializeCommitment(
   deps: MaterializeDeps,
   fact: IndexedFileFactRow,
 ): Promise<MaterializeResult> {
-  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readJsonObject(fact.raw);
   const commitment = readCommitment(raw);
   if (!commitment) return { kind: "skipped", reason: "invalid_commitment" };

--- a/packages/server/src/entities/materialize-decision.ts
+++ b/packages/server/src/entities/materialize-decision.ts
@@ -5,7 +5,6 @@ import { readJsonObject } from "./materialize-json";
 import type { IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
 
 export async function materializeDecision(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
-  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readJsonObject(fact.raw);
   const decision = readDecision(raw);
   if (!decision) return { kind: "skipped", reason: "invalid_decision" };

--- a/packages/server/src/entities/materialize-deps.ts
+++ b/packages/server/src/entities/materialize-deps.ts
@@ -36,7 +36,6 @@ let configuredBirthGateTypes = new Set<ProposeEntityType>();
 let configuredBirthGateLiveTypes = new Set<ProposeEntityType>();
 let configuredStructuralAutoBirthTypes = new Set<ProposeEntityType>();
 let configuredBirthGateDryRun = true;
-let configuredExperimentalFlag = false;
 
 /**
  * Set the default `llmPromotionThreshold` used by entry points
@@ -52,7 +51,6 @@ export function configureMaterializeDefaults(opts: {
   birthGateLiveTypes?: Set<ProposeEntityType>;
   structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
-  experimentalFlag?: boolean;
 }): void {
   if (typeof opts.llmPromotionThreshold === "number" && opts.llmPromotionThreshold >= 1) {
     configuredLlmPromotionThreshold = Math.floor(opts.llmPromotionThreshold);
@@ -67,7 +65,6 @@ export function configureMaterializeDefaults(opts: {
   if (opts.birthGateLiveTypes) configuredBirthGateLiveTypes = new Set(opts.birthGateLiveTypes);
   if (opts.structuralAutoBirthTypes) configuredStructuralAutoBirthTypes = new Set(opts.structuralAutoBirthTypes);
   if (typeof opts.birthGateDryRun === "boolean") configuredBirthGateDryRun = opts.birthGateDryRun;
-  if (typeof opts.experimentalFlag === "boolean") configuredExperimentalFlag = opts.experimentalFlag;
 }
 
 async function buildLookupIndex(db: Kysely<DB>): Promise<LookupIndex> {
@@ -325,7 +322,6 @@ export interface BuildMaterializeDepsOptions {
   birthGateLiveTypes?: Set<ProposeEntityType>;
   structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
-  experimentalFlag?: boolean;
   embeddingProvider?: EmbeddingProvider | null;
 }
 
@@ -355,7 +351,6 @@ export async function buildMaterializeDeps(
   const birthGateLiveTypes = new Set(opts.birthGateLiveTypes ?? configuredBirthGateLiveTypes);
   const structuralAutoBirthTypes = new Set(opts.structuralAutoBirthTypes ?? configuredStructuralAutoBirthTypes);
   const birthGateDryRun = opts.birthGateDryRun ?? configuredBirthGateDryRun;
-  const experimentalFlag = opts.experimentalFlag ?? configuredExperimentalFlag;
   const embeddingProvider = opts.embeddingProvider ?? null;
 
   const lookup: EntityLookup = {
@@ -397,7 +392,7 @@ export async function buildMaterializeDeps(
     getPersonScopeKeys: (entityId) => index.personScopeKeysByEntityId.get(entityId) ?? [],
     findLlmExtractedThirdPartyMention: (name) => findLlmExtractedThirdPartyMention(db, name),
   };
-  if (embeddingProvider && experimentalFlag) {
+  if (embeddingProvider) {
     lookup.retrieveEmbeddingCandidates = async (entityType, name): Promise<RankedCandidate[]> => {
       if (!isNameDedupEntityType(entityType)) return [];
       try {
@@ -440,7 +435,6 @@ export async function buildMaterializeDeps(
     birthGateLiveTypes,
     structuralAutoBirthTypes,
     birthGateDryRun,
-    experimentalFlag,
     embeddingProvider,
     readEmail: (e: Entity) => readPersonEmailFromMetadata(e.metadata),
     onEntityResolved: (entity: Entity) => refreshResolvedEntityIndex(db, index, entity),

--- a/packages/server/src/entities/materialize-feature.ts
+++ b/packages/server/src/entities/materialize-feature.ts
@@ -9,7 +9,6 @@ import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult 
 export type FeatureReconcileReason = "minted" | "feature_parent_absent" | "below_threshold" | "noise_rejected";
 
 export async function materializeFeature(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
-  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readJsonObject(fact.raw);
   const feature = readFeature(raw);
   if (!feature) return { kind: "skipped", reason: "invalid_feature" };
@@ -51,7 +50,6 @@ export async function reconcileFeatureSubEntity(
   deps: MaterializeDeps,
   corroborationKey: string,
 ): Promise<{ support: number; materialized: boolean; reason: FeatureReconcileReason; subEntityId?: string }> {
-  if (!deps.experimentalFlag) return { support: 0, materialized: false, reason: "below_threshold" };
   const entries = await loadCorroboratingFeatureFacts(deps, corroborationKey);
   const support = distinctIndexedFileCount(entries);
   if (entries.length === 0) {

--- a/packages/server/src/entities/materialize-llm-mentions.ts
+++ b/packages/server/src/entities/materialize-llm-mentions.ts
@@ -14,9 +14,7 @@ export async function materializeLlmExtractedFact(
     return { kind: "skipped", reason: "missing_llm_subject" };
   }
   const raw = readJsonObject(fact.raw);
-  const mentionType = normalizeMentionType(
-    coerceMentionType(fact.subject_name, String(raw.type ?? ""), deps.experimentalFlag),
-  );
+  const mentionType = normalizeMentionType(coerceMentionType(fact.subject_name, String(raw.type ?? "")));
   if (!mentionType) {
     return { kind: "skipped", reason: "missing_or_invalid_mention_type" };
   }

--- a/packages/server/src/entities/materialize-llm-task.test.ts
+++ b/packages/server/src/entities/materialize-llm-task.test.ts
@@ -4,12 +4,7 @@ import { upsertLlmTaskFact } from "../db/repositories/indexed-file-facts";
 import { TEST_ACCOUNT_ENTITY_ID, createTaskRepository } from "../db/repositories/tasks";
 import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
-import {
-  buildMaterializeDeps,
-  materializeFromFact,
-  materializeUnmaterializedFacts,
-  shouldMarkMaterialized,
-} from "./materialize";
+import { buildMaterializeDeps, materializeFromFact, materializeUnmaterializedFacts } from "./materialize";
 
 const U1 = "llm-task-u1";
 const U2 = "llm-task-u2";
@@ -28,9 +23,8 @@ describe("llm task materialization", () => {
     await db.destroy();
   });
 
-  it("drops chatter and keeps flag-off emission and materialization invisible", async () => {
-    const offEmission = await upsertLlmTaskFact(db, {
-      experimentalFlag: false,
+  it("drops chatter without minting an uncorroborated task", async () => {
+    const emission = await upsertLlmTaskFact(db, {
       indexedFileId: "llm-file-1",
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: U1,
@@ -41,28 +35,39 @@ describe("llm task materialization", () => {
       promptVersion: PROMPT_VERSION,
     });
     let factCount = await countRows("indexed_file_facts");
-    expect(offEmission).toEqual({ emitted: false });
-    expect(factCount).toBe(0);
+    expect(emission).toEqual({ emitted: true, factKey: expect.any(String), candidateId: expect.any(String) });
+    expect(factCount).toBe(1);
 
+    const fact = await db
+      .selectFrom("indexed_file_facts")
+      .selectAll()
+      .where("indexed_file_id", "=", "llm-file-1")
+      .executeTakeFirstOrThrow();
+    const deps = await buildMaterializeDeps(db, { llmTaskCorroborationThreshold: 2 });
+    const result = await materializeFromFact(deps, fact);
+    factCount = await countRows("tasks");
+    expect(result).toEqual({ kind: "skipped", reason: "llm_task_ungated" });
+    expect(factCount).toBe(0);
+  });
+
+  it("materializes owner-action tasks with default dependencies", async () => {
     await seedLlmFact({
       fileId: "llm-file-1",
-      candidateId: "chatter-1",
-      title: "let's circle back on pricing",
-      hasOwnerVerbObject: false,
+      candidateId: "owner-action-1",
+      title: "Send pricing deck",
+      hasOwnerVerbObject: true,
       ownerUserId: U1,
-      corroborationKey: "lets circle back on pricing|global",
+      owner: { name: "Owner One" },
+      corroborationKey: "send pricing deck|global",
     });
     const fact = await db.selectFrom("indexed_file_facts").selectAll().executeTakeFirstOrThrow();
-    const depsOff = await buildMaterializeDeps(db, { experimentalFlag: false });
-    const offResult = await materializeFromFact(depsOff, fact);
-    expect(offResult).toEqual({ kind: "skipped", reason: "experimental_off" });
-    expect(shouldMarkMaterialized(offResult)).toBe(true);
-
-    const depsOn = await buildMaterializeDeps(db, { experimentalFlag: true, llmTaskCorroborationThreshold: 2 });
-    const onResult = await materializeFromFact(depsOn, fact);
-    factCount = await countRows("tasks");
-    expect(onResult).toEqual({ kind: "skipped", reason: "llm_task_ungated" });
-    expect(factCount).toBe(0);
+    await expect(materializeFromFact(await buildMaterializeDeps(db, {}), fact)).resolves.toMatchObject({
+      kind: "task_materialized",
+      created: true,
+    });
+    const tasks = await db.selectFrom("tasks").selectAll().execute();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({ title: "Send pricing deck", source: "llm", created_by_user_id: U1 });
   });
 
   it("mints only after owner-scoped distinct-file corroboration", async () => {
@@ -84,7 +89,6 @@ describe("llm task materialization", () => {
     });
 
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
     expect(await countRows("tasks")).toBe(0);
@@ -98,7 +102,6 @@ describe("llm task materialization", () => {
       corroborationKey: "send pricing deck|global",
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
 
@@ -128,7 +131,6 @@ describe("llm task materialization", () => {
       corroborationKey: "send pricing deck|global",
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
 
@@ -159,7 +161,6 @@ describe("llm task materialization", () => {
     });
 
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
 
@@ -194,7 +195,6 @@ describe("llm task materialization", () => {
     });
 
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
 
@@ -247,7 +247,6 @@ describe("llm task materialization", () => {
       entityIds: ["project-x", TEST_ACCOUNT_ENTITY_ID],
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
 
@@ -280,7 +279,6 @@ describe("llm task materialization", () => {
       corroborationKey: "follow up on launch note|global",
     });
     await materializeUnmaterializedFacts(db, createTestLogger(), {
-      experimentalFlag: true,
       llmTaskCorroborationThreshold: 2,
     });
     await repo.expireOrphanedTasks();
@@ -302,7 +300,6 @@ describe("llm task materialization", () => {
     entityIds?: string[];
   }): Promise<string> {
     await upsertLlmTaskFact(db, {
-      experimentalFlag: true,
       indexedFileId: input.fileId,
       connectorConfigId: CONNECTOR_ID,
       createdByUserId: input.ownerUserId,

--- a/packages/server/src/entities/materialize-llm-task.ts
+++ b/packages/server/src/entities/materialize-llm-task.ts
@@ -5,7 +5,6 @@ import { readJsonObject } from "./materialize-json";
 import type { EntityRow, IndexedFileFactRow, MaterializeDeps, MaterializeResult } from "./materialize-types";
 
 export async function materializeLlmTask(deps: MaterializeDeps, fact: IndexedFileFactRow): Promise<MaterializeResult> {
-  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readLlmTask(readJsonObject(fact.raw));
   if (!raw) return { kind: "skipped", reason: "invalid_llm_task" };
 

--- a/packages/server/src/entities/materialize-milestone.ts
+++ b/packages/server/src/entities/materialize-milestone.ts
@@ -9,7 +9,6 @@ export async function materializeMilestone(
   deps: MaterializeDeps,
   fact: IndexedFileFactRow,
 ): Promise<MaterializeResult> {
-  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readJsonObject(fact.raw);
   const milestone = readMilestone(raw);
   if (!milestone) return { kind: "skipped", reason: "invalid_milestone" };

--- a/packages/server/src/entities/materialize-relations.ts
+++ b/packages/server/src/entities/materialize-relations.ts
@@ -27,8 +27,8 @@ export async function materializeLlmRelationFact(
 ): Promise<MaterializeResult> {
   const raw = readJsonObject(fact.raw);
   const relationType = normalizeRelationType(raw.relationType ?? fact.relation);
-  const source = readCoercedRelationEndpoint(raw, "source", deps.experimentalFlag);
-  const target = readCoercedRelationEndpoint(raw, "target", deps.experimentalFlag);
+  const source = readCoercedRelationEndpoint(raw, "source");
+  const target = readCoercedRelationEndpoint(raw, "target");
   const confidenceScore = typeof raw.confidence === "number" ? raw.confidence : 0;
   const sourceConfidence = typeof raw.sourceConfidence === "number" ? raw.sourceConfidence : 0;
   const targetConfidence = typeof raw.targetConfidence === "number" ? raw.targetConfidence : 0;
@@ -201,13 +201,12 @@ function readCrmRelationEndpoint(raw: Record<string, unknown>, key: "source" | "
 function readCoercedRelationEndpoint(
   raw: Record<string, unknown>,
   key: "source" | "target",
-  experimentalFlag: boolean,
 ): EntityGraphRelationEndpoint | null {
   const endpoint = raw[key];
   if (!endpoint || typeof endpoint !== "object" || Array.isArray(endpoint)) return null;
   const record = endpoint as Record<string, unknown>;
   if (typeof record.name !== "string") return null;
-  const coercedType = coerceMentionType(record.name, String(record.type ?? ""), experimentalFlag);
+  const coercedType = coerceMentionType(record.name, String(record.type ?? ""));
   const type = normalizeRelationEndpointType(coercedType);
   if (!type) return null;
   const variations = Array.isArray(record.variations)
@@ -240,7 +239,7 @@ async function materializeRelationEndpoint(
   | { kind: "suppressed_endpoint" }
 > {
   const raw = readJsonObject(fact.raw);
-  const coercedType = normalizeMentionType(coerceMentionType(endpoint.name, endpoint.type, deps.experimentalFlag));
+  const coercedType = normalizeMentionType(coerceMentionType(endpoint.name, endpoint.type));
   if (coercedType === "tool") return { kind: "suppressed_endpoint" };
   const normalized = normalizeEntityMatchName(endpoint.type, endpoint.name);
   if (await deps.suppressionRepo.isSuppressed(normalized, endpoint.type)) {

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -181,7 +181,6 @@ export async function replaySourceFacts(
     birthGateLiveTypes: opts.birthGateLiveTypes,
     structuralAutoBirthTypes: opts.structuralAutoBirthTypes,
     birthGateDryRun: opts.birthGateDryRun,
-    experimentalFlag: opts.experimentalFlag,
     embeddingProvider: opts.embeddingProvider,
   });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));
@@ -256,7 +255,6 @@ async function materializeUnmaterializedFactsInner(
     birthGateLiveTypes: opts.birthGateLiveTypes,
     structuralAutoBirthTypes: opts.structuralAutoBirthTypes,
     birthGateDryRun: opts.birthGateDryRun,
-    experimentalFlag: opts.experimentalFlag,
     embeddingProvider: opts.embeddingProvider,
   });
   const orderRank = new Map<string, number>(FACT_REPLAY_ORDER.map((t, i) => [t, i]));

--- a/packages/server/src/entities/materialize-task.test.ts
+++ b/packages/server/src/entities/materialize-task.test.ts
@@ -8,12 +8,7 @@ import { TEST_ACCOUNT_ENTITY_ID, createTaskRepository } from "../db/repositories
 import { getCycleRollup } from "../db/repositories/work-cycles";
 import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
-import {
-  buildMaterializeDeps,
-  materializeFromFact,
-  materializeUnmaterializedFacts,
-  shouldMarkMaterialized,
-} from "./materialize";
+import { materializeUnmaterializedFacts } from "./materialize";
 
 const USER_ID = "task-user";
 const CONNECTOR_ID = "task-config";
@@ -204,7 +199,7 @@ describe("structural task materialization", () => {
       project: { name: "Launch List", source: "clickup", sourceId: "list-1" },
     });
 
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const rows = await db.selectFrom("tasks").selectAll().orderBy("source_task_id").execute();
     const byId = new Map(rows.map((row) => [row.source_task_id, row]));
@@ -233,7 +228,7 @@ describe("structural task materialization", () => {
       assignee: { name: "Priya Shah", source: "linear", sourceId: "user-1" },
     });
 
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const before = await db.selectFrom("tasks").selectAll().executeTakeFirstOrThrow();
     expect(before.parent_entity_id).toBeNull();
@@ -259,66 +254,51 @@ describe("structural task materialization", () => {
     expect(after.parent_entity_id).toBe(project.id);
   });
 
-  it("keeps flag-off parity, updates status idempotently, and expires deleted structural tasks", async () => {
+  it("emits task facts, updates status idempotently, and expires deleted structural tasks", async () => {
     await seedBase(db, "linear");
     const connector = { type: "linear" } as Connector;
     const item: SyncedItem = {
       providerFileId: "task-1",
       providerUrl: null,
-      fileName: "Flag task",
+      fileName: "Task",
       fileType: "issue",
       contentCategory: "structured",
-      content: "Flag task",
+      content: "Task",
       sourcePath: null,
-      contentHash: "hash-flag",
+      contentHash: "hash-task",
       sourceCreatedAt: null,
       sourceUpdatedAt: null,
-      task: { sourceTaskId: "flag-task", title: "Flag task", statusType: "started", statusRaw: "Started" },
+      task: { sourceTaskId: "task-1", title: "Task", statusType: "started", statusRaw: "Started" },
     };
     await emitFactsForSyncedItem({
       factRepo: createIndexedFileFactRepository(db),
       connector,
       connectorType: "linear",
-      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-off" },
+      factContext: { connectorConfigId: CONNECTOR_ID, createdByUserId: USER_ID, lastSeenSyncRunId: "sync-1" },
       item,
       indexedFileId: "file-1",
-      experimentalFlag: false,
     });
     let factCount = await db
       .selectFrom("indexed_file_facts")
       .select((eb) => eb.fn.countAll<number>().as("count"))
       .where("fact_type", "=", "structural_task")
       .executeTakeFirstOrThrow();
-    expect(Number(factCount.count)).toBe(0);
+    expect(Number(factCount.count)).toBe(1);
 
-    await upsertTaskFact(db, { sourceTaskId: "flag-task", statusType: "started", statusRaw: "Started" });
-    const depsOff = await buildMaterializeDeps(db, { experimentalFlag: false });
-    const fact = await db.selectFrom("indexed_file_facts").selectAll().executeTakeFirstOrThrow();
-    const offResult = await materializeFromFact(depsOff, fact);
-    expect(offResult).toEqual({ kind: "skipped", reason: "experimental_off" });
-    expect(shouldMarkMaterialized(offResult)).toBe(true);
-    await db.updateTable("indexed_file_facts").set({ materialized_at: new Date().toISOString() }).execute();
-    let taskCount = await db
-      .selectFrom("tasks")
-      .select((eb) => eb.fn.countAll<number>().as("count"))
-      .executeTakeFirstOrThrow();
-    expect(Number(taskCount.count)).toBe(0);
-
-    await upsertTaskFact(db, { sourceTaskId: "flag-task", statusType: "started", statusRaw: "Started" });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     const started = await db.selectFrom("tasks").selectAll().executeTakeFirstOrThrow();
     await upsertTaskFact(db, {
-      sourceTaskId: "flag-task",
+      sourceTaskId: "task-1",
       statusType: "completed",
       statusRaw: "Done",
-      title: "Flag task renamed",
+      title: "Task renamed",
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
     const completedRows = await db.selectFrom("tasks").selectAll().execute();
     expect(completedRows).toHaveLength(1);
     expect(completedRows[0]).toMatchObject({
       id: started.id,
-      title: "Flag task renamed",
+      title: "Task renamed",
       status: "done",
       valid_to: null,
     });
@@ -340,7 +320,7 @@ describe("structural task materialization", () => {
       .select((eb) => eb.fn.countAll<number>().as("count"))
       .where("fact_type", "=", "structural_task")
       .executeTakeFirstOrThrow();
-    taskCount = await db
+    const taskCount = await db
       .selectFrom("tasks")
       .select((eb) => eb.fn.countAll<number>().as("count"))
       .executeTakeFirstOrThrow();
@@ -369,7 +349,7 @@ describe("structural task materialization", () => {
         isSprint: true,
       },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const cycle = await db.selectFrom("work_cycles").selectAll().executeTakeFirstOrThrow();
     const openBefore = await db
@@ -388,7 +368,7 @@ describe("structural task materialization", () => {
       title: "Move from sprint",
       project: { name: "Delivery Folder", source: "clickup", sourceId: "folder-1" },
     });
-    await materializeUnmaterializedFacts(db, createTestLogger(), { experimentalFlag: true });
+    await materializeUnmaterializedFacts(db, createTestLogger(), {});
 
     const memberships = await db
       .selectFrom("task_cycle_memberships")

--- a/packages/server/src/entities/materialize-task.ts
+++ b/packages/server/src/entities/materialize-task.ts
@@ -25,7 +25,6 @@ export async function materializeStructuralTask(
   deps: MaterializeDeps,
   fact: IndexedFileFactRow,
 ): Promise<MaterializeResult> {
-  if (!deps.experimentalFlag) return { kind: "skipped", reason: "experimental_off" };
   const raw = readJsonObject(fact.raw);
   const task = readTask(raw.task);
   const indexedFileId = typeof raw.indexedFileId === "string" ? raw.indexedFileId : fact.indexed_file_id;
@@ -52,32 +51,30 @@ export async function materializeStructuralTask(
     sourceTaskId: task.sourceTaskId,
   });
   await repo.upsertEvidence(result.taskId, "file", indexedFileId);
-  if (deps.experimentalFlag) {
-    const now = new Date().toISOString();
-    if (task.cycle?.isSprint) {
-      if (!fact.connector_config_id) throw new Error("Work cycle materialization requires connector_config_id");
-      const scopeEntityId = resolveCycleScope(deps, task.cycle.scopeRef)?.id ?? null;
-      const cycle = await upsertWorkCycle(deps.db, {
-        scopeEntityId,
-        connectorConfigId: fact.connector_config_id,
-        source: fact.source,
-        externalRef: task.cycle.externalRef,
-        name: task.cycle.name,
-        sequence: task.cycle.sequence ?? deriveSprintSequence(task.cycle.name),
-        startsAt: task.cycle.startsAt ?? null,
-        endsAt: task.cycle.endsAt ?? null,
-        state: "active",
-        lastSeenSyncRunId: fact.last_seen_sync_run_id,
-      });
-      await assignMembership(deps.db, {
-        taskId: result.taskId,
-        cycleId: cycle.cycleId,
-        sourceFactId: fact.id,
-        at: now,
-      });
-    } else {
-      await closeOpenMembershipForTask(deps.db, { taskId: result.taskId, at: now });
-    }
+  const now = new Date().toISOString();
+  if (task.cycle?.isSprint) {
+    if (!fact.connector_config_id) throw new Error("Work cycle materialization requires connector_config_id");
+    const scopeEntityId = resolveCycleScope(deps, task.cycle.scopeRef)?.id ?? null;
+    const cycle = await upsertWorkCycle(deps.db, {
+      scopeEntityId,
+      connectorConfigId: fact.connector_config_id,
+      source: fact.source,
+      externalRef: task.cycle.externalRef,
+      name: task.cycle.name,
+      sequence: task.cycle.sequence ?? deriveSprintSequence(task.cycle.name),
+      startsAt: task.cycle.startsAt ?? null,
+      endsAt: task.cycle.endsAt ?? null,
+      state: "active",
+      lastSeenSyncRunId: fact.last_seen_sync_run_id,
+    });
+    await assignMembership(deps.db, {
+      taskId: result.taskId,
+      cycleId: cycle.cycleId,
+      sourceFactId: fact.id,
+      at: now,
+    });
+  } else {
+    await closeOpenMembershipForTask(deps.db, { taskId: result.taskId, at: now });
   }
   return { kind: "task_materialized", taskId: result.taskId, created: result.created };
 }

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -65,7 +65,6 @@ export interface MaterializeDeps {
   birthGateLiveTypes: Set<ProposeEntityType>;
   structuralAutoBirthTypes: Set<ProposeEntityType>;
   birthGateDryRun: boolean;
-  experimentalFlag: boolean;
   embeddingProvider: EmbeddingProvider | null;
 }
 
@@ -99,7 +98,6 @@ export interface ReplaySourceFactsOptions {
   birthGateLiveTypes?: Set<ProposeEntityType>;
   structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
-  experimentalFlag?: boolean;
   embeddingProvider?: EmbeddingProvider | null;
 }
 
@@ -117,7 +115,6 @@ export interface MaterializeUnmaterializedOptions {
   birthGateLiveTypes?: Set<ProposeEntityType>;
   structuralAutoBirthTypes?: Set<ProposeEntityType>;
   birthGateDryRun?: boolean;
-  experimentalFlag?: boolean;
   embeddingProvider?: EmbeddingProvider | null;
   factTypes?: IndexedFileFactType[];
   /**

--- a/packages/server/src/entities/propose.test.ts
+++ b/packages/server/src/entities/propose.test.ts
@@ -1745,21 +1745,21 @@ describe("proposeEntity", () => {
     expect(retrieveEmbeddingCandidates).not.toHaveBeenCalled();
   });
 
-  it("34. materialize deps leave embedding lookup off without provider or experimental flag", async () => {
+  it("34. materialize deps leave embedding lookup off without provider and enable it with a provider", async () => {
     const provider = makeEmbeddingProvider();
-    const withoutProvider = await buildMaterializeDeps(db, { experimentalFlag: true });
-    const flagOff = await buildMaterializeDeps(db, { experimentalFlag: false, embeddingProvider: provider });
+    const withoutProvider = await buildMaterializeDeps(db, {});
+    const withProvider = await buildMaterializeDeps(db, { embeddingProvider: provider });
 
     expect(withoutProvider.lookup.retrieveEmbeddingCandidates).toBeUndefined();
-    expect(flagOff.lookup.retrieveEmbeddingCandidates).toBeUndefined();
+    expect(withProvider.lookup.retrieveEmbeddingCandidates).toEqual(expect.any(Function));
 
     const result = await proposeEntity(
       {
-        entityRepo: flagOff.entityRepo,
-        reviewRepo: flagOff.reviewRepo,
-        lookup: flagOff.lookup,
-        readEmail: flagOff.readEmail,
-        onEntityResolved: flagOff.onEntityResolved,
+        entityRepo: withoutProvider.entityRepo,
+        reviewRepo: withoutProvider.reviewRepo,
+        lookup: withoutProvider.lookup,
+        readEmail: withoutProvider.readEmail,
+        onEntityResolved: withoutProvider.onEntityResolved,
       },
       {
         name: "No Provider Person",

--- a/packages/server/src/entities/recreate-structural-assignee.test.ts
+++ b/packages/server/src/entities/recreate-structural-assignee.test.ts
@@ -22,7 +22,6 @@ type MaterializeDefaultsSnapshot = Pick<
   | "birthGateLiveTypes"
   | "structuralAutoBirthTypes"
   | "birthGateDryRun"
-  | "experimentalFlag"
 >;
 
 async function snapshotMaterializeDefaults(db: Kysely<DB>): Promise<MaterializeDefaultsSnapshot> {
@@ -35,7 +34,6 @@ async function snapshotMaterializeDefaults(db: Kysely<DB>): Promise<MaterializeD
     birthGateLiveTypes: new Set(deps.birthGateLiveTypes),
     structuralAutoBirthTypes: new Set(deps.structuralAutoBirthTypes),
     birthGateDryRun: deps.birthGateDryRun,
-    experimentalFlag: deps.experimentalFlag,
   };
 }
 
@@ -183,16 +181,14 @@ async function seedCoMentionFacts(db: Kysely<DB>, fileIds: string[]): Promise<vo
   }
 }
 
-async function runRecreate(db: Kysely<DB>, experimentalFlag: boolean): Promise<void> {
+async function runRecreate(db: Kysely<DB>): Promise<void> {
   configureMaterializeDefaults({
     structuralAutoBirthTypes: new Set<ProposeEntityType>(["project"]),
-    experimentalFlag: true,
   });
   await recreateEntityGraph({
     db,
     logger: createTestLogger(),
     triggeredByUserId: USER_ID,
-    experimentalFlag,
     skipEnrichment: true,
     coMentionContributesToThreshold: 2,
   });
@@ -225,7 +221,7 @@ describe("recreateEntityGraph structural assignee rebuild", () => {
   it("mints a structural_assignee contributes_to edge during reconstruct", async () => {
     await seedStructuralFacts(db);
 
-    await runRecreate(db, true);
+    await runRecreate(db);
 
     const relationships = await contributesToRows(db);
     expect(relationships).toHaveLength(1);
@@ -236,20 +232,11 @@ describe("recreateEntityGraph structural assignee rebuild", () => {
     });
   });
 
-  it("does not mint structural_assignee edges when experimentalFlag is false", async () => {
-    await seedStructuralFacts(db);
-
-    await runRecreate(db, false);
-
-    const relationships = await contributesToRows(db);
-    expect(relationships.filter((row) => row.source === "structural_assignee")).toHaveLength(0);
-  });
-
   it("keeps structural_assignee precedence over recreate co-mention sweep", async () => {
     await seedStructuralFacts(db);
     await seedCoMentionFacts(db, ["co-mention-1", "co-mention-2"]);
 
-    await runRecreate(db, true);
+    await runRecreate(db);
 
     const relationships = await contributesToRows(db);
     expect(relationships.map((row) => row.source)).toEqual(["structural_assignee"]);

--- a/packages/server/src/entities/recreate.ts
+++ b/packages/server/src/entities/recreate.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import type { Logger } from "pino";
-import { type EnrichmentResult, isEnrichmentActive, linkEntitiesByDeterministicMatch } from "../connectors/enrichment";
+import { type EnrichmentResult, isEnrichmentActive } from "../connectors/enrichment";
 import { type DomainSweepResult, sweepDomainPromotions } from "../connectors/smart-enrichment";
 import { getSyncProgress, seedTeamDirectoryEntities } from "../connectors/sync";
 import type { IndexedFileFactType } from "../db/repositories/indexed-file-facts";
@@ -278,7 +278,7 @@ export async function resetDerivedEntityData(
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// Phase 3 — Reset → materialize facts → deterministic substring linking.
+// Phase 3 — Reset → materialize facts → relationship sweeps.
 // ─────────────────────────────────────────────────────────────────────────
 
 export interface RecreateSummary {
@@ -369,10 +369,8 @@ export async function recreateEntityGraph(deps: RecreateDeps): Promise<RecreateS
       scope: { kind: "full" },
     });
     if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
-    // Domain promotions run between materialize and deterministic linking so
-    // any new company entity (and its `works_at` edges) is visible to the
-    // linker. Sweep also runs on every live sync — keep the two paths
-    // calling the same helper so recreate doesn't drift.
+    // Domain promotions run after materialize so any new company entity and
+    // its `works_at` edges are available before downstream sweeps.
     const domainSweep = await sweepDomainPromotions(db, logger.child({ component: "recreate-domain-sweep" }));
     if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
     await fixupPreservedEntityDomainReferences(db, logger.child({ component: "recreate-domain-fixup" }));
@@ -393,11 +391,13 @@ export async function recreateEntityGraph(deps: RecreateDeps): Promise<RecreateS
       };
     }
 
-    const deterministic = await linkEntitiesByDeterministicMatch(
-      db,
-      logger.child({ component: "recreate-deterministic-linking" }),
-    );
-    return { reset, replay, domainSweep, enrichmentIterations: 1, enrichment: deterministic };
+    return {
+      reset,
+      replay,
+      domainSweep,
+      enrichmentIterations: 0,
+      enrichment: { filesProcessed: 0, filesSkipped: 0, filesFailed: 0, errors: [] },
+    };
   };
 
   return deps.lockAlreadyHeld ? run() : withRecreateLock(run);

--- a/packages/server/src/entities/recreate.ts
+++ b/packages/server/src/entities/recreate.ts
@@ -320,11 +320,6 @@ export interface RecreateDeps {
   featureAutoMintThreshold?: number;
   coMentionContributesToThreshold?: number;
   /**
-   * Enables experimental rebuild phases that must stay invisible when the
-   * org-level experimental flag is off.
-   */
-  experimentalFlag?: boolean;
-  /**
    * Restrict the materialize replay to a subset of fact types. Used by
    * category reset+rebuild to avoid replaying unrelated pending facts.
    */
@@ -365,17 +360,15 @@ export async function recreateEntityGraph(deps: RecreateDeps): Promise<RecreateS
     });
 
     if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
-    if (deps.experimentalFlag) {
-      const taskRepo = createTaskRepository(db);
-      await taskRepo.reanchorNullParentTasks();
-      if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
-      await taskRepo.expireOrphanedTasks();
-      if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
-      await reconcileStructuralAssigneeContributesTo(db, logger.child({ component: "recreate-structural-assignee" }), {
-        scope: { kind: "full" },
-      });
-      if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
-    }
+    const taskRepo = createTaskRepository(db);
+    await taskRepo.reanchorNullParentTasks();
+    if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
+    await taskRepo.expireOrphanedTasks();
+    if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
+    await reconcileStructuralAssigneeContributesTo(db, logger.child({ component: "recreate-structural-assignee" }), {
+      scope: { kind: "full" },
+    });
+    if (deps.shouldCancel?.()) throw new Error("Re-enrich stopped");
     // Domain promotions run between materialize and deterministic linking so
     // any new company entity (and its `works_at` edges) is visible to the
     // linker. Sweep also runs on every live sync — keep the two paths

--- a/packages/server/src/entities/reenrich.test.ts
+++ b/packages/server/src/entities/reenrich.test.ts
@@ -118,7 +118,7 @@ describe("entity re-enrich", () => {
     await db.destroy();
   });
 
-  it("tombstones only LLM facts and preserves connector mentions", async () => {
+  it("tombstones LLM facts and clears stale deterministic mentions while preserving connector mentions", async () => {
     await seedEntity(db, "person-1", "Alice");
     await seedLlmExtractedFact(db, "Alice");
     await seedLlmRelationFact(db);

--- a/packages/server/src/entities/reenrich.test.ts
+++ b/packages/server/src/entities/reenrich.test.ts
@@ -320,10 +320,12 @@ describe("entity re-enrich", () => {
     expect(newEntity?.name).toBe("New Person");
   });
 
-  it("threads experimentalFlag into the re-enrich extraction phase", async () => {
-    const seenFlags: Array<boolean | undefined> = [];
+  it("runs re-enrich extraction with the current enrichment dependencies", async () => {
+    let calls = 0;
     const capture = async (deps: EnrichmentDeps) => {
-      seenFlags.push(deps.experimentalFlag);
+      expect(deps.db).toBe(db);
+      expect(deps.logger).toBeDefined();
+      calls++;
       return { filesProcessed: 1, filesSkipped: 0, filesFailed: 0, errors: [] };
     };
 
@@ -333,19 +335,10 @@ describe("entity re-enrich", () => {
       triggeredByUserId: "owner",
       fileIds: ["file-1"],
       runAfter: false,
-      experimentalFlag: true,
-      runEnrichmentImpl: capture,
-    });
-    await runReenrichJob({
-      db,
-      logger,
-      triggeredByUserId: "owner",
-      fileIds: ["file-1"],
-      runAfter: false,
       runEnrichmentImpl: capture,
     });
 
-    expect(seenFlags).toEqual([true, undefined]);
+    expect(calls).toBe(1);
   });
 
   it("uses decrypted OpenRouter settings for re-enrichment embeddings", async () => {

--- a/packages/server/src/entities/reenrich.ts
+++ b/packages/server/src/entities/reenrich.ts
@@ -77,14 +77,6 @@ export interface ReenrichDeps {
   openRouterApiKey?: string | null;
   settingsEncryptionKey?: string;
   /**
-   * Threads the experimental gate into the re-enrich extraction phase so the
-   * flag-gated extraction-time spine features (tool classification,
-   * person-anchored file scope) run on re-extracted files exactly as they do
-   * on the live sync path. Materialization-time gating (the birth gate) reads
-   * its own module-level config and is unaffected by this flag.
-   */
-  experimentalFlag?: boolean;
-  /**
    * Set when the caller already promoted a pending recreate lock (two-step
    * rebuild flow). Skips the internal beginRecreateLock/endRecreateLock so
    * we don't double-acquire; the caller's `finally` is responsible for
@@ -528,7 +520,6 @@ export async function runReenrichJob(deps: ReenrichDeps): Promise<ReenrichSummar
         geminiApiKey: settings?.gemini_api_key,
         geminiMaxRpm: deps.geminiMaxRpm,
         geminiMaxRetries: deps.geminiMaxRetries,
-        experimentalFlag: deps.experimentalFlag,
         runEnrichmentImpl: deps.runEnrichmentImpl,
         onProgress: deps.onProgress,
         shouldCancel: deps.shouldCancel,
@@ -552,7 +543,6 @@ export async function runReenrichJob(deps: ReenrichDeps): Promise<ReenrichSummar
         llmPromotionThreshold: deps.llmPromotionThreshold,
         featureAutoMintThreshold: deps.featureAutoMintThreshold,
         coMentionContributesToThreshold: deps.coMentionContributesToThreshold,
-        experimentalFlag: deps.experimentalFlag,
         materializeFactTypes: deps.materializeFactTypes ?? [...AI_EXTRACTION_FACT_TYPES],
         onProgress: deps.onProgress,
         shouldCancel: deps.shouldCancel,

--- a/packages/server/src/entities/replay.test.ts
+++ b/packages/server/src/entities/replay.test.ts
@@ -490,7 +490,7 @@ describe("recreateEntityGraph", () => {
     await db.destroy();
   });
 
-  it("runs the full reset → fact materialization → deterministic linking chain idempotently", async () => {
+  it("runs the full reset → fact materialization → sweep chain idempotently", async () => {
     const first = await recreateEntityGraph({
       db,
       logger: createTestLogger(),
@@ -500,7 +500,7 @@ describe("recreateEntityGraph", () => {
 
     expect(first.replay.factsRead).toBe(5);
 
-    // Snapshot the deterministic tuples (entity name, file id, relation, source)
+    // Snapshot the mention tuples (entity name, file id, relation, source)
     // so we can assert stability across recreate runs without depending on
     // entity IDs (which churn — that's an explicit out-of-scope guarantee).
     const snapshot = async () => {

--- a/packages/server/src/entities/review.test.ts
+++ b/packages/server/src/entities/review.test.ts
@@ -4,7 +4,7 @@
  * Resolve-logic coverage lives in resolve.test.ts; this file focuses on
  * what only the HTTP layer can express: owner-scope enforcement,
  * auth-before-mutation on GET /:id, multi-user-evidence admin escalation,
- * and the EXPERIMENTAL_FLAG gate on the mount point.
+ * and the entity-review route mount point.
  */
 import { randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";
@@ -282,26 +282,11 @@ async function structuralContributesToEvidenceNotes(db: Kysely<DB>, relationship
 }
 
 describe("entity-review routes — mounting", () => {
-  it("returns 200 without EXPERIMENTAL_FLAG (Files is GA, route always mounted)", async () => {
+  it("returns 200 for the Files review route", async () => {
     const db = await createTestDb();
     try {
       await seedUsers(db);
-      const app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: false }), {
-        logger: createTestLogger(),
-      });
-      const cookie = await login(app, OWNER_EMAIL);
-      const res = await app.request("/api/entity-review", { headers: { Cookie: cookie } });
-      expect(res.status).toBe(200);
-    } finally {
-      await db.destroy();
-    }
-  });
-
-  it("returns 200 when flag is on", async () => {
-    const db = await createTestDb();
-    try {
-      await seedUsers(db);
-      const app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+      const app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), {
         logger: createTestLogger(),
       });
       const cookie = await login(app, OWNER_EMAIL);
@@ -329,7 +314,7 @@ describe("entity-review routes — owner-scope & auth-before-mutation", () => {
     otherId = await userIdByEmail(db, OTHER_EMAIL);
     await seedConnectorConfig(db, "config-owner", ownerId);
     await seedConnectorConfig(db, "config-other", otherId);
-    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), {
       logger: createTestLogger(),
     });
     ownerCookie = await login(app, OWNER_EMAIL);
@@ -493,7 +478,7 @@ describe("entity-review routes — list endpoint shape", () => {
     await seedConnectorConfig(db, "config-owner", ownerId);
     const otherId = await userIdByEmail(db, OTHER_EMAIL);
     await seedConnectorConfig(db, "config-other", otherId);
-    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), {
       logger: createTestLogger(),
     });
     ownerCookie = await login(app, OWNER_EMAIL);
@@ -569,7 +554,7 @@ describe("entity-review routes — types filter", () => {
     db = await createTestDb();
     await seedUsers(db);
     ownerId = await userIdByEmail(db, OWNER_EMAIL);
-    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), {
       logger: createTestLogger(),
     });
     adminCookie = await login(app, ADMIN_EMAIL);
@@ -617,7 +602,6 @@ describe("entity-review A4 backend", () => {
   let ownerId: string;
   let otherId: string;
   let ownerCookie: string;
-  let offApp: ReturnType<typeof createApp>;
 
   beforeEach(async () => {
     db = await createTestDb();
@@ -628,10 +612,7 @@ describe("entity-review A4 backend", () => {
     await seedConnectorConfig(db, "config-other", otherId);
     await seedIndexedFile(db, "a4-owner-file", "config-owner");
     await seedIndexedFile(db, "a4-other-file", "config-other");
-    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
-      logger: createTestLogger(),
-    });
-    offApp = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: false }), {
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), {
       logger: createTestLogger(),
     });
     ownerCookie = await login(app, OWNER_EMAIL);
@@ -915,62 +896,6 @@ describe("entity-review A4 backend", () => {
     expect(task.parent_entity_id).toBe(body.targetEntityId);
   });
 
-  it("does not run confirm-time structural assignee backfill when experimental flag is off", async () => {
-    const projectName = "A4 Flag Off Backfill Project";
-    const personId = await seedEntity(db, { name: "A4 Flag Off Person", sourceType: "person" });
-    const single = await seedReviewRow(db, {
-      proposedName: projectName,
-      entityType: "project",
-      triggeredBy: ownerId,
-      evidenceFileIds: ["a4-owner-file"],
-      source: "linear",
-      sourceId: "a4-flag-off-backfill-project",
-      candidateReason: "birth-gated",
-    });
-    const singleTaskId = await seedStructuralTask(db, {
-      sourceTaskId: "a4-flag-off-single-task",
-      fileId: "a4-owner-file",
-      assigneeEntityId: personId,
-      parentEntityId: null,
-      parentName: projectName,
-      parentSourceRef: "linear:a4-flag-off-backfill-project",
-    });
-
-    const offCookie = await login(offApp, OWNER_EMAIL);
-    const singleRes = await offApp.request(`/api/entity-review/${single.id}/confirm`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Cookie: offCookie },
-      body: JSON.stringify({ candidateGeneratedAt: single.candidateGeneratedAt }),
-    });
-    expect(singleRes.status).toBe(200);
-    const singleTask = await db
-      .selectFrom("tasks")
-      .select("parent_entity_id")
-      .where("id", "=", singleTaskId)
-      .executeTakeFirstOrThrow();
-    expect(singleTask.parent_entity_id).toBeNull();
-    await expect(structuralContributesToRows(db)).resolves.toHaveLength(0);
-
-    const batch = await seedReviewRow(db, {
-      proposedName: "A4 Flag Off Batch Backfill Project",
-      entityType: "project",
-      triggeredBy: ownerId,
-      evidenceFileIds: ["a4-owner-file"],
-      source: "linear",
-      sourceId: "a4-flag-off-batch-backfill-project",
-      candidateReason: "birth-gated",
-    });
-    const batchRes = await offApp.request("/api/entity-review/confirm-batch", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Cookie: offCookie },
-      body: JSON.stringify({
-        items: [{ reviewId: batch.id, candidateGeneratedAt: batch.candidateGeneratedAt }],
-      }),
-    });
-    expect(batchRes.status).toBe(404);
-    await expect(structuralContributesToRows(db)).resolves.toHaveLength(0);
-  });
-
   it("reclassify changes type, merges compatible collisions, and refuses incompatible source or seed refs", async () => {
     const product = await seedReviewRow(db, {
       proposedName: "A4 Solo Foo",
@@ -1129,7 +1054,7 @@ describe("entity-review A4 backend", () => {
     expect(invalidTypeRes.status).toBe(400);
   });
 
-  it("separates tracker and inferred bulk accept paths and keeps A4 routes absent when flag is off", async () => {
+  it("separates tracker and inferred bulk accept paths", async () => {
     const tracker = await seedReviewRow(db, {
       proposedName: "A4 Tracker Project",
       entityType: "project",
@@ -1176,43 +1101,6 @@ describe("entity-review A4 backend", () => {
     };
     expect(batch.results.find((result) => result.reviewId === tracker.id)?.ok).toBe(true);
     expect(batch.results.find((result) => result.reviewId === inferred.id)?.error?.code).toBe("CANDIDATE_MISSING");
-
-    const offCookie = await login(offApp, OWNER_EMAIL);
-    for (const path of [
-      "/api/entity-review/summary",
-      "/api/entity-review/confirm-batch",
-      "/api/entity-review/reject-batch",
-      `/api/entity-review/${inferred.id}/reclassify-type`,
-    ]) {
-      const res = await offApp.request(path, {
-        method: path.includes("summary") ? "GET" : "POST",
-        headers: { "Content-Type": "application/json", Cookie: offCookie },
-        body: path.includes("summary")
-          ? undefined
-          : JSON.stringify({
-              items: [],
-              newEntityType: "project",
-              candidateGeneratedAt: inferred.candidateGeneratedAt,
-            }),
-      });
-      expect(res.status).toBe(404);
-    }
-
-    const single = await seedReviewRow(db, {
-      proposedName: "A4 Flag Off Single",
-      entityType: "project",
-      triggeredBy: ownerId,
-      evidenceFileIds: ["a4-owner-file"],
-      source: "linear",
-      sourceId: "flag-off-single",
-      candidateReason: "birth-gated",
-    });
-    const singleRes = await offApp.request(`/api/entity-review/${single.id}/confirm`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Cookie: offCookie },
-      body: JSON.stringify({ candidateGeneratedAt: single.candidateGeneratedAt }),
-    });
-    expect(singleRes.status).toBe(200);
   });
 });
 
@@ -1228,7 +1116,7 @@ describe("entity-review routes — dismiss endpoint", () => {
     await seedUsers(db);
     ownerId = await userIdByEmail(db, OWNER_EMAIL);
     await seedConnectorConfig(db, "config-owner", ownerId);
-    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), {
       logger: createTestLogger(),
     });
     ownerCookie = await login(app, OWNER_EMAIL);
@@ -1342,7 +1230,7 @@ describe("entity-review routes — child tasks preview", () => {
     otherId = await userIdByEmail(db, OTHER_EMAIL);
     await seedConnectorConfig(db, "config-owner", ownerId);
     await seedConnectorConfig(db, "config-other", otherId);
-    app = createApp(db, createTestConfig({ ENCRYPTION_KEY, EXPERIMENTAL_FLAG: true }), {
+    app = createApp(db, createTestConfig({ ENCRYPTION_KEY }), {
       logger: createTestLogger(),
     });
     ownerCookie = await login(app, OWNER_EMAIL);

--- a/packages/server/src/entities/review.ts
+++ b/packages/server/src/entities/review.ts
@@ -32,7 +32,6 @@ import { type Context, Hono } from "hono";
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
 import { getContentViewer, isAdmin } from "../api/auth-helpers";
-import type { Config } from "../config";
 import { createEntityRepository } from "../db/repositories/entities";
 import { createEntityReviewRepo, readReviewFreezeMs } from "../db/repositories/entity-review";
 import { createIndexedFileFactRepository } from "../db/repositories/indexed-file-facts";
@@ -143,10 +142,7 @@ async function backfillStructuralAssigneeForConfirmedProjects(
   await reconcileStructuralAssigneeContributesTo(db, logger, { scope: { kind: "tasks", taskIds } });
 }
 
-export function entityReviewRoutes(
-  db: Kysely<DB>,
-  deps: { config: Pick<Config, "EXPERIMENTAL_FLAG">; logger: Logger },
-) {
+export function entityReviewRoutes(db: Kysely<DB>, deps: { logger: Logger }) {
   const app = new Hono();
 
   app.get("/", async (c) => {
@@ -233,153 +229,151 @@ export function entityReviewRoutes(
     return c.json({ rows: rowsWithSummary, total });
   });
 
-  if (deps.config.EXPERIMENTAL_FLAG) {
-    app.get("/summary", async (c) => {
-      const repo = createEntityReviewRepo(db);
-      const summary = await repo.summarizePendingByTypeAndOrigin({
-        ownerUserId: c.get("sub"),
-        isAdmin: isAdmin(c),
-      });
-      return c.json(summary);
+  app.get("/summary", async (c) => {
+    const repo = createEntityReviewRepo(db);
+    const summary = await repo.summarizePendingByTypeAndOrigin({
+      ownerUserId: c.get("sub"),
+      isAdmin: isAdmin(c),
     });
+    return c.json(summary);
+  });
 
-    app.post("/confirm-batch", async (c) => {
-      const body = (await c.req.json().catch(() => ({}))) as {
-        items?: Array<{ reviewId?: string; candidateGeneratedAt?: string; mergeIntoEntityId?: string }>;
-      };
-      if (!Array.isArray(body.items)) {
-        return c.json({ error: { code: "BAD_REQUEST", message: "items is required" } }, 400);
-      }
-      const repo = createEntityReviewRepo(db);
-      const results: Array<{
-        reviewId: string;
-        ok: boolean;
-        targetEntityId?: string;
-        error?: { code: string; message: string };
-      }> = [];
-      const confirmedProjectTargetEntityIds = new Set<string>();
-      for (const item of body.items) {
-        const reviewId = item.reviewId ?? "";
-        if (!item.reviewId || !item.candidateGeneratedAt) {
-          results.push({
-            reviewId,
-            ok: false,
-            error: { code: "BAD_REQUEST", message: "reviewId and candidateGeneratedAt are required" },
-          });
-          continue;
-        }
-        const row = await repo.getById(item.reviewId);
-        if (!row) {
-          results.push({
-            reviewId: item.reviewId,
-            ok: false,
-            error: { code: "ROW_NOT_FOUND", message: "review row not found" },
-          });
-          continue;
-        }
-        const denied = await denyIfNotOwnerOrAdmin(c, repo, row);
-        if (denied) {
-          results.push({ reviewId: item.reviewId, ok: false, error: await readErrorResponse(denied) });
-          continue;
-        }
-        try {
-          const result = await confirmReview({ db, userId: c.get("sub") }, item.reviewId, {
-            mergeIntoEntityId: item.mergeIntoEntityId,
-            candidateGeneratedAt: item.candidateGeneratedAt,
-          });
-          if (result.row.entity_type === "project") confirmedProjectTargetEntityIds.add(result.targetEntityId);
-          results.push({ reviewId: item.reviewId, ok: true, targetEntityId: result.targetEntityId });
-        } catch (err) {
-          results.push({ reviewId: item.reviewId, ok: false, error: batchError(err) });
-        }
-      }
-      if (deps.config.EXPERIMENTAL_FLAG && confirmedProjectTargetEntityIds.size > 0) {
-        await backfillStructuralAssigneeForConfirmedProjects(db, deps.logger, [...confirmedProjectTargetEntityIds]);
-      }
-      return c.json({ results });
-    });
-
-    app.post("/reject-batch", async (c) => {
-      const body = (await c.req.json().catch(() => ({}))) as {
-        items?: Array<{ reviewId?: string; candidateGeneratedAt?: string }>;
-      };
-      if (!Array.isArray(body.items)) {
-        return c.json({ error: { code: "BAD_REQUEST", message: "items is required" } }, 400);
-      }
-      const repo = createEntityReviewRepo(db);
-      const results: Array<{ reviewId: string; ok: boolean; error?: { code: string; message: string } }> = [];
-      for (const item of body.items) {
-        const reviewId = item.reviewId ?? "";
-        if (!item.reviewId || !item.candidateGeneratedAt) {
-          results.push({
-            reviewId,
-            ok: false,
-            error: { code: "BAD_REQUEST", message: "reviewId and candidateGeneratedAt are required" },
-          });
-          continue;
-        }
-        const row = await repo.getById(item.reviewId);
-        if (!row) {
-          results.push({
-            reviewId: item.reviewId,
-            ok: false,
-            error: { code: "ROW_NOT_FOUND", message: "review row not found" },
-          });
-          continue;
-        }
-        const denied = await denyIfNotOwnerOrAdmin(c, repo, row);
-        if (denied) {
-          results.push({ reviewId: item.reviewId, ok: false, error: await readErrorResponse(denied) });
-          continue;
-        }
-        try {
-          await rejectReview({ db, userId: c.get("sub") }, item.reviewId, {
-            candidateGeneratedAt: item.candidateGeneratedAt,
-          });
-          results.push({ reviewId: item.reviewId, ok: true });
-        } catch (err) {
-          results.push({ reviewId: item.reviewId, ok: false, error: batchError(err) });
-        }
-      }
-      return c.json({ results });
-    });
-
-    app.post("/:id/reclassify-type", async (c) => {
-      const id = c.req.param("id");
-      const body = (await c.req.json().catch(() => ({}))) as {
-        newEntityType?: string;
-        candidateGeneratedAt?: string;
-      };
-      if (!body.candidateGeneratedAt || !body.newEntityType) {
-        return c.json(
-          { error: { code: "BAD_REQUEST", message: "newEntityType and candidateGeneratedAt are required" } },
-          400,
-        );
-      }
-      if (!RECLASSIFIABLE_TYPES.has(body.newEntityType)) {
-        return c.json(
-          { error: { code: "BAD_REQUEST", message: "newEntityType must be project, product, or team" } },
-          400,
-        );
-      }
-
-      const repo = createEntityReviewRepo(db);
-      const row = await repo.getById(id);
-      if (!row) return c.json({ error: { code: "NOT_FOUND", message: "review row not found" } }, 404);
-      const denied = await denyIfNotOwnerOrAdmin(c, repo, row);
-      if (denied) return denied;
-
-      try {
-        const result = await reclassifyReview({ db, userId: c.get("sub") }, id, {
-          newEntityType: body.newEntityType,
-          candidateGeneratedAt: body.candidateGeneratedAt,
+  app.post("/confirm-batch", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as {
+      items?: Array<{ reviewId?: string; candidateGeneratedAt?: string; mergeIntoEntityId?: string }>;
+    };
+    if (!Array.isArray(body.items)) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "items is required" } }, 400);
+    }
+    const repo = createEntityReviewRepo(db);
+    const results: Array<{
+      reviewId: string;
+      ok: boolean;
+      targetEntityId?: string;
+      error?: { code: string; message: string };
+    }> = [];
+    const confirmedProjectTargetEntityIds = new Set<string>();
+    for (const item of body.items) {
+      const reviewId = item.reviewId ?? "";
+      if (!item.reviewId || !item.candidateGeneratedAt) {
+        results.push({
+          reviewId,
+          ok: false,
+          error: { code: "BAD_REQUEST", message: "reviewId and candidateGeneratedAt are required" },
         });
-        return c.json(result);
-      } catch (err) {
-        return handleResolveError(c, err);
+        continue;
       }
-    });
-  }
+      const row = await repo.getById(item.reviewId);
+      if (!row) {
+        results.push({
+          reviewId: item.reviewId,
+          ok: false,
+          error: { code: "ROW_NOT_FOUND", message: "review row not found" },
+        });
+        continue;
+      }
+      const denied = await denyIfNotOwnerOrAdmin(c, repo, row);
+      if (denied) {
+        results.push({ reviewId: item.reviewId, ok: false, error: await readErrorResponse(denied) });
+        continue;
+      }
+      try {
+        const result = await confirmReview({ db, userId: c.get("sub") }, item.reviewId, {
+          mergeIntoEntityId: item.mergeIntoEntityId,
+          candidateGeneratedAt: item.candidateGeneratedAt,
+        });
+        if (result.row.entity_type === "project") confirmedProjectTargetEntityIds.add(result.targetEntityId);
+        results.push({ reviewId: item.reviewId, ok: true, targetEntityId: result.targetEntityId });
+      } catch (err) {
+        results.push({ reviewId: item.reviewId, ok: false, error: batchError(err) });
+      }
+    }
+    if (confirmedProjectTargetEntityIds.size > 0) {
+      await backfillStructuralAssigneeForConfirmedProjects(db, deps.logger, [...confirmedProjectTargetEntityIds]);
+    }
+    return c.json({ results });
+  });
+
+  app.post("/reject-batch", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as {
+      items?: Array<{ reviewId?: string; candidateGeneratedAt?: string }>;
+    };
+    if (!Array.isArray(body.items)) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "items is required" } }, 400);
+    }
+    const repo = createEntityReviewRepo(db);
+    const results: Array<{ reviewId: string; ok: boolean; error?: { code: string; message: string } }> = [];
+    for (const item of body.items) {
+      const reviewId = item.reviewId ?? "";
+      if (!item.reviewId || !item.candidateGeneratedAt) {
+        results.push({
+          reviewId,
+          ok: false,
+          error: { code: "BAD_REQUEST", message: "reviewId and candidateGeneratedAt are required" },
+        });
+        continue;
+      }
+      const row = await repo.getById(item.reviewId);
+      if (!row) {
+        results.push({
+          reviewId: item.reviewId,
+          ok: false,
+          error: { code: "ROW_NOT_FOUND", message: "review row not found" },
+        });
+        continue;
+      }
+      const denied = await denyIfNotOwnerOrAdmin(c, repo, row);
+      if (denied) {
+        results.push({ reviewId: item.reviewId, ok: false, error: await readErrorResponse(denied) });
+        continue;
+      }
+      try {
+        await rejectReview({ db, userId: c.get("sub") }, item.reviewId, {
+          candidateGeneratedAt: item.candidateGeneratedAt,
+        });
+        results.push({ reviewId: item.reviewId, ok: true });
+      } catch (err) {
+        results.push({ reviewId: item.reviewId, ok: false, error: batchError(err) });
+      }
+    }
+    return c.json({ results });
+  });
+
+  app.post("/:id/reclassify-type", async (c) => {
+    const id = c.req.param("id");
+    const body = (await c.req.json().catch(() => ({}))) as {
+      newEntityType?: string;
+      candidateGeneratedAt?: string;
+    };
+    if (!body.candidateGeneratedAt || !body.newEntityType) {
+      return c.json(
+        { error: { code: "BAD_REQUEST", message: "newEntityType and candidateGeneratedAt are required" } },
+        400,
+      );
+    }
+    if (!RECLASSIFIABLE_TYPES.has(body.newEntityType)) {
+      return c.json(
+        { error: { code: "BAD_REQUEST", message: "newEntityType must be project, product, or team" } },
+        400,
+      );
+    }
+
+    const repo = createEntityReviewRepo(db);
+    const row = await repo.getById(id);
+    if (!row) return c.json({ error: { code: "NOT_FOUND", message: "review row not found" } }, 404);
+    const denied = await denyIfNotOwnerOrAdmin(c, repo, row);
+    if (denied) return denied;
+
+    try {
+      const result = await reclassifyReview({ db, userId: c.get("sub") }, id, {
+        newEntityType: body.newEntityType,
+        candidateGeneratedAt: body.candidateGeneratedAt,
+      });
+      return c.json(result);
+    } catch (err) {
+      return handleResolveError(c, err);
+    }
+  });
 
   app.get("/:id", async (c) => {
     const id = c.req.param("id");
@@ -472,7 +466,7 @@ export function entityReviewRoutes(
         candidateGeneratedAt: body.candidateGeneratedAt,
         nameOverride: body.nameOverride,
       });
-      if (deps.config.EXPERIMENTAL_FLAG && result.row.entity_type === "project") {
+      if (result.row.entity_type === "project") {
         await backfillStructuralAssigneeForConfirmedProjects(db, deps.logger, [result.targetEntityId]);
       }
       return c.json({

--- a/packages/server/src/entities/tool-type.test.ts
+++ b/packages/server/src/entities/tool-type.test.ts
@@ -160,11 +160,16 @@ describe("tool entity type", () => {
     await db.destroy();
   });
 
+  it("coerces denylisted names to tool without a flag", () => {
+    expect(coerceMentionType("Slack", "product")).toBe("tool");
+    expect(coerceMentionType("Internal Portal", "product")).toBe("product");
+  });
+
   it("classifies and materializes Slack mentions as tool while dropping tool relation endpoints", async () => {
     await seedFile(db, "file-tool-classify", "Slack and Acme Corp were discussed.");
     await seedFile(db, "file-tool-classify-2", "Slack and Acme Corp were discussed again.");
 
-    expect(coerceMentionType("Slack", "product", true)).toBe("tool");
+    expect(coerceMentionType("Slack", "product")).toBe("tool");
     expect(normalizeMentionType("tool")).toBe("tool");
 
     for (const fileId of ["file-tool-classify", "file-tool-classify-2"]) {
@@ -174,7 +179,6 @@ describe("tool entity type", () => {
           logger: createTestLogger(),
           generator: fakeGenerator(),
           embeddingProvider: null,
-          experimentalFlag: true,
         },
         {
           id: fileId,
@@ -241,7 +245,6 @@ describe("tool entity type", () => {
       llmPromotionThreshold: 1,
       birthGateTypes: A1_BIRTH_GATE_TYPES,
       birthGateDryRun: false,
-      experimentalFlag: true,
     });
 
     expect(await db.selectFrom("entity_relationships").select("id").execute()).toHaveLength(0);

--- a/packages/server/src/entities/tool-type.test.ts
+++ b/packages/server/src/entities/tool-type.test.ts
@@ -5,7 +5,6 @@ import { handleSearch, handleSearchEntities } from "../agent/tools/search";
 import { UploadCollector } from "../agent/tools/types";
 import { connectorRoutes } from "../api/connectors";
 import { createEntityProfileRoutes } from "../api/entities/profile-routes";
-import { linkEntitiesByDeterministicMatch } from "../connectors/enrichment";
 import type { GeminiGenerator } from "../connectors/gemini-generate";
 import { matchEntities, smartEnrichFile } from "../connectors/smart-enrichment";
 import { createConnectorRepository } from "../db/repositories/connectors";
@@ -258,7 +257,7 @@ describe("tool entity type", () => {
     ).toHaveLength(0);
   });
 
-  it("excludes tools from default search, API, graph, deterministic linking, file detail, and matching", async () => {
+  it("excludes tools from default search, API, graph, file detail, and matching", async () => {
     await seedFile(db, "file-tool-hidden", "Slack and Project Apollo are in this document.");
     await seedEntity(db, "entity-tool-slack", "Slack", "tool");
     await seedEntity(db, "entity-project-apollo", "Project Apollo", "project");
@@ -290,15 +289,6 @@ describe("tool entity type", () => {
     const graphRes = await entityApp.request("/graph");
     const graphBody = (await graphRes.json()) as { nodes: Array<{ name: string }> };
     expect(graphBody.nodes.map((node) => node.name)).not.toContain("Slack");
-
-    await linkEntitiesByDeterministicMatch(db, createTestLogger());
-    const deterministicToolMentions = await db
-      .selectFrom("entity_mentions")
-      .select("id")
-      .where("entity_id", "=", "entity-tool-slack")
-      .where("source", "=", "deterministic_substring")
-      .execute();
-    expect(deterministicToolMentions).toHaveLength(0);
 
     const connectorApp = adminApp(connectorRoutes(createConnectorRepository(db), db, createTestLogger()));
     const fileRes = await connectorApp.request("/files/file-tool-hidden/content");

--- a/packages/server/src/entities/validators.test.ts
+++ b/packages/server/src/entities/validators.test.ts
@@ -26,7 +26,7 @@ describe("validateLlmMention", () => {
     ).toEqual({ ok: false, reason: "short_token_no_boundary" });
   });
 
-  it("rejects removed LLM entity types", () => {
+  it("accepts feature LLM entity types", () => {
     expect(
       validateLlmMention({
         displayName: "Aviation Edge scraper",
@@ -34,7 +34,7 @@ describe("validateLlmMention", () => {
         fileContent: "Aviation Edge scraper was discussed.",
         source: "llm_extraction",
       }),
-    ).toEqual({ ok: false, reason: "type_removed" });
+    ).toEqual({ ok: true });
   });
 
   it("rejects domain-shaped LLM names while preserving normal project names", () => {

--- a/packages/server/src/entities/validators.ts
+++ b/packages/server/src/entities/validators.ts
@@ -9,7 +9,6 @@ export type LlmMentionValidationResult =
       reason:
         | "name_absent_from_content"
         | "short_token_no_boundary"
-        | "type_removed"
         | "missing_current_reference"
         | "name_is_domain_or_url";
     };
@@ -80,16 +79,11 @@ export function validateLlmMention(input: {
   fileContent: string;
   resolutionContext?: string | null;
   source: "llm_extraction" | "connector_extracted";
-  experimentalFlag?: boolean;
 }): LlmMentionValidationResult {
   if (input.source !== "llm_extraction") return { ok: true };
   if (isDomainOrUrlOrEmailName(input.displayName)) {
     return { ok: false, reason: "name_is_domain_or_url" };
   }
-  if (!input.experimentalFlag && input.entityType?.trim().toLowerCase() === "feature") {
-    return { ok: false, reason: "type_removed" };
-  }
-
   const content = normalizePresenceText(input.fileContent);
   const names = [input.displayName, ...(input.aliases ?? [])]
     .map((name) => normalizePresenceText(name))

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1225,23 +1225,6 @@ describe("Setup endpoints", () => {
       const body = await res.json();
       expect(body.completed).toBe(true);
     });
-
-    it("exposes experimentalFlag (true)", async () => {
-      const flaggedConfig = createTestConfig({ EXPERIMENTAL_FLAG: true });
-      const app = createApp(db, flaggedConfig);
-      const res = await app.request("/api/setup/status");
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body.experimentalFlag).toBe(true);
-    });
-
-    it("exposes experimentalFlag (false) by default", async () => {
-      const app = createApp(db, config);
-      const res = await app.request("/api/setup/status");
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body.experimentalFlag).toBe(false);
-    });
   });
 
   describe("POST /api/setup/slack/verify", () => {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -330,7 +330,6 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     "/api/setup",
     setupRoutes(settings, {
       managedUrl: config.MANAGED_URL,
-      experimentalFlag: config.EXPERIMENTAL_FLAG,
       onSlackTokensUpdated: deps?.onSlackTokensUpdated,
       onLlmSettingsUpdated: deps?.onLlmSettingsUpdated,
       userRepo: users,
@@ -457,10 +456,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   }
   app.route("/api/entities", entityRoutes(db, { logger, config }));
   app.route("/api/projects", createProjectRoutes(db));
-  if (config.EXPERIMENTAL_FLAG) {
-    app.route("/api/products", productRoutes(db));
-  }
-  app.route("/api/entity-review", entityReviewRoutes(db, { config, logger }));
+  app.route("/api/products", productRoutes(db));
+  app.route("/api/entity-review", entityReviewRoutes(db, { logger }));
   app.route("/api/api-tokens", apiTokenRoutes(db, { baseUrl: config.BASE_URL }));
   mountPublicMcpServer({
     app,

--- a/packages/server/src/mcp/server/public-server.test.ts
+++ b/packages/server/src/mcp/server/public-server.test.ts
@@ -44,15 +44,15 @@ function mcpHeaders(token: string) {
 }
 
 describe("public MCP server", () => {
-  it("is available without EXPERIMENTAL_FLAG and advertises OAuth discovery", async () => {
-    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: false }), { logger: createTestLogger() });
+  it("is available and advertises OAuth discovery", async () => {
+    const app = createApp(db, createTestConfig({}), { logger: createTestLogger() });
     const res = await app.request("/mcp", { method: "POST" });
     expect(res.status).toBe(401);
     expect(res.headers.get("www-authenticate")).toContain("/.well-known/oauth-protected-resource");
   });
 
   it("rejects non-Sketch PAT bearer tokens", async () => {
-    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    const app = createApp(db, createTestConfig({}), { logger: createTestLogger() });
     const res = await app.request("/mcp", {
       method: "POST",
       headers: mcpHeaders("sk_live_wrong"),
@@ -63,7 +63,7 @@ describe("public MCP server", () => {
 
   it("lists the four public sketch tools for a valid PAT", async () => {
     const token = await createPat();
-    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    const app = createApp(db, createTestConfig({}), { logger: createTestLogger() });
 
     const res = await app.request("/mcp", {
       method: "POST",
@@ -83,7 +83,7 @@ describe("public MCP server", () => {
 
   it("rate limits by token even when the forwarded IP changes", async () => {
     const token = await createPat();
-    const app = createApp(db, createTestConfig({ EXPERIMENTAL_FLAG: true }), { logger: createTestLogger() });
+    const app = createApp(db, createTestConfig({}), { logger: createTestLogger() });
     const statuses: number[] = [];
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
 

--- a/packages/server/src/slack/adapter.isolated.test.ts
+++ b/packages/server/src/slack/adapter.isolated.test.ts
@@ -1341,9 +1341,9 @@ describe("slack/adapter", () => {
   });
 
   describe("Assistant-pane DM shimmer", () => {
-    it("calls setAssistantStatus and skips eyes/✅ reactions for DMs with a threadTs when EXPERIMENTAL_FLAG is on", async () => {
+    it("calls setAssistantStatus and skips eyes/✅ reactions for DMs with a threadTs", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
       });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
 
@@ -1364,7 +1364,6 @@ describe("slack/adapter", () => {
             DATA_DIR: "/tmp/test-data",
             PORT: 0,
             LOG_LEVEL: "error",
-            EXPERIMENTAL_FLAG: true,
           }),
           runAgent: vi.fn().mockImplementation(async (params) => {
             await params.onProgressEvent({ kind: "tool_use", toolName: "Read", input: { file_path: "a.ts" } });
@@ -1385,7 +1384,7 @@ describe("slack/adapter", () => {
 
     it("honors the selected tool-progress mode for Assistant shimmer text", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
         runAgent: vi.fn().mockImplementation(async (params) => {
           await params.onProgressEvent({ kind: "tool_use", toolName: "Read", input: { file_path: "a.ts" } });
           return makeAgentResult();
@@ -1403,7 +1402,7 @@ describe("slack/adapter", () => {
 
     it("streams reasoning text into the shimmer when reasoningText is on", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
         runAgent: vi.fn().mockImplementation(async (params) => {
           await params.onProgressEvent({ kind: "intermediate_text", text: "thinking about it" });
           return makeAgentResult();
@@ -1421,7 +1420,7 @@ describe("slack/adapter", () => {
 
     it("collapses repeated tool calls into an (xN) multiplier in the shimmer", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
         runAgent: vi.fn().mockImplementation(async (params) => {
           await params.onProgressEvent({ kind: "tool_use", toolName: "Read", input: { file_path: "a.ts" } });
           await params.onProgressEvent({ kind: "tool_use", toolName: "Read", input: { file_path: "a.ts" } });
@@ -1440,7 +1439,7 @@ describe("slack/adapter", () => {
 
     it("passes threadTs to runAgent for assistant-pane DMs", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
       });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
 
@@ -1454,7 +1453,7 @@ describe("slack/adapter", () => {
 
     it("posts the final reply inside the assistant thread", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
       });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
 
@@ -1468,7 +1467,7 @@ describe("slack/adapter", () => {
 
     it("posts _No response_ as a thread reply for assistant-pane DMs", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
         runAgent: vi
           .fn()
           .mockResolvedValue(makeAgentResult({ messageSent: false, trace: { progressEvents: [], finalText: null } })),
@@ -1485,7 +1484,7 @@ describe("slack/adapter", () => {
 
     it("posts the error message as a thread reply for assistant-pane DMs", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
         runAgent: vi.fn().mockRejectedValue(new Error("boom")),
       });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
@@ -1500,7 +1499,7 @@ describe("slack/adapter", () => {
 
     it("uploads pending files inside the assistant thread", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
         runAgent: vi.fn().mockResolvedValue(makeAgentResult({ pendingUploads: ["/tmp/out.pdf"] })),
       });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
@@ -1514,7 +1513,7 @@ describe("slack/adapter", () => {
 
     it("does not pass threadTs to runAgent for top-level (no-thread) Messages-tab DMs", async () => {
       const deps = makeDeps({
-        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error", EXPERIMENTAL_FLAG: true }),
+        config: createTestConfig({ DATA_DIR: "/tmp/test-data", PORT: 0, LOG_LEVEL: "error" }),
       });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
 

--- a/packages/server/src/test-utils.ts
+++ b/packages/server/src/test-utils.ts
@@ -167,7 +167,6 @@ export function createTestConfig(overrides: Partial<Config> = {}): Config {
     MAX_CONCURRENT_AGENT_RUNS: 4,
     MAX_FILE_SIZE_MB: 20,
     MAX_UPLOAD_SIZE_MB: 50,
-    EXPERIMENTAL_FLAG: false,
     BIRTH_GATE_DRY_RUN: true,
     LLM_PROMOTION_THRESHOLD: 2,
     LLM_TASK_CORROBORATION_THRESHOLD: 2,

--- a/packages/web/src/components/app-sidebar.tsx
+++ b/packages/web/src/components/app-sidebar.tsx
@@ -58,14 +58,11 @@ interface NavItem {
   href: string;
   disabled?: boolean;
   adminOnly?: boolean;
-  memberVisibleWhenExperimental?: boolean;
-  /** Render only when `setupStatus.experimentalFlag === true`. */
-  experimentalOnly?: boolean;
   /** Optional render-prop for a trailing element (e.g. a count badge). */
   trailing?: React.ReactNode;
   /**
-   * When experimental, relabel to "Your org" and show a pending-review count
-   * badge scoped to the org-taxonomy spine.
+   * Relabel to "Your org" and show a pending-review count badge scoped to the
+   * org-taxonomy spine.
    */
   yourOrgBadge?: boolean;
 }
@@ -126,18 +123,15 @@ export function AppSidebar({
     queryFn: () => api.setup.status(),
   });
 
-  const experimentalEnabled = setupStatus?.experimentalFlag === true;
   const { data: yourOrgReview } = useQuery({
     queryKey: ["entity-review", "band-count", "spine"],
     queryFn: () => api.entityReview.list({ limit: 0, types: ["product", "project", "team"] }),
-    enabled: experimentalEnabled && role === "admin",
+    enabled: role === "admin",
     refetchInterval: 30000,
   });
   const yourOrgCount = yourOrgReview?.total ?? 0;
   const primaryNav = allPrimaryNav.filter((item) => {
-    if (item.adminOnly && role !== "admin" && !(item.memberVisibleWhenExperimental && experimentalEnabled))
-      return false;
-    if (item.experimentalOnly && !experimentalEnabled) return false;
+    if (item.adminOnly && role !== "admin") return false;
     return true;
   });
   const roleLabel = formatRole(role);
@@ -177,7 +171,7 @@ export function AppSidebar({
           <SidebarGroupContent>
             <SidebarMenu>
               {primaryNav.map((item) => {
-                const yourOrg = item.yourOrgBadge && experimentalEnabled;
+                const yourOrg = item.yourOrgBadge === true;
                 const label = yourOrg ? "Your org" : item.label;
                 return (
                   <SidebarMenuItem key={item.href}>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -247,7 +247,6 @@ export interface SetupStatus {
   slackConnected: boolean;
   llmConnected: boolean;
   llmProvider: LlmProvider | null;
-  experimentalFlag?: boolean;
   managedUrl?: string;
 }
 

--- a/packages/web/src/routes/files/connector-picker.isolated.test.tsx
+++ b/packages/web/src/routes/files/connector-picker.isolated.test.tsx
@@ -30,7 +30,6 @@ function setupStatus() {
         slackConnected: true,
         llmConnected: true,
         llmProvider: "anthropic",
-        experimentalFlag: false,
       }),
     ),
   );

--- a/packages/web/src/routes/files/entity-explorer.isolated.test.tsx
+++ b/packages/web/src/routes/files/entity-explorer.isolated.test.tsx
@@ -6,7 +6,7 @@
  * - count-probe short-circuits when no pending rows exist (no list query)
  * - pending review rows render as "ghost rows" at the top of the entities
  *   table; a divider separates them from confirmed entities
- * - Files is GA: the count probe fires regardless of EXPERIMENTAL_FLAG
+ * - the count probe always fires (no ghost rows when the queue is empty)
  * - clicking a ghost row opens the drawer in review mode (two-column
  *   reconcile view with the proposed entity + ReviewActions)
  * - "Confirm" inside the drawer resolves the row and shrinks the ghost set
@@ -46,8 +46,8 @@ const baseStatus = {
   llmProvider: "anthropic" as const,
 };
 
-function statusResponse(experimentalFlag: boolean) {
-  return HttpResponse.json({ ...baseStatus, experimentalFlag });
+function statusResponse() {
+  return HttpResponse.json({ ...baseStatus });
 }
 
 function entityListResponse(entities: Array<Partial<Record<string, unknown>>>) {
@@ -101,10 +101,10 @@ function rowFactory(over: Partial<Record<string, unknown>> = {}) {
 }
 
 describe("EntityExplorer ECR-03B inline review", () => {
-  it("Files GA: count probe fires regardless of EXPERIMENTAL_FLAG (no ghost rows when empty)", async () => {
+  it("count probe fires and renders no ghost rows when the queue is empty", async () => {
     let probeCalls = 0;
     server.use(
-      http.get("/api/setup/status", () => statusResponse(false)),
+      http.get("/api/setup/status", () => statusResponse()),
       http.get("/api/entities", () => entityListResponse([{ id: "ent-1", name: "Simran S" }])),
       http.get("/api/entity-review", () => {
         probeCalls++;
@@ -122,7 +122,7 @@ describe("EntityExplorer ECR-03B inline review", () => {
   it("count=0: probe fires, list query does NOT, no ghost rows rendered", async () => {
     let listCalls = 0;
     server.use(
-      http.get("/api/setup/status", () => statusResponse(true)),
+      http.get("/api/setup/status", () => statusResponse()),
       http.get("/api/entities", () => entityListResponse([{ id: "ent-1", name: "Simran S" }])),
       http.get("/api/entity-review", ({ request }) => {
         const url = new URL(request.url);
@@ -140,7 +140,7 @@ describe("EntityExplorer ECR-03B inline review", () => {
 
   it("renders ghost rows above the entities divider when there are pending proposals", async () => {
     server.use(
-      http.get("/api/setup/status", () => statusResponse(true)),
+      http.get("/api/setup/status", () => statusResponse()),
       http.get("/api/entities", () => entityListResponse([{ id: "ent-1", name: "Simran S" }])),
       http.get("/api/entity-review", ({ request }) => {
         const url = new URL(request.url);
@@ -169,7 +169,7 @@ describe("EntityExplorer ECR-03B inline review", () => {
   it("clicking a ghost row opens the drawer in review mode with proposed + candidate columns", async () => {
     const user = userEvent.setup();
     server.use(
-      http.get("/api/setup/status", () => statusResponse(true)),
+      http.get("/api/setup/status", () => statusResponse()),
       http.get("/api/entities", () => entityListResponse([{ id: "ent-1", name: "Simran S" }])),
       http.get("/api/entities/ent-1", () =>
         HttpResponse.json({
@@ -241,7 +241,7 @@ describe("EntityExplorer ECR-03B inline review", () => {
     const user = userEvent.setup();
     let listFetches = 0;
     server.use(
-      http.get("/api/setup/status", () => statusResponse(true)),
+      http.get("/api/setup/status", () => statusResponse()),
       http.get("/api/entities", () => entityListResponse([{ id: "ent-1", name: "Simran S" }])),
       http.get("/api/entities/ent-1", () =>
         HttpResponse.json({
@@ -299,7 +299,7 @@ describe("EntityExplorer ECR-03B inline review", () => {
   it("shows picked entity identity when choosing a different candidate", async () => {
     const user = userEvent.setup();
     server.use(
-      http.get("/api/setup/status", () => statusResponse(true)),
+      http.get("/api/setup/status", () => statusResponse()),
       http.get("/api/entities", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("search")) {
@@ -394,7 +394,7 @@ describe("EntityExplorer ECR-03B inline review", () => {
 describe("EntityExplorer rebuild dialog", () => {
   function setupBaseHandlers() {
     server.use(
-      http.get("/api/setup/status", () => statusResponse(false)),
+      http.get("/api/setup/status", () => statusResponse()),
       http.get("/api/entities", () => entityListResponse([])),
     );
   }

--- a/packages/web/src/routes/files/entity-explorer.tsx
+++ b/packages/web/src/routes/files/entity-explorer.tsx
@@ -156,12 +156,10 @@ export function EntityExplorer() {
   const total = data?.total ?? 0;
   const tentativeCount = entities.filter((e) => e.status === "tentative").length;
 
-  // When the experimental Your Org surface is live it owns the org-taxonomy
-  // spine (product/project/team), so this band narrows to person/company to
-  // avoid a row appearing in two places. Flag off → unchanged (all types here).
-  const { data: setupStatus } = useQuery({ queryKey: ["setup", "status"], queryFn: () => api.setup.status() });
-  const reviewTypes = setupStatus?.experimentalFlag ? ["person", "company"] : undefined;
-  const reviewScope = reviewTypes?.join(",") ?? "all";
+  // The Your Org surface owns the org-taxonomy spine (product/project/team), so
+  // this band narrows to person/company to avoid a row appearing in two places.
+  const reviewTypes = ["person", "company"];
+  const reviewScope = reviewTypes.join(",");
 
   // ECR-03B inline review surface — two-stage fetch:
   // the cheap count probe gates the (heavier) list query.

--- a/packages/web/src/routes/files/manage-connector-dialog.tsx
+++ b/packages/web/src/routes/files/manage-connector-dialog.tsx
@@ -442,9 +442,7 @@ function ScopeEditorDispatch({
   scopeEntries: [string, unknown][];
   onBrowsingChange?: (browsing: boolean) => void;
 }) {
-  const { data: setupStatus } = useQuery({ queryKey: ["setup", "status"], queryFn: () => api.setup.status() });
-  const experimentalEnabled = setupStatus?.experimentalFlag === true;
-  const showHierarchy = experimentalEnabled && Array.isArray(hierarchyLevels) && hierarchyLevels.length > 0;
+  const showHierarchy = Array.isArray(hierarchyLevels) && hierarchyLevels.length > 0;
 
   if (connectorType === "gmail") {
     return <EmailScopeEditor connectorId={connectorId} scopeConfig={scopeConfig} />;

--- a/packages/web/src/routes/projects/index.test.tsx
+++ b/packages/web/src/routes/projects/index.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders } from "@/test/utils";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { ProjectsPage } from "./index";
 
 function projectsReturn(projects: unknown[]) {
@@ -34,12 +34,19 @@ function StackProbe() {
 }
 
 describe("ProjectsPage", () => {
+  beforeEach(() => {
+    server.use(
+      http.get("/api/products", () => HttpResponse.json({ products: [] })),
+      http.get("/api/entities", () => HttpResponse.json({ entities: [], total: 0 })),
+    );
+  });
+
   it("groups projects by whether they have data sources", async () => {
     projectsReturn([DERIVED_WIRED, DEFINED_BARE]);
     renderWithProviders(<ProjectsPage />);
 
-    expect(await screen.findByText("Needs sources")).toBeInTheDocument();
-    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(await screen.findByText("Projects · needs sources")).toBeInTheDocument();
+    expect(screen.getByText("Projects · active")).toBeInTheDocument();
     expect(screen.getByText("Helios")).toBeInTheDocument();
     expect(screen.getByText("Atlas Rollout")).toBeInTheDocument();
     expect(screen.getByText("2 sources · 1 sub-project")).toBeInTheDocument();
@@ -67,17 +74,13 @@ describe("ProjectsPage", () => {
     expect(await screen.findByText(/No projects yet/i)).toBeInTheDocument();
   });
 
-  it("renders the Your Org surface with a product tier chip when experimental", async () => {
+  it("renders the Your Org surface with a product tier chip", async () => {
     server.use(
-      http.get("/api/setup/status", () =>
-        HttpResponse.json({ completed: true, botName: "Sketch", experimentalFlag: true }),
-      ),
       http.get("/api/products", () =>
         HttpResponse.json({
           products: [{ id: "prod-1", name: "Canvas Copilot", aliases: [], hotness: 3, provenance_tier: "declared" }],
         }),
       ),
-      http.get("/api/entities", () => HttpResponse.json({ entities: [], total: 0 })),
     );
     projectsReturn([DERIVED_WIRED]);
     renderWithProviders(<ProjectsPage />);

--- a/packages/web/src/routes/projects/index.tsx
+++ b/packages/web/src/routes/projects/index.tsx
@@ -39,41 +39,28 @@ export const projectsRoute = createRoute({
 
 export function ProjectsPage() {
   const [showAdd, setShowAdd] = useState(false);
-  const { data: setupStatus } = useQuery({ queryKey: ["setup", "status"], queryFn: () => api.setup.status() });
-  const yourOrg = setupStatus?.experimentalFlag === true;
 
-  // Flag off → the GA Projects-only page, unchanged. Flag on → the full Your
-  // Org surface (review band + products + teams + the curated add control).
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div className="mb-7 flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-[22px] font-medium text-foreground">{yourOrg ? "Your org" : "Projects"}</h1>
+          <h1 className="text-[22px] font-medium text-foreground">Your org</h1>
           <p className="mt-1 text-[13px] text-muted-foreground">
-            {yourOrg
-              ? "The products, projects, and teams the graph is made of — confirm what the system proposes, and declare what it should already know."
-              : "Each project is a slice of the graph. Born from a connector or defined by you, then wired to the data sources that feed it."}
+            The products, projects, and teams the graph is made of — confirm what the system proposes, and declare what
+            it should already know.
           </p>
         </div>
-        {yourOrg ? (
-          <Button variant="outline" size="sm" className="h-7 shrink-0 gap-1.5 text-xs" onClick={() => setShowAdd(true)}>
-            <PlusIcon size={12} />
-            Add
-          </Button>
-        ) : null}
+        <Button variant="outline" size="sm" className="h-7 shrink-0 gap-1.5 text-xs" onClick={() => setShowAdd(true)}>
+          <PlusIcon size={12} />
+          Add
+        </Button>
       </div>
 
-      {yourOrg ? (
-        <>
-          <ReviewBand types={SPINE_TYPES} />
-          <ProductsSection />
-          <ProjectsSection legacyLabels={false} />
-          <TeamsSection />
-          <AddEntityDialog open={showAdd} onOpenChange={setShowAdd} defaultType="product" />
-        </>
-      ) : (
-        <ProjectsSection legacyLabels />
-      )}
+      <ReviewBand types={SPINE_TYPES} />
+      <ProductsSection />
+      <ProjectsSection />
+      <TeamsSection />
+      <AddEntityDialog open={showAdd} onOpenChange={setShowAdd} defaultType="product" />
     </div>
   );
 }
@@ -144,17 +131,15 @@ function TierBadge({ tier }: { tier: string }) {
   );
 }
 
-function ProjectsSection({ legacyLabels }: { legacyLabels: boolean }) {
+function ProjectsSection() {
   const { data, isLoading } = useQuery({ queryKey: ["projects", "index"], queryFn: () => api.projects.list() });
   const projects = data?.projects ?? [];
   const needsSources = projects.filter((p) => p.sourceCount === 0);
   const active = projects.filter((p) => p.sourceCount > 0);
-  const needsLabel = legacyLabels ? "Needs sources" : "Projects · needs sources";
-  const activeLabel = legacyLabels ? "Active" : "Projects · active";
   if (!isLoading && projects.length === 0) {
     return (
       <section>
-        {legacyLabels ? null : <GroupLabel label="Projects" note="0 tracked" />}
+        <GroupLabel label="Projects" note="0 tracked" />
         <EmptyHint>
           No projects yet — they appear here as the graph derives them from your connectors, or when you define one.
         </EmptyHint>
@@ -165,7 +150,7 @@ function ProjectsSection({ legacyLabels }: { legacyLabels: boolean }) {
     <>
       {needsSources.length > 0 ? (
         <section>
-          <GroupLabel label={needsLabel} note={`${needsSources.length} born · not wired yet`} accent={legacyLabels} />
+          <GroupLabel label="Projects · needs sources" note={`${needsSources.length} born · not wired yet`} />
           <div className="flex flex-col gap-1">
             {needsSources.map((project) => (
               <ProjectRow key={project.id} project={project} />
@@ -174,7 +159,7 @@ function ProjectsSection({ legacyLabels }: { legacyLabels: boolean }) {
         </section>
       ) : null}
       <section>
-        <GroupLabel label={activeLabel} note={`${active.length} fed by the graph`} />
+        <GroupLabel label="Projects · active" note={`${active.length} fed by the graph`} />
         {isLoading ? (
           <Skeleton className="h-12 w-full" />
         ) : active.length > 0 ? (

--- a/scripts/pr3-recreate-check.ts
+++ b/scripts/pr3-recreate-check.ts
@@ -101,12 +101,10 @@ async function main() {
   if (!(summary.reset.factsMarkedUnmaterialized > 0))
     issues.push(`[T2] factsMarkedUnmaterialized expected > 0, got ${summary.reset.factsMarkedUnmaterialized}`);
 
-  // TEST 3: INFERRED mentions exist via deterministic_substring
-  const inferredDeterministic = breakdown.find(
-    (r) => r.confidence === "INFERRED" && r.source === "deterministic_substring",
-  );
-  if (!inferredDeterministic || inferredDeterministic.count === 0)
-    issues.push(`[T3] no INFERRED mentions with source='deterministic_substring' — substring linker didn't fire`);
+  // TEST 3: deterministic_substring mentions are no longer produced
+  const deterministic = breakdown.find((r) => r.source === "deterministic_substring");
+  if (deterministic && deterministic.count > 0)
+    issues.push(`[T3] unexpected deterministic_substring mentions after recreate: ${deterministic.count}`);
 
   // TEST 3: no INFERRED llm_extraction mentions (we haven't run smart-enrichment)
   const llmInferred = breakdown.find((r) => r.confidence === "INFERRED" && r.source === "llm_extraction");


### PR DESCRIPTION
Stacked context-graph slice 27/27.

Base: `feat/context-graph-26-person-company-dedup-context`
Head: `feat/context-graph-27-ga-cleanup-hardening`

Removes the remaining GA cleanup hazards and hardens tests for the final stack.

Validation run on the final stacked tip:
- `bash scripts/with-node-version.sh pnpm lint`
- `bash scripts/with-node-version.sh pnpm typecheck`
- `bash scripts/with-node-version.sh pnpm test`
- `bash scripts/with-node-version.sh pnpm build`