### PR TITLE
feat: per-source summariser routing core

### DIFF
--- a/packages/server/src/agents/definitions/conversation-summary.test.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.test.ts
@@ -121,6 +121,7 @@ describe("buildConversationSummaryRuntimeContext", () => {
         focus: null,
         delivery: null,
         sources: [source()],
+        sourceKey: "slack:channel:C_SUMMARY",
       },
     });
 
@@ -148,6 +149,8 @@ describe("buildConversationSummaryRuntimeContext", () => {
         agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
         user_id: user.id,
         output_date: "2026-07-01",
+        source_key: "slack:channel:C_SUMMARY",
+        source_label: "#summary-room",
         timezone: "UTC",
         status: "completed",
         trigger_type: "scheduled",
@@ -191,6 +194,7 @@ describe("buildConversationSummaryRuntimeContext", () => {
         focus: null,
         delivery: null,
         sources: [source()],
+        sourceKey: "slack:channel:C_SUMMARY",
       },
     });
 

--- a/packages/server/src/agents/definitions/conversation-summary.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.ts
@@ -1,8 +1,9 @@
 import type { Kysely } from "kysely";
-import type {
-  AgentOutputItemInput,
-  AgentSourceConfig,
-  AgentStructuredPayload,
+import {
+  type AgentOutputItemInput,
+  type AgentSourceConfig,
+  type AgentStructuredPayload,
+  createAgentOutputRepository,
 } from "../../db/repositories/agent-outputs";
 import { type StoredConversationMessage, createConversationRepository } from "../../db/repositories/conversations";
 import type { DB } from "../../db/schema";
@@ -54,16 +55,23 @@ function fallbackWindowStart(now: Date): string {
   return new Date(now.getTime() - CONVERSATION_SUMMARY_FIRST_RUN_LOOKBACK_HOURS * 60 * 60 * 1000).toISOString();
 }
 
-async function findLatestCompletedOutput(db: Kysely<DB>, userId: string): Promise<LatestOutputRow | undefined> {
-  return db
-    .selectFrom("agent_outputs")
-    .select(["id", "generated_at", "raw_payload_json", "updated_at"])
-    .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
-    .where("user_id", "=", userId)
-    .where("status", "=", "completed")
-    .orderBy("generated_at", "desc")
-    .orderBy("id", "desc")
-    .executeTakeFirst();
+async function findLatestCompletedOutput(
+  db: Kysely<DB>,
+  userId: string,
+  sourceKey: string,
+): Promise<LatestOutputRow | undefined> {
+  const latest = await createAgentOutputRepository(db).findLatestCompletedForScope(
+    CONVERSATION_SUMMARY_AGENT_KEY,
+    userId,
+    sourceKey,
+  );
+  if (!latest) return undefined;
+  return {
+    id: latest.output.id,
+    generated_at: latest.output.generated_at,
+    raw_payload_json: latest.output.raw_payload_json,
+    updated_at: latest.output.updated_at,
+  };
 }
 
 function summaryWindowEndFromRawPayload(rawPayloadJson: string | null): string | null {
@@ -127,7 +135,11 @@ export async function buildConversationSummaryRuntimeContext(
   params: AgentRuntimeContextParams,
 ): Promise<Record<string, unknown>> {
   const sources = params.agentConfig?.sources ?? [];
-  const previousOutput = await findLatestCompletedOutput(params.db, params.user.id);
+  const previousOutput = await findLatestCompletedOutput(
+    params.db,
+    params.user.id,
+    params.agentConfig?.sourceKey ?? "",
+  );
   const windowEnd = params.now.toISOString();
   const windowStart = previousOutputWatermark(previousOutput, params.now);
   const conversations = createConversationRepository(params.db);

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -1,13 +1,17 @@
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
 import { agentRoutes } from "./routes";
-import { AgentDeliveryTargetError, type AgentRunService, AgentSourceTargetError } from "./service";
+import { AgentDeliveryTargetError, AgentRunService, type AgentRunServiceDeps, AgentSourceTargetError } from "./service";
 
-function createRoutesTestApp(service: AgentRunService) {
+function createRoutesTestApp(service: AgentRunService, sub = "auth-user", email = "user@example.com") {
   const app = new Hono();
   app.use("*", async (c, next) => {
-    c.set("sub", "auth-user");
-    c.set("email", "user@example.com");
+    c.set("sub", sub);
+    c.set("email", email);
     await next();
   });
   app.route("/api/agents", agentRoutes(service));
@@ -20,28 +24,21 @@ function createService(overrides: Record<string, unknown> = {}) {
     resolveDeliveryConfigForUser: vi.fn(async (_userId, delivery) => delivery),
     listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
     listOutputsForUser: vi.fn(async () => ({ outputs: [], nextCursor: null })),
+    requestGenerationForUser: vi.fn(async () => []),
     updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
     ...overrides,
   } as unknown as AgentRunService & {
     resolveDeliveryConfigForUser: ReturnType<typeof vi.fn>;
     listOutputsForUser: ReturnType<typeof vi.fn>;
+    requestGenerationForUser: ReturnType<typeof vi.fn>;
     updateConfigForUser: ReturnType<typeof vi.fn>;
   };
 }
 
 describe("agentRoutes", () => {
-  it("resolves delivery config before saving it", async () => {
-    const resolved = {
-      enabled: true as const,
-      platform: "slack" as const,
-      targetType: "dm" as const,
-      targetId: "U_SELF",
-      label: "Agent User <user@example.com>",
-      mentions: [{ platform: "slack" as const, targetId: "U_OWNER", label: "Owner" }],
-    };
+  it("passes parsed delivery config to the service for saving", async () => {
     const service = createService({
-      resolveDeliveryConfigForUser: vi.fn(async () => resolved),
-      updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: resolved })),
+      updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
     });
     const app = createRoutesTestApp(service);
 
@@ -64,14 +61,14 @@ describe("agentRoutes", () => {
     expect(service.updateConfigForUser).toHaveBeenCalledWith(
       "daily-brief",
       "user-1",
-      expect.objectContaining({ delivery: resolved }),
-    );
-    expect(service.resolveDeliveryConfigForUser).toHaveBeenCalledWith(
-      "user-1",
       expect.objectContaining({
-        mentions: [{ platform: "slack", targetId: "U_OWNER", label: "Spoofed Owner" }],
+        delivery: expect.objectContaining({
+          targetId: "U_SELF",
+          mentions: [{ platform: "slack", targetId: "U_OWNER", label: "Spoofed Owner" }],
+        }),
       }),
     );
+    expect(service.resolveDeliveryConfigForUser).not.toHaveBeenCalled();
   });
 
   it("rejects delivery mentions for the wrong platform", async () => {
@@ -100,9 +97,9 @@ describe("agentRoutes", () => {
     expect(service.updateConfigForUser).not.toHaveBeenCalled();
   });
 
-  it("rejects unauthorized delivery config before saving it", async () => {
+  it("returns service validation errors for unauthorized delivery config", async () => {
     const service = createService({
-      resolveDeliveryConfigForUser: vi.fn(async () => {
+      updateConfigForUser: vi.fn(async () => {
         throw new AgentDeliveryTargetError("Slack DM delivery must target the current user");
       }),
     });
@@ -126,10 +123,10 @@ describe("agentRoutes", () => {
       error: { code: "VALIDATION_ERROR", message: "Slack DM delivery must target the current user" },
     });
     expect(res.status).toBe(400);
-    expect(service.updateConfigForUser).not.toHaveBeenCalled();
+    expect(service.updateConfigForUser).toHaveBeenCalled();
   });
 
-  it("rejects unauthorized source config before saving it", async () => {
+  it("returns service validation errors for unauthorized source config", async () => {
     const service = createService({
       updateConfigForUser: vi.fn(async () => {
         throw new AgentSourceTargetError("Slack channel is not available for this user");
@@ -170,5 +167,89 @@ describe("agentRoutes", () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ outputs: [{ id: "out-1" }], nextCursor: "out-1" });
     expect(service.listOutputsForUser).toHaveBeenCalledWith("daily-brief", "user-1", { limit: 10, cursor: "old" });
+  });
+
+  it("returns fan-out generations while keeping legacy generation", async () => {
+    const service = createService({
+      listDefinitions: vi.fn(() => [{ key: "conversation_summary" }]),
+      requestGenerationForUser: vi.fn(async () => [
+        {
+          id: "out-a",
+          status: "running",
+          output_date: "2026-07-04",
+          source_key: "slack:channel:C_A",
+        },
+        {
+          id: "out-b",
+          status: "running",
+          output_date: "2026-07-04",
+          source_key: "slack:channel:C_B",
+        },
+      ]),
+    });
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request("/api/agents/conversation_summary/runs", { method: "POST" });
+
+    expect(res.status).toBe(202);
+    await expect(res.json()).resolves.toEqual({
+      generation: { id: "out-a", sourceKey: "slack:channel:C_A", status: "running", outputDate: "2026-07-04" },
+      generations: [
+        { id: "out-a", sourceKey: "slack:channel:C_A", status: "running", outputDate: "2026-07-04" },
+        { id: "out-b", sourceKey: "slack:channel:C_B", status: "running", outputDate: "2026-07-04" },
+      ],
+    });
+  });
+
+  it("rejects combined delivery to a selected source through the public config route", async () => {
+    const db = await createTestDb();
+    try {
+      const users = createUserRepository(db);
+      const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+      const service = new AgentRunService({
+        db,
+        config: createTestConfig(),
+        logger: createTestLogger(),
+        users,
+        settings: createSettingsRepository(db),
+        runAgent: vi.fn(async () => {
+          throw new Error("runAgent should not be called");
+        }) as unknown as AgentRunServiceDeps["runAgent"],
+        getSlack: () => ({
+          listChannels: vi.fn(async () => [{ id: "C_SOURCE", name: "source", type: "public_channel", isMember: true }]),
+          isUserInChannel: vi.fn(async () => true),
+        }),
+      });
+      const app = createRoutesTestApp(service, user.id, user.email ?? undefined);
+
+      const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sources: [{ platform: "slack", targetType: "channel", targetId: "C_SOURCE", label: "#source" }],
+          deliveryModel: {
+            mode: "combined",
+            combined: {
+              enabled: true,
+              platform: "slack",
+              targetType: "channel",
+              targetId: "C_SOURCE",
+              label: "#source",
+              ackNonDm: true,
+            },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toMatchObject({
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Combined delivery cannot target one of the selected sources",
+        },
+      });
+    } finally {
+      await db.destroy();
+    }
   });
 });

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -68,7 +68,14 @@ describe("agentRoutes", () => {
         }),
       }),
     );
-    expect(service.resolveDeliveryConfigForUser).not.toHaveBeenCalled();
+    expect(service.resolveDeliveryConfigForUser).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({
+        platform: "slack",
+        targetType: "dm",
+        targetId: "U_SELF",
+      }),
+    );
   });
 
   it("rejects delivery mentions for the wrong platform", async () => {
@@ -99,7 +106,7 @@ describe("agentRoutes", () => {
 
   it("returns service validation errors for unauthorized delivery config", async () => {
     const service = createService({
-      updateConfigForUser: vi.fn(async () => {
+      resolveDeliveryConfigForUser: vi.fn(async () => {
         throw new AgentDeliveryTargetError("Slack DM delivery must target the current user");
       }),
     });
@@ -123,7 +130,40 @@ describe("agentRoutes", () => {
       error: { code: "VALIDATION_ERROR", message: "Slack DM delivery must target the current user" },
     });
     expect(res.status).toBe(400);
-    expect(service.updateConfigForUser).toHaveBeenCalled();
+    expect(service.updateConfigForUser).not.toHaveBeenCalled();
+  });
+
+  it("validates combined delivery model targets before saving config", async () => {
+    const service = createService({
+      resolveDeliveryConfigForUser: vi.fn(async () => {
+        throw new AgentDeliveryTargetError("Slack channel is not available for delivery");
+      }),
+    });
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        deliveryModel: {
+          mode: "combined",
+          combined: {
+            enabled: true,
+            platform: "slack",
+            targetType: "channel",
+            targetId: "C_PRIVATE",
+            label: "#private",
+            ackNonDm: true,
+          },
+        },
+      }),
+    });
+
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "Slack channel is not available for delivery" },
+    });
+    expect(res.status).toBe(400);
+    expect(service.updateConfigForUser).not.toHaveBeenCalled();
   });
 
   it("returns service validation errors for unauthorized source config", async () => {

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -290,6 +290,17 @@ function parseConfigPatch(body: Record<string, unknown>) {
   return patch;
 }
 
+async function validateDeliveryTargets(
+  service: AgentRunService,
+  userId: string,
+  patch: ReturnType<typeof parseConfigPatch>,
+) {
+  if (patch.delivery !== undefined) await service.resolveDeliveryConfigForUser(userId, patch.delivery);
+  if (patch.deliveryModel?.mode === "combined") {
+    await service.resolveDeliveryConfigForUser(userId, patch.deliveryModel.combined);
+  }
+}
+
 export function agentRoutes(service: AgentRunService) {
   const routes = new Hono();
 
@@ -324,6 +335,7 @@ export function agentRoutes(service: AgentRunService) {
     let agent: Awaited<ReturnType<AgentRunService["updateConfigForUser"]>>;
     try {
       patch = parseConfigPatch(body);
+      await validateDeliveryTargets(service, userId, patch);
       agent = await service.updateConfigForUser(agentKey, userId, patch);
     } catch (err) {
       if (

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -3,7 +3,9 @@ import type { Kysely } from "kysely";
 import type {
   AgentDeliveryConfig,
   AgentDeliveryMention,
+  AgentDeliveryModel,
   AgentDeliveryPlatform,
+  AgentPerSourceDelivery,
   AgentSourceConfig,
 } from "../db/repositories/agent-outputs";
 import type { DB } from "../db/schema";
@@ -38,6 +40,10 @@ function toBriefShape(output: AgentOutputApi | null) {
       active_projects: output.sections.active_projects ?? [],
     },
   };
+}
+
+function toGenerationShape(row: { id: string; status: string; output_date: string; source_key: string }) {
+  return { id: row.id, sourceKey: row.source_key, status: row.status, outputDate: row.output_date };
 }
 
 /**
@@ -89,12 +95,13 @@ export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>) {
     if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
     const body = (await c.req.json().catch(() => ({}))) as { briefDate?: unknown };
     const outputDate = typeof body.briefDate === "string" && body.briefDate.trim() ? body.briefDate.trim() : undefined;
-    const row = await service.requestGenerationForUser({
+    const rows = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId,
       outputDate,
       triggerType: "manual",
     });
+    const row = rows[0] ?? null;
     return c.json({ generation: row ? { id: row.id, status: row.status, briefDate: row.output_date } : null }, 202);
   });
 
@@ -167,6 +174,54 @@ function parseDeliveryConfig(value: unknown): AgentDeliveryConfig | null | undef
   };
 }
 
+function parseRequiredDeliveryConfig(value: unknown, path: string): AgentDeliveryConfig {
+  const parsed = parseDeliveryConfig(value);
+  if (!parsed) throw new ConfigPatchError(`${path} must be an enabled delivery object`);
+  return parsed;
+}
+
+function parsePerSourceDelivery(value: unknown): AgentPerSourceDelivery {
+  if (!value || typeof value !== "object")
+    throw new ConfigPatchError("deliveryModel.perSource route must be an object");
+  const raw = value as Record<string, unknown>;
+  if (raw.kind === "self" || raw.kind === "off") return { kind: raw.kind };
+  throw new ConfigPatchError("deliveryModel.perSource route kind must be self or off");
+}
+
+function parseDeliveryModel(value: unknown): AgentDeliveryModel | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigPatchError("deliveryModel must be an object");
+  }
+  const raw = value as Record<string, unknown>;
+  if (raw.mode === "combined") {
+    const combined = parseRequiredDeliveryConfig(raw.combined, "deliveryModel.combined");
+    const ackNonDm = (raw.combined as Record<string, unknown>).ackNonDm;
+    if (ackNonDm !== undefined && ackNonDm !== true) {
+      throw new ConfigPatchError("deliveryModel.combined.ackNonDm must be true when present");
+    }
+    return {
+      mode: "combined",
+      combined: {
+        ...combined,
+        ...(ackNonDm === true ? { ackNonDm: true as const } : {}),
+      },
+    };
+  }
+
+  if (raw.mode !== "per_source") throw new ConfigPatchError("deliveryModel.mode must be per_source or combined");
+  const defaultRoute = raw.defaultRoute === "self" ? "self" : raw.defaultRoute === "off" ? "off" : null;
+  if (!defaultRoute) throw new ConfigPatchError("deliveryModel.defaultRoute must be self or off");
+  if (!raw.perSource || typeof raw.perSource !== "object" || Array.isArray(raw.perSource)) {
+    throw new ConfigPatchError("deliveryModel.perSource must be an object");
+  }
+  const perSource: Record<string, AgentPerSourceDelivery> = {};
+  for (const [key, route] of Object.entries(raw.perSource as Record<string, unknown>)) {
+    perSource[key] = parsePerSourceDelivery(route);
+  }
+  return { mode: "per_source", defaultRoute, perSource, combined: null };
+}
+
 function parseSourceConfigs(value: unknown): AgentSourceConfig[] | undefined {
   if (value === undefined) return undefined;
   if (!Array.isArray(value)) throw new ConfigPatchError("sources must be an array");
@@ -203,6 +258,7 @@ function parseConfigPatch(body: Record<string, unknown>) {
     sections?: Record<string, boolean>;
     focus?: string | null;
     delivery?: AgentDeliveryConfig | null;
+    deliveryModel?: AgentDeliveryModel;
     sources?: AgentSourceConfig[];
   } = {};
   if (typeof body.enabled === "boolean") patch.enabled = body.enabled;
@@ -227,6 +283,8 @@ function parseConfigPatch(body: Record<string, unknown>) {
   }
   const delivery = parseDeliveryConfig(body.delivery);
   if (delivery !== undefined) patch.delivery = delivery;
+  const deliveryModel = parseDeliveryModel(body.deliveryModel);
+  if (deliveryModel !== undefined) patch.deliveryModel = deliveryModel;
   const sources = parseSourceConfigs(body.sources);
   if (sources !== undefined) patch.sources = sources;
   return patch;
@@ -266,9 +324,6 @@ export function agentRoutes(service: AgentRunService) {
     let agent: Awaited<ReturnType<AgentRunService["updateConfigForUser"]>>;
     try {
       patch = parseConfigPatch(body);
-      if (patch.delivery !== undefined) {
-        patch.delivery = await service.resolveDeliveryConfigForUser(userId, patch.delivery);
-      }
       agent = await service.updateConfigForUser(agentKey, userId, patch);
     } catch (err) {
       if (
@@ -316,8 +371,9 @@ export function agentRoutes(service: AgentRunService) {
     if (!service.listDefinitions().some((def) => def.key === agentKey)) {
       return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     }
-    const row = await service.requestGenerationForUser({ agentKey, userId, triggerType: "manual" });
-    return c.json({ generation: row ? { id: row.id, status: row.status, outputDate: row.output_date } : null }, 202);
+    const rows = await service.requestGenerationForUser({ agentKey, userId, triggerType: "manual" });
+    const generations = rows.map(toGenerationShape);
+    return c.json({ generation: generations[0] ?? null, generations }, 202);
   });
 
   return routes;

--- a/packages/server/src/agents/scheduler.ts
+++ b/packages/server/src/agents/scheduler.ts
@@ -49,13 +49,19 @@ export class AgentScheduler {
           try {
             const due = await this.deps.service.shouldGenerateForUser(def, user, now);
             if (!due) continue;
-            await this.deps.service.requestGenerationForUser({
+            const generations = await this.deps.service.requestGenerationForUser({
               agentKey: def.key,
               userId: user.id,
               outputDate: due.outputDate,
               triggerType: "scheduled",
               skipIfCompleted: true,
             });
+            for (const generation of generations) {
+              this.deps.logger.debug(
+                { userId: user.id, agentKey: def.key, outputId: generation.id, sourceKey: generation.source_key },
+                "Agent scheduler generation considered",
+              );
+            }
           } catch (err) {
             this.deps.logger.warn({ err, userId: user.id, agentKey: def.key }, "Agent scheduler skipped user");
           }

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -1,6 +1,12 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type AgentOutputItemInput, createAgentOutputRepository } from "../db/repositories/agent-outputs";
+import {
+  type AgentDeliveryModel,
+  type AgentOutputItemInput,
+  type AgentSourceConfig,
+  createAgentOutputRepository,
+} from "../db/repositories/agent-outputs";
+import { createConversationRepository } from "../db/repositories/conversations";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
@@ -8,7 +14,7 @@ import type { DB } from "../db/schema";
 import type { QueueManager } from "../queue";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 import type { WhatsAppBot } from "../whatsapp/bot";
-import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
+import { CONVERSATION_SUMMARY_AGENT_KEY, conversationSummaryDefinition } from "./definitions/conversation-summary";
 import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION, dailyBriefDefinition } from "./definitions/daily-brief";
 import type { AgentOutputDeliveryPublisher } from "./output-delivery";
 import { AgentRunService, type AgentRunServiceDeps } from "./service";
@@ -125,11 +131,43 @@ function allowSlackDelivery(
   };
 }
 
+function slackSource(id: string, name: string): AgentSourceConfig {
+  return { platform: "slack", targetType: "channel", targetId: id, label: `#${name}` };
+}
+
+function perSourceSelfModel(): AgentDeliveryModel {
+  return { mode: "per_source", defaultRoute: "self", perSource: {}, combined: null };
+}
+
 function runtimeContextFromUserMessage(userMessage: string): Record<string, unknown> {
   const marker = "Runtime context:\n";
   const markerIndex = userMessage.indexOf(marker);
   if (markerIndex === -1) throw new Error("Runtime context marker missing");
   return JSON.parse(userMessage.slice(markerIndex + marker.length)) as Record<string, unknown>;
+}
+
+async function seedSlackConversationMessage(
+  db: Kysely<DB>,
+  source: AgentSourceConfig,
+  params: { messageId: string; text: string; receivedAt: string },
+): Promise<void> {
+  const conversations = createConversationRepository(db);
+  const conversation = await conversations.getOrCreate(
+    {
+      platform: source.platform,
+      kind: "channel",
+      providerConversationId: source.targetId,
+    },
+    source.label,
+  );
+  await conversations.insertMessage({
+    conversationId: conversation.id,
+    providerMessageId: params.messageId,
+    senderJid: "U_SENDER",
+    senderName: "Sender",
+    text: params.text,
+    receivedAt: params.receivedAt,
+  });
 }
 
 async function seedIndexedFile(
@@ -235,6 +273,40 @@ function briefItem(overrides: Partial<AgentOutputItemInput> = {}): AgentOutputIt
   };
 }
 
+function successfulRunResult() {
+  return {
+    messageSent: true,
+    sessionId: "agent-session",
+    costUsd: 0,
+    auxCostUsd: 0,
+    pendingUploads: [],
+    durationMs: 0,
+    durationApiMs: 0,
+    numTurns: 0,
+    stopReason: null,
+    errorSubtype: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    webSearchRequests: 0,
+    webFetchRequests: 0,
+    model: null,
+    isResumedSession: false,
+    totalAttachments: 0,
+    imageCount: 0,
+    nonImageCount: 0,
+    mimeTypes: [],
+    fileSizes: [],
+    promptMode: "text" as const,
+    toolCalls: [],
+    auxLlmCalls: [],
+    sdkCostUsd: 0,
+    rawUsage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+    trace: { progressEvents: [], finalText: "Done" },
+  };
+}
+
 describe("AgentRunService", () => {
   let db: Kysely<DB>;
 
@@ -271,7 +343,7 @@ describe("AgentRunService", () => {
       .execute();
 
     const service = createService(db, tasks);
-    const replacement = await service.requestGenerationForUser({
+    const [replacement] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -438,7 +510,7 @@ describe("AgentRunService", () => {
       }),
     );
 
-    const row = await service.requestGenerationForUser({
+    const [row] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -465,7 +537,7 @@ describe("AgentRunService", () => {
       }),
     );
 
-    const row = await service.requestGenerationForUser({
+    const [row] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -560,7 +632,7 @@ describe("AgentRunService", () => {
       queueManager: createPausedQueueManager(tasks),
     });
 
-    const row = await service.requestGenerationForUser({
+    const [row] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -603,7 +675,7 @@ describe("AgentRunService", () => {
     const service = createService(db, tasks);
     const userRow = await users.findById(user.id);
     const shouldGenerate = await service.shouldGenerateForUser(dailyBriefDefinition, userRow ?? user, NOW);
-    const request = await service.requestGenerationForUser({
+    const [request] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -679,6 +751,64 @@ describe("AgentRunService", () => {
 
     const reread = await service.getConfigView(DAILY_BRIEF_AGENT_KEY, user.id);
     expect(reread?.delivery?.targetId).toBe("C_DAILY");
+  });
+
+  it("normalizes delivery models with defaultRoute and full-key legacy matching", async () => {
+    const users = createUserRepository(db);
+    const slackDelivery = allowSlackDelivery([
+      { id: "C_A", name: "alpha" },
+      { id: "C_B", name: "beta" },
+      { id: "U_AGENT", name: "user-like-channel" },
+    ]);
+
+    const defaultRouteUser = await users.create({
+      name: "Default Route User",
+      email: "default-route@example.com",
+      slackUserId: "U_DEFAULT",
+    });
+    const defaultRouteService = createService(db, [], slackDelivery);
+    await defaultRouteService.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, defaultRouteUser.id, {
+      sources: [slackSource("C_A", "alpha")],
+      deliveryModel: perSourceSelfModel(),
+    });
+    const reconciled = await defaultRouteService.updateConfigForUser(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      defaultRouteUser.id,
+      {
+        sources: [slackSource("C_A", "alpha"), slackSource("C_B", "beta")],
+      },
+    );
+
+    expect(reconciled?.deliveryModel).toMatchObject({
+      mode: "per_source",
+      defaultRoute: "self",
+      perSource: {
+        "slack:channel:C_A": { kind: "self" },
+        "slack:channel:C_B": { kind: "self" },
+      },
+    });
+
+    const fullKeyUser = await users.create({
+      name: "Full Key User",
+      email: "full-key@example.com",
+      slackUserId: "U_AGENT",
+    });
+    const fullKeyService = createService(db, [], slackDelivery);
+    const fullKeyConfig = await fullKeyService.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, fullKeyUser.id, {
+      sources: [slackSource("U_AGENT", "user-like-channel")],
+      delivery: {
+        enabled: true,
+        platform: "slack",
+        targetType: "dm",
+        targetId: "U_AGENT",
+        label: "Self DM",
+      },
+    });
+
+    expect(fullKeyConfig?.deliveryModel).toMatchObject({
+      mode: "combined",
+      combined: { targetType: "dm", targetId: "U_AGENT" },
+    });
   });
 
   it("resolves delivery config to the current user's Slack DM", async () => {
@@ -1025,28 +1155,332 @@ describe("AgentRunService", () => {
     });
 
     currentUserInChannel = false;
-    const row = await service.requestGenerationForUser({
+    const rows = await service.requestGenerationForUser({
       agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
       triggerType: "manual",
     });
-    if (!row) throw new Error("Expected a generated output row");
-    await tasks[0]();
 
-    const runtimeContext = runtimeContextFromUserMessage(runAgent.mock.calls[0][0].userMessage);
-    const completed = await db
-      .selectFrom("agent_outputs")
-      .select("raw_payload_json")
-      .where("id", "=", row.id)
-      .executeTakeFirstOrThrow();
-    const rawPayload = JSON.parse(completed.raw_payload_json ?? "{}") as Record<string, unknown>;
-
-    expect(runtimeContext.sources).toEqual([]);
-    expect(runtimeContext.summarySources).toEqual([]);
-    expect(JSON.stringify(runtimeContext)).not.toContain("C_PRIVATE");
-    expect(rawPayload.summaryWindow).toMatchObject({ end: NOW.toISOString() });
+    expect(rows).toEqual([]);
+    expect(tasks).toHaveLength(0);
+    expect(runAgent).not.toHaveBeenCalled();
     expect(isUserInChannel).toHaveBeenCalledWith("C_PRIVATE", "U_AGENT");
+  });
+
+  it("fans out per-source summaries with serialized context isolated to each source", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    await seedSlackConversationMessage(db, sourceA, {
+      messageId: "a-1",
+      text: "Alpha launch decision",
+      receivedAt: "2026-06-15T07:00:00.000Z",
+    });
+    await seedSlackConversationMessage(db, sourceB, {
+      messageId: "b-1",
+      text: "Beta support risk",
+      receivedAt: "2026-06-15T07:05:00.000Z",
+    });
+    await db
+      .insertInto("agent_outputs")
+      .values({
+        id: "previous-beta",
+        agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+        user_id: user.id,
+        output_date: OUTPUT_DATE,
+        source_key: "slack:channel:C_B",
+        source_label: "#beta",
+        timezone: "UTC",
+        status: "completed",
+        trigger_type: "scheduled",
+        agent_version: "test",
+        masthead_json: JSON.stringify({ title: "Previous beta", summary: "Previous beta" }),
+        raw_payload_json: "{}",
+        generated_at: "2026-06-15T07:30:00.000Z",
+      })
+      .execute();
+    await db
+      .insertInto("agent_output_items")
+      .values({
+        id: "previous-beta-item",
+        agent_output_id: "previous-beta",
+        section_key: "highlights",
+        title: "Beta-only previous item",
+        summary: "Beta-only previous summary",
+        priority: "high",
+        label: "highlight",
+        display_ref: "#beta",
+        action_type: null,
+        action_label: null,
+        action_prompt: null,
+        knowledge_refs_json: JSON.stringify({ entityIds: [], fileIds: [] }),
+        source_url: null,
+        sort_order: 0,
+        created_at: NOW.toISOString(),
+      })
+      .execute();
+
+    const contexts: Record<string, Record<string, unknown>> = {};
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      const runtimeContext = runtimeContextFromUserMessage(params.userMessage);
+      contexts[String(runtimeContext.outputId)] = runtimeContext;
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "Summary" },
+        rawPayload: {},
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const outputDelivery = {
+      deliver: vi.fn(async () => {}),
+    } satisfies AgentOutputDeliveryPublisher;
+    const slackDelivery = allowSlackDelivery([
+      { id: "C_A", name: "alpha" },
+      { id: "C_B", name: "beta" },
+    ]);
+    const service = createService(db, tasks, {
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      outputDelivery,
+      ...slackDelivery,
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [sourceA, sourceB],
+      deliveryModel: perSourceSelfModel(),
+    });
+
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(rows.map((row) => row.source_key).sort()).toEqual(["slack:channel:C_A", "slack:channel:C_B"]);
+    for (const row of rows) {
+      const context = contexts[row.id];
+      expect(context.sources).toEqual([
+        expect.objectContaining({
+          targetId: row.source_key === "slack:channel:C_A" ? "C_A" : "C_B",
+        }),
+      ]);
+      expect(context.summarySources).toEqual([
+        expect.objectContaining({
+          targetId: row.source_key === "slack:channel:C_A" ? "C_A" : "C_B",
+        }),
+      ]);
+      expect(context.sameDayPreviousOutput).toBeNull();
+      expect(context.previousDayOutput).toBeNull();
+      expect(JSON.stringify(context)).not.toContain(row.source_key === "slack:channel:C_A" ? "C_B" : "C_A");
+      expect(JSON.stringify(context)).not.toContain(row.source_key === "slack:channel:C_A" ? "Beta-only" : "Alpha");
+    }
+    expect(outputDelivery.deliver).toHaveBeenCalledTimes(2);
+    expect(outputDelivery.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({ delivery: expect.objectContaining({ targetId: "C_A" }) }),
+    );
+    expect(outputDelivery.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({ delivery: expect.objectContaining({ targetId: "C_B" }) }),
+    );
+  });
+
+  it("schedules only incomplete per-source scopes and reruns an aged failed source", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const slackDelivery = allowSlackDelivery([
+      { id: "C_A", name: "alpha" },
+      { id: "C_B", name: "beta" },
+    ]);
+    const service = createService(db, tasks, slackDelivery);
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      scheduleHour: 8,
+      scheduleMinute: 0,
+      sources: [sourceA, sourceB],
+      deliveryModel: perSourceSelfModel(),
+    });
+    await db
+      .insertInto("agent_outputs")
+      .values([
+        {
+          id: "completed-a",
+          agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+          user_id: user.id,
+          output_date: OUTPUT_DATE,
+          source_key: "slack:channel:C_A",
+          source_label: "#alpha",
+          timezone: "UTC",
+          status: "completed",
+          trigger_type: "scheduled",
+          agent_version: "test",
+          generated_at: NOW.toISOString(),
+          created_at: NOW.toISOString(),
+          updated_at: NOW.toISOString(),
+        },
+        {
+          id: "aged-failed-b",
+          agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+          user_id: user.id,
+          output_date: OUTPUT_DATE,
+          source_key: "slack:channel:C_B",
+          source_label: "#beta",
+          timezone: "UTC",
+          status: "failed",
+          trigger_type: "scheduled",
+          agent_version: "test",
+          error_message: "Old failure",
+          created_at: new Date(NOW.getTime() - 2 * 60 * 60 * 1000).toISOString(),
+          updated_at: new Date(NOW.getTime() - 2 * 60 * 60 * 1000).toISOString(),
+        },
+      ])
+      .execute();
+
+    const userRow = await users.findById(user.id);
+    const due = await service.shouldGenerateForUser(conversationSummaryDefinition, userRow ?? user, NOW);
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "scheduled",
+      skipIfCompleted: true,
+    });
+
+    const running = await db
+      .selectFrom("agent_outputs")
+      .select(["source_key", "status"])
+      .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+      .where("user_id", "=", user.id)
+      .where("output_date", "=", OUTPUT_DATE)
+      .where("status", "=", "running")
+      .execute();
+
+    expect(due).toEqual({ outputDate: OUTPUT_DATE });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source_key).toBe("slack:channel:C_B");
+    expect(running).toEqual([{ source_key: "slack:channel:C_B", status: "running" }]);
+    expect(tasks).toHaveLength(1);
+  });
+
+  it("preserves legacy delivery semantics without newly posting to added sources", async () => {
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const channels = [
+      { id: "C_A", name: "alpha" },
+      { id: "C_B", name: "beta" },
+      { id: "C_DEST", name: "leadership" },
+    ];
+
+    async function runScenario(
+      userIdPrefix: string,
+      initialPatch: Parameters<AgentRunService["updateConfigForUser"]>[2],
+      nextSources?: AgentSourceConfig[],
+    ) {
+      const tasks: Array<() => Promise<void>> = [];
+      const users = createUserRepository(db);
+      const user = await users.create({
+        name: `Agent User ${userIdPrefix}`,
+        email: `${userIdPrefix}@example.com`,
+        slackUserId: `U_${userIdPrefix}`,
+      });
+      const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
+      const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+        if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+        await params.agentOutputWriter.write({
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Summarizer", summary: "Summary" },
+          rawPayload: {},
+          items: [],
+        });
+        return successfulRunResult();
+      });
+      const service = createService(db, tasks, {
+        runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+        outputDelivery,
+        ...allowSlackDelivery(channels),
+      });
+      await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+        enabled: true,
+        ...initialPatch,
+      });
+      if (nextSources) {
+        await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, { sources: nextSources });
+      }
+      const config = await service.getConfigView(CONVERSATION_SUMMARY_AGENT_KEY, user.id);
+      const rows = await service.requestGenerationForUser({
+        agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+        userId: user.id,
+        outputDate: OUTPUT_DATE,
+        triggerType: "manual",
+      });
+      for (const task of tasks) await task();
+      return { config, rows, outputDelivery };
+    }
+
+    const allOff = await runScenario("OFF", { sources: [sourceA], delivery: null }, [sourceA, sourceB]);
+    expect(allOff.config?.deliveryModel).toMatchObject({
+      mode: "per_source",
+      defaultRoute: "off",
+      perSource: {
+        "slack:channel:C_A": { kind: "off" },
+        "slack:channel:C_B": { kind: "off" },
+      },
+    });
+    expect(allOff.rows.map((row) => row.source_key).sort()).toEqual(["slack:channel:C_A", "slack:channel:C_B"]);
+    expect(allOff.outputDelivery.deliver).not.toHaveBeenCalled();
+
+    const sourceDelivery = await runScenario("SRC", {
+      sources: [sourceA, sourceB],
+      delivery: {
+        enabled: true,
+        platform: "slack",
+        targetType: "channel",
+        targetId: "C_A",
+        label: "#alpha",
+      },
+    });
+    expect(sourceDelivery.config?.deliveryModel).toMatchObject({
+      mode: "per_source",
+      defaultRoute: "off",
+      perSource: {
+        "slack:channel:C_A": { kind: "self" },
+        "slack:channel:C_B": { kind: "off" },
+      },
+    });
+    expect(sourceDelivery.outputDelivery.deliver).toHaveBeenCalledTimes(1);
+    expect(sourceDelivery.outputDelivery.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({ delivery: expect.objectContaining({ targetId: "C_A" }) }),
+    );
+
+    const combined = await runScenario("COMBINED", {
+      sources: [sourceA, sourceB],
+      delivery: {
+        enabled: true,
+        platform: "slack",
+        targetType: "channel",
+        targetId: "C_DEST",
+        label: "#leadership",
+      },
+    });
+    expect(combined.config?.deliveryModel).toMatchObject({
+      mode: "combined",
+      combined: { targetId: "C_DEST", ackNonDm: true },
+    });
+    expect(combined.rows).toHaveLength(1);
+    expect(combined.rows[0].source_key).toBe("");
+    expect(combined.outputDelivery.deliver).toHaveBeenCalledTimes(1);
+    expect(combined.outputDelivery.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({ delivery: expect.objectContaining({ targetId: "C_DEST" }) }),
+    );
   });
 
   it("rejects WhatsApp group delivery when the current user is not a participant", async () => {
@@ -1110,7 +1544,7 @@ describe("AgentRunService", () => {
       },
     });
 
-    const row = await service.requestGenerationForUser({
+    const [row] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -1169,7 +1603,7 @@ describe("AgentRunService", () => {
       },
     });
 
-    const row = await service.requestGenerationForUser({
+    const [row] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -1214,7 +1648,7 @@ describe("AgentRunService", () => {
       },
     });
 
-    const row = await service.requestGenerationForUser({
+    const [row] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
@@ -1262,7 +1696,7 @@ describe("AgentRunService", () => {
       },
     });
 
-    const row = await service.requestGenerationForUser({
+    const [row] = await service.requestGenerationForUser({
       agentKey: DAILY_BRIEF_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -22,6 +22,15 @@ import { AgentRunService, type AgentRunServiceDeps } from "./service";
 const NOW = new Date("2026-06-15T08:05:00.000Z");
 const OUTPUT_DATE = "2026-06-15";
 
+function emptySummaryPayload(summary = "Summary") {
+  return {
+    outputDate: OUTPUT_DATE,
+    timezone: "UTC",
+    masthead: { title: "Summarizer", summary },
+    items: [],
+  };
+}
+
 function createPausedQueueManager(tasks: Array<() => Promise<void>>): QueueManager {
   return {
     getQueue: () => ({
@@ -1232,7 +1241,7 @@ describe("AgentRunService", () => {
         outputDate: OUTPUT_DATE,
         timezone: "UTC",
         masthead: { title: "Summarizer", summary: "Summary" },
-        rawPayload: {},
+        rawPayload: emptySummaryPayload(),
         items: [],
       });
       return successfulRunResult();
@@ -1398,7 +1407,7 @@ describe("AgentRunService", () => {
           outputDate: OUTPUT_DATE,
           timezone: "UTC",
           masthead: { title: "Summarizer", summary: "Summary" },
-          rawPayload: {},
+          rawPayload: emptySummaryPayload(),
           items: [],
         });
         return successfulRunResult();

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -7,12 +7,15 @@ import type { AgentOutputWriter, WriteAgentOutputPayload } from "../agent/tools/
 import { ensureWorkspace } from "../agent/workspace";
 import type { Config } from "../config";
 import {
+  type AgentCombinedDeliveryConfig,
   type AgentDeliveryConfig,
   type AgentDeliveryMention,
+  type AgentDeliveryModel,
   type AgentMasthead,
   type AgentOutputItemInput,
   type AgentOutputRow,
   type AgentOutputTriggerType,
+  type AgentPerSourceDelivery,
   type AgentSourceConfig,
   type AgentUserPrefs,
   createAgentOutputRepository,
@@ -25,6 +28,7 @@ import type { Logger } from "../logger";
 import type { QueueManager } from "../queue";
 import type { SlackBot } from "../slack/bot";
 import type { WhatsAppBot } from "../whatsapp/bot";
+import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
 import type { AgentOutputDeliveryPublisher } from "./output-delivery";
 import { getAgentDefinition, listAgentDefinitions, requireAgentDefinition } from "./registry";
 import type { AgentApiItem, AgentDefinition, AgentSourceConfigDef } from "./types";
@@ -33,6 +37,12 @@ const RUNNING_STALE_AFTER_MS = 30 * 60 * 1000;
 const SCHEDULED_FAILURE_SUPPRESS_AFTER_MS = 60 * 60 * 1000;
 
 type UserRow = Selectable<UsersTable>;
+
+export type AgentGenerationScope =
+  | { kind: "combined"; sourceKey: ""; sourceLabel: null }
+  | { kind: "source"; source: AgentSourceConfig; sourceKey: string; sourceLabel: string | null };
+
+type AgentExpectedScope = AgentGenerationScope & { sources: AgentSourceConfig[] };
 
 export interface AgentRunServiceDeps {
   db: Kysely<DB>;
@@ -70,6 +80,7 @@ export interface ResolvedAgentConfig {
   enabledSections: Record<string, boolean>;
   focus: string | null;
   delivery: AgentDeliveryConfig | null;
+  deliveryModel: AgentDeliveryModel;
   sources: AgentSourceConfig[];
 }
 
@@ -92,6 +103,7 @@ export interface AgentConfigView {
   itemsPerSectionRange: { min: number; max: number };
   focus: string | null;
   delivery: AgentDeliveryConfig | null;
+  deliveryModel: AgentDeliveryModel;
   sourceConfig: AgentSourceConfigDef | null;
   sources: AgentSourceConfig[];
   sections: AgentSectionView[];
@@ -104,6 +116,8 @@ export interface AgentOutputApi {
   outputDate: string;
   timezone: string;
   status: string;
+  sourceKey: string;
+  sourceLabel: string | null;
   generatedAt: string | null;
   masthead: AgentMasthead | null;
   sections: Record<string, AgentApiItem[]>;
@@ -123,6 +137,141 @@ export interface AgentSummaryView {
 
 export class AgentDeliveryTargetError extends Error {}
 export class AgentSourceTargetError extends Error {}
+
+function sourceKeyForTarget(target: Pick<AgentSourceConfig, "platform" | "targetType" | "targetId">): string {
+  return `${target.platform}:${target.targetType}:${target.targetId}`;
+}
+
+function deliveryKeyForTarget(target: Pick<AgentDeliveryConfig, "platform" | "targetType" | "targetId">): string {
+  return `${target.platform}:${target.targetType}:${target.targetId}`;
+}
+
+function isDmDelivery(delivery: AgentDeliveryConfig): boolean {
+  return delivery.targetType === "dm";
+}
+
+function sourceAsDelivery(source: AgentSourceConfig): AgentDeliveryConfig {
+  return {
+    enabled: true,
+    platform: source.platform,
+    targetType: source.targetType,
+    targetId: source.targetId,
+    label: source.label,
+  };
+}
+
+function routeFromDefault(defaultRoute: "self" | "off"): AgentPerSourceDelivery {
+  return defaultRoute === "self" ? { kind: "self" } : { kind: "off" };
+}
+
+function normalizePerSourceDelivery(value: unknown, defaultRoute: "self" | "off"): AgentPerSourceDelivery {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const kind = (value as Record<string, unknown>).kind;
+    if (kind === "self" || kind === "off") return { kind };
+  }
+  return routeFromDefault(defaultRoute);
+}
+
+function looksLikeDeliveryConfig(value: unknown): value is AgentDeliveryConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const raw = value as Record<string, unknown>;
+  return (
+    raw.enabled === true &&
+    (raw.platform === "slack" || raw.platform === "whatsapp") &&
+    (raw.targetType === "channel" || raw.targetType === "dm" || raw.targetType === "group") &&
+    typeof raw.targetId === "string" &&
+    raw.targetId.length > 0
+  );
+}
+
+function normalizeDeliveryModelFromValue(value: unknown, sources: AgentSourceConfig[]): AgentDeliveryModel | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.mode === "combined" && looksLikeDeliveryConfig(raw.combined)) {
+    const combined = raw.combined as AgentCombinedDeliveryConfig;
+    return {
+      mode: "combined",
+      combined: {
+        ...combined,
+        ...(combined.ackNonDm === true ? { ackNonDm: true as const } : {}),
+      },
+    };
+  }
+
+  if (raw.mode !== "per_source") return null;
+  const defaultRoute = raw.defaultRoute === "self" ? "self" : "off";
+  const rawPerSource =
+    raw.perSource && typeof raw.perSource === "object" && !Array.isArray(raw.perSource)
+      ? (raw.perSource as Record<string, unknown>)
+      : {};
+  const perSource: Record<string, AgentPerSourceDelivery> = {};
+  for (const source of sources) {
+    const key = sourceKeyForTarget(source);
+    perSource[key] = normalizePerSourceDelivery(rawPerSource[key], defaultRoute);
+  }
+  return { mode: "per_source", defaultRoute, perSource, combined: null };
+}
+
+function normalizeLegacyDeliveryModel(
+  delivery: AgentDeliveryConfig | null | undefined,
+  sources: AgentSourceConfig[],
+): AgentDeliveryModel {
+  const offModel = (): AgentDeliveryModel => ({
+    mode: "per_source",
+    defaultRoute: "off",
+    perSource: Object.fromEntries(sources.map((source) => [sourceKeyForTarget(source), { kind: "off" as const }])),
+    combined: null,
+  });
+  if (!delivery) return offModel();
+
+  const matchingSource = sources.find((source) => sourceKeyForTarget(source) === deliveryKeyForTarget(delivery));
+  if (matchingSource) {
+    return {
+      mode: "per_source",
+      defaultRoute: "off",
+      perSource: Object.fromEntries(
+        sources.map((source) => [
+          sourceKeyForTarget(source),
+          { kind: sourceKeyForTarget(source) === sourceKeyForTarget(matchingSource) ? "self" : "off" },
+        ]),
+      ) as Record<string, AgentPerSourceDelivery>,
+      combined: null,
+    };
+  }
+
+  return {
+    mode: "combined",
+    combined: {
+      ...delivery,
+      ...(!isDmDelivery(delivery) ? { ackNonDm: true as const } : {}),
+    },
+  };
+}
+
+function reconcileDeliveryModel(model: AgentDeliveryModel, sources: AgentSourceConfig[]): AgentDeliveryModel {
+  if (model.mode === "combined") return model;
+  const perSource: Record<string, AgentPerSourceDelivery> = {};
+  for (const source of sources) {
+    const key = sourceKeyForTarget(source);
+    perSource[key] = normalizePerSourceDelivery(model.perSource[key], model.defaultRoute);
+  }
+  return { ...model, perSource, combined: null };
+}
+
+function projectLegacyDelivery(model: AgentDeliveryModel, sources: AgentSourceConfig[]): AgentDeliveryConfig | null {
+  if (model.mode === "combined") {
+    const { ackNonDm: _ackNonDm, ...delivery } = model.combined;
+    return delivery;
+  }
+
+  const selfSources = sources.filter((source) => model.perSource[sourceKeyForTarget(source)]?.kind === "self");
+  return selfSources.length === 1 ? sourceAsDelivery(selfSources[0]) : null;
+}
+
+function perSourceDeliveryFor(model: AgentDeliveryModel, sourceKey: string): AgentPerSourceDelivery | null {
+  if (model.mode !== "per_source") return null;
+  return normalizePerSourceDelivery(model.perSource[sourceKey], model.defaultRoute);
+}
 
 function whatsappNumberToJid(whatsappNumber: string): string {
   return `${normalizeWhatsappNumber(whatsappNumber)}@s.whatsapp.net`;
@@ -263,6 +412,10 @@ export class AgentRunService {
     for (const section of def.sections) {
       enabledSections[section.key] = prefs.sections?.[section.key] ?? section.enabledByDefault;
     }
+    const sources = prefs.sources ?? [];
+    const deliveryModel =
+      normalizeDeliveryModelFromValue(prefs.deliveryModel, sources) ??
+      normalizeLegacyDeliveryModel(prefs.delivery ?? null, sources);
     return {
       enabled: raw.exists ? raw.enabled : def.defaults.enabled,
       scheduleHour: raw.scheduleHour ?? def.defaults.scheduleHour,
@@ -271,8 +424,9 @@ export class AgentRunService {
       maxItemsPerSection: raw.maxItemsPerSection ?? def.defaults.maxItemsPerSection,
       enabledSections,
       focus: prefs.focus ?? null,
-      delivery: prefs.delivery ?? null,
-      sources: prefs.sources ?? [],
+      delivery: projectLegacyDelivery(deliveryModel, sources),
+      deliveryModel,
+      sources,
     };
   }
 
@@ -316,6 +470,7 @@ export class AgentRunService {
       itemsPerSectionRange: def.itemsPerSectionRange,
       focus: config.focus,
       delivery: config.delivery,
+      deliveryModel: config.deliveryModel,
       sourceConfig: def.sourceConfig ?? null,
       sources: config.sources,
       sections: def.sections.map((section) => ({
@@ -337,6 +492,7 @@ export class AgentRunService {
       sections?: Record<string, boolean>;
       focus?: string | null;
       delivery?: AgentDeliveryConfig | null;
+      deliveryModel?: AgentDeliveryModel;
       sources?: AgentSourceConfig[];
     },
   ): Promise<AgentConfigView | null> {
@@ -355,6 +511,7 @@ export class AgentRunService {
       patch.sections !== undefined ||
       patch.focus !== undefined ||
       patch.delivery !== undefined ||
+      patch.deliveryModel !== undefined ||
       patch.sources !== undefined
     ) {
       const sections: Record<string, boolean> = { ...current.enabledSections };
@@ -364,12 +521,19 @@ export class AgentRunService {
         }
       }
       const focus = patch.focus !== undefined ? (patch.focus?.trim() ? patch.focus.trim() : null) : current.focus;
-      const delivery = patch.delivery !== undefined ? patch.delivery : current.delivery;
       const sources =
         patch.sources !== undefined
           ? await this.resolveSourceConfigsForUser(def, userId, patch.sources)
           : current.sources;
-      prefs = { sections, focus, delivery, sources };
+      const deliveryModel = this.resolveDeliveryModelForUser(
+        sources,
+        patch.deliveryModel !== undefined
+          ? patch.deliveryModel
+          : patch.delivery !== undefined
+            ? normalizeLegacyDeliveryModel(patch.delivery, sources)
+            : reconcileDeliveryModel(current.deliveryModel, sources),
+      );
+      prefs = { sections, focus, delivery: projectLegacyDelivery(deliveryModel, sources), deliveryModel, sources };
     }
 
     await this.repo.upsertConfig(
@@ -390,6 +554,24 @@ export class AgentRunService {
       },
     );
     return this.getConfigView(agentKey, userId);
+  }
+
+  private resolveDeliveryModelForUser(
+    sources: AgentSourceConfig[],
+    deliveryModel: AgentDeliveryModel,
+  ): AgentDeliveryModel {
+    const reconciled = reconcileDeliveryModel(deliveryModel, sources);
+    if (reconciled.mode === "per_source") return reconciled;
+
+    const deliveryKey = deliveryKeyForTarget(reconciled.combined);
+    if (sources.some((source) => sourceKeyForTarget(source) === deliveryKey)) {
+      throw new AgentDeliveryTargetError("Combined delivery cannot target one of the selected sources");
+    }
+    if (!isDmDelivery(reconciled.combined) && reconciled.combined.ackNonDm !== true) {
+      throw new AgentDeliveryTargetError("Non-DM combined delivery requires acknowledgement");
+    }
+
+    return reconciled;
   }
 
   async resolveDeliveryConfigForUser(
@@ -655,7 +837,7 @@ export class AgentRunService {
 
   private toApiOutput(
     def: AgentDefinition,
-    value: Awaited<ReturnType<ReturnType<typeof createAgentOutputRepository>["findLatestCompleted"]>>,
+    value: Awaited<ReturnType<ReturnType<typeof createAgentOutputRepository>["findLatestCompletedForScope"]>>,
   ): AgentOutputApi | null {
     if (!value) return null;
     const sections = emptySections(def);
@@ -670,6 +852,8 @@ export class AgentRunService {
       outputDate: value.output.output_date,
       timezone: value.output.timezone,
       status: value.output.status,
+      sourceKey: value.output.source_key,
+      sourceLabel: value.output.source_label,
       generatedAt: value.output.generated_at,
       masthead: value.masthead,
       sections,
@@ -695,8 +879,8 @@ export class AgentRunService {
     const date = outputDate || localDateInTimezone(new Date(), timezone);
     const now = new Date();
     const [completed, running] = await Promise.all([
-      this.repo.findLatestCompleted(def.key, user.id, date),
-      this.repo.findRunning(def.key, user.id, date),
+      this.repo.findLatestCompletedAcrossScopes(def.key, user.id, date),
+      this.repo.findRunningAcrossScopes(def.key, user.id, date),
     ]);
     return {
       output: this.toApiOutput(def, completed),
@@ -728,7 +912,30 @@ export class AgentRunService {
     };
   }
 
-  async requestGenerationForUser(params: RequestAgentGenerationParams): Promise<AgentOutputRow | null> {
+  private async resolveExpectedScopesForUser(
+    def: AgentDefinition,
+    user: UserRow,
+    config: ResolvedAgentConfig,
+  ): Promise<AgentExpectedScope[]> {
+    if (!def.sourceConfig) {
+      return [{ kind: "combined", sourceKey: "", sourceLabel: null, sources: [] }];
+    }
+
+    const sources = await this.resolveSourcesForRun(def, user.id, config.sources);
+    if (config.deliveryModel.mode === "combined") {
+      return [{ kind: "combined", sourceKey: "", sourceLabel: null, sources }];
+    }
+
+    return sources.map((source) => ({
+      kind: "source",
+      source,
+      sourceKey: sourceKeyForTarget(source),
+      sourceLabel: source.label,
+      sources: [source],
+    }));
+  }
+
+  async requestGenerationForUser(params: RequestAgentGenerationParams): Promise<AgentOutputRow[]> {
     const def = requireAgentDefinition(params.agentKey);
     const user = await this.deps.users.findById(params.userId);
     if (!user) throw new Error("User not found");
@@ -736,31 +943,48 @@ export class AgentRunService {
     const timezone = config.timezone || user.timezone || "UTC";
     const outputDate = params.outputDate || localDateInTimezone(new Date(), timezone);
     const now = new Date();
+    const scopes = await this.resolveExpectedScopesForUser(def, user, config);
+    const rows: AgentOutputRow[] = [];
 
-    let recoveredStaleRunning = false;
-    const existingRunning = await this.repo.findRunning(def.key, user.id, outputDate);
-    if (existingRunning) {
-      if (!this.isRunningStale(existingRunning, now)) return existingRunning;
-      recoveredStaleRunning = true;
-      await this.repo.markFailed(existingRunning.id, "Generation expired after being left running.");
+    for (const scope of scopes) {
+      let recoveredStaleRunning = false;
+      const existingRunning = await this.repo.findRunning(def.key, user.id, outputDate, scope.sourceKey);
+      if (existingRunning) {
+        if (!this.isRunningStale(existingRunning, now)) {
+          rows.push(existingRunning);
+          continue;
+        }
+        recoveredStaleRunning = true;
+        await this.repo.markFailed(existingRunning.id, "Generation expired after being left running.");
+      }
+      if (
+        params.skipIfCompleted &&
+        (await this.repo.findLatestCompletedForScope(def.key, user.id, scope.sourceKey, outputDate))
+      ) {
+        continue;
+      }
+      if (params.skipIfCompleted && params.triggerType === "scheduled" && !recoveredStaleRunning) {
+        const latest = await this.repo.findLatestAny(def.key, user.id, outputDate, scope.sourceKey);
+        if (latest && this.isRecentScheduledFailure(latest, now)) {
+          rows.push(latest);
+          continue;
+        }
+      }
+      const result = await this.repo.createRunning({
+        agentKey: def.key,
+        agentVersion: def.version,
+        userId: user.id,
+        outputDate,
+        sourceKey: scope.sourceKey,
+        sourceLabel: scope.sourceLabel,
+        timezone,
+        triggerType: params.triggerType,
+      });
+      if (result.created) this.enqueueRun(def.key, result.row.id, user.id);
+      rows.push(result.row);
     }
-    if (params.skipIfCompleted && (await this.repo.findLatestCompleted(def.key, user.id, outputDate))) {
-      return null;
-    }
-    if (params.skipIfCompleted && params.triggerType === "scheduled" && !recoveredStaleRunning) {
-      const latest = await this.repo.findLatestAny(def.key, user.id, outputDate);
-      if (latest && this.isRecentScheduledFailure(latest, now)) return latest;
-    }
-    const result = await this.repo.createRunning({
-      agentKey: def.key,
-      agentVersion: def.version,
-      userId: user.id,
-      outputDate,
-      timezone,
-      triggerType: params.triggerType,
-    });
-    if (result.created) this.enqueueRun(def.key, result.row.id, user.id);
-    return result.row;
+
+    return rows;
   }
 
   async listSchedulableUsers(): Promise<UserRow[]> {
@@ -787,15 +1011,22 @@ export class AgentRunService {
     const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
     if (hour !== config.scheduleHour || minute < config.scheduleMinute) return null;
     const outputDate = localDateInTimezone(now, timezone);
-    const [running, completed] = await Promise.all([
-      this.repo.findRunning(def.key, user.id, outputDate),
-      this.repo.findLatestCompleted(def.key, user.id, outputDate),
-    ]);
-    if (running && !this.isRunningStale(running, now)) return null;
-    if (completed) return null;
-    const latest = await this.repo.findLatestAny(def.key, user.id, outputDate);
-    if (latest && this.isRecentScheduledFailure(latest, now)) return null;
-    return { outputDate };
+    const scopes = await this.resolveExpectedScopesForUser(def, user, config);
+    if (scopes.length === 0) return null;
+
+    for (const scope of scopes) {
+      const [running, completed] = await Promise.all([
+        this.repo.findRunning(def.key, user.id, outputDate, scope.sourceKey),
+        this.repo.findLatestCompletedForScope(def.key, user.id, scope.sourceKey, outputDate),
+      ]);
+      if (completed) continue;
+      if (running && !this.isRunningStale(running, now)) continue;
+      const latest = await this.repo.findLatestAny(def.key, user.id, outputDate, scope.sourceKey);
+      if (latest && this.isRecentScheduledFailure(latest, now)) continue;
+      return { outputDate };
+    }
+
+    return null;
   }
 
   private isRunningStale(output: AgentOutputRow, now: Date): boolean {
@@ -845,6 +1076,45 @@ export class AgentRunService {
     };
   }
 
+  private async resolveScopeForOutput(
+    def: AgentDefinition,
+    user: UserRow,
+    config: ResolvedAgentConfig,
+    output: AgentOutputRow,
+  ): Promise<AgentExpectedScope | null> {
+    if (!def.sourceConfig) {
+      return { kind: "combined", sourceKey: "", sourceLabel: null, sources: [] };
+    }
+
+    const sources = await this.resolveSourcesForRun(def, user.id, config.sources);
+    if (output.source_key === "") {
+      return { kind: "combined", sourceKey: "", sourceLabel: null, sources };
+    }
+
+    const source = sources.find((candidate) => sourceKeyForTarget(candidate) === output.source_key);
+    if (!source) return null;
+    return {
+      kind: "source",
+      source,
+      sourceKey: output.source_key,
+      sourceLabel: output.source_label ?? source.label,
+      sources: [source],
+    };
+  }
+
+  private async getPreviousOutputForContext(
+    def: AgentDefinition,
+    user: UserRow,
+    outputDate: string,
+    scope: AgentGenerationScope,
+  ): Promise<AgentOutputApi | null> {
+    if (def.key === CONVERSATION_SUMMARY_AGENT_KEY && scope.kind === "source") return null;
+    return this.toApiOutput(
+      def,
+      await this.repo.findLatestCompletedForScope(def.key, user.id, scope.sourceKey, outputDate),
+    );
+  }
+
   private async generateExistingOutput(agentKey: string, outputId: string, userId: string): Promise<void> {
     const def = requireAgentDefinition(agentKey);
     const output = await this.repo.findById(def.key, outputId);
@@ -853,7 +1123,11 @@ export class AgentRunService {
 
     let saved = false;
     const config = await this.resolveConfig(def, user.id);
-    const sources = await this.resolveSourcesForRun(def, user.id, config.sources);
+    const scope = await this.resolveScopeForOutput(def, user, config, output);
+    if (!scope) {
+      await this.repo.markFailed(outputId, "Generation source is no longer available.");
+      return;
+    }
     const enabledSections = def.sections.filter((s) => config.enabledSections[s.key]).map((s) => s.key);
 
     try {
@@ -865,8 +1139,8 @@ export class AgentRunService {
           ? undefined
           : await this.deps.users.getAllEmailsForUser(user.id);
       const [sameDayPrevious, previousDay, definitionContext] = await Promise.all([
-        this.getLatestForUser(def.key, user.id, output.output_date),
-        this.getLatestForUser(def.key, user.id, addDays(output.output_date, -1)),
+        this.getPreviousOutputForContext(def, user, output.output_date, scope),
+        this.getPreviousOutputForContext(def, user, addDays(output.output_date, -1), scope),
         def.buildRuntimeContext
           ? def.buildRuntimeContext({
               db: this.deps.db,
@@ -881,7 +1155,8 @@ export class AgentRunService {
                 maxItemsPerSection: config.maxItemsPerSection,
                 focus: config.focus,
                 delivery: config.delivery,
-                sources,
+                sources: scope.sources,
+                sourceKey: scope.sourceKey,
               },
             })
           : Promise.resolve({}),
@@ -896,9 +1171,9 @@ export class AgentRunService {
         sections: enabledSections,
         maxItemsPerSection: config.maxItemsPerSection,
         focus: config.focus,
-        sources,
-        sameDayPreviousOutput: this.formatOutputForContext(sameDayPrevious.output),
-        previousDayOutput: this.formatOutputForContext(previousDay.output),
+        sources: scope.sources,
+        sameDayPreviousOutput: this.formatOutputForContext(sameDayPrevious),
+        previousDayOutput: this.formatOutputForContext(previousDay),
         ...definitionContext,
       };
       const writer = this.createWriter(def, {
@@ -972,7 +1247,13 @@ export class AgentRunService {
   private async deliverCompletedOutput(def: AgentDefinition, outputId: string, userId: string): Promise<void> {
     if (!this.deps.outputDelivery) return;
     try {
-      const configuredDelivery = (await this.resolveConfig(def, userId)).delivery;
+      const output = await this.repo.findById(def.key, outputId);
+      const user = await this.deps.users.findById(userId);
+      if (!output || !user) return;
+      const config = await this.resolveConfig(def, userId);
+      const scope = await this.resolveScopeForOutput(def, user, config, output);
+      if (!scope) return;
+      const configuredDelivery = this.deliveryForScope(config.deliveryModel, scope);
       if (!configuredDelivery) return;
       const delivery = await this.resolveDeliveryConfigForUser(userId, configuredDelivery);
       if (!delivery) return;
@@ -982,6 +1263,21 @@ export class AgentRunService {
     } catch (err) {
       this.deps.logger.warn({ err, agentKey: def.key, outputId, userId }, "Agent: output delivery failed");
     }
+  }
+
+  private deliveryForScope(deliveryModel: AgentDeliveryModel, scope: AgentExpectedScope): AgentDeliveryConfig | null {
+    if (scope.kind === "combined") {
+      if (deliveryModel.mode !== "combined") return null;
+      if (!isDmDelivery(deliveryModel.combined) && deliveryModel.combined.ackNonDm !== true) return null;
+      const deliveryKey = deliveryKeyForTarget(deliveryModel.combined);
+      if (scope.sources.some((source) => sourceKeyForTarget(source) === deliveryKey)) return null;
+      return deliveryModel.combined;
+    }
+
+    const route = perSourceDeliveryFor(deliveryModel, scope.sourceKey);
+    if (!route || route.kind === "off") return null;
+    if (route.kind === "target") return null;
+    return sourceAsDelivery(scope.source);
   }
 
   private createWriter(

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -64,6 +64,7 @@ export interface AgentRuntimeContextParams {
     focus: string | null;
     delivery: AgentDeliveryConfig | null;
     sources: AgentSourceConfig[];
+    sourceKey: string;
   };
 }
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -118,6 +118,7 @@ import * as m115 from "./migrations/115-whatsapp-template-mappings-and-provider-
 import * as m116 from "./migrations/116-connector-credential-source";
 import * as m117 from "./migrations/117-conversation-message-window-index";
 import * as m118 from "./migrations/118-whatsapp-window-keepalives";
+import * as m119 from "./migrations/119-agent-outputs-source-scope";
 import type { DB } from "./schema";
 
 export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean }): Promise<void> {
@@ -240,6 +241,7 @@ export async function runMigrations(db: Kysely<DB>, options?: { quiet?: boolean 
           "116-connector-credential-source": m116,
           "117-conversation-message-window-index": m117,
           "118-whatsapp-window-keepalives": m118,
+          "119-agent-outputs-source-scope": m119,
         };
       },
     },

--- a/packages/server/src/db/migrations/119-agent-outputs-source-scope.ts
+++ b/packages/server/src/db/migrations/119-agent-outputs-source-scope.ts
@@ -1,0 +1,60 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Adds output scope to the generic prebuilt-agent output table.
+ *
+ * The running coalescing constraint stays partial and only applies to rows whose
+ * status is `running`, now keyed by source. Completed history remains append-only
+ * for manual reruns and repeated same-day generations.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const columns = await getColumns(db, "agent_outputs");
+
+  if (!columns.has("source_key")) {
+    await db.schema
+      .alterTable("agent_outputs")
+      .addColumn("source_key", "text", (col) => col.notNull().defaultTo(""))
+      .execute();
+  }
+  if (!columns.has("source_label")) {
+    await db.schema.alterTable("agent_outputs").addColumn("source_label", "text").execute();
+  }
+
+  await sql`DROP INDEX IF EXISTS idx_agent_outputs_key_user_date`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_agent_outputs_latest`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_agent_outputs_latest_unscoped`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_agent_outputs_running_unique`.execute(db);
+
+  await db.schema
+    .createIndex("idx_agent_outputs_key_user_date")
+    .on("agent_outputs")
+    .columns(["agent_key", "user_id", "output_date", "source_key"])
+    .execute();
+  await db.schema
+    .createIndex("idx_agent_outputs_latest")
+    .on("agent_outputs")
+    .columns(["agent_key", "user_id", "output_date", "source_key", "status", "generated_at"])
+    .execute();
+  await db.schema
+    .createIndex("idx_agent_outputs_latest_unscoped")
+    .on("agent_outputs")
+    .columns(["agent_key", "user_id", "output_date", "status", "generated_at"])
+    .execute();
+  await sql`
+    CREATE UNIQUE INDEX idx_agent_outputs_running_unique
+      ON agent_outputs (agent_key, user_id, output_date, source_key)
+     WHERE status = 'running'
+  `.execute(db);
+}
+
+export async function down(): Promise<void> {
+  throw new Error(
+    "Migration 119-agent-outputs-source-scope is irreversible: it adds persisted source scope columns to agent_outputs.",
+  );
+}
+
+async function getColumns(db: Kysely<unknown>, tableName: string): Promise<Set<string>> {
+  const tables = await db.introspection.getTables();
+  const table = tables.find((candidate) => candidate.name === tableName);
+  return new Set(table?.columns.map((column) => column.name) ?? []);
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -18,7 +18,7 @@ import { createTestPgDb, getSharedPgDb } from "../../test-utils";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 114;
+const EXPECTED_MIGRATION_COUNT = 115;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -147,6 +147,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[111]).toBe("116-connector-credential-source");
     expect(names[112]).toBe("117-conversation-message-window-index");
     expect(names[113]).toBe("118-whatsapp-window-keepalives");
+    expect(names[114]).toBe("119-agent-outputs-source-scope");
   });
 
   it("running migrations twice is idempotent", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMigrations } from "../migrate";
 import type { DB } from "../schema";
 
-const EXPECTED_MIGRATION_COUNT = 114;
+const EXPECTED_MIGRATION_COUNT = 115;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -170,6 +170,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[111]).toBe("116-connector-credential-source");
     expect(names[112]).toBe("117-conversation-message-window-index");
     expect(names[113]).toBe("118-whatsapp-window-keepalives");
+    expect(names[114]).toBe("119-agent-outputs-source-scope");
   });
 
   it("creates the entity merge ledger tombstone schema", async () => {
@@ -566,7 +567,8 @@ describe("runMigrations — incremental upgrade", () => {
         '115-whatsapp-template-mappings-and-provider-events',
         '116-connector-credential-source',
         '117-conversation-message-window-index',
-        '118-whatsapp-window-keepalives'
+        '118-whatsapp-window-keepalives',
+        '119-agent-outputs-source-scope'
       )
     `.execute(db);
     await sql`DROP TABLE agent_output_deliveries`.execute(db);
@@ -591,7 +593,8 @@ describe("runMigrations — incremental upgrade", () => {
         '115-whatsapp-template-mappings-and-provider-events',
         '116-connector-credential-source',
         '117-conversation-message-window-index',
-        '118-whatsapp-window-keepalives'
+        '118-whatsapp-window-keepalives',
+        '119-agent-outputs-source-scope'
       )
       ORDER BY name ASC
     `.execute(db);
@@ -608,6 +611,7 @@ describe("runMigrations — incremental upgrade", () => {
       { name: "116-connector-credential-source" },
       { name: "117-conversation-message-window-index" },
       { name: "118-whatsapp-window-keepalives" },
+      { name: "119-agent-outputs-source-scope" },
     ]);
   });
 });

--- a/packages/server/src/db/repositories/agent-outputs-pg.integration.test.ts
+++ b/packages/server/src/db/repositories/agent-outputs-pg.integration.test.ts
@@ -1,0 +1,78 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createAgentOutputRepository } from "./agent-outputs";
+
+describe("createAgentOutputRepository output scopes on Postgres", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestPgDb();
+  }, 30000);
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("coalesces running rows per source while allowing other scopes and completed history", async () => {
+    const repo = createAgentOutputRepository(db);
+    const base = {
+      agentKey: "conversation_summary",
+      agentVersion: "test",
+      userId: "user-1",
+      outputDate: "2026-07-04",
+      timezone: "UTC",
+      triggerType: "manual" as const,
+    };
+
+    const sourceA = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_A",
+      sourceLabel: "#a",
+    });
+    const duplicateSourceA = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_A",
+      sourceLabel: "#a",
+    });
+    const sourceB = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_B",
+      sourceLabel: "#b",
+    });
+
+    expect(sourceA.created).toBe(true);
+    expect(duplicateSourceA.created).toBe(false);
+    expect(duplicateSourceA.row.id).toBe(sourceA.row.id);
+    expect(sourceB.created).toBe(true);
+
+    await repo.completeOutput({
+      outputId: sourceA.row.id,
+      masthead: { title: "A", summary: "A" },
+      rawPayload: {},
+      items: [],
+    });
+    const rerunSourceA = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_A",
+      sourceLabel: "#a",
+    });
+
+    const running = await db
+      .selectFrom("agent_outputs")
+      .select(["source_key", "status"])
+      .where("agent_key", "=", base.agentKey)
+      .where("user_id", "=", base.userId)
+      .where("output_date", "=", base.outputDate)
+      .where("status", "=", "running")
+      .orderBy("source_key", "asc")
+      .execute();
+
+    expect(rerunSourceA.created).toBe(true);
+    expect(running).toEqual([
+      { source_key: "slack:channel:C_A", status: "running" },
+      { source_key: "slack:channel:C_B", status: "running" },
+    ]);
+  });
+});

--- a/packages/server/src/db/repositories/agent-outputs.test.ts
+++ b/packages/server/src/db/repositories/agent-outputs.test.ts
@@ -1,0 +1,78 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createAgentOutputRepository } from "./agent-outputs";
+
+describe("createAgentOutputRepository output scopes", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("coalesces running rows per source while allowing other scopes and completed history", async () => {
+    const repo = createAgentOutputRepository(db);
+    const base = {
+      agentKey: "conversation_summary",
+      agentVersion: "test",
+      userId: "user-1",
+      outputDate: "2026-07-04",
+      timezone: "UTC",
+      triggerType: "manual" as const,
+    };
+
+    const sourceA = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_A",
+      sourceLabel: "#a",
+    });
+    const duplicateSourceA = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_A",
+      sourceLabel: "#a",
+    });
+    const sourceB = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_B",
+      sourceLabel: "#b",
+    });
+
+    expect(sourceA.created).toBe(true);
+    expect(duplicateSourceA.created).toBe(false);
+    expect(duplicateSourceA.row.id).toBe(sourceA.row.id);
+    expect(sourceB.created).toBe(true);
+
+    await repo.completeOutput({
+      outputId: sourceA.row.id,
+      masthead: { title: "A", summary: "A" },
+      rawPayload: {},
+      items: [],
+    });
+    const rerunSourceA = await repo.createRunning({
+      ...base,
+      sourceKey: "slack:channel:C_A",
+      sourceLabel: "#a",
+    });
+
+    const running = await db
+      .selectFrom("agent_outputs")
+      .select(["source_key", "status"])
+      .where("agent_key", "=", base.agentKey)
+      .where("user_id", "=", base.userId)
+      .where("output_date", "=", base.outputDate)
+      .where("status", "=", "running")
+      .orderBy("source_key", "asc")
+      .execute();
+
+    expect(rerunSourceA.created).toBe(true);
+    expect(running).toEqual([
+      { source_key: "slack:channel:C_A", status: "running" },
+      { source_key: "slack:channel:C_B", status: "running" },
+    ]);
+  });
+});

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -60,6 +60,29 @@ export interface AgentDeliveryConfig {
   mentions?: AgentDeliveryMention[];
 }
 
+export type AgentSourceKey = `${AgentSourcePlatform}:${AgentSourceTargetType}:${string}`;
+
+export interface AgentCombinedDeliveryConfig extends AgentDeliveryConfig {
+  ackNonDm?: true;
+}
+
+export type AgentPerSourceDelivery =
+  | { kind: "self" }
+  | { kind: "off" }
+  | { kind: "target"; target: AgentDeliveryConfig };
+
+export type AgentDeliveryModel =
+  | {
+      mode: "per_source";
+      defaultRoute: "self" | "off";
+      perSource: Record<string, AgentPerSourceDelivery>;
+      combined: null;
+    }
+  | {
+      mode: "combined";
+      combined: AgentCombinedDeliveryConfig;
+    };
+
 export interface AgentSourceConfig {
   platform: AgentSourcePlatform;
   targetType: AgentSourceTargetType;
@@ -76,6 +99,7 @@ export interface AgentUserPrefs {
   sections?: Record<string, boolean>;
   focus?: string | null;
   delivery?: AgentDeliveryConfig | null;
+  deliveryModel?: AgentDeliveryModel;
   sources?: AgentSourceConfig[];
 }
 
@@ -235,15 +259,20 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
       agentVersion: string;
       userId: string;
       outputDate: string;
+      sourceKey?: string;
+      sourceLabel?: string | null;
       timezone: string;
       triggerType: AgentOutputTriggerType;
     }): Promise<{ row: AgentOutputRow; created: boolean }> {
       const now = new Date().toISOString();
+      const sourceKey = params.sourceKey ?? "";
       const row: NewAgentOutput = {
         id: randomUUID(),
         agent_key: params.agentKey,
         user_id: params.userId,
         output_date: params.outputDate,
+        source_key: sourceKey,
+        source_label: params.sourceLabel ?? null,
         timezone: params.timezone,
         status: "running",
         trigger_type: params.triggerType,
@@ -261,6 +290,7 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
           .where("agent_key", "=", params.agentKey)
           .where("user_id", "=", params.userId)
           .where("output_date", "=", params.outputDate)
+          .where("source_key", "=", sourceKey)
           .where("status", "=", "running")
           .executeTakeFirst();
         if (existing) return { row: existing, created: false };
@@ -281,7 +311,29 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
         .executeTakeFirst();
     },
 
-    async findRunning(agentKey: string, userId: string, outputDate: string): Promise<AgentOutputRow | undefined> {
+    async findRunning(
+      agentKey: string,
+      userId: string,
+      outputDate: string,
+      sourceKey = "",
+    ): Promise<AgentOutputRow | undefined> {
+      return db
+        .selectFrom("agent_outputs")
+        .selectAll()
+        .where("agent_key", "=", agentKey)
+        .where("user_id", "=", userId)
+        .where("output_date", "=", outputDate)
+        .where("source_key", "=", sourceKey)
+        .where("status", "=", "running")
+        .orderBy("created_at", "desc")
+        .executeTakeFirst();
+    },
+
+    async findRunningAcrossScopes(
+      agentKey: string,
+      userId: string,
+      outputDate: string,
+    ): Promise<AgentOutputRow | undefined> {
       return db
         .selectFrom("agent_outputs")
         .selectAll()
@@ -293,19 +345,55 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
         .executeTakeFirst();
     },
 
-    async findLatestAny(agentKey: string, userId: string, outputDate: string): Promise<AgentOutputRow | undefined> {
+    async findLatestAny(
+      agentKey: string,
+      userId: string,
+      outputDate: string,
+      sourceKey = "",
+    ): Promise<AgentOutputRow | undefined> {
       return db
         .selectFrom("agent_outputs")
         .selectAll()
         .where("agent_key", "=", agentKey)
         .where("user_id", "=", userId)
         .where("output_date", "=", outputDate)
+        .where("source_key", "=", sourceKey)
         .orderBy("created_at", "desc")
         .orderBy("id", "desc")
         .executeTakeFirst();
     },
 
-    async findLatestCompleted(
+    async findLatestCompletedForScope(
+      agentKey: string,
+      userId: string,
+      sourceKey: string,
+      outputDate?: string,
+    ): Promise<AgentOutputWithItems | null> {
+      let query = db
+        .selectFrom("agent_outputs")
+        .selectAll()
+        .where("agent_key", "=", agentKey)
+        .where("user_id", "=", userId)
+        .where("source_key", "=", sourceKey)
+        .where("status", "=", "completed");
+      if (outputDate) query = query.where("output_date", "=", outputDate);
+      const output = await query.orderBy("generated_at", "desc").orderBy("id", "desc").executeTakeFirst();
+      if (!output) return null;
+      const items = await db
+        .selectFrom("agent_output_items")
+        .selectAll()
+        .where("agent_output_id", "=", output.id)
+        .orderBy("section_key", "asc")
+        .orderBy("sort_order", "asc")
+        .execute();
+      return {
+        output,
+        masthead: parseJson<AgentMasthead>(output.masthead_json),
+        items: items.map(withRefs),
+      };
+    },
+
+    async findLatestCompletedAcrossScopes(
       agentKey: string,
       userId: string,
       outputDate: string,

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -535,6 +535,8 @@ export interface AgentOutputsTable {
   agent_key: string;
   user_id: string;
   output_date: string;
+  source_key: Generated<string>;
+  source_label: string | null;
   timezone: string;
   status: string;
   trigger_type: string;

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -288,9 +288,7 @@ function OutputsTab({
                     : "text-muted-foreground hover:bg-muted/50",
                 )}
               >
-                <span className="block truncate text-[12.5px] font-medium">
-                  {output.sourceLabel ?? "Summary"}
-                </span>
+                <span className="block truncate text-[12.5px] font-medium">{output.sourceLabel ?? "Summary"}</span>
                 <span className="mt-0.5 block truncate font-mono text-[10px] uppercase tracking-[0.08em]">
                   {formatDate(output.generatedAt ?? output.outputDate)}
                 </span>

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -7,6 +7,7 @@ import {
   type AgentConfig,
   type AgentDeliveryConfig,
   type AgentDeliveryMention,
+  type AgentDeliveryModel,
   type AgentDetailResponse,
   type AgentOutput,
   type AgentOutputsResponse,
@@ -22,6 +23,7 @@ import {
   UserIcon,
   UsersThreeIcon,
   WhatsappLogoIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import {
   Sheet,
@@ -39,7 +41,9 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 type Tab = "outputs" | "config";
-type EditField = "schedule" | "focus" | "volume" | "delivery" | "sources" | null;
+type EditField = "schedule" | "focus" | "volume" | "delivery" | "sources" | "routing" | null;
+
+type PerSourceRoute = "self" | "off";
 
 function detailKey(agentKey: string) {
   return ["agents", "detail", agentKey];
@@ -62,6 +66,42 @@ function deliverySummary(delivery: AgentDeliveryConfig | null): string {
     return `Slack ${delivery.label ?? delivery.targetId}${tagged}`;
   if (delivery.platform === "slack") return `Slack DM ${delivery.label ?? delivery.targetId}${tagged}`;
   return `WhatsApp ${delivery.label ?? delivery.targetId}${tagged}`;
+}
+
+/**
+ * Reads the per-source route for a source from the delivery model. A source
+ * summarizes on its own and either posts back to itself ("self") or stays
+ * web-only ("off"). A legacy combined model is shown as "self" in this
+ * per-source view; saving migrates it to explicit per-source routes.
+ */
+function routeForSource(model: AgentDeliveryModel, source: AgentSourceConfig): PerSourceRoute {
+  if (model.mode !== "per_source") return "self";
+  return model.perSource[sourceKey(source)]?.kind === "self" ? "self" : "off";
+}
+
+function buildDeliveryModel(routes: Record<string, PerSourceRoute>, sources: AgentSourceConfig[]): AgentDeliveryModel {
+  const perSource: Record<string, { kind: PerSourceRoute }> = {};
+  for (const source of sources) {
+    const key = sourceKey(source);
+    perSource[key] = { kind: routes[key] ?? "self" };
+  }
+  return { mode: "per_source", defaultRoute: "off", perSource, combined: null };
+}
+
+function routingSummary(agent: AgentConfig): string {
+  if (agent.sources.length === 0) return "No sources selected";
+  const posted = agent.sources.filter((source) => routeForSource(agent.deliveryModel, source) === "self").length;
+  const webOnly = agent.sources.length - posted;
+  const parts = [`${agent.sources.length} ${agent.sources.length === 1 ? "source" : "sources"}`];
+  if (posted > 0) parts.push(`${posted} post back`);
+  if (webOnly > 0) parts.push(`${webOnly} web only`);
+  return parts.join(" · ");
+}
+
+function initRoutes(model: AgentDeliveryModel, sources: AgentSourceConfig[]): Record<string, PerSourceRoute> {
+  const out: Record<string, PerSourceRoute> = {};
+  for (const source of sources) out[sourceKey(source)] = routeForSource(model, source);
+  return out;
 }
 
 export function AgentDetail({ agentKey }: { agentKey: string }) {
@@ -248,11 +288,11 @@ function OutputsTab({
                     : "text-muted-foreground hover:bg-muted/50",
                 )}
               >
-                <span className="block text-[12.5px] font-medium">
-                  {formatDate(output.generatedAt ?? output.outputDate)}
+                <span className="block truncate text-[12.5px] font-medium">
+                  {output.sourceLabel ?? "Summary"}
                 </span>
                 <span className="mt-0.5 block truncate font-mono text-[10px] uppercase tracking-[0.08em]">
-                  {output.outputDate}
+                  {formatDate(output.generatedAt ?? output.outputDate)}
                 </span>
               </button>
             ))}
@@ -358,20 +398,18 @@ function ConfigTab({
           </p>
         </Row>
         {agent.sourceConfig ? (
-          <Row label="Sources" onEdit={() => onEdit("sources")}>
-            <p className="line-clamp-2 text-[12.5px] leading-relaxed text-foreground/85">
-              {agent.sources.length > 0
-                ? agent.sources.map((source) => source.label ?? source.targetId).join(", ")
-                : "No sources selected"}
-            </p>
+          <Row label="Sources & delivery" onEdit={() => onEdit("routing")}>
+            <p className="line-clamp-2 text-[12.5px] leading-relaxed text-foreground/85">{routingSummary(agent)}</p>
           </Row>
         ) : null}
         <Row label="Volume" onEdit={() => onEdit("volume")}>
           <p className="text-[12.5px] text-foreground/85">Up to {agent.maxItemsPerSection} items per section</p>
         </Row>
-        <Row label="Deliver to" onEdit={() => onEdit("delivery")}>
-          <p className="text-[12.5px] text-foreground/85">{deliverySummary(agent.delivery)}</p>
-        </Row>
+        {agent.sourceConfig ? null : (
+          <Row label="Deliver to" onEdit={() => onEdit("delivery")}>
+            <p className="text-[12.5px] text-foreground/85">{deliverySummary(agent.delivery)}</p>
+          </Row>
+        )}
       </div>
 
       <div className="mb-3 mt-7 flex items-baseline justify-between border-b border-border/60 pb-2">
@@ -471,6 +509,10 @@ const EDIT_META: Record<Exclude<EditField, null>, { title: string; hint: string 
   schedule: { title: "Runs on", hint: "When the agent runs each day, in your timezone." },
   focus: { title: "Focus", hint: "Plain-language emphasis. Added as a hint — it never overrides what the agent does." },
   sources: { title: "Sources", hint: "Shared conversations this agent summarizes." },
+  routing: {
+    title: "Sources & delivery",
+    hint: "Each source is summarized on its own. Choose where its digest goes.",
+  },
   volume: { title: "Volume", hint: "How many items each section can hold." },
   delivery: { title: "Deliver to", hint: "Where completed outputs are sent after generation finishes." },
 };
@@ -493,6 +535,9 @@ function EditDrawer({
   const [minute, setMinute] = useState(agent.scheduleMinute);
   const [focus, setFocus] = useState(agent.focus ?? "");
   const [sources, setSources] = useState<AgentSourceConfig[]>(agent.sources);
+  const [routes, setRoutes] = useState<Record<string, PerSourceRoute>>(() =>
+    initRoutes(agent.deliveryModel, agent.sources),
+  );
   const [volume, setVolume] = useState(agent.maxItemsPerSection);
   const [delivery, setDelivery] = useState<AgentDeliveryConfig | null>(agent.delivery);
 
@@ -502,6 +547,7 @@ function EditDrawer({
       setMinute(agent.scheduleMinute);
       setFocus(agent.focus ?? "");
       setSources(agent.sources);
+      setRoutes(initRoutes(agent.deliveryModel, agent.sources));
       setVolume(agent.maxItemsPerSection);
       setDelivery(agent.delivery);
     }
@@ -511,6 +557,7 @@ function EditDrawer({
     agent.scheduleMinute,
     agent.focus,
     agent.sources,
+    agent.deliveryModel,
     agent.maxItemsPerSection,
     agent.delivery,
   ]);
@@ -521,6 +568,8 @@ function EditDrawer({
         return api.agents.updateConfig(agentKey, { scheduleHour: hour, scheduleMinute: minute });
       if (field === "focus") return api.agents.updateConfig(agentKey, { focus: focus.trim() ? focus.trim() : null });
       if (field === "sources") return api.agents.updateConfig(agentKey, { sources });
+      if (field === "routing")
+        return api.agents.updateConfig(agentKey, { sources, deliveryModel: buildDeliveryModel(routes, sources) });
       if (field === "volume") return api.agents.updateConfig(agentKey, { maxItemsPerSection: volume });
       if (field === "delivery") return api.agents.updateConfig(agentKey, { delivery });
       return Promise.resolve({ agent });
@@ -574,6 +623,16 @@ function EditDrawer({
             />
           ) : field === "sources" && agent.sourceConfig ? (
             <SourceEditor agent={agent} value={sources} onChange={setSources} />
+          ) : field === "routing" && agent.sourceConfig ? (
+            <SourcesDeliveryEditor
+              agent={agent}
+              sources={sources}
+              routes={routes}
+              onChange={(nextSources, nextRoutes) => {
+                setSources(nextSources);
+                setRoutes(nextRoutes);
+              }}
+            />
           ) : field === "delivery" ? (
             <DeliveryEditor value={delivery} sources={agent.sources} onChange={setDelivery} />
           ) : null}
@@ -730,6 +789,146 @@ function SourceEditor({
         />
       ) : null}
       <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">{countSummary}</p>
+    </div>
+  );
+}
+
+function SourcesDeliveryEditor({
+  agent,
+  sources,
+  routes,
+  onChange,
+}: {
+  agent: AgentConfig;
+  sources: AgentSourceConfig[];
+  routes: Record<string, PerSourceRoute>;
+  onChange: (sources: AgentSourceConfig[], routes: Record<string, PerSourceRoute>) => void;
+}) {
+  const slackChannels = useQuery({ queryKey: ["slack-channels"], queryFn: () => api.channels.listSlack() });
+  const whatsappGroups = useQuery({ queryKey: ["whatsapp-groups"], queryFn: () => api.channels.listWhatsAppGroups() });
+  const selected = new Set(sources.map(sourceKey));
+  const maxSources = agent.sourceConfig?.maxSources ?? 0;
+
+  const toggle = (source: AgentSourceConfig) => {
+    const key = sourceKey(source);
+    if (selected.has(key)) {
+      const nextRoutes = { ...routes };
+      delete nextRoutes[key];
+      onChange(
+        sources.filter((item) => sourceKey(item) !== key),
+        nextRoutes,
+      );
+      return;
+    }
+    if (sources.length >= maxSources) return;
+    onChange([...sources, source], { ...routes, [key]: "self" });
+  };
+
+  const setRoute = (source: AgentSourceConfig, route: PerSourceRoute) => {
+    onChange(sources, { ...routes, [sourceKey(source)]: route });
+  };
+
+  const slackOptions = (slackChannels.data?.channels ?? [])
+    .filter((channel) => channel.isMember)
+    .map(
+      (channel): AgentSourceConfig => ({
+        platform: "slack",
+        targetType: "channel",
+        targetId: channel.id,
+        label: `#${channel.name}`,
+      }),
+    );
+  const whatsappOptions = (whatsappGroups.data?.groups ?? []).map(
+    (group): AgentSourceConfig => ({
+      platform: "whatsapp",
+      targetType: "group",
+      targetId: group.jid,
+      label: group.name,
+    }),
+  );
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Selected</span>
+        {sources.length === 0 ? (
+          <p className="mt-2 rounded-lg border-[0.5px] border-dashed border-border px-3 py-3 text-[12px] text-muted-foreground">
+            Add a source below. Each source is summarized on its own.
+          </p>
+        ) : (
+          <div className="mt-2 flex flex-col gap-2">
+            {sources.map((source) => {
+              const route = routes[sourceKey(source)] ?? "self";
+              return (
+                <div key={sourceKey(source)} className="rounded-lg border-[0.5px] border-border px-3 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <span className="shrink-0">
+                      {source.platform === "slack" ? (
+                        <HashIcon size={14} aria-hidden />
+                      ) : (
+                        <UsersThreeIcon size={14} aria-hidden />
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-foreground">
+                      {source.label ?? source.targetId}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => toggle(source)}
+                      aria-label={`Remove ${source.label ?? source.targetId}`}
+                      className="shrink-0 text-muted-foreground/50 transition-colors hover:text-foreground"
+                    >
+                      <XIcon size={13} weight="bold" aria-hidden />
+                    </button>
+                  </div>
+                  <div className="mt-2 grid grid-cols-2 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1">
+                    {(["self", "off"] as const).map((option) => (
+                      <button
+                        key={option}
+                        type="button"
+                        onClick={() => setRoute(source, option)}
+                        className={cn(
+                          "rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-colors",
+                          route === option
+                            ? "bg-background text-foreground shadow-sm"
+                            : "text-muted-foreground hover:text-foreground",
+                        )}
+                      >
+                        {option === "self" ? "Post back" : "Web only"}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {agent.sourceConfig?.supportsSlackChannels ? (
+        <SourceGroup
+          title="Add Slack channels"
+          loading={slackChannels.isLoading}
+          empty="No Slack channels available."
+          selected={selected}
+          options={slackOptions}
+          onToggle={toggle}
+        />
+      ) : null}
+      {agent.sourceConfig?.supportsWhatsAppGroups ? (
+        <SourceGroup
+          title="Add WhatsApp groups"
+          loading={whatsappGroups.isLoading}
+          empty="No WhatsApp groups available."
+          selected={selected}
+          options={whatsappOptions}
+          onToggle={toggle}
+        />
+      ) : null}
+      <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
+        {sources.length} selected{maxSources > 0 ? ` · limit ${maxSources}` : ""} · post back = to the source · web only
+        = not posted
+      </p>
     </div>
   );
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1052,6 +1052,10 @@ export interface AgentDeliveryConfig {
   mentions?: AgentDeliveryMention[];
 }
 
+export interface AgentCombinedDeliveryConfig extends AgentDeliveryConfig {
+  ackNonDm?: true;
+}
+
 export interface AgentDeliveryMention {
   platform: "slack" | "whatsapp";
   targetId: string;
@@ -1064,6 +1068,23 @@ export interface AgentSourceConfig {
   targetId: string;
   label: string | null;
 }
+
+export type AgentPerSourceDelivery =
+  | { kind: "self" }
+  | { kind: "off" }
+  | { kind: "target"; target: AgentDeliveryConfig };
+
+export type AgentDeliveryModel =
+  | {
+      mode: "per_source";
+      defaultRoute: "self" | "off";
+      perSource: Record<string, AgentPerSourceDelivery>;
+      combined: null;
+    }
+  | {
+      mode: "combined";
+      combined: AgentCombinedDeliveryConfig;
+    };
 
 export interface AgentSourceConfigMeta {
   maxSources: number;
@@ -1084,6 +1105,7 @@ export interface AgentConfig {
   itemsPerSectionRange: { min: number; max: number };
   focus: string | null;
   delivery: AgentDeliveryConfig | null;
+  deliveryModel: AgentDeliveryModel;
   sourceConfig: AgentSourceConfigMeta | null;
   sources: AgentSourceConfig[];
   sections: AgentSectionConfig[];
@@ -1112,6 +1134,8 @@ export interface AgentOutput {
   agentKey: string;
   userId: string;
   outputDate: string;
+  sourceKey: string;
+  sourceLabel: string | null;
   timezone: string;
   status: string;
   generatedAt: string | null;
@@ -1139,6 +1163,7 @@ export interface AgentConfigPatch {
   sections?: Record<string, boolean>;
   focus?: string | null;
   delivery?: AgentDeliveryConfig | null;
+  deliveryModel?: AgentDeliveryModel;
   sources?: AgentSourceConfig[];
 }
 
@@ -1258,10 +1283,10 @@ export const api = {
       });
     },
     run(agentKey: string) {
-      return request<{ generation: { id: string; status: string; outputDate: string } | null }>(
-        `/api/agents/${agentKey}/runs`,
-        { method: "POST", body: JSON.stringify({}) },
-      );
+      return request<{
+        generation: { id: string; sourceKey: string; status: string; outputDate: string } | null;
+        generations: Array<{ id: string; sourceKey: string; status: string; outputDate: string }>;
+      }>(`/api/agents/${agentKey}/runs`, { method: "POST", body: JSON.stringify({}) });
     },
     outputs(agentKey: string, opts?: { limit?: number; cursor?: string | null }) {
       const params = new URLSearchParams();


### PR DESCRIPTION
Stack: 1/7
Base: main
Merge before: feat: add summariser route config model

Summary:
- Add per-source summary output scoping and persistence support.
- Teach summary generation, scheduling, and delivery paths about source-specific outputs.
- Add the first config UI affordance for per-source routing.

Verification:
- pnpm biome check
- pnpm typecheck
- pnpm test
- pnpm build

All stack tips were checked locally under Node v24.8.0; the pushed stack also passed the pre-push hook under Node v24.8.0.