### PR TITLE
feat: send logical template keys to the managed WhatsApp gateway

### DIFF
--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -260,7 +260,6 @@ export async function createServer(config: Config, options?: CreateServerOptions
           platformUrl: config.MANAGED_WHATSAPP_PLATFORM_URL ?? "",
           tenantToken: config.MANAGED_WHATSAPP_TENANT_TOKEN ?? "",
           logger,
-          templateMappings: whatsappTemplateMappingsRepo,
         })
       : null;
   const whatsappRuntime = createWhatsAppRuntime({

--- a/packages/server/src/whatsapp/providers/managed.test.ts
+++ b/packages/server/src/whatsapp/providers/managed.test.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "pino";
 import { describe, expect, it, vi } from "vitest";
-import { createWhatsAppTemplateMappingRepository } from "../../db/repositories/whatsapp-template-mappings";
-import { createTestDb, createTestLogger } from "../../test-utils";
+import { createTestLogger } from "../../test-utils";
 import type { WhatsAppInboundMessage } from "../provider";
 import { WHATSAPP_TEMPLATE_KEYS } from "../templates";
 import {
@@ -200,109 +199,110 @@ describe("managed WhatsApp provider", () => {
     }
   });
 
-  it("sends mapped logical templates through the platform template API", async () => {
-    const db = await createTestDb();
-    try {
-      const templateMappings = createWhatsAppTemplateMappingRepository(db);
-      await templateMappings.upsertMapping({
-        provider: "managed",
-        logicalKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
-        providerTemplateName: "sketch_magic_link",
-        language: "en_US",
-        status: "approved",
-        parameterMap: {
-          name: "recipientName",
-          bot: "botName",
-          link: "magicLinkUrl",
-          missing: "missingValue",
-        },
-      });
-      const requestFetch = vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              ok: true,
-              message: {
-                providerMessageId: "wamid.template",
-                providerConversationId: "conversation-1",
-                providerTimestamp: "2026-07-02T10:02:00.000Z",
-              },
-            }),
-          ),
-      );
-      const provider = createManagedWhatsAppProvider({
-        platformUrl: "https://app.getsketch.ai",
-        tenantToken: "tenant-token",
-        logger: createTestLogger(),
-        templateMappings,
-        fetch: requestFetch as typeof fetch,
-      });
+  it("sends logical template keys through the platform template API", async () => {
+    const requestFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            message: {
+              providerMessageId: "wamid.template",
+              providerConversationId: "conversation-1",
+              providerTimestamp: "2026-07-02T10:02:00.000Z",
+            },
+          }),
+        ),
+    );
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
 
-      expect(provider.dmProvider.capabilities.templates).toBe(true);
-      expect(provider.dmProvider.capabilities.templateProvisioning).toBe("manual");
-      const sent = await provider.dmProvider.sendTemplate?.(
-        { kind: "dm", phoneE164: "+15551234567", providerConversationId: "conversation-1" },
-        {
-          key: WHATSAPP_TEMPLATE_KEYS.magicLink,
-          params: {
-            recipientName: "Alice",
-            botName: "Sketch",
-            magicLinkUrl: "https://sketch.test/magic",
-            missingValue: null,
-          },
-        },
-      );
-
-      expect(sent).toMatchObject({
-        providerMessageId: "wamid.template",
-        providerConversationId: "conversation-1",
-        providerTimestamp: "2026-07-02T10:02:00.000Z",
-      });
-      const [url, init] = requestFetch.mock.calls[0] as unknown as [string, RequestInit];
-      expect(url).toBe("https://app.getsketch.ai/api/whatsapp/outbound/templates");
-      expect(init.headers).toMatchObject({
-        Authorization: "Bearer tenant-token",
-        "Content-Type": "application/json",
-      });
-      expect(init.signal).toBeInstanceOf(AbortSignal);
-      expect(JSON.parse(init.body as string)).toEqual({
-        to: "+15551234567",
-        templateName: "sketch_magic_link",
+    expect(provider.dmProvider.capabilities.templates).toBe(true);
+    expect(provider.dmProvider.capabilities.templateProvisioning).toBe("manual");
+    const sent = await provider.dmProvider.sendTemplate?.(
+      { kind: "dm", phoneE164: "+15551234567", providerConversationId: "conversation-1" },
+      {
+        key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+        language: "hi_IN",
         params: {
-          name: "Alice",
-          bot: "Sketch",
-          link: "https://sketch.test/magic",
-          missing: "",
+          recipientName: "Alice\nExample",
+          botName: "Sketch\tBot",
+          magicLinkUrl: "https://sketch.test/magic",
+          missingValue: null,
         },
-        providerConversationId: "conversation-1",
-      });
-    } finally {
-      await db.destroy();
-    }
+      },
+    );
+
+    expect(sent).toMatchObject({
+      providerMessageId: "wamid.template",
+      providerConversationId: "conversation-1",
+      providerTimestamp: "2026-07-02T10:02:00.000Z",
+    });
+    const [url, init] = requestFetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://app.getsketch.ai/api/whatsapp/outbound/templates");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer tenant-token",
+      "Content-Type": "application/json",
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    const payload = JSON.parse(init.body as string);
+    expect(payload).not.toHaveProperty("templateName");
+    expect(payload).toEqual({
+      to: "+15551234567",
+      templateKey: WHATSAPP_TEMPLATE_KEYS.magicLink,
+      language: "hi_IN",
+      params: {
+        recipientName: "Alice Example",
+        botName: "Sketch Bot",
+        magicLinkUrl: "https://sketch.test/magic",
+        missingValue: "",
+      },
+      providerConversationId: "conversation-1",
+    });
   });
 
-  it("fails template sends clearly when no approved managed mapping exists", async () => {
-    const db = await createTestDb();
-    try {
-      const provider = createManagedWhatsAppProvider({
-        platformUrl: "https://app.getsketch.ai",
-        tenantToken: "tenant-token",
-        logger: createTestLogger(),
-        templateMappings: createWhatsAppTemplateMappingRepository(db),
-        fetch: vi.fn() as unknown as typeof fetch,
-      });
-
-      await expect(
-        provider.dmProvider.sendTemplate?.(
-          { kind: "dm", phoneE164: "+15551234567" },
-          {
-            key: WHATSAPP_TEMPLATE_KEYS.magicLink,
-            params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
-          },
+  it("surfaces template_not_found platform failures from template sends", async () => {
+    const requestFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "SEND_FAILED",
+              message: "Template mapping not found",
+              providerCode: "template_not_found",
+              providerInfo: "provider rejected template",
+            },
+          }),
+          { status: 502 },
         ),
-      ).rejects.toThrow("No approved WhatsApp template mapping configured for whatsapp.magic_link");
-    } finally {
-      await db.destroy();
+    );
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    try {
+      await provider.dmProvider.sendTemplate?.(
+        { kind: "dm", phoneE164: "+15551234567" },
+        {
+          key: WHATSAPP_TEMPLATE_KEYS.magicLink,
+          params: { recipientName: "Alice", botName: "Sketch", magicLinkUrl: "https://sketch.test/magic" },
+        },
+      );
+      throw new Error("expected send to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ManagedWhatsAppRequestError);
+      expect(error).toMatchObject({
+        status: 502,
+        providerCode: "template_not_found",
+        providerInfo: "provider rejected template",
+      });
+      expect((error as Error).message).toContain("template_not_found");
     }
   });
 

--- a/packages/server/src/whatsapp/providers/managed.ts
+++ b/packages/server/src/whatsapp/providers/managed.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import type { createWhatsAppTemplateMappingRepository } from "../../db/repositories/whatsapp-template-mappings";
 import type { Logger } from "../../logger";
 import {
   type WhatsAppCapabilities,
@@ -12,7 +11,7 @@ import {
   type WhatsAppTarget,
   canonicalDmConversationId,
 } from "../provider";
-import { mapTemplateParams } from "../template-params";
+import { sanitizeTemplateParamValue } from "../template-params";
 import type { WhatsAppTemplateParamValue, WhatsAppTemplateRequest } from "../templates";
 
 export const WHATSAPP_MANAGED_PROVIDER_ID = "managed";
@@ -80,7 +79,6 @@ export interface ManagedWhatsAppConfig {
   platformUrl: string;
   tenantToken: string;
   logger: Logger;
-  templateMappings?: ReturnType<typeof createWhatsAppTemplateMappingRepository>;
   fetch?: typeof fetch;
 }
 
@@ -151,16 +149,6 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
   ): Promise<WhatsAppSendResult | null> => {
     if (target.kind !== "dm") throw new Error("Managed WhatsApp cannot send group messages");
     assertValidE164Target(target.phoneE164, config.logger);
-    if (!config.templateMappings) throw new Error("WhatsApp template mappings are not configured");
-
-    const mapping = await config.templateMappings.findApprovedMapping(
-      WHATSAPP_MANAGED_PROVIDER_ID,
-      template.key,
-      template.language,
-    );
-    if (!mapping) {
-      throw new Error(`No approved WhatsApp template mapping configured for ${template.key}`);
-    }
 
     const body = await fetchManagedJson(requestFetch, `${platformUrl}/api/whatsapp/outbound/templates`, {
       method: "POST",
@@ -170,8 +158,9 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
       },
       body: JSON.stringify({
         to: target.phoneE164,
-        templateName: mapping.provider_template_name,
-        params: providerTemplateParamRecord(mapping.parameterMap, template.params),
+        templateKey: template.key,
+        language: template.language,
+        params: logicalTemplateParamRecord(template.params),
         providerConversationId: target.providerConversationId,
       }),
     });
@@ -302,11 +291,8 @@ function inboundMessageText(text: string | undefined, mediaType: string | undefi
   return text ?? "";
 }
 
-function providerTemplateParamRecord(
-  parameterMap: Record<string, string> | null,
-  params: Record<string, WhatsAppTemplateParamValue>,
-): Record<string, string> {
-  return Object.fromEntries(mapTemplateParams(parameterMap, params));
+function logicalTemplateParamRecord(params: Record<string, WhatsAppTemplateParamValue>): Record<string, string> {
+  return Object.fromEntries(Object.entries(params).map(([key, value]) => [key, sanitizeTemplateParamValue(value)]));
 }
 
 function managedRequestError(status: number, text: string): ManagedWhatsAppRequestError {
@@ -315,7 +301,8 @@ function managedRequestError(status: number, text: string): ManagedWhatsAppReque
   const providerMessage = optionalString(error?.message);
   const providerCode = optionalString(error?.providerCode);
   const providerInfo = optionalString(error?.providerInfo);
-  const snippet = boundedResponseSnippet(providerMessage ?? text);
+  const detail = providerCode ? `${providerCode}${providerMessage ? `: ${providerMessage}` : ""}` : providerMessage;
+  const snippet = boundedResponseSnippet(detail ?? text);
   return new ManagedWhatsAppRequestError(
     `Managed WhatsApp request failed: HTTP ${status}${snippet ? `: ${snippet}` : ""}`,
     { status, providerCode, providerInfo },

--- a/packages/server/src/whatsapp/providers/wati.test.ts
+++ b/packages/server/src/whatsapp/providers/wati.test.ts
@@ -277,6 +277,34 @@ describe("Wati outbound provider", () => {
     });
   });
 
+  it("throws when Wati session text responses report body-level failure", async () => {
+    const requestFetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          result: false,
+          error: "session message rejected",
+        }),
+      );
+    });
+    const provider = createWatiWhatsAppProvider({
+      apiEndpoint: "https://live-mt-server.wati.io/tenant-1/",
+      accessToken: "wati-token",
+      webhookToken: "webhook-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+
+    try {
+      await provider.dmProvider.sendText({ kind: "dm", phoneE164: "+15551234567" }, "hello");
+      throw new Error("expected send to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("Wati message send failed: provider rejected request");
+      expect((error as Error).message).not.toContain("hello");
+      expect((error as Error).message).not.toContain("+15551234567");
+    }
+  });
+
   it("sends files through the v1 session file endpoint when no channel is configured", async () => {
     const requestFetch = vi.fn(async () => new Response(JSON.stringify({ ok: true, result: "success" })));
     const provider = createWatiWhatsAppProvider({

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -123,21 +123,31 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
     form.set("file", new Blob([new Uint8Array(fileBytes)], { type: mimeType }), fileName);
 
     if (!channelPhoneDigits) {
-      await fetchJson(requestFetch, new URL(`${endpoint}/api/v1/sendSessionFile/${encodeURIComponent(phone)}`), {
-        method: "POST",
-        headers: authorizationHeaders(config.accessToken),
-        body: form,
-      });
+      const responseBody = await fetchJson(
+        requestFetch,
+        new URL(`${endpoint}/api/v1/sendSessionFile/${encodeURIComponent(phone)}`),
+        {
+          method: "POST",
+          headers: authorizationHeaders(config.accessToken),
+          body: form,
+        },
+      );
+      assertWatiFileSendAccepted(responseBody);
       return;
     }
 
     form.set("target", `${channelPhoneDigits}:${phone}`);
 
-    await fetchJson(requestFetch, new URL(`${v3Endpoint}/api/ext/v3/conversations/messages/file`), {
-      method: "POST",
-      headers: authorizationHeaders(config.accessToken),
-      body: form,
-    });
+    const responseBody = await fetchJson(
+      requestFetch,
+      new URL(`${v3Endpoint}/api/ext/v3/conversations/messages/file`),
+      {
+        method: "POST",
+        headers: authorizationHeaders(config.accessToken),
+        body: form,
+      },
+    );
+    assertWatiFileSendAccepted(responseBody);
   };
 
   const sendTemplate = async (
@@ -543,6 +553,8 @@ async function fetchJson(requestFetch: typeof fetch, url: URL, init: RequestInit
 function sendResultFromWatiBody(body: unknown, target: WhatsAppTarget): WhatsAppSendResult | null {
   const record = isRecord(body) ? body : {};
   const message = isRecord(record.message) ? record.message : record;
+  const failureReason = watiMessageSendFailure(record, message);
+  if (failureReason) throw new Error(failureReason);
   const fallbackConversationId =
     target.kind === "dm" ? (target.providerConversationId ?? `wati:${target.phoneE164}`) : target.groupId;
 
@@ -565,6 +577,43 @@ function sendResultFromWatiBody(body: unknown, target: WhatsAppTarget): WhatsApp
       parseWatiTimestamp(record.created),
     rawProviderPayload: body,
   };
+}
+
+function watiMessageSendFailure(record: Record<string, unknown>, message: Record<string, unknown>): string | null {
+  if (hasWatiSendFailure(record, message)) return "Wati message send failed: provider rejected request";
+  return null;
+}
+
+function assertWatiFileSendAccepted(body: unknown): void {
+  const record = isRecord(body) ? body : {};
+  const message = isRecord(record.message) ? record.message : record;
+  if (hasWatiSendFailure(record, message)) throw new Error("Wati file send failed: provider rejected request");
+}
+
+function hasWatiSendFailure(record: Record<string, unknown>, message: Record<string, unknown>): boolean {
+  if (
+    isExplicitFalse(record.result) ||
+    isExplicitFalse(record.ok) ||
+    isExplicitFalse(record.success) ||
+    isExplicitFalse(message.result) ||
+    isExplicitFalse(message.ok) ||
+    isExplicitFalse(message.success) ||
+    hasProviderErrors(record.error) ||
+    hasProviderErrors(record.errors) ||
+    hasProviderErrors(message.error) ||
+    hasProviderErrors(message.errors)
+  ) {
+    return true;
+  }
+
+  const status =
+    optionalString(message.status) ??
+    optionalString(message.statusString) ??
+    optionalString(message.result) ??
+    optionalString(record.status) ??
+    optionalString(record.statusString) ??
+    optionalString(record.result);
+  return isFailureStatus(status);
 }
 
 function sendResultFromWatiTemplateBody(body: unknown, target: WhatsAppTarget): WhatsAppSendResult | null {
@@ -636,6 +685,11 @@ function hasProviderErrors(value: unknown): boolean {
   if (Array.isArray(value)) return value.length > 0;
   if (typeof value === "string") return value.trim().length > 0;
   return true;
+}
+
+function isFailureStatus(value: string | null): boolean {
+  if (!value) return false;
+  return /fail|error|reject/iu.test(value);
 }
 
 function parseWatiTemplateList(body: unknown): ProviderTemplateSummary[] {


### PR DESCRIPTION
## What & Why

SKE-261 (resolve-at-send, option 3): the platform now owns the logical→Wati template mapping. The managed provider stops resolving template keys against the tenant-local `whatsapp_template_mappings` table and posts the logical key instead — managed tenants no longer carry template mapping state (no seeding, no drift).

## How

- `managed.ts sendTemplate` posts `{ to, templateKey, language, params (sanitized logical values), providerConversationId }` to the platform outbound templates endpoint; the local mapping lookup and its 'no approved mapping' error are removed (the platform returns 502 `providerCode: template_not_found` instead, parsed by `ManagedWhatsAppRequestError`).
- Direct-Wati provider keeps its local mapping behavior unchanged.
- Folded in: Wati HTTP-200-with-`result:false` responses on session sends now throw instead of counting as success (observability nit from the v0.43.0 review).

## Deploy order

Platform must deploy first (sketch-platform PR: resolve-at-send endpoint + seeded mappings). Existing `provider='managed'` rows in tenant DBs become inert; left in place.

## Testing

Provider unit tests updated for the new contract (templateKey shape, template_not_found surfacing, result:false rejection, direct-wati unchanged). Full gates green.