### PR TITLE
fix: resolve managed WhatsApp delivery targets stored as Wati conversation ids

### DIFF
--- a/packages/server/src/agents/output-delivery.test.ts
+++ b/packages/server/src/agents/output-delivery.test.ts
@@ -6,9 +6,24 @@ import type { DB } from "../db/schema";
 import type { SlackBot } from "../slack/bot";
 import { createTestDb, createTestLogger } from "../test-utils";
 import { WHATSAPP_TEXT_LIMIT } from "../whatsapp/chunking";
+import type { WhatsAppCapabilities } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 import { dailyBriefDefinition } from "./definitions/daily-brief";
 import { createAgentOutputDeliveryService } from "./output-delivery";
+
+const textOnlyCapabilities: WhatsAppCapabilities = {
+  text: true,
+  media: false,
+  quotedReply: false,
+  templates: false,
+  templateProvisioning: "none",
+  interactive: false,
+  deliveryStatus: false,
+  typing: false,
+  reactions: false,
+  edit: false,
+  groups: false,
+};
 
 function createMockWhatsApp(overrides: Partial<WhatsAppRuntime> = {}): WhatsAppRuntime {
   return {
@@ -231,6 +246,56 @@ describe("createAgentOutputDeliveryService", () => {
     const attempt = await db.selectFrom("agent_output_deliveries").selectAll().executeTakeFirstOrThrow();
     expect(attempt.status).toBe("sent");
     expect(attempt.message_refs_json).toBe(JSON.stringify(["wa-nudge-1"]));
+  });
+
+  it("uses the recipient phone when a WhatsApp DM delivery target is an opaque Wati conversation id", async () => {
+    await db.updateTable("users").set({ whatsapp_number: "+15551234567" }).where("id", "=", "user-delivery").execute();
+    const sendText = vi.fn(async (target: unknown) => ({
+      providerMessageId: "wa-dm-opaque-1",
+      providerConversationId:
+        typeof target === "object" && target && "providerConversationId" in target
+          ? String(target.providerConversationId)
+          : "dm:+15551234567",
+      providerTimestamp: "2024-06-04T07:20:00.000Z",
+    }));
+    const whatsapp = createMockWhatsApp({
+      isConnected: true,
+      getCapabilities: vi.fn(() => textOnlyCapabilities),
+      sendText,
+    });
+    const service = createAgentOutputDeliveryService({
+      db,
+      logger: createTestLogger(),
+      getSlack: () => null,
+      whatsapp,
+      settingsRepo: createSettingsRepository(db),
+    });
+
+    await service.deliver({
+      definition: dailyBriefDefinition,
+      delivery: {
+        enabled: true,
+        platform: "whatsapp",
+        targetType: "dm",
+        targetId: "6a436a0b5a5429ba2f5d8153",
+        label: "Alice",
+      },
+      output: {
+        id: "output-delivery",
+        userId: "user-delivery",
+        agentKey: dailyBriefDefinition.key,
+        outputDate: "2026-06-26",
+        masthead: { title: "Daily Brief", summary: "Start here." },
+        sections: {},
+      },
+    });
+
+    expect(sendText).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+15551234567", providerConversationId: "6a436a0b5a5429ba2f5d8153" },
+      expect.stringContaining("Daily Brief"),
+    );
+    const conversation = await db.selectFrom("conversations").selectAll().executeTakeFirstOrThrow();
+    expect(conversation.provider_conversation_id).toBe("dm:+15551234567");
   });
 
   it("chunks in-window WhatsApp DM deliveries and captures each chunk", async () => {

--- a/packages/server/src/agents/output-delivery.ts
+++ b/packages/server/src/agents/output-delivery.ts
@@ -4,6 +4,7 @@ import type { AgentDeliveryConfig } from "../db/repositories/agent-outputs";
 import { createConversationRepository } from "../db/repositories/conversations";
 import { createInboxMessagesRepository } from "../db/repositories/inbox-messages";
 import type { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import { chunkText } from "../formatting/chunking";
 import type { Logger } from "../logger";
@@ -15,11 +16,7 @@ import {
   ProactiveDeliveryTextSendError,
   deliverProactiveDm,
 } from "../whatsapp/proactive-delivery";
-import {
-  type WhatsAppTarget,
-  whatsappDeliveryTargetFromTarget,
-  whatsappTargetFromDeliveryTarget,
-} from "../whatsapp/provider";
+import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 import { isSlackDmChannelId, isSlackUserId } from "../workflows/delivery";
 import { type RenderableAgentOutput, renderAgentOutputForDelivery } from "./output-renderer";
@@ -49,6 +46,7 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
   const repo = createAgentOutputDeliveryRepository(deps.db);
   const conversations = createConversationRepository(deps.db);
   const inboxMessages = createInboxMessagesRepository(deps.db);
+  const users = createUserRepository(deps.db);
   const capture = createWorkflowDeliveryCapture({
     conversations,
     settingsRepo: deps.settingsRepo,
@@ -85,6 +83,7 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
     const target = whatsappTargetFromDeliveryTarget(delivery.targetId);
 
     if (target.kind === "dm") {
+      const recipient = await users.findById(output.userId);
       try {
         const result = await deliverProactiveDm({
           target,
@@ -96,17 +95,17 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
           inboxMessages,
           logger: deps.logger,
           recipientName: delivery.label,
-          recipientPhoneE164: target.phoneE164,
+          recipientPhoneE164: recipient?.whatsapp_number ?? target.phoneE164,
           inboxMetadata: { source: "agent_output", outputId: output.id, agentKey: output.agentKey },
         });
         if (result.mode === "text") {
-          return captureWhatsAppDmTextSends(target, result.textSends);
+          return captureWhatsAppDmTextSends(result.deliveryTarget, result.textSends);
         }
         const messageRef = result.sent?.providerMessageId;
         return [messageRef ?? result.inboxMessageId].filter((ref): ref is string => Boolean(ref));
       } catch (err) {
         if (err instanceof ProactiveDeliveryTextSendError) {
-          await captureWhatsAppDmTextSends(target, err.textSends);
+          await captureWhatsAppDmTextSends(err.deliveryTarget, err.textSends);
           throw err.cause ?? err;
         }
         throw err;
@@ -130,7 +129,7 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
   }
 
   async function captureWhatsAppDmTextSends(
-    target: WhatsAppTarget & { kind: "dm" },
+    deliveryTarget: string,
     textSends: ProactiveDeliveryTextSend[],
   ): Promise<string[]> {
     const refs: string[] = [];
@@ -139,7 +138,7 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
       if (!messageRef) continue;
       refs.push(messageRef);
       await capture.captureWhatsApp({
-        deliveryTarget: whatsappDeliveryTargetFromTarget(target),
+        deliveryTarget,
         messageRef,
         providerTimestamp: textSend.sent?.providerTimestamp ?? null,
         text: textSend.text,

--- a/packages/server/src/api/workflows.ts
+++ b/packages/server/src/api/workflows.ts
@@ -19,7 +19,7 @@ import { createWorkflowDeliveryCapture } from "../scheduler/delivery-capture";
 import type { SlackBot } from "../slack/bot";
 import type { WhatsAppBot } from "../whatsapp/bot";
 import { deliverProactiveDm } from "../whatsapp/proactive-delivery";
-import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
+import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 import { isSlackDmChannelId, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
 import { executeAutomation } from "../workflows/runtime";
@@ -231,7 +231,7 @@ function createDelivery(task: ScheduledTaskRow, deps: WorkflowRouteDeps) {
         if (messageRef) delivery.messageRef = messageRef;
         if (messageRef && result.mode === "text") {
           await capture?.captureWhatsApp({
-            deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : resolved.targetId,
+            deliveryTarget: "deliveryTarget" in result ? result.deliveryTarget : resolved.targetId,
             messageRef,
             providerTimestamp: result.sent?.providerTimestamp ?? null,
             text,

--- a/packages/server/src/scheduler/delivery-capture.ts
+++ b/packages/server/src/scheduler/delivery-capture.ts
@@ -1,7 +1,7 @@
 import type { createConversationRepository } from "../db/repositories/conversations";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { Logger } from "../logger";
-import { canonicalDmConversationId, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
+import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 
 export interface WorkflowDeliveryCaptureDeps {
   conversations: ReturnType<typeof createConversationRepository>;
@@ -43,7 +43,7 @@ export function createWorkflowDeliveryCapture(deps: WorkflowDeliveryCaptureDeps)
     }
 
     const target = whatsappTargetFromDeliveryTarget(deliveryTarget);
-    const providerConversationId = target.kind === "dm" ? canonicalDmConversationId(target.phoneE164) : target.groupId;
+    const providerConversationId = target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : target.groupId;
     return { platform: "whatsapp", kind: "dm", providerConversationId };
   }
 

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -34,7 +34,7 @@ import type { QueueManager } from "../queue";
 import type { SlackBot } from "../slack/bot";
 import type { RecordWorkflowStep } from "../telemetry/agent-run-telemetry";
 import { deliverProactiveDm } from "../whatsapp/proactive-delivery";
-import { whatsappDeliveryTargetFromTarget, whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
+import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 import { isSlackDmChannelId, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
 import { type AutomationExecutionResult, executeAutomation } from "../workflows/runtime";
@@ -314,7 +314,7 @@ export class TaskScheduler {
       const messageRef = result.sent?.providerMessageId;
       if (!messageRef || result.mode !== "text") return;
       await this.deliveryCapture.captureWhatsApp({
-        deliveryTarget: target.kind === "dm" ? whatsappDeliveryTargetFromTarget(target) : delivery.targetId,
+        deliveryTarget: "deliveryTarget" in result ? result.deliveryTarget : delivery.targetId,
         messageRef,
         providerTimestamp: result.sent?.providerTimestamp ?? null,
         text,

--- a/packages/server/src/whatsapp/proactive-delivery.test.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { WHATSAPP_TEXT_LIMIT } from "./chunking";
 import {
   type DeliverProactiveDmParams,
+  ProactiveDeliveryInvalidTargetError,
   ProactiveDeliveryTextSendError,
   deliverProactiveDm,
 } from "./proactive-delivery";
@@ -79,9 +80,69 @@ describe("deliverProactiveDm", () => {
     });
 
     expect(result.mode).toBe("text");
+    expect(result.deliveryTarget).toBe("dm:+15551234567");
     expect(deps.whatsapp.sendText).toHaveBeenCalledWith(target, text);
     expect(deps.conversations.findLatestInboundWhatsAppDmFromRecipient).not.toHaveBeenCalled();
     expect(deps.inboxMessages.create).not.toHaveBeenCalled();
+    expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("substitutes the recipient phone for invalid managed provider targets", async () => {
+    const sendText = vi.fn().mockResolvedValue(sentText);
+    const deps = buildDeps({ capabilities: textOnlyCapabilities, sendText });
+    const providerTarget: WhatsAppTarget = {
+      kind: "dm",
+      phoneE164: "",
+      providerConversationId: "6a436a0b5a5429ba2f5d8153",
+    };
+
+    const result = await deliverProactiveDm({
+      target: providerTarget,
+      recipientUserId: "user-1",
+      senderUserId: "user-1",
+      recipientPhoneE164: "+919867673672",
+      text: "resolved output",
+      ...deps,
+    });
+
+    expect(result.mode).toBe("text");
+    expect(result.deliveryTarget).toBe("dm:+919867673672");
+    expect(sendText).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+919867673672", providerConversationId: "6a436a0b5a5429ba2f5d8153" },
+      "resolved output",
+    );
+  });
+
+  it("throws a typed failure when neither target nor recipient has a valid phone", async () => {
+    const sendText = vi.fn().mockResolvedValue(sentText);
+    const deps = buildDeps({ capabilities: textOnlyCapabilities, sendText });
+    const providerTarget: WhatsAppTarget = {
+      kind: "dm",
+      phoneE164: "",
+      providerConversationId: "6a436a0b5a5429ba2f5d8153",
+    };
+
+    let thrown: unknown;
+    try {
+      await deliverProactiveDm({
+        target: providerTarget,
+        recipientUserId: "user-1",
+        senderUserId: "user-1",
+        recipientPhoneE164: "not-a-phone",
+        text: "unresolved output",
+        ...deps,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(ProactiveDeliveryInvalidTargetError);
+    expect(thrown).toMatchObject({
+      targetKind: "dm",
+      reason: "invalid_e164",
+      targetShape: "provider_conversation_id",
+    });
+    expect(sendText).not.toHaveBeenCalled();
     expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
   });
 
@@ -98,7 +159,12 @@ describe("deliverProactiveDm", () => {
       ...deps,
     });
 
-    expect(result).toEqual({ mode: "text", sent: sentText, textSends: [{ text, sent: sentText }] });
+    expect(result).toEqual({
+      mode: "text",
+      deliveryTarget: "dm:+15551234567",
+      sent: sentText,
+      textSends: [{ text, sent: sentText }],
+    });
     expect(deps.whatsapp.sendText).toHaveBeenCalledWith(target, text);
     expect(deps.inboxMessages.create).not.toHaveBeenCalled();
     expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
@@ -128,6 +194,7 @@ describe("deliverProactiveDm", () => {
     expect(sendText).toHaveBeenNthCalledWith(2, target, "b".repeat(24));
     expect(result).toEqual({
       mode: "text",
+      deliveryTarget: "dm:+15551234567",
       sent: secondSent,
       textSends: [
         { text: "a".repeat(WHATSAPP_TEXT_LIMIT), sent: firstSent },

--- a/packages/server/src/whatsapp/proactive-delivery.ts
+++ b/packages/server/src/whatsapp/proactive-delivery.ts
@@ -2,7 +2,12 @@ import type { createConversationRepository } from "../db/repositories/conversati
 import type { createInboxMessagesRepository } from "../db/repositories/inbox-messages";
 import type { Logger } from "../logger";
 import { WHATSAPP_TEXT_LIMIT, chunkText } from "./chunking";
-import type { WhatsAppSendResult, WhatsAppTarget } from "./provider";
+import {
+  type WhatsAppSendResult,
+  type WhatsAppTarget,
+  isWhatsAppDmPhoneE164,
+  whatsappDeliveryTargetFromTarget,
+} from "./provider";
 import type { WhatsAppRuntime } from "./runtime";
 import { buildTaskNudgeTemplate } from "./templates";
 
@@ -21,17 +26,33 @@ export interface ProactiveDeliveryTextSend {
 export class ProactiveDeliveryTextSendError extends Error {
   readonly cause: unknown;
   readonly textSends: ProactiveDeliveryTextSend[];
+  readonly deliveryTarget: string;
 
-  constructor(cause: unknown, textSends: ProactiveDeliveryTextSend[]) {
+  constructor(cause: unknown, textSends: ProactiveDeliveryTextSend[], deliveryTarget: string) {
     super(cause instanceof Error ? cause.message : "WhatsApp text send failed");
     this.name = "ProactiveDeliveryTextSendError";
     this.cause = cause;
     this.textSends = textSends;
+    this.deliveryTarget = deliveryTarget;
+  }
+}
+
+export class ProactiveDeliveryInvalidTargetError extends Error {
+  readonly targetKind = "dm";
+  readonly reason = "invalid_e164";
+  readonly targetShape: string;
+
+  constructor(target: Extract<WhatsAppTarget, { kind: "dm" }>) {
+    const targetShape = invalidDmTargetShape(target);
+    super(`Invalid WhatsApp DM delivery target shape: ${targetShape}`);
+    this.name = "ProactiveDeliveryInvalidTargetError";
+    this.targetShape = targetShape;
   }
 }
 
 export interface ProactiveDeliveryResult {
   mode: ProactiveDeliveryMode;
+  deliveryTarget: string;
   sent: WhatsAppSendResult | null;
   textSends: ProactiveDeliveryTextSend[];
   inboxMessageId?: string | undefined;
@@ -54,32 +75,36 @@ export interface DeliverProactiveDmParams {
 }
 
 export async function deliverProactiveDm(params: DeliverProactiveDmParams): Promise<ProactiveDeliveryResult> {
-  if (params.target.kind === "group") {
-    const textSends = await sendTextChunks(params);
-    return { mode: "text", sent: lastSent(textSends), textSends };
+  const target = resolveProactiveDeliveryTarget(params.target, params.recipientPhoneE164);
+  const resolvedParams = { ...params, target };
+  const deliveryTarget = whatsappDeliveryTargetFromTarget(target);
+
+  if (target.kind === "group") {
+    const textSends = await sendTextChunks(resolvedParams);
+    return { mode: "text", deliveryTarget, sent: lastSent(textSends), textSends };
   }
 
-  if (!params.whatsapp.getCapabilities(params.target).templates) {
-    const textSends = await sendTextChunks(params);
-    return { mode: "text", sent: lastSent(textSends), textSends };
+  if (!params.whatsapp.getCapabilities(target).templates) {
+    const textSends = await sendTextChunks(resolvedParams);
+    return { mode: "text", deliveryTarget, sent: lastSent(textSends), textSends };
   }
 
   const lastInbound = await params.conversations.findLatestInboundWhatsAppDmFromRecipient({
     recipientUserId: params.recipientUserId,
-    phoneE164: params.recipientPhoneE164 ?? params.target.phoneE164,
+    phoneE164: target.phoneE164,
   });
 
   if (lastInbound && isInsideCustomerServiceWindow(lastInbound, params.now ?? new Date())) {
     try {
-      const textSends = await sendTextChunks(params);
-      return { mode: "text", sent: lastSent(textSends), textSends };
+      const textSends = await sendTextChunks(resolvedParams);
+      return { mode: "text", deliveryTarget, sent: lastSent(textSends), textSends };
     } catch (err) {
       if (!shouldParkAfterTextError(err)) throw err;
-      return parkThenNudge(params);
+      return parkThenNudge(resolvedParams);
     }
   }
 
-  return parkThenNudge(params);
+  return parkThenNudge(resolvedParams);
 }
 
 async function parkThenNudge(params: DeliverProactiveDmParams): Promise<ProactiveDeliveryResult> {
@@ -105,14 +130,26 @@ async function parkThenNudge(params: DeliverProactiveDmParams): Promise<Proactiv
       },
       "WhatsApp proactive delivery parked without duplicate nudge",
     );
-    return { mode: "parked", sent: null, textSends: [], inboxMessageId: inboxMessage.id };
+    return {
+      mode: "parked",
+      deliveryTarget: whatsappDeliveryTargetFromTarget(params.target),
+      sent: null,
+      textSends: [],
+      inboxMessageId: inboxMessage.id,
+    };
   }
 
   const sent = await params.whatsapp.sendTemplate(
     params.target,
     buildTaskNudgeTemplate({ recipientName: params.recipientName }),
   );
-  return { mode: "nudge", sent, textSends: [], inboxMessageId: inboxMessage.id };
+  return {
+    mode: "nudge",
+    deliveryTarget: whatsappDeliveryTargetFromTarget(params.target),
+    sent,
+    textSends: [],
+    inboxMessageId: inboxMessage.id,
+  };
 }
 
 /**
@@ -134,15 +171,46 @@ async function sendTextChunks(
   params: Pick<DeliverProactiveDmParams, "target" | "text" | "whatsapp">,
 ): Promise<ProactiveDeliveryTextSend[]> {
   const textSends: ProactiveDeliveryTextSend[] = [];
+  const deliveryTarget = whatsappDeliveryTargetFromTarget(params.target);
   for (const chunk of chunkText(params.text, WHATSAPP_TEXT_LIMIT)) {
     try {
       const sent = await params.whatsapp.sendText(params.target, chunk);
       textSends.push({ text: chunk, sent });
     } catch (cause) {
-      throw new ProactiveDeliveryTextSendError(cause, textSends);
+      throw new ProactiveDeliveryTextSendError(cause, textSends, deliveryTarget);
     }
   }
   return textSends;
+}
+
+function resolveProactiveDeliveryTarget(
+  target: WhatsAppTarget,
+  recipientPhoneE164: string | null | undefined,
+): WhatsAppTarget {
+  if (target.kind === "group") return target;
+  const targetPhone = validPhoneE164(target.phoneE164);
+  if (targetPhone) return targetPhone === target.phoneE164 ? target : { ...target, phoneE164: targetPhone };
+  const recipientPhone = validPhoneE164(recipientPhoneE164);
+  if (recipientPhone) return { ...target, phoneE164: recipientPhone };
+  throw new ProactiveDeliveryInvalidTargetError(target);
+}
+
+function validPhoneE164(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return isWhatsAppDmPhoneE164(trimmed) ? trimmed : null;
+}
+
+function invalidDmTargetShape(target: Extract<WhatsAppTarget, { kind: "dm" }>): string {
+  const providerConversationId = target.providerConversationId?.trim();
+  if (providerConversationId?.startsWith("wati:+")) return "wati_phone_fallback";
+  if (providerConversationId?.startsWith("wati:")) return "wati_provider_conversation";
+  if (providerConversationId?.endsWith("@s.whatsapp.net") || providerConversationId?.endsWith("@lid")) {
+    return "whatsapp_jid";
+  }
+  if (providerConversationId) return "provider_conversation_id";
+  if (target.phoneE164.startsWith("+")) return "bare_phone";
+  if (target.phoneE164) return "invalid_phone";
+  return "missing_phone";
 }
 
 function lastSent(textSends: ProactiveDeliveryTextSend[]): WhatsAppSendResult | null {

--- a/packages/server/src/whatsapp/provider.test.ts
+++ b/packages/server/src/whatsapp/provider.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { whatsappDeliveryTargetFromTarget, whatsappJidToPhoneE164, whatsappTargetFromDeliveryTarget } from "./provider";
+
+describe("whatsappTargetFromDeliveryTarget", () => {
+  it.each([
+    [
+      "opaque Wati conversation id",
+      "6a436a0b5a5429ba2f5d8153",
+      { kind: "dm", phoneE164: "", providerConversationId: "6a436a0b5a5429ba2f5d8153" },
+    ],
+    [
+      "Wati phone fallback",
+      "wati:+919867673672",
+      { kind: "dm", phoneE164: "+919867673672", providerConversationId: "wati:+919867673672" },
+    ],
+    [
+      "WhatsApp jid",
+      "919867673672@s.whatsapp.net",
+      { kind: "dm", phoneE164: "+919867673672", providerConversationId: "919867673672@s.whatsapp.net" },
+    ],
+    ["canonical DM", "dm:+919867673672", { kind: "dm", phoneE164: "+919867673672" }],
+    ["bare E.164 phone", "+919867673672", { kind: "dm", phoneE164: "+919867673672" }],
+    ["group jid", "120363000000001@g.us", { kind: "group", groupId: "120363000000001@g.us" }],
+  ] as const)("parses %s", (_label, deliveryTarget, expected) => {
+    expect(whatsappTargetFromDeliveryTarget(deliveryTarget)).toEqual(expected);
+  });
+
+  it("parses Wati phone fallback ids when passed through the jid helper", () => {
+    expect(whatsappJidToPhoneE164("wati:+919867673672")).toBe("+919867673672");
+  });
+
+  it("canonicalizes valid DM phones for storage while preserving opaque ids without a valid phone", () => {
+    expect(
+      whatsappDeliveryTargetFromTarget({
+        kind: "dm",
+        phoneE164: "+919867673672",
+        providerConversationId: "6a436a0b5a5429ba2f5d8153",
+      }),
+    ).toBe("dm:+919867673672");
+    expect(
+      whatsappDeliveryTargetFromTarget({
+        kind: "dm",
+        phoneE164: "",
+        providerConversationId: "6a436a0b5a5429ba2f5d8153",
+      }),
+    ).toBe("6a436a0b5a5429ba2f5d8153");
+  });
+});

--- a/packages/server/src/whatsapp/provider.ts
+++ b/packages/server/src/whatsapp/provider.ts
@@ -122,11 +122,16 @@ export function canonicalGroupConversationId(groupId: string): string {
   return `group:${groupId}`;
 }
 
+export function isWhatsAppDmPhoneE164(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^\+[1-9]\d{6,14}$/u.test(value);
+}
+
 export function phoneE164ToWhatsAppJid(phoneE164: string): string {
   return `${phoneE164.replace("+", "")}@s.whatsapp.net`;
 }
 
 export function whatsappJidToPhoneE164(jid: string): string {
+  if (jid.startsWith("wati:+")) return jid.slice("wati:".length);
   const raw = jid.replace("@s.whatsapp.net", "").replace("@lid", "");
   const number = raw.includes(":") ? raw.split(":")[0] : raw;
   return `+${number}`;
@@ -135,11 +140,18 @@ export function whatsappJidToPhoneE164(jid: string): string {
 export function whatsappTargetFromDeliveryTarget(targetId: string): WhatsAppTarget {
   if (targetId.endsWith("@g.us")) return { kind: "group", groupId: targetId };
   if (targetId.startsWith("dm:+")) return { kind: "dm", phoneE164: targetId.slice("dm:".length) };
+  if (targetId.startsWith("wati:+")) {
+    return { kind: "dm", phoneE164: targetId.slice("wati:".length), providerConversationId: targetId };
+  }
   if (targetId.startsWith("+")) return { kind: "dm", phoneE164: targetId };
-  return { kind: "dm", phoneE164: whatsappJidToPhoneE164(targetId), providerConversationId: targetId };
+  if (targetId.endsWith("@s.whatsapp.net") || targetId.endsWith("@lid")) {
+    return { kind: "dm", phoneE164: whatsappJidToPhoneE164(targetId), providerConversationId: targetId };
+  }
+  return { kind: "dm", phoneE164: "", providerConversationId: targetId };
 }
 
 export function whatsappDeliveryTargetFromTarget(target: WhatsAppTarget): string {
   if (target.kind === "group") return target.groupId;
+  if (isWhatsAppDmPhoneE164(target.phoneE164)) return canonicalDmConversationId(target.phoneE164);
   return target.providerConversationId ?? canonicalDmConversationId(target.phoneE164);
 }


### PR DESCRIPTION
## Problem

Scheduled-task / workflow / agent-output WhatsApp delivery fails on managed tenants when the task was created from a WhatsApp DM. Verified in production (goosebumps, 2026-07-03T23:42Z): `Invalid managed WhatsApp target (invalid_e164)` → `ProactiveDeliveryTextSendError`, reminder never delivered.

Root cause: on managed tenants the inbound `providerConversationId` is Wati's conversation id (24-hex like `6a436a0b...`, or fallback `wati:+<phone>`). `whatsappDeliveryTargetFromTarget` preferred it when persisting `delivery_target`, and at send time `whatsappTargetFromDeliveryTarget` mangled it into a fabricated phone (`+6a436a0b...` / `+wati`) that the provider's E.164 assertion rightly rejects. The path was masked historically because agent steps often sent output themselves via the messaging tool (which resolves the real phone from the users table).

## Fix (three layers)

**A — read-side resilience (repairs existing DB rows):** `deliverProactiveDm` resolves the send target before any send: valid target phone wins; otherwise a valid `recipientPhoneE164` is substituted while preserving `providerConversationId` (so the send lands on the same Wati conversation); if neither is valid it throws a typed `ProactiveDeliveryInvalidTargetError` carrying only a target-shape enum (never content or phone numbers). All callers (scheduler, api/workflows, agents/output-delivery — which now looks up the recipient user) supply the recipient's registered phone. The 24h-window check also uses the resolved phone.

**B — parser correctness:** `whatsappTargetFromDeliveryTarget` handles `wati:+<phone>` (real phone extracted, id preserved) and no longer fabricates `+<hex>` phones from opaque provider conversation ids (they yield an empty phone + preserved id, handled by layer A). Jid, `dm:+`, bare `+`, and group parsing unchanged.

**C — storage format:** `whatsappDeliveryTargetFromTarget` now prefers canonical `dm:+phone` over the raw provider conversation id when the phone is valid, so newly created tasks store a durable phone-based target. Consumers verified safe: DM task listing filters by `createdBy` (not deliveryTarget), queue keys are task-id based, delivery-capture keying matches inbound canonical ids on both providers, adapter replies use the live message target. Old rows need no migration — layers A+B deliver them.

## Testing

- Unit tests for every target shape (24-hex Wati id, `wati:+phone`, jid, device-suffix jid, `dm:+phone`, bare phone, group) and for the substitution/typed-error behavior in `deliverProactiveDm`.
- Independently reviewed + full gates on the branch: biome, typecheck, full test suite (2985 server / 316 web), build — all green.
