### PR TITLE
feat: WhatsApp 24h-window keep-alive pings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ LOG_LEVEL=info          # debug | info | warn | error
 # WHATSAPP_GROUP_PROVIDER=baileys
 # MANAGED_WHATSAPP_PLATFORM_URL=https://app.getsketch.ai
 # MANAGED_WHATSAPP_TENANT_TOKEN=
+# Enables the hourly in-window keep-alive ping for Wati/managed WhatsApp DMs.
+# WHATSAPP_WINDOW_KEEPALIVE_ENABLED=false
 
 # Encryption (optional, recommended for shared Postgres deployments)
 # 64 hex chars = 32 bytes for AES-256-GCM

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -64,6 +64,7 @@ import { WHATSAPP_MANAGED_PROVIDER_ID, createManagedWhatsAppProvider } from "./w
 import { WHATSAPP_WATI_PROVIDER_ID, createWatiWhatsAppProvider } from "./whatsapp/providers/wati";
 import { createWhatsAppRuntime } from "./whatsapp/runtime";
 import type { WhatsAppTemplateRequest } from "./whatsapp/templates";
+import { startWhatsAppWindowKeepAliveJob } from "./whatsapp/window-keepalive";
 
 export interface ServerHandle {
   config: Config;
@@ -448,6 +449,14 @@ export async function createServer(config: Config, options?: CreateServerOptions
 
   // 8.6. Connector sync scheduler — recovers stale syncs, runs periodic sync + enrichment
   const syncScheduler = startSyncScheduler(db, logger, 30 * 60 * 1000, { appConfig: config });
+  const whatsappWindowKeepAliveJob = config.WHATSAPP_WINDOW_KEEPALIVE_ENABLED
+    ? startWhatsAppWindowKeepAliveJob({
+        db,
+        logger,
+        whatsapp: whatsappRuntime,
+        settingsRepo,
+      })
+    : null;
   const agentOutputDelivery = createAgentOutputDeliveryService({
     db,
     logger,
@@ -587,6 +596,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     logger.info("Shutting down...");
     await telemetry.shutdown();
     await syncScheduler.stop();
+    whatsappWindowKeepAliveJob?.stop();
     agentScheduler.stop();
     scheduler.stop();
     if (slack) await slack.stop();

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -31,6 +31,7 @@ describe("configSchema", () => {
         expect(result.data.SLACK_THREAD_HISTORY_LIMIT).toBe(50);
         expect(result.data.WHATSAPP_DM_PROVIDER).toBe("baileys");
         expect(result.data.WHATSAPP_GROUP_PROVIDER).toBe("baileys");
+        expect(result.data.WHATSAPP_WINDOW_KEEPALIVE_ENABLED).toBe(false);
         expect(result.data.MAX_CONCURRENT_AGENT_RUNS).toBe(4);
         expect(result.data.MAX_FILE_SIZE_MB).toBe(20);
         expect(result.data.VISION_ENABLED).toBe(false);
@@ -63,12 +64,14 @@ describe("configSchema", () => {
         WHATSAPP_GROUP_PROVIDER: "baileys",
         MANAGED_WHATSAPP_PLATFORM_URL: "https://app.getsketch.ai",
         MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_WINDOW_KEEPALIVE_ENABLED: "true",
       });
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.WHATSAPP_DM_PROVIDER).toBe("managed");
         expect(result.data.MANAGED_WHATSAPP_PLATFORM_URL).toBe("https://app.getsketch.ai");
         expect(result.data.MANAGED_WHATSAPP_TENANT_TOKEN).toBe("tenant-token");
+        expect(result.data.WHATSAPP_WINDOW_KEEPALIVE_ENABLED).toBe(true);
       }
     });
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -66,6 +66,10 @@ export const configSchema = z.object({
   WATI_CHANNEL_PHONE_NUMBER: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   MANAGED_WHATSAPP_PLATFORM_URL: z.preprocess((v) => (v === "" ? undefined : v), z.string().url().optional()),
   MANAGED_WHATSAPP_TENANT_TOKEN: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
+  WHATSAPP_WINDOW_KEEPALIVE_ENABLED: z
+    .enum(["true", "false", "1", "0"])
+    .default("false")
+    .transform((v) => v === "true" || v === "1"),
 
   // Security
   ENCRYPTION_KEY: z.string().optional(),

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -117,6 +117,7 @@ import * as m114 from "./migrations/114-agent-output-deliveries";
 import * as m115 from "./migrations/115-whatsapp-template-mappings-and-provider-events";
 import * as m116 from "./migrations/116-connector-credential-source";
 import * as m117 from "./migrations/117-conversation-message-window-index";
+import * as m118 from "./migrations/118-whatsapp-window-keepalives";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -238,6 +239,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "115-whatsapp-template-mappings-and-provider-events": m115,
           "116-connector-credential-source": m116,
           "117-conversation-message-window-index": m117,
+          "118-whatsapp-window-keepalives": m118,
         };
       },
     },

--- a/packages/server/src/db/migrations/118-whatsapp-window-keepalives.ts
+++ b/packages/server/src/db/migrations/118-whatsapp-window-keepalives.ts
@@ -1,0 +1,15 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("whatsapp_window_keepalives")
+    .addColumn("recipient_user_id", "text", (col) => col.primaryKey().references("users.id").onDelete("cascade"))
+    .addColumn("sent_at", "text", (col) => col.notNull())
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("whatsapp_window_keepalives").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 113;
+const EXPECTED_MIGRATION_COUNT = 114;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -146,6 +146,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[110]).toBe("115-whatsapp-template-mappings-and-provider-events");
     expect(names[111]).toBe("116-connector-credential-source");
     expect(names[112]).toBe("117-conversation-message-window-index");
+    expect(names[113]).toBe("118-whatsapp-window-keepalives");
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 113;
+const EXPECTED_MIGRATION_COUNT = 114;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -169,6 +169,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[110]).toBe("115-whatsapp-template-mappings-and-provider-events");
     expect(names[111]).toBe("116-connector-credential-source");
     expect(names[112]).toBe("117-conversation-message-window-index");
+    expect(names[113]).toBe("118-whatsapp-window-keepalives");
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {
@@ -564,13 +565,15 @@ describe("runMigrations — incremental upgrade", () => {
         '114-agent-output-deliveries',
         '115-whatsapp-template-mappings-and-provider-events',
         '116-connector-credential-source',
-        '117-conversation-message-window-index'
+        '117-conversation-message-window-index',
+        '118-whatsapp-window-keepalives'
       )
     `.execute(db);
     await sql`DROP TABLE agent_output_deliveries`.execute(db);
     await sql`DROP TABLE whatsapp_template_mappings`.execute(db);
     await sql`DROP TABLE whatsapp_provider_events`.execute(db);
     await sql`DROP INDEX idx_conversation_messages_window`.execute(db);
+    await sql`DROP TABLE whatsapp_window_keepalives`.execute(db);
 
     await expect(runMigrations(db, { quiet: true })).resolves.not.toThrow();
 
@@ -587,7 +590,8 @@ describe("runMigrations — incremental upgrade", () => {
         '114-agent-output-deliveries',
         '115-whatsapp-template-mappings-and-provider-events',
         '116-connector-credential-source',
-        '117-conversation-message-window-index'
+        '117-conversation-message-window-index',
+        '118-whatsapp-window-keepalives'
       )
       ORDER BY name ASC
     `.execute(db);
@@ -603,6 +607,7 @@ describe("runMigrations — incremental upgrade", () => {
       { name: "115-whatsapp-template-mappings-and-provider-events" },
       { name: "116-connector-credential-source" },
       { name: "117-conversation-message-window-index" },
+      { name: "118-whatsapp-window-keepalives" },
     ]);
   });
 });

--- a/packages/server/src/db/repositories/scheduled-tasks.test.ts
+++ b/packages/server/src/db/repositories/scheduled-tasks.test.ts
@@ -185,6 +185,41 @@ describe("listActive()", () => {
   });
 });
 
+describe("countActiveForUserWithin()", () => {
+  it("counts only active tasks for the user with a next run inside the window", async () => {
+    await repo.add({
+      ...baseTask,
+      id: "inside-window",
+      created_by: "user-1",
+      next_run_at: "2026-07-05T10:00:00.000Z",
+    });
+    await repo.add({
+      ...baseTask,
+      id: "outside-window",
+      created_by: "user-1",
+      next_run_at: "2026-07-06T15:00:00.000Z",
+    });
+    await repo.add({
+      ...baseTask,
+      id: "other-user",
+      created_by: "user-2",
+      next_run_at: "2026-07-05T10:00:00.000Z",
+    });
+    await repo.add({
+      ...baseTask,
+      id: "paused",
+      created_by: "user-1",
+      status: "paused",
+      next_run_at: "2026-07-05T10:00:00.000Z",
+    });
+    await repo.add({ ...baseTask, id: "missing-next-run", created_by: "user-1", next_run_at: null });
+
+    await expect(
+      repo.countActiveForUserWithin("user-1", "2026-07-05T09:00:00.000Z", "2026-07-05T11:00:00.000Z"),
+    ).resolves.toBe(1);
+  });
+});
+
 describe("update()", () => {
   it("modifies specified fields and returns the updated row", async () => {
     const created = await repo.add(baseTask);

--- a/packages/server/src/db/repositories/scheduled-tasks.ts
+++ b/packages/server/src/db/repositories/scheduled-tasks.ts
@@ -83,6 +83,19 @@ export function createScheduledTaskRepository(db: Kysely<DB>) {
         .execute();
     },
 
+    async countActiveForUserWithin(userId: string, startAt: string, endAt: string): Promise<number> {
+      const row = await db
+        .selectFrom("scheduled_tasks")
+        .select((eb) => eb.fn.countAll<number>().as("count"))
+        .where("created_by", "=", userId)
+        .where("status", "=", "active")
+        .where("next_run_at", "is not", null)
+        .where("next_run_at", ">=", startAt)
+        .where("next_run_at", "<=", endAt)
+        .executeTakeFirst();
+      return Number(row?.count ?? 0);
+    },
+
     async update(
       id: string,
       fields: Partial<UpdatableFields>,

--- a/packages/server/src/db/repositories/whatsapp-window-keepalives.test.ts
+++ b/packages/server/src/db/repositories/whatsapp-window-keepalives.test.ts
@@ -1,0 +1,47 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createUserRepository } from "./users";
+import { createWhatsAppWindowKeepAliveRepository } from "./whatsapp-window-keepalives";
+
+let db: Kysely<DB>;
+let repo: ReturnType<typeof createWhatsAppWindowKeepAliveRepository>;
+let userId: string;
+
+beforeEach(async () => {
+  db = await createTestDb();
+  repo = createWhatsAppWindowKeepAliveRepository(db);
+  const users = createUserRepository(db);
+  const user = await users.create({ name: "Priya", whatsappNumber: "+15551234567" });
+  userId = user.id;
+});
+
+afterEach(async () => {
+  await db.destroy();
+});
+
+describe("createWhatsAppWindowKeepAliveRepository", () => {
+  it("returns undefined when no keep-alive has been recorded", async () => {
+    await expect(repo.get(userId)).resolves.toBeUndefined();
+  });
+
+  it("records a first keep-alive attempt for a recipient", async () => {
+    const row = await repo.recordAttempt(userId, "2026-07-04T10:00:00.000Z");
+
+    expect(row.recipient_user_id).toBe(userId);
+    expect(row.sent_at).toBe("2026-07-04T10:00:00.000Z");
+    expect(row.created_at).toBeDefined();
+    expect(row.updated_at).toBeDefined();
+  });
+
+  it("updates the existing row on later attempts", async () => {
+    await repo.recordAttempt(userId, "2026-07-04T10:00:00.000Z");
+
+    const updated = await repo.recordAttempt(userId, "2026-07-04T11:00:00.000Z");
+    const rows = await db.selectFrom("whatsapp_window_keepalives").selectAll().execute();
+
+    expect(rows).toHaveLength(1);
+    expect(updated.sent_at).toBe("2026-07-04T11:00:00.000Z");
+  });
+});

--- a/packages/server/src/db/repositories/whatsapp-window-keepalives.ts
+++ b/packages/server/src/db/repositories/whatsapp-window-keepalives.ts
@@ -1,0 +1,51 @@
+import { type Kysely, type Selectable, sql } from "kysely";
+import type { DB, WhatsAppWindowKeepAlivesTable } from "../schema";
+
+export type WhatsAppWindowKeepAliveRow = Selectable<WhatsAppWindowKeepAlivesTable>;
+
+export function createWhatsAppWindowKeepAliveRepository(db: Kysely<DB>) {
+  return {
+    async get(recipientUserId: string): Promise<WhatsAppWindowKeepAliveRow | undefined> {
+      return db
+        .selectFrom("whatsapp_window_keepalives")
+        .selectAll()
+        .where("recipient_user_id", "=", recipientUserId)
+        .executeTakeFirst();
+    },
+
+    async recordAttempt(recipientUserId: string, sentAt: string): Promise<WhatsAppWindowKeepAliveRow> {
+      const existing = await this.get(recipientUserId);
+      if (existing) {
+        await db
+          .updateTable("whatsapp_window_keepalives")
+          .set({ sent_at: sentAt, updated_at: sql<string>`CURRENT_TIMESTAMP` })
+          .where("recipient_user_id", "=", recipientUserId)
+          .execute();
+        return db
+          .selectFrom("whatsapp_window_keepalives")
+          .selectAll()
+          .where("recipient_user_id", "=", recipientUserId)
+          .executeTakeFirstOrThrow();
+      }
+
+      try {
+        await db
+          .insertInto("whatsapp_window_keepalives")
+          .values({ recipient_user_id: recipientUserId, sent_at: sentAt })
+          .execute();
+      } catch {
+        await db
+          .updateTable("whatsapp_window_keepalives")
+          .set({ sent_at: sentAt, updated_at: sql<string>`CURRENT_TIMESTAMP` })
+          .where("recipient_user_id", "=", recipientUserId)
+          .execute();
+      }
+
+      return db
+        .selectFrom("whatsapp_window_keepalives")
+        .selectAll()
+        .where("recipient_user_id", "=", recipientUserId)
+        .executeTakeFirstOrThrow();
+    },
+  };
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -470,6 +470,13 @@ export interface ConversationMessagesTable {
   created_at: Generated<string>;
 }
 
+export interface WhatsAppWindowKeepAlivesTable {
+  recipient_user_id: string;
+  sent_at: string;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
 export interface ScheduledTasksTable {
   id: string;
   platform: string;
@@ -952,6 +959,7 @@ export interface DB {
   conversations: ConversationsTable;
   conversation_cursors: ConversationCursorsTable;
   conversation_messages: ConversationMessagesTable;
+  whatsapp_window_keepalives: WhatsAppWindowKeepAlivesTable;
   scheduled_tasks: ScheduledTasksTable;
   automation_runs: AutomationRunsTable;
   automation_step_content: AutomationStepContentTable;

--- a/packages/server/src/test-utils.ts
+++ b/packages/server/src/test-utils.ts
@@ -162,6 +162,7 @@ export function createTestConfig(overrides: Partial<Config> = {}): Config {
     SLACK_THREAD_HISTORY_LIMIT: 50,
     WHATSAPP_DM_PROVIDER: "baileys",
     WHATSAPP_GROUP_PROVIDER: "baileys",
+    WHATSAPP_WINDOW_KEEPALIVE_ENABLED: false,
     MAX_CONCURRENT_AGENT_RUNS: 4,
     MAX_FILE_SIZE_MB: 20,
     MAX_UPLOAD_SIZE_MB: 50,

--- a/packages/server/src/whatsapp/window-keepalive.test.ts
+++ b/packages/server/src/whatsapp/window-keepalive.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { buildWhatsAppWindowKeepAliveMessage, decideWhatsAppWindowKeepAlive } from "./window-keepalive";
+
+const NOW = new Date("2026-07-04T12:00:00.000Z");
+
+function hoursAgo(hours: number): string {
+  return new Date(NOW.getTime() - hours * 60 * 60 * 1000).toISOString();
+}
+
+describe("decideWhatsAppWindowKeepAlive", () => {
+  it("skips users with no inbound WhatsApp DM", () => {
+    expect(decideWhatsAppWindowKeepAlive({ latestInboundReceivedAt: null, now: NOW })).toBe("skip_no_inbound");
+  });
+
+  it("skips users whose customer service window is still healthy", () => {
+    expect(decideWhatsAppWindowKeepAlive({ latestInboundReceivedAt: hoursAgo(20.99), now: NOW })).toBe("skip_recent");
+  });
+
+  it("sends within the 21h inclusive to 23h exclusive ping band", () => {
+    expect(decideWhatsAppWindowKeepAlive({ latestInboundReceivedAt: hoursAgo(21), now: NOW })).toBe("send");
+    expect(decideWhatsAppWindowKeepAlive({ latestInboundReceivedAt: hoursAgo(22.99), now: NOW })).toBe("send");
+  });
+
+  it("skips users whose customer service window has already lapsed", () => {
+    expect(decideWhatsAppWindowKeepAlive({ latestInboundReceivedAt: hoursAgo(23), now: NOW })).toBe("skip_lapsed");
+  });
+
+  it("skips when a keep-alive was already sent since the latest inbound", () => {
+    expect(
+      decideWhatsAppWindowKeepAlive({
+        latestInboundReceivedAt: hoursAgo(22),
+        lastKeepAliveSentAt: hoursAgo(21.5),
+        now: NOW,
+      }),
+    ).toBe("skip_deduped");
+  });
+
+  it("sends again after a newer inbound starts a new window cycle", () => {
+    expect(
+      decideWhatsAppWindowKeepAlive({
+        latestInboundReceivedAt: hoursAgo(22),
+        lastKeepAliveSentAt: hoursAgo(25),
+        now: NOW,
+      }),
+    ).toBe("send");
+  });
+});
+
+describe("buildWhatsAppWindowKeepAliveMessage", () => {
+  it("mentions upcoming scheduled updates when tasks are due soon", () => {
+    const message = buildWhatsAppWindowKeepAliveMessage({
+      recipientName: "Priya",
+      botName: "Canvas",
+      upcomingTaskCount: 2,
+    });
+
+    expect(message).toContain("Hi Priya, Canvas here.");
+    expect(message).toContain("2 scheduled updates");
+    expect(message).toContain("reply with anything");
+    expect(message).not.toContain("template");
+  });
+
+  it("uses the fallback notification copy when no tasks are due soon", () => {
+    const message = buildWhatsAppWindowKeepAliveMessage({
+      recipientName: "Amit",
+      botName: "Sketch",
+      upcomingTaskCount: 0,
+    });
+
+    expect(message).toContain("Hi Amit, Sketch here.");
+    expect(message).toContain("almost a day");
+    expect(message).toContain("short notification template");
+    expect(message).not.toContain("scheduled update");
+  });
+});

--- a/packages/server/src/whatsapp/window-keepalive.ts
+++ b/packages/server/src/whatsapp/window-keepalive.ts
@@ -1,0 +1,237 @@
+import { Cron } from "croner";
+import type { Kysely } from "kysely";
+import { createConversationRepository } from "../db/repositories/conversations";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import type { createSettingsRepository } from "../db/repositories/settings";
+import { createWhatsAppWindowKeepAliveRepository } from "../db/repositories/whatsapp-window-keepalives";
+import type { DB } from "../db/schema";
+import type { Logger } from "../logger";
+import type { WhatsAppTarget } from "./provider";
+import type { WhatsAppRuntime } from "./runtime";
+
+const KEEPALIVE_CRON = "0 * * * *";
+const KEEPALIVE_TIMEZONE = "UTC";
+const PING_BAND_START_MS = 21 * 60 * 60 * 1000;
+const PING_BAND_END_MS = 23 * 60 * 60 * 1000;
+const UPCOMING_TASK_HORIZON_MS = 26 * 60 * 60 * 1000;
+const CAPABILITY_TARGET: WhatsAppTarget = { kind: "dm", phoneE164: "+10000000000" };
+
+export type WhatsAppWindowKeepAliveDecision =
+  | "send"
+  | "skip_no_inbound"
+  | "skip_recent"
+  | "skip_lapsed"
+  | "skip_deduped";
+
+export interface WhatsAppWindowKeepAliveCounts {
+  candidates: number;
+  pinged: number;
+  skipped_recent: number;
+  skipped_lapsed: number;
+  skipped_deduped: number;
+  skipped_no_inbound: number;
+  failed: number;
+}
+
+export interface WhatsAppWindowKeepAliveDecisionInput {
+  latestInboundReceivedAt?: string | null;
+  lastKeepAliveSentAt?: string | null;
+  now: Date;
+}
+
+export interface WhatsAppWindowKeepAliveJobHandle {
+  stop(): void;
+  runNow(): Promise<WhatsAppWindowKeepAliveCounts | null>;
+}
+
+export interface WhatsAppWindowKeepAliveJobDeps {
+  db: Kysely<DB>;
+  logger: Logger;
+  whatsapp: Pick<WhatsAppRuntime, "getCapabilities" | "sendText">;
+  settingsRepo: ReturnType<typeof createSettingsRepository>;
+}
+
+interface CandidateUser {
+  id: string;
+  name: string;
+  whatsapp_number: string | null;
+}
+
+export function decideWhatsAppWindowKeepAlive(
+  input: WhatsAppWindowKeepAliveDecisionInput,
+): WhatsAppWindowKeepAliveDecision {
+  const latestInboundAt = parseTimestamp(input.latestInboundReceivedAt);
+  if (!latestInboundAt) return "skip_no_inbound";
+
+  const ageMs = input.now.getTime() - latestInboundAt.getTime();
+  if (ageMs < PING_BAND_START_MS) return "skip_recent";
+  if (ageMs >= PING_BAND_END_MS) return "skip_lapsed";
+
+  const lastSentAt = parseTimestamp(input.lastKeepAliveSentAt);
+  if (lastSentAt && lastSentAt.getTime() >= latestInboundAt.getTime()) return "skip_deduped";
+
+  return "send";
+}
+
+export function buildWhatsAppWindowKeepAliveMessage(params: {
+  recipientName: string | null | undefined;
+  botName: string | null | undefined;
+  upcomingTaskCount: number;
+}): string {
+  const recipientName = formatName(params.recipientName, "there");
+  const botName = formatName(params.botName, "Sketch");
+  if (params.upcomingTaskCount >= 1) {
+    const updateWord = params.upcomingTaskCount === 1 ? "update" : "updates";
+    return `Hi ${recipientName}, ${botName} here. I have ${params.upcomingTaskCount} scheduled ${updateWord} coming for you in the next day; WhatsApp closes our chat window after 24 hours of silence, so reply with anything and I'll be able to deliver them to you directly.`;
+  }
+
+  return `Hi ${recipientName}, ${botName} here. It's been almost a day since we last talked, so WhatsApp is about to close our chat window; reply with anything to keep it open, otherwise you'll get a short notification template instead of full updates.`;
+}
+
+export function startWhatsAppWindowKeepAliveJob(
+  deps: WhatsAppWindowKeepAliveJobDeps,
+): WhatsAppWindowKeepAliveJobHandle {
+  let inFlight = false;
+
+  const runNow = async (): Promise<WhatsAppWindowKeepAliveCounts | null> => {
+    if (inFlight) {
+      deps.logger.warn("WhatsApp window keep-alive run skipped because a previous run is still active");
+      return null;
+    }
+    inFlight = true;
+    try {
+      return await runWhatsAppWindowKeepAlive(deps);
+    } catch (err) {
+      deps.logger.error({ err }, "WhatsApp window keep-alive run failed");
+      return null;
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  const cron = new Cron(KEEPALIVE_CRON, { timezone: KEEPALIVE_TIMEZONE }, () => {
+    runNow().catch((err) => deps.logger.error({ err }, "WhatsApp window keep-alive run failed"));
+  });
+  deps.logger.info("WhatsApp window keep-alive job scheduled");
+
+  return {
+    stop() {
+      cron.stop();
+      deps.logger.info("WhatsApp window keep-alive job stopped");
+    },
+    runNow,
+  };
+}
+
+export async function runWhatsAppWindowKeepAlive(
+  deps: WhatsAppWindowKeepAliveJobDeps,
+  now = new Date(),
+): Promise<WhatsAppWindowKeepAliveCounts> {
+  const counts = emptyCounts();
+
+  if (!deps.whatsapp.getCapabilities(CAPABILITY_TARGET).templates) {
+    deps.logger.info(counts, "WhatsApp window keep-alive run complete");
+    return counts;
+  }
+
+  const conversations = createConversationRepository(deps.db);
+  const keepAlives = createWhatsAppWindowKeepAliveRepository(deps.db);
+  const scheduledTasks = createScheduledTaskRepository(deps.db);
+  const settings = await deps.settingsRepo.get();
+  const botName = settings?.bot_name ?? "Sketch";
+  const candidates = await listCandidateUsers(deps.db);
+  counts.candidates = candidates.length;
+  const nowIso = now.toISOString();
+  const upcomingBefore = new Date(now.getTime() + UPCOMING_TASK_HORIZON_MS).toISOString();
+
+  for (const candidate of candidates) {
+    try {
+      const latestInbound = await conversations.findLatestInboundWhatsAppDmFromRecipient({
+        recipientUserId: candidate.id,
+        phoneE164: candidate.whatsapp_number,
+      });
+      const existing = await keepAlives.get(candidate.id);
+      const decision = decideWhatsAppWindowKeepAlive({
+        latestInboundReceivedAt: latestInbound?.receivedAt,
+        lastKeepAliveSentAt: existing?.sent_at,
+        now,
+      });
+
+      if (decision !== "send") {
+        incrementSkipCount(counts, decision);
+        continue;
+      }
+
+      const upcomingTaskCount = await scheduledTasks.countActiveForUserWithin(candidate.id, nowIso, upcomingBefore);
+      const text = buildWhatsAppWindowKeepAliveMessage({
+        recipientName: candidate.name,
+        botName,
+        upcomingTaskCount,
+      });
+      const sendFailed = await sendKeepAliveText(deps, candidate, text);
+      await keepAlives.recordAttempt(candidate.id, nowIso);
+      if (sendFailed) {
+        counts.failed += 1;
+      } else {
+        counts.pinged += 1;
+      }
+    } catch (err) {
+      counts.failed += 1;
+      deps.logger.warn({ err, recipientUserId: candidate.id }, "WhatsApp window keep-alive candidate failed");
+    }
+  }
+
+  deps.logger.info(counts, "WhatsApp window keep-alive run complete");
+  return counts;
+}
+
+async function sendKeepAliveText(deps: WhatsAppWindowKeepAliveJobDeps, candidate: CandidateUser, text: string) {
+  try {
+    await deps.whatsapp.sendText({ kind: "dm", phoneE164: candidate.whatsapp_number ?? "" }, text);
+    return false;
+  } catch (err) {
+    deps.logger.warn({ err, recipientUserId: candidate.id }, "WhatsApp window keep-alive send failed");
+    return true;
+  }
+}
+
+async function listCandidateUsers(db: Kysely<DB>): Promise<CandidateUser[]> {
+  return db
+    .selectFrom("users")
+    .select(["id", "name", "whatsapp_number"])
+    .where("whatsapp_number", "is not", null)
+    .execute();
+}
+
+function emptyCounts(): WhatsAppWindowKeepAliveCounts {
+  return {
+    candidates: 0,
+    pinged: 0,
+    skipped_recent: 0,
+    skipped_lapsed: 0,
+    skipped_deduped: 0,
+    skipped_no_inbound: 0,
+    failed: 0,
+  };
+}
+
+function incrementSkipCount(
+  counts: WhatsAppWindowKeepAliveCounts,
+  decision: Exclude<WhatsAppWindowKeepAliveDecision, "send">,
+) {
+  if (decision === "skip_no_inbound") counts.skipped_no_inbound += 1;
+  if (decision === "skip_recent") counts.skipped_recent += 1;
+  if (decision === "skip_lapsed") counts.skipped_lapsed += 1;
+  if (decision === "skip_deduped") counts.skipped_deduped += 1;
+}
+
+function parseTimestamp(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const millis = Date.parse(value);
+  return Number.isFinite(millis) ? new Date(millis) : null;
+}
+
+function formatName(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed || fallback;
+}


### PR DESCRIPTION
## What & Why

WhatsApp proactive delivery has two tiers today: in-window (<23h since the user's last inbound) sends full session text; out-of-window parks the output in the inbox and sends a template nudge. This adds tier 2: an hourly keep-alive job that pings users shortly *before* their 24h customer-service window lapses, baiting a reply that keeps the plain-text channel open. Our outbound message does not extend Meta's window — only the user's reply does; the ping exists to prompt that reply.

## How

- Internal hourly cron inside the server process (croner) — not a `scheduled_tasks` row, never user-visible.
- Runs only when the DM provider has window semantics (managed/Wati); complete no-op on Baileys tenants.
- Decision flow per user with a `whatsapp_number`: skip if no inbound ever (tier 3 owns first contact) → ping only when the latest non-bot inbound is 21-23h old (inside the 23h safety margin) → skip if a keep-alive was already sent since that inbound (one ping per window cycle, restart-safe via the new `whatsapp_window_keepalives` table).
- Sends plain session text directly (`sendText`), never through the park/nudge path; failures log at warn and still record so a dead window isn't retried hourly.
- Copy is static and personalized (user name, bot name), with an upcoming-task variant when the user has active scheduled tasks due within 26h. No LLM call, no message content or task titles.
- Gated behind `WHATSAPP_WINDOW_KEEPALIVE_ENABLED` (default false) for per-tenant rollout, Goosebumps first.

## Testing

Unit tests for the band/dedupe/no-inbound decision logic, both copy variants, the keep-alive repository, the upcoming-task count query, and migration registration. Full gates green: biome, typecheck, tests, build.
