### PR TITLE
feat: add summariser route config model

### DIFF
--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -25,12 +25,14 @@ function createService(overrides: Record<string, unknown> = {}) {
     resolveDeliveryConfigForUser: vi.fn(async (_userId, delivery) => delivery),
     listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
     listOutputsForUser: vi.fn(async () => ({ outputs: [], nextCursor: null })),
+    listEligibleRouteMembers: vi.fn(async () => []),
     requestGenerationForUser: vi.fn(async () => []),
     updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
     ...overrides,
   } as unknown as AgentRunService & {
     resolveDeliveryConfigForUser: ReturnType<typeof vi.fn>;
     listOutputsForUser: ReturnType<typeof vi.fn>;
+    listEligibleRouteMembers: ReturnType<typeof vi.fn>;
     requestGenerationForUser: ReturnType<typeof vi.fn>;
     updateConfigForUser: ReturnType<typeof vi.fn>;
   };
@@ -243,8 +245,10 @@ describe("agentRoutes", () => {
     );
   });
 
-  it("rejects multi-source routes in Arc 2", async () => {
-    const service = createService();
+  it("passes multi-source routes and Slack member destinations to the service for saving", async () => {
+    const service = createService({
+      updateConfigForUser: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, routes: [] })),
+    });
     const app = createRoutesTestApp(service);
 
     const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
@@ -258,26 +262,35 @@ describe("agentRoutes", () => {
         routes: [
           {
             id: "combined-route",
-            sources: ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
+            sources: ["slack:channel:C_ALPHA", "slack:channel:C_ALPHA", "slack:channel:C_BETA"],
             focus: null,
             sections: null,
             maxItemsPerSection: null,
             schedule: null,
-            destination: { kind: "off" },
+            destination: { kind: "member", platform: "slack", memberUserId: "  member-1  " },
             enabled: true,
           },
         ],
       }),
     });
 
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toMatchObject({
-      error: { code: "VALIDATION_ERROR", message: "Arc 2 routes must include exactly one source" },
-    });
-    expect(service.updateConfigForUser).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(service.updateConfigForUser).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "user-1",
+      expect.objectContaining({
+        routes: [
+          expect.objectContaining({
+            id: "combined-route",
+            sources: ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
+            destination: { kind: "member", platform: "slack", memberUserId: "member-1" },
+          }),
+        ],
+      }),
+    );
   });
 
-  it("rejects member route destinations in Arc 2", async () => {
+  it("rejects combined routes with self delivery", async () => {
     const service = createService();
     const app = createRoutesTestApp(service);
 
@@ -285,16 +298,19 @@ describe("agentRoutes", () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        sources: [{ platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" }],
+        sources: [
+          { platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" },
+          { platform: "slack", targetType: "channel", targetId: "C_BETA", label: "#beta" },
+        ],
         routes: [
           {
-            id: "member-route",
-            sources: ["slack:channel:C_ALPHA"],
+            id: "combined-self-route",
+            sources: ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
             focus: null,
             sections: null,
             maxItemsPerSection: null,
             schedule: null,
-            destination: { kind: "member", platform: "slack", memberUserId: "U_MEMBER" },
+            destination: { kind: "self" },
             enabled: true,
           },
         ],
@@ -303,9 +319,66 @@ describe("agentRoutes", () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toMatchObject({
-      error: { code: "VALIDATION_ERROR", message: "Member route destinations are not supported until Arc 1b" },
+      error: { code: "VALIDATION_ERROR", message: "Combined routes cannot use self destination" },
     });
     expect(service.updateConfigForUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects member route destinations with WhatsApp sources", async () => {
+    const service = createService();
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [{ platform: "whatsapp", targetType: "group", targetId: "120363000000001@g.us", label: "Leads" }],
+        routes: [
+          {
+            id: "whatsapp-member-route",
+            sources: ["whatsapp:group:120363000000001@g.us"],
+            focus: null,
+            sections: null,
+            maxItemsPerSection: null,
+            schedule: null,
+            destination: { kind: "member", platform: "slack", memberUserId: "member-1" },
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "Member route destinations support Slack sources only" },
+    });
+    expect(service.updateConfigForUser).not.toHaveBeenCalled();
+  });
+
+  it("lists route members through the agent route-members endpoint", async () => {
+    const service = createService({
+      listEligibleRouteMembers: vi.fn(async () => [
+        { userId: "member-1", name: "Member One", slackUserId: "U_MEMBER_1" },
+      ]),
+    });
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/route-members`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: ["slack:channel:C_ALPHA", "slack:channel:C_ALPHA", "slack:channel:C_BETA"],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      members: [{ userId: "member-1", name: "Member One", slackUserId: "U_MEMBER_1" }],
+    });
+    expect(service.listEligibleRouteMembers).toHaveBeenCalledWith("user-1", [
+      "slack:channel:C_ALPHA",
+      "slack:channel:C_BETA",
+    ]);
   });
 
   it("lists completed outputs for an agent", async () => {

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -4,6 +4,7 @@ import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
+import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import { agentRoutes } from "./routes";
 import { AgentDeliveryTargetError, AgentRunService, type AgentRunServiceDeps, AgentSourceTargetError } from "./service";
 
@@ -42,7 +43,7 @@ describe("agentRoutes", () => {
     });
     const app = createRoutesTestApp(service);
 
-    const res = await app.request("/api/agents/daily-brief/config", {
+    const res = await app.request(`/api/agents/${DAILY_BRIEF_AGENT_KEY}/config`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -59,7 +60,7 @@ describe("agentRoutes", () => {
 
     expect(res.status).toBe(200);
     expect(service.updateConfigForUser).toHaveBeenCalledWith(
-      "daily-brief",
+      DAILY_BRIEF_AGENT_KEY,
       "user-1",
       expect.objectContaining({
         delivery: expect.objectContaining({
@@ -82,7 +83,7 @@ describe("agentRoutes", () => {
     const service = createService();
     const app = createRoutesTestApp(service);
 
-    const res = await app.request("/api/agents/daily-brief/config", {
+    const res = await app.request(`/api/agents/${DAILY_BRIEF_AGENT_KEY}/config`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -112,7 +113,7 @@ describe("agentRoutes", () => {
     });
     const app = createRoutesTestApp(service);
 
-    const res = await app.request("/api/agents/daily-brief/config", {
+    const res = await app.request(`/api/agents/${DAILY_BRIEF_AGENT_KEY}/config`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -174,7 +175,7 @@ describe("agentRoutes", () => {
     });
     const app = createRoutesTestApp(service);
 
-    const res = await app.request("/api/agents/daily-brief/config", {
+    const res = await app.request(`/api/agents/${DAILY_BRIEF_AGENT_KEY}/config`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -193,6 +194,118 @@ describe("agentRoutes", () => {
       error: { code: "VALIDATION_ERROR", message: "Slack channel is not available for this user" },
     });
     expect(res.status).toBe(400);
+  });
+
+  it("passes parsed routes to the service for saving", async () => {
+    const service = createService({
+      updateConfigForUser: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, routes: [] })),
+    });
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [{ platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" }],
+        routes: [
+          {
+            id: "alpha-route",
+            sources: ["slack:channel:C_ALPHA"],
+            focus: "  launch blockers  ",
+            sections: { highlights: true, decisions: false },
+            maxItemsPerSection: 2,
+            schedule: { hour: 9, minute: 15 },
+            destination: { kind: "self" },
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.updateConfigForUser).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "user-1",
+      expect.objectContaining({
+        routes: [
+          {
+            id: "alpha-route",
+            sources: ["slack:channel:C_ALPHA"],
+            focus: "launch blockers",
+            sections: { highlights: true, decisions: false },
+            maxItemsPerSection: 2,
+            schedule: { hour: 9, minute: 15 },
+            destination: { kind: "self" },
+            enabled: true,
+          },
+        ],
+      }),
+    );
+  });
+
+  it("rejects multi-source routes in Arc 2", async () => {
+    const service = createService();
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [
+          { platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" },
+          { platform: "slack", targetType: "channel", targetId: "C_BETA", label: "#beta" },
+        ],
+        routes: [
+          {
+            id: "combined-route",
+            sources: ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
+            focus: null,
+            sections: null,
+            maxItemsPerSection: null,
+            schedule: null,
+            destination: { kind: "off" },
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "Arc 2 routes must include exactly one source" },
+    });
+    expect(service.updateConfigForUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects member route destinations in Arc 2", async () => {
+    const service = createService();
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [{ platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" }],
+        routes: [
+          {
+            id: "member-route",
+            sources: ["slack:channel:C_ALPHA"],
+            focus: null,
+            sections: null,
+            maxItemsPerSection: null,
+            schedule: null,
+            destination: { kind: "member", platform: "slack", memberUserId: "U_MEMBER" },
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "Member route destinations are not supported until Arc 1b" },
+    });
+    expect(service.updateConfigForUser).not.toHaveBeenCalled();
   });
 
   it("lists completed outputs for an agent", async () => {

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -6,11 +6,16 @@ import type {
   AgentDeliveryModel,
   AgentDeliveryPlatform,
   AgentPerSourceDelivery,
+  AgentRoute,
+  AgentRouteDestination,
   AgentSourceConfig,
+  AgentSourceKey,
 } from "../db/repositories/agent-outputs";
 import type { DB } from "../db/schema";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
+import { getAgentDefinition } from "./registry";
 import { AgentDeliveryTargetError, type AgentOutputApi, type AgentRunService, AgentSourceTargetError } from "./service";
+import type { AgentDefinition } from "./types";
 
 async function getCurrentUserId(c: { get: (key: "sub" | "email") => string | undefined }, service: AgentRunService) {
   const sub = c.get("sub");
@@ -249,7 +254,120 @@ function parseSourceConfigs(value: unknown): AgentSourceConfig[] | undefined {
   });
 }
 
-function parseConfigPatch(body: Record<string, unknown>) {
+function sourceKeyForConfig(source: AgentSourceConfig): AgentSourceKey {
+  return `${source.platform}:${source.targetType}:${source.targetId}`;
+}
+
+function parseRouteSourceKey(value: unknown): AgentSourceKey {
+  if (typeof value !== "string" || !value.trim()) throw new ConfigPatchError("route source must be a source key");
+  const [platform, targetType, ...targetParts] = value.trim().split(":");
+  const targetId = targetParts.join(":");
+  if ((platform !== "slack" && platform !== "whatsapp") || !targetId) {
+    throw new ConfigPatchError("route source must be a valid source key");
+  }
+  if (targetType !== "channel" && targetType !== "group") {
+    throw new ConfigPatchError("route source must be a valid source key");
+  }
+  if (platform === "slack" && targetType !== "channel") {
+    throw new ConfigPatchError("Slack route sources must be channels");
+  }
+  if (platform === "whatsapp" && targetType !== "group") {
+    throw new ConfigPatchError("WhatsApp route sources must be groups");
+  }
+  return `${platform}:${targetType}:${targetId}`;
+}
+
+function parseRouteSections(value: unknown, def: AgentDefinition): Record<string, boolean> | null {
+  if (value === null || value === undefined) return null;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigPatchError("route.sections must be an object or null");
+  }
+  const knownSections = new Set(def.sections.map((section) => section.key));
+  const sections: Record<string, boolean> = {};
+  for (const [key, enabled] of Object.entries(value as Record<string, unknown>)) {
+    if (!knownSections.has(key)) throw new ConfigPatchError(`Unknown route section: ${key}`);
+    if (typeof enabled !== "boolean") throw new ConfigPatchError("route section values must be booleans");
+    sections[key] = enabled;
+  }
+  return sections;
+}
+
+function parseRouteSchedule(value: unknown): AgentRoute["schedule"] {
+  if (value === null || value === undefined) return null;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigPatchError("route.schedule must be an object or null");
+  }
+  const raw = value as Record<string, unknown>;
+  if (!Number.isInteger(raw.hour) || Number(raw.hour) < 0 || Number(raw.hour) > 23) {
+    throw new ConfigPatchError("route.schedule.hour must be an integer from 0 to 23");
+  }
+  if (!Number.isInteger(raw.minute) || Number(raw.minute) < 0 || Number(raw.minute) > 59) {
+    throw new ConfigPatchError("route.schedule.minute must be an integer from 0 to 59");
+  }
+  return { hour: Number(raw.hour), minute: Number(raw.minute) };
+}
+
+function parseRouteDestination(value: unknown): AgentRouteDestination {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigPatchError("route.destination must be an object");
+  }
+  const raw = value as Record<string, unknown>;
+  if (raw.kind === "self" || raw.kind === "off") return { kind: raw.kind };
+  if (raw.kind === "member") throw new ConfigPatchError("Member route destinations are not supported until Arc 1b");
+  throw new ConfigPatchError("route.destination.kind must be self or off");
+}
+
+function parseRoutes(value: unknown, def: AgentDefinition): AgentRoute[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new ConfigPatchError("routes must be an array");
+  const routes: AgentRoute[] = [];
+  const seenIds = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new ConfigPatchError("route must be an object");
+    }
+    const raw = entry as Record<string, unknown>;
+    const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : "";
+    if (!id) throw new ConfigPatchError("route.id is required");
+    if (seenIds.has(id)) throw new ConfigPatchError("route.id values must be unique");
+    seenIds.add(id);
+    if (!Array.isArray(raw.sources)) throw new ConfigPatchError("route.sources must be an array");
+    if (raw.sources.length !== 1) throw new ConfigPatchError("Arc 2 routes must include exactly one source");
+    const sources = raw.sources.map(parseRouteSourceKey);
+    const maxItemsPerSection =
+      raw.maxItemsPerSection === null || raw.maxItemsPerSection === undefined
+        ? null
+        : Number.isInteger(raw.maxItemsPerSection)
+          ? Number(raw.maxItemsPerSection)
+          : null;
+    if (raw.maxItemsPerSection !== null && raw.maxItemsPerSection !== undefined && maxItemsPerSection === null) {
+      throw new ConfigPatchError("route.maxItemsPerSection must be an integer or null");
+    }
+    routes.push({
+      id,
+      sources,
+      focus: typeof raw.focus === "string" && raw.focus.trim() ? raw.focus.trim() : null,
+      sections: parseRouteSections(raw.sections, def),
+      maxItemsPerSection,
+      schedule: parseRouteSchedule(raw.schedule),
+      destination: parseRouteDestination(raw.destination),
+      enabled: raw.enabled !== false,
+    });
+  }
+  return routes;
+}
+
+function assertRoutesReferenceSources(routes: AgentRoute[] | undefined, sources: AgentSourceConfig[] | undefined) {
+  if (!routes || !sources) return;
+  const sourceKeys = new Set(sources.map(sourceKeyForConfig));
+  for (const route of routes) {
+    for (const sourceKey of route.sources) {
+      if (!sourceKeys.has(sourceKey)) throw new ConfigPatchError("Route source must be one of the selected sources");
+    }
+  }
+}
+
+function parseConfigPatch(body: Record<string, unknown>, def: AgentDefinition) {
   const patch: {
     enabled?: boolean;
     scheduleHour?: number;
@@ -260,6 +378,7 @@ function parseConfigPatch(body: Record<string, unknown>) {
     delivery?: AgentDeliveryConfig | null;
     deliveryModel?: AgentDeliveryModel;
     sources?: AgentSourceConfig[];
+    routes?: AgentRoute[];
   } = {};
   if (typeof body.enabled === "boolean") patch.enabled = body.enabled;
   if (typeof body.scheduleHour === "number" && Number.isInteger(body.scheduleHour)) {
@@ -287,6 +406,9 @@ function parseConfigPatch(body: Record<string, unknown>) {
   if (deliveryModel !== undefined) patch.deliveryModel = deliveryModel;
   const sources = parseSourceConfigs(body.sources);
   if (sources !== undefined) patch.sources = sources;
+  const routes = parseRoutes(body.routes, def);
+  assertRoutesReferenceSources(routes, sources);
+  if (routes !== undefined) patch.routes = routes;
   return patch;
 }
 
@@ -330,11 +452,13 @@ export function agentRoutes(service: AgentRunService) {
     const userId = await getCurrentUserId(c, service);
     if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
     const agentKey = c.req.param("agentKey");
+    const def = getAgentDefinition(agentKey);
+    if (!def) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
     let patch: ReturnType<typeof parseConfigPatch>;
     let agent: Awaited<ReturnType<AgentRunService["updateConfigForUser"]>>;
     try {
-      patch = parseConfigPatch(body);
+      patch = parseConfigPatch(body, def);
       await validateDeliveryTargets(service, userId, patch);
       agent = await service.updateConfigForUser(agentKey, userId, patch);
     } catch (err) {

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -313,8 +313,13 @@ function parseRouteDestination(value: unknown): AgentRouteDestination {
   }
   const raw = value as Record<string, unknown>;
   if (raw.kind === "self" || raw.kind === "off") return { kind: raw.kind };
-  if (raw.kind === "member") throw new ConfigPatchError("Member route destinations are not supported until Arc 1b");
-  throw new ConfigPatchError("route.destination.kind must be self or off");
+  if (raw.kind === "member") {
+    if (raw.platform !== "slack") throw new ConfigPatchError("route.destination.platform must be slack");
+    const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
+    if (!memberUserId) throw new ConfigPatchError("route.destination.memberUserId is required");
+    return { kind: "member", platform: "slack", memberUserId };
+  }
+  throw new ConfigPatchError("route.destination.kind must be self, off, or member");
 }
 
 function parseRoutes(value: unknown, def: AgentDefinition): AgentRoute[] | undefined {
@@ -332,8 +337,21 @@ function parseRoutes(value: unknown, def: AgentDefinition): AgentRoute[] | undef
     if (seenIds.has(id)) throw new ConfigPatchError("route.id values must be unique");
     seenIds.add(id);
     if (!Array.isArray(raw.sources)) throw new ConfigPatchError("route.sources must be an array");
-    if (raw.sources.length !== 1) throw new ConfigPatchError("Arc 2 routes must include exactly one source");
-    const sources = raw.sources.map(parseRouteSourceKey);
+    const sources: AgentSourceKey[] = [];
+    const seenSources = new Set<string>();
+    for (const source of raw.sources.map(parseRouteSourceKey)) {
+      if (seenSources.has(source)) continue;
+      seenSources.add(source);
+      sources.push(source);
+    }
+    if (sources.length === 0) throw new ConfigPatchError("route.sources must include at least one source");
+    const destination = parseRouteDestination(raw.destination);
+    if (sources.length > 1 && destination.kind === "self") {
+      throw new ConfigPatchError("Combined routes cannot use self destination");
+    }
+    if (destination.kind === "member" && sources.some((source) => source.startsWith("whatsapp:"))) {
+      throw new ConfigPatchError("Member route destinations support Slack sources only");
+    }
     const maxItemsPerSection =
       raw.maxItemsPerSection === null || raw.maxItemsPerSection === undefined
         ? null
@@ -350,11 +368,23 @@ function parseRoutes(value: unknown, def: AgentDefinition): AgentRoute[] | undef
       sections: parseRouteSections(raw.sections, def),
       maxItemsPerSection,
       schedule: parseRouteSchedule(raw.schedule),
-      destination: parseRouteDestination(raw.destination),
+      destination,
       enabled: raw.enabled !== false,
     });
   }
   return routes;
+}
+
+function parseRouteMemberSources(value: unknown): AgentSourceKey[] {
+  if (!Array.isArray(value)) throw new ConfigPatchError("sources must be an array");
+  const sources: AgentSourceKey[] = [];
+  const seen = new Set<string>();
+  for (const source of value.map(parseRouteSourceKey)) {
+    if (seen.has(source)) continue;
+    seen.add(source);
+    sources.push(source);
+  }
+  return sources;
 }
 
 function assertRoutesReferenceSources(routes: AgentRoute[] | undefined, sources: AgentSourceConfig[] | undefined) {
@@ -473,6 +503,24 @@ export function agentRoutes(service: AgentRunService) {
     }
     if (!agent) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     return c.json({ agent });
+  });
+
+  routes.post("/:agentKey/route-members", async (c) => {
+    const userId = await getCurrentUserId(c, service);
+    if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
+    const agentKey = c.req.param("agentKey");
+    const def = getAgentDefinition(agentKey);
+    if (!def) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
+    const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+    try {
+      const sources = parseRouteMemberSources(body.sources);
+      return c.json({ members: await service.listEligibleRouteMembers(userId, sources) });
+    } catch (err) {
+      if (err instanceof ConfigPatchError) {
+        return c.json({ error: { code: "VALIDATION_ERROR", message: err.message } }, 400);
+      }
+      throw err;
+    }
   });
 
   routes.get("/:agentKey/outputs", async (c) => {

--- a/packages/server/src/agents/scheduler.ts
+++ b/packages/server/src/agents/scheduler.ts
@@ -55,6 +55,7 @@ export class AgentScheduler {
               outputDate: due.outputDate,
               triggerType: "scheduled",
               skipIfCompleted: true,
+              scopeKeys: due.scopeKeys,
             });
             for (const generation of generations) {
               this.deps.logger.debug(

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -1333,6 +1333,223 @@ describe("AgentRunService", () => {
     );
   });
 
+  it("generates one combined route output with isolated source context and member delivery", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const member = await users.create({ name: "Route Member", email: "member@example.com", slackUserId: "U_MEMBER" });
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const sourceC = slackSource("C_C", "gamma");
+    const route: AgentRoute = {
+      id: "alpha-beta",
+      sources: ["slack:channel:C_A", "slack:channel:C_B"],
+      focus: "Combined launch status",
+      sections: { highlights: true, decisions: true, action_items: false, open_questions: false },
+      maxItemsPerSection: 3,
+      schedule: null,
+      destination: { kind: "member", platform: "slack", memberUserId: member.id },
+      enabled: true,
+    };
+    await seedSlackConversationMessage(db, sourceA, {
+      messageId: "a-combined-1",
+      text: "Alpha launch decision",
+      receivedAt: "2026-06-15T07:00:00.000Z",
+    });
+    await seedSlackConversationMessage(db, sourceB, {
+      messageId: "b-combined-1",
+      text: "Beta support risk",
+      receivedAt: "2026-06-15T07:05:00.000Z",
+    });
+    await seedSlackConversationMessage(db, sourceC, {
+      messageId: "c-combined-1",
+      text: "Gamma private escalation",
+      receivedAt: "2026-06-15T07:10:00.000Z",
+    });
+
+    const contexts: Record<string, Record<string, unknown>> = {};
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      const runtimeContext = runtimeContextFromUserMessage(params.userMessage);
+      contexts[String(runtimeContext.outputId)] = runtimeContext;
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "Summary" },
+        rawPayload: {
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Summarizer", summary: "Summary" },
+          items: [],
+        },
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
+    const isUserInChannel = vi.fn(async (channelId: string, slackUserId: string) => {
+      if (slackUserId === "U_AGENT") return ["C_A", "C_B", "C_C"].includes(channelId);
+      if (slackUserId === "U_MEMBER") return ["C_A", "C_B"].includes(channelId);
+      return false;
+    });
+    const service = createService(db, tasks, {
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      outputDelivery,
+      getSlack: () => ({
+        listChannels: vi.fn(async () => [
+          { id: "C_A", name: "alpha", type: "public_channel", isMember: true },
+          { id: "C_B", name: "beta", type: "public_channel", isMember: true },
+          { id: "C_C", name: "gamma", type: "public_channel", isMember: true },
+        ]),
+        isUserInChannel,
+      }),
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [sourceA, sourceB, sourceC],
+      routes: [route],
+    });
+
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source_key).toBe(scopeKeyForRoute(route, [sourceA, sourceB]));
+    expect(rows[0].source_key).toMatch(/^route:[a-f0-9]{12}$/);
+    const context = contexts[rows[0].id];
+    expect(context.sources).toEqual([
+      expect.objectContaining({ targetId: "C_A" }),
+      expect.objectContaining({ targetId: "C_B" }),
+    ]);
+    expect(context.summarySources).toEqual([
+      expect.objectContaining({ targetId: "C_A" }),
+      expect.objectContaining({ targetId: "C_B" }),
+    ]);
+    expect(JSON.stringify(context)).toContain("Alpha launch decision");
+    expect(JSON.stringify(context)).toContain("Beta support risk");
+    expect(JSON.stringify(context)).not.toContain("Gamma private escalation");
+    expect(outputDelivery.deliver).toHaveBeenCalledTimes(1);
+    expect(outputDelivery.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delivery: {
+          enabled: true,
+          platform: "slack",
+          targetType: "dm",
+          targetId: "U_MEMBER",
+          label: "Route Member",
+        },
+      }),
+    );
+    expect(isUserInChannel).toHaveBeenCalledWith("C_A", "U_MEMBER");
+    expect(isUserInChannel).toHaveBeenCalledWith("C_B", "U_MEMBER");
+  });
+
+  it("guards member delivery by source intersection and lists only eligible route members", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const member = await users.create({
+      name: "Eligible Member",
+      email: "member@example.com",
+      slackUserId: "U_MEMBER",
+    });
+    const partial = await users.create({
+      name: "Partial Member",
+      email: "partial@example.com",
+      slackUserId: "U_PARTIAL",
+    });
+    await users.create({ name: "No Slack", email: "noslack@example.com" });
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const isUserInChannel = vi.fn(async (channelId: string, slackUserId: string) => {
+      if (slackUserId === "U_AGENT" || slackUserId === "U_MEMBER") return ["C_A", "C_B"].includes(channelId);
+      if (slackUserId === "U_PARTIAL") return channelId === "C_A";
+      return false;
+    });
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "Summary" },
+        rawPayload: {
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Summarizer", summary: "Summary" },
+          items: [],
+        },
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
+    const service = createService(db, tasks, {
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      outputDelivery,
+      getSlack: () => ({
+        listChannels: vi.fn(async () => [
+          { id: "C_A", name: "alpha", type: "public_channel", isMember: true },
+          { id: "C_B", name: "beta", type: "public_channel", isMember: true },
+        ]),
+        isUserInChannel,
+      }),
+    });
+
+    const eligible = await service.listEligibleRouteMembers(user.id, ["slack:channel:C_A", "slack:channel:C_B"]);
+    const whatsappEligible = await service.listEligibleRouteMembers(user.id, [
+      "slack:channel:C_A",
+      "whatsapp:group:120363000000001@g.us",
+    ]);
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [sourceA, sourceB],
+      routes: [
+        {
+          id: "partial-member-route",
+          sources: ["slack:channel:C_A", "slack:channel:C_B"],
+          focus: null,
+          sections: null,
+          maxItemsPerSection: null,
+          schedule: null,
+          destination: { kind: "member", platform: "slack", memberUserId: partial.id },
+          enabled: true,
+        },
+      ],
+    });
+
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(eligible).toEqual(
+      expect.arrayContaining([{ userId: member.id, name: "Eligible Member", slackUserId: "U_MEMBER" }]),
+    );
+    expect(eligible).not.toEqual(
+      expect.arrayContaining([{ userId: partial.id, name: "Partial Member", slackUserId: "U_PARTIAL" }]),
+    );
+    expect(eligible.some((candidate) => candidate.name === "No Slack")).toBe(false);
+    expect(whatsappEligible).toEqual([]);
+    expect(outputDelivery.deliver).not.toHaveBeenCalled();
+    const output = await db
+      .selectFrom("agent_outputs")
+      .select(["status", "error_message"])
+      .where("id", "=", rows[0].id)
+      .executeTakeFirstOrThrow();
+    expect(output).toEqual({
+      status: "failed",
+      error_message: "Recipient is not a member of every source",
+    });
+  });
+
   it("schedules only due routes and treats completed outputs per route", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type AgentDeliveryModel,
   type AgentOutputItemInput,
+  type AgentRoute,
   type AgentSourceConfig,
   createAgentOutputRepository,
 } from "../db/repositories/agent-outputs";
@@ -17,7 +18,7 @@ import type { WhatsAppBot } from "../whatsapp/bot";
 import { CONVERSATION_SUMMARY_AGENT_KEY, conversationSummaryDefinition } from "./definitions/conversation-summary";
 import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION, dailyBriefDefinition } from "./definitions/daily-brief";
 import type { AgentOutputDeliveryPublisher } from "./output-delivery";
-import { AgentRunService, type AgentRunServiceDeps } from "./service";
+import { AgentRunService, type AgentRunServiceDeps, scopeKeyForRoute } from "./service";
 
 const NOW = new Date("2026-06-15T08:05:00.000Z");
 const OUTPUT_DATE = "2026-06-15";
@@ -146,6 +147,24 @@ function slackSource(id: string, name: string): AgentSourceConfig {
 
 function perSourceSelfModel(): AgentDeliveryModel {
   return { mode: "per_source", defaultRoute: "self", perSource: {}, combined: null };
+}
+
+function sourceRoute(
+  source: AgentSourceConfig,
+  overrides: Partial<Omit<AgentRoute, "id" | "sources">> = {},
+): AgentRoute {
+  const sourceKey = `${source.platform}:${source.targetType}:${source.targetId}` as AgentRoute["sources"][number];
+  return {
+    id: sourceKey,
+    sources: [sourceKey],
+    focus: null,
+    sections: null,
+    maxItemsPerSection: null,
+    schedule: null,
+    destination: { kind: "self" },
+    enabled: true,
+    ...overrides,
+  };
 }
 
 function runtimeContextFromUserMessage(userMessage: string): Record<string, unknown> {
@@ -1177,7 +1196,7 @@ describe("AgentRunService", () => {
     expect(isUserInChannel).toHaveBeenCalledWith("C_PRIVATE", "U_AGENT");
   });
 
-  it("fans out per-source summaries with serialized context isolated to each source", async () => {
+  it("fans out per-route summaries with source and content isolated to each route", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);
     const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
@@ -1261,7 +1280,18 @@ describe("AgentRunService", () => {
     await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
       enabled: true,
       sources: [sourceA, sourceB],
-      deliveryModel: perSourceSelfModel(),
+      routes: [
+        sourceRoute(sourceA, {
+          focus: "Alpha customers",
+          sections: { highlights: true, decisions: false, action_items: true, open_questions: false },
+          maxItemsPerSection: 2,
+        }),
+        sourceRoute(sourceB, {
+          focus: "Beta support",
+          sections: { highlights: false, decisions: true, action_items: false, open_questions: true },
+          maxItemsPerSection: 4,
+        }),
+      ],
     });
 
     const rows = await service.requestGenerationForUser({
@@ -1275,20 +1305,24 @@ describe("AgentRunService", () => {
     expect(rows.map((row) => row.source_key).sort()).toEqual(["slack:channel:C_A", "slack:channel:C_B"]);
     for (const row of rows) {
       const context = contexts[row.id];
+      const isAlpha = row.source_key === "slack:channel:C_A";
       expect(context.sources).toEqual([
         expect.objectContaining({
-          targetId: row.source_key === "slack:channel:C_A" ? "C_A" : "C_B",
+          targetId: isAlpha ? "C_A" : "C_B",
         }),
       ]);
       expect(context.summarySources).toEqual([
         expect.objectContaining({
-          targetId: row.source_key === "slack:channel:C_A" ? "C_A" : "C_B",
+          targetId: isAlpha ? "C_A" : "C_B",
         }),
       ]);
+      expect(context.focus).toBe(isAlpha ? "Alpha customers" : "Beta support");
+      expect(context.maxItemsPerSection).toBe(isAlpha ? 2 : 4);
+      expect(context.sections).toEqual(isAlpha ? ["highlights", "action_items"] : ["decisions", "open_questions"]);
       expect(context.sameDayPreviousOutput).toBeNull();
       expect(context.previousDayOutput).toBeNull();
-      expect(JSON.stringify(context)).not.toContain(row.source_key === "slack:channel:C_A" ? "C_B" : "C_A");
-      expect(JSON.stringify(context)).not.toContain(row.source_key === "slack:channel:C_A" ? "Beta-only" : "Alpha");
+      expect(JSON.stringify(context)).not.toContain(isAlpha ? "C_B" : "C_A");
+      expect(JSON.stringify(context)).not.toContain(isAlpha ? "Beta-only" : "Alpha launch");
     }
     expect(outputDelivery.deliver).toHaveBeenCalledTimes(2);
     expect(outputDelivery.deliver).toHaveBeenCalledWith(
@@ -1299,69 +1333,68 @@ describe("AgentRunService", () => {
     );
   });
 
-  it("schedules only incomplete per-source scopes and reruns an aged failed source", async () => {
+  it("schedules only due routes and treats completed outputs per route", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);
     const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
     const sourceA = slackSource("C_A", "alpha");
     const sourceB = slackSource("C_B", "beta");
+    const sourceC = slackSource("C_C", "gamma");
     const slackDelivery = allowSlackDelivery([
       { id: "C_A", name: "alpha" },
       { id: "C_B", name: "beta" },
+      { id: "C_C", name: "gamma" },
     ]);
     const service = createService(db, tasks, slackDelivery);
     await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
       enabled: true,
-      scheduleHour: 8,
+      scheduleHour: 9,
       scheduleMinute: 0,
-      sources: [sourceA, sourceB],
-      deliveryModel: perSourceSelfModel(),
+      sources: [sourceA, sourceB, sourceC],
+      routes: [
+        sourceRoute(sourceA, { schedule: { hour: 9, minute: 0 } }),
+        sourceRoute(sourceB, { schedule: { hour: 18, minute: 0 } }),
+        sourceRoute(sourceC, { schedule: null }),
+      ],
     });
     await db
       .insertInto("agent_outputs")
-      .values([
-        {
-          id: "completed-a",
-          agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
-          user_id: user.id,
-          output_date: OUTPUT_DATE,
-          source_key: "slack:channel:C_A",
-          source_label: "#alpha",
-          timezone: "UTC",
-          status: "completed",
-          trigger_type: "scheduled",
-          agent_version: "test",
-          generated_at: NOW.toISOString(),
-          created_at: NOW.toISOString(),
-          updated_at: NOW.toISOString(),
-        },
-        {
-          id: "aged-failed-b",
-          agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
-          user_id: user.id,
-          output_date: OUTPUT_DATE,
-          source_key: "slack:channel:C_B",
-          source_label: "#beta",
-          timezone: "UTC",
-          status: "failed",
-          trigger_type: "scheduled",
-          agent_version: "test",
-          error_message: "Old failure",
-          created_at: new Date(NOW.getTime() - 2 * 60 * 60 * 1000).toISOString(),
-          updated_at: new Date(NOW.getTime() - 2 * 60 * 60 * 1000).toISOString(),
-        },
-      ])
+      .values({
+        id: "completed-c",
+        agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+        user_id: user.id,
+        output_date: OUTPUT_DATE,
+        source_key: "slack:channel:C_C",
+        source_label: "#gamma",
+        timezone: "UTC",
+        status: "completed",
+        trigger_type: "scheduled",
+        agent_version: "test",
+        generated_at: "2026-06-15T09:01:00.000Z",
+        created_at: "2026-06-15T09:01:00.000Z",
+        updated_at: "2026-06-15T09:01:00.000Z",
+      })
       .execute();
 
     const userRow = await users.findById(user.id);
-    const due = await service.shouldGenerateForUser(conversationSummaryDefinition, userRow ?? user, NOW);
+    const dueAtNine = await service.shouldGenerateForUser(
+      conversationSummaryDefinition,
+      userRow ?? user,
+      new Date("2026-06-15T09:05:00.000Z"),
+    );
     const rows = await service.requestGenerationForUser({
       agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
       userId: user.id,
       outputDate: OUTPUT_DATE,
       triggerType: "scheduled",
       skipIfCompleted: true,
+      scopeKeys: dueAtNine?.scopeKeys,
     });
+    const dueAtEighteen = await service.shouldGenerateForUser(
+      conversationSummaryDefinition,
+      userRow ?? user,
+      new Date("2026-06-15T18:05:00.000Z"),
+    );
 
     const running = await db
       .selectFrom("agent_outputs")
@@ -1370,107 +1403,160 @@ describe("AgentRunService", () => {
       .where("user_id", "=", user.id)
       .where("output_date", "=", OUTPUT_DATE)
       .where("status", "=", "running")
+      .orderBy("source_key", "asc")
       .execute();
 
-    expect(due).toEqual({ outputDate: OUTPUT_DATE });
+    expect(dueAtNine).toEqual({ outputDate: OUTPUT_DATE, scopeKeys: ["slack:channel:C_A"] });
     expect(rows).toHaveLength(1);
-    expect(rows[0].source_key).toBe("slack:channel:C_B");
-    expect(running).toEqual([{ source_key: "slack:channel:C_B", status: "running" }]);
+    expect(rows[0].source_key).toBe("slack:channel:C_A");
+    expect(dueAtEighteen).toEqual({ outputDate: OUTPUT_DATE, scopeKeys: ["slack:channel:C_B"] });
+    expect(running).toEqual([{ source_key: "slack:channel:C_A", status: "running" }]);
     expect(tasks).toHaveLength(1);
   });
 
-  it("preserves legacy delivery semantics without newly posting to added sources", async () => {
+  it("derives deterministic scope keys for source and combined routes", () => {
     const sourceA = slackSource("C_A", "alpha");
     const sourceB = slackSource("C_B", "beta");
-    const channels = [
-      { id: "C_A", name: "alpha" },
-      { id: "C_B", name: "beta" },
-      { id: "C_DEST", name: "leadership" },
-    ];
+    const single = sourceRoute(sourceA);
+    const combined: AgentRoute = {
+      id: "combined-route",
+      sources: ["slack:channel:C_A", "slack:channel:C_B"],
+      focus: null,
+      sections: null,
+      maxItemsPerSection: null,
+      schedule: null,
+      destination: { kind: "off" },
+      enabled: true,
+    };
 
-    async function runScenario(
-      userIdPrefix: string,
-      initialPatch: Parameters<AgentRunService["updateConfigForUser"]>[2],
-      nextSources?: AgentSourceConfig[],
-    ) {
-      const tasks: Array<() => Promise<void>> = [];
-      const users = createUserRepository(db);
-      const user = await users.create({
-        name: `Agent User ${userIdPrefix}`,
-        email: `${userIdPrefix}@example.com`,
-        slackUserId: `U_${userIdPrefix}`,
-      });
-      const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
-      const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
-        if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
-        await params.agentOutputWriter.write({
-          outputDate: OUTPUT_DATE,
-          timezone: "UTC",
-          masthead: { title: "Summarizer", summary: "Summary" },
-          rawPayload: emptySummaryPayload(),
-          items: [],
-        });
-        return successfulRunResult();
-      });
-      const service = createService(db, tasks, {
-        runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
-        outputDelivery,
-        ...allowSlackDelivery(channels),
-      });
-      await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
-        enabled: true,
-        ...initialPatch,
-      });
-      if (nextSources) {
-        await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, { sources: nextSources });
-      }
-      const config = await service.getConfigView(CONVERSATION_SUMMARY_AGENT_KEY, user.id);
-      const rows = await service.requestGenerationForUser({
-        agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
-        userId: user.id,
+    expect(scopeKeyForRoute(single, [sourceA])).toBe("slack:channel:C_A");
+    expect(scopeKeyForRoute(combined, [sourceA, sourceB])).toBe(scopeKeyForRoute(combined, [sourceA, sourceB]));
+    expect(scopeKeyForRoute(combined, [sourceB, sourceA])).toBe(scopeKeyForRoute(combined, [sourceA, sourceB]));
+    expect(scopeKeyForRoute(combined, [sourceA, sourceB])).toMatch(/^route:[a-f0-9]{12}$/);
+  });
+
+  it("synthesizes legacy deliveryModel-only configs into equivalent routes", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const user = await users.create({ name: "Agent User", email: "agent@example.com", slackUserId: "U_AGENT" });
+    const contexts: Record<string, Record<string, unknown>> = {};
+    const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      const runtimeContext = runtimeContextFromUserMessage(params.userMessage);
+      contexts[String(runtimeContext.outputId)] = runtimeContext;
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
         outputDate: OUTPUT_DATE,
-        triggerType: "manual",
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "Summary" },
+        rawPayload: emptySummaryPayload(),
+        items: [],
       });
-      for (const task of tasks) await task();
-      return { config, rows, outputDelivery };
-    }
-
-    const allOff = await runScenario("OFF", { sources: [sourceA], delivery: null }, [sourceA, sourceB]);
-    expect(allOff.config?.deliveryModel).toMatchObject({
-      mode: "per_source",
-      defaultRoute: "off",
-      perSource: {
-        "slack:channel:C_A": { kind: "off" },
-        "slack:channel:C_B": { kind: "off" },
-      },
+      return successfulRunResult();
     });
-    expect(allOff.rows.map((row) => row.source_key).sort()).toEqual(["slack:channel:C_A", "slack:channel:C_B"]);
-    expect(allOff.outputDelivery.deliver).not.toHaveBeenCalled();
+    const service = createService(db, tasks, {
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      outputDelivery,
+      ...allowSlackDelivery([
+        { id: "C_A", name: "alpha" },
+        { id: "C_B", name: "beta" },
+      ]),
+    });
+    await db
+      .insertInto("agent_user_configs")
+      .values({
+        agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+        user_id: user.id,
+        enabled: 1,
+        schedule_hour: 9,
+        schedule_minute: 30,
+        timezone: "UTC",
+        max_items_per_section: 3,
+        prefs_json: JSON.stringify({
+          sources: [sourceA, sourceB],
+          focus: "Customer escalations",
+          sections: { highlights: true, decisions: false, action_items: false, open_questions: true },
+          deliveryModel: {
+            mode: "per_source",
+            defaultRoute: "off",
+            perSource: {
+              "slack:channel:C_A": { kind: "self" },
+              "slack:channel:C_B": { kind: "off" },
+            },
+            combined: null,
+          },
+        }),
+        created_at: NOW.toISOString(),
+        updated_at: NOW.toISOString(),
+      })
+      .execute();
 
-    const sourceDelivery = await runScenario("SRC", {
-      sources: [sourceA, sourceB],
-      delivery: {
+    const config = await service.getConfigView(CONVERSATION_SUMMARY_AGENT_KEY, user.id);
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(config?.routes).toEqual([
+      {
+        id: "slack:channel:C_A",
+        sources: ["slack:channel:C_A"],
+        focus: "Customer escalations",
+        sections: { highlights: true, decisions: false, action_items: false, open_questions: true },
+        maxItemsPerSection: 3,
+        schedule: null,
+        destination: { kind: "self" },
         enabled: true,
-        platform: "slack",
-        targetType: "channel",
-        targetId: "C_A",
-        label: "#alpha",
       },
-    });
-    expect(sourceDelivery.config?.deliveryModel).toMatchObject({
-      mode: "per_source",
-      defaultRoute: "off",
-      perSource: {
-        "slack:channel:C_A": { kind: "self" },
-        "slack:channel:C_B": { kind: "off" },
+      {
+        id: "slack:channel:C_B",
+        sources: ["slack:channel:C_B"],
+        focus: "Customer escalations",
+        sections: { highlights: true, decisions: false, action_items: false, open_questions: true },
+        maxItemsPerSection: 3,
+        schedule: null,
+        destination: { kind: "off" },
+        enabled: true,
       },
-    });
-    expect(sourceDelivery.outputDelivery.deliver).toHaveBeenCalledTimes(1);
-    expect(sourceDelivery.outputDelivery.deliver).toHaveBeenCalledWith(
+    ]);
+    expect(rows.map((row) => row.source_key).sort()).toEqual(["slack:channel:C_A", "slack:channel:C_B"]);
+    for (const row of rows) {
+      const context = contexts[row.id];
+      expect(context.focus).toBe("Customer escalations");
+      expect(context.maxItemsPerSection).toBe(3);
+      expect(context.sections).toEqual(["highlights", "open_questions"]);
+      expect(context.sources).toEqual([
+        expect.objectContaining({ targetId: row.source_key === "slack:channel:C_A" ? "C_A" : "C_B" }),
+      ]);
+    }
+    expect(outputDelivery.deliver).toHaveBeenCalledTimes(1);
+    expect(outputDelivery.deliver).toHaveBeenCalledWith(
       expect.objectContaining({ delivery: expect.objectContaining({ targetId: "C_A" }) }),
     );
+  });
 
-    const combined = await runScenario("COMBINED", {
+  it("synthesizes combined legacy delivery as an off combined route for Arc 2", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const user = await users.create({ name: "Agent User", email: "combined@example.com", slackUserId: "U_COMBINED" });
+    const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
+    const service = createService(db, tasks, {
+      outputDelivery,
+      ...allowSlackDelivery([
+        { id: "C_A", name: "alpha" },
+        { id: "C_B", name: "beta" },
+        { id: "C_DEST", name: "leadership" },
+      ]),
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
       sources: [sourceA, sourceB],
       delivery: {
         enabled: true,
@@ -1480,16 +1566,24 @@ describe("AgentRunService", () => {
         label: "#leadership",
       },
     });
-    expect(combined.config?.deliveryModel).toMatchObject({
-      mode: "combined",
-      combined: { targetId: "C_DEST", ackNonDm: true },
+
+    const config = await service.getConfigView(CONVERSATION_SUMMARY_AGENT_KEY, user.id);
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
     });
-    expect(combined.rows).toHaveLength(1);
-    expect(combined.rows[0].source_key).toBe("");
-    expect(combined.outputDelivery.deliver).toHaveBeenCalledTimes(1);
-    expect(combined.outputDelivery.deliver).toHaveBeenCalledWith(
-      expect.objectContaining({ delivery: expect.objectContaining({ targetId: "C_DEST" }) }),
-    );
+
+    expect(config?.routes).toEqual([
+      expect.objectContaining({
+        sources: ["slack:channel:C_A", "slack:channel:C_B"],
+        destination: { kind: "off" },
+      }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source_key).toMatch(/^route:[a-f0-9]{12}$/);
+    expect(outputDelivery.deliver).not.toHaveBeenCalled();
   });
 
   it("rejects WhatsApp group delivery when the current user is not a participant", async () => {

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -679,6 +679,50 @@ describe("AgentRunService", () => {
     expect(userMessage).toContain('"hotFallbackEntities": []');
   });
 
+  it("passes saved non-route Daily Brief section and volume preferences into the runtime message", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com" });
+    const contexts: Record<string, Record<string, unknown>> = {};
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      const runtimeContext = runtimeContextFromUserMessage(params.userMessage);
+      contexts[String(runtimeContext.outputId)] = runtimeContext;
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Daily Brief", summary: "Summary" },
+        rawPayload: {
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Daily Brief", summary: "Summary" },
+          items: [],
+        },
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const service = createService(db, tasks, { runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"] });
+
+    await service.updateConfigForUser(DAILY_BRIEF_AGENT_KEY, user.id, {
+      sections: { customer_updates: false, active_projects: false },
+      maxItemsPerSection: 2,
+      focus: "  Prioritize urgent work  ",
+    });
+    const [row] = await service.requestGenerationForUser({
+      agentKey: DAILY_BRIEF_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    if (!row) throw new Error("Expected a generated output row");
+    await tasks[0]();
+
+    expect(contexts[row.id].sections).toEqual(["meetings", "todos"]);
+    expect(contexts[row.id].maxItemsPerSection).toBe(2);
+    expect(contexts[row.id].focus).toBe("Prioritize urgent work");
+  });
+
   it("suppresses recent failed scheduled attempts during the schedule window", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);
@@ -1645,11 +1689,48 @@ describe("AgentRunService", () => {
       destination: { kind: "off" },
       enabled: true,
     };
+    const reversed: AgentRoute = { ...combined, sources: ["slack:channel:C_B", "slack:channel:C_A"] };
 
     expect(scopeKeyForRoute(single, [sourceA])).toBe("slack:channel:C_A");
-    expect(scopeKeyForRoute(combined, [sourceA, sourceB])).toBe(scopeKeyForRoute(combined, [sourceA, sourceB]));
-    expect(scopeKeyForRoute(combined, [sourceB, sourceA])).toBe(scopeKeyForRoute(combined, [sourceA, sourceB]));
+    expect(scopeKeyForRoute(reversed, [sourceB, sourceA])).toBe(scopeKeyForRoute(combined, [sourceA, sourceB]));
     expect(scopeKeyForRoute(combined, [sourceA, sourceB])).toMatch(/^route:[a-f0-9]{12}$/);
+  });
+
+  it("rejects duplicate combined routes regardless of source order", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const user = await users.create({ name: "Agent User", email: "agent@example.com", slackUserId: "U_AGENT" });
+    const service = createService(
+      db,
+      tasks,
+      allowSlackDelivery([
+        { id: "C_A", name: "alpha" },
+        { id: "C_B", name: "beta" },
+      ]),
+    );
+
+    await expect(
+      service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+        enabled: true,
+        sources: [sourceA, sourceB],
+        routes: [
+          {
+            ...sourceRoute(sourceA),
+            id: "alpha-beta",
+            sources: ["slack:channel:C_A", "slack:channel:C_B"],
+            destination: { kind: "off" },
+          },
+          {
+            ...sourceRoute(sourceB),
+            id: "beta-alpha",
+            sources: ["slack:channel:C_B", "slack:channel:C_A"],
+            destination: { kind: "off" },
+          },
+        ],
+      }),
+    ).rejects.toThrow("Routes must not duplicate the same output scope");
   });
 
   it("synthesizes legacy deliveryModel-only configs into equivalent routes", async () => {

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { areJidsSameUser } from "@whiskeysockets/baileys";
 import type { Kysely, Selectable } from "kysely";
@@ -16,7 +17,10 @@ import {
   type AgentOutputRow,
   type AgentOutputTriggerType,
   type AgentPerSourceDelivery,
+  type AgentRoute,
+  type AgentRouteDestination,
   type AgentSourceConfig,
+  type AgentSourceKey,
   type AgentUserPrefs,
   createAgentOutputRepository,
 } from "../db/repositories/agent-outputs";
@@ -39,10 +43,12 @@ const SCHEDULED_FAILURE_SUPPRESS_AFTER_MS = 60 * 60 * 1000;
 type UserRow = Selectable<UsersTable>;
 
 export type AgentGenerationScope =
-  | { kind: "combined"; sourceKey: ""; sourceLabel: null }
+  | { kind: "combined"; sourceKey: string; sourceLabel: string | null }
   | { kind: "source"; source: AgentSourceConfig; sourceKey: string; sourceLabel: string | null };
 
-type AgentExpectedScope = AgentGenerationScope & { sources: AgentSourceConfig[] };
+export type ResolvedRoute = AgentRoute & { resolvedSources: AgentSourceConfig[] };
+
+type AgentExpectedScope = AgentGenerationScope & { sources: AgentSourceConfig[]; route?: ResolvedRoute };
 
 export interface AgentRunServiceDeps {
   db: Kysely<DB>;
@@ -69,6 +75,7 @@ export interface RequestAgentGenerationParams {
   outputDate?: string;
   triggerType: AgentOutputTriggerType;
   skipIfCompleted?: boolean;
+  scopeKeys?: string[];
 }
 
 export interface ResolvedAgentConfig {
@@ -82,6 +89,8 @@ export interface ResolvedAgentConfig {
   delivery: AgentDeliveryConfig | null;
   deliveryModel: AgentDeliveryModel;
   sources: AgentSourceConfig[];
+  routes: ResolvedRoute[];
+  configuredRoutes: AgentRoute[];
 }
 
 export interface AgentSectionView {
@@ -106,6 +115,7 @@ export interface AgentConfigView {
   deliveryModel: AgentDeliveryModel;
   sourceConfig: AgentSourceConfigDef | null;
   sources: AgentSourceConfig[];
+  routes: AgentRoute[];
   sections: AgentSectionView[];
 }
 
@@ -138,7 +148,9 @@ export interface AgentSummaryView {
 export class AgentDeliveryTargetError extends Error {}
 export class AgentSourceTargetError extends Error {}
 
-function sourceKeyForTarget(target: Pick<AgentSourceConfig, "platform" | "targetType" | "targetId">): string {
+export function sourceKeyForTarget(
+  target: Pick<AgentSourceConfig, "platform" | "targetType" | "targetId">,
+): AgentSourceKey {
   return `${target.platform}:${target.targetType}:${target.targetId}`;
 }
 
@@ -157,6 +169,36 @@ function sourceAsDelivery(source: AgentSourceConfig): AgentDeliveryConfig {
     targetType: source.targetType,
     targetId: source.targetId,
     label: source.label,
+  };
+}
+
+function stableRouteHash(parts: readonly string[]): string {
+  return createHash("sha256").update(parts.join("|")).digest("hex").slice(0, 12);
+}
+
+function routeIdForSources(sources: readonly AgentSourceKey[]): string {
+  if (sources.length === 1) return sources[0];
+  return `route:${stableRouteHash(sources)}`;
+}
+
+export function scopeKeyForRoute(route: Pick<AgentRoute, "sources">, resolvedSources: AgentSourceConfig[]): string {
+  if (route.sources.length === 1) return sourceKeyForTarget(resolvedSources[0] ?? parseSourceKey(route.sources[0]));
+  return `route:${stableRouteHash(route.sources)}`;
+}
+
+export function labelForRoute(route: Pick<AgentRoute, "sources">, resolvedSources: AgentSourceConfig[]): string | null {
+  if (resolvedSources.length === 0) return null;
+  const first = resolvedSources[0].label ?? resolvedSources[0].targetId;
+  return route.sources.length === 1 ? first : `${first} +${route.sources.length - 1}`;
+}
+
+function parseSourceKey(sourceKey: AgentSourceKey): AgentSourceConfig {
+  const [platform, targetType, ...targetParts] = sourceKey.split(":");
+  return {
+    platform: platform as AgentSourceConfig["platform"],
+    targetType: targetType as AgentSourceConfig["targetType"],
+    targetId: targetParts.join(":"),
+    label: null,
   };
 }
 
@@ -268,9 +310,134 @@ function projectLegacyDelivery(model: AgentDeliveryModel, sources: AgentSourceCo
   return selfSources.length === 1 ? sourceAsDelivery(selfSources[0]) : null;
 }
 
-function perSourceDeliveryFor(model: AgentDeliveryModel, sourceKey: string): AgentPerSourceDelivery | null {
-  if (model.mode !== "per_source") return null;
-  return normalizePerSourceDelivery(model.perSource[sourceKey], model.defaultRoute);
+function isAgentRouteDestination(value: unknown): value is AgentRouteDestination {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const raw = value as Record<string, unknown>;
+  if (raw.kind === "self" || raw.kind === "off") return true;
+  return raw.kind === "member" && raw.platform === "slack" && typeof raw.memberUserId === "string";
+}
+
+function normalizeRouteSchedule(value: unknown): AgentRoute["schedule"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  return Number.isInteger(raw.hour) &&
+    Number.isInteger(raw.minute) &&
+    Number(raw.hour) >= 0 &&
+    Number(raw.hour) <= 23 &&
+    Number(raw.minute) >= 0 &&
+    Number(raw.minute) <= 59
+    ? { hour: Number(raw.hour), minute: Number(raw.minute) }
+    : null;
+}
+
+function normalizeRouteSections(value: unknown): Record<string, boolean> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, enabled]) => [key, Boolean(enabled)]),
+  );
+}
+
+function normalizeRouteSources(value: unknown): AgentSourceKey[] {
+  if (!Array.isArray(value)) return [];
+  const result: AgentSourceKey[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const source = parseSourceKey(entry as AgentSourceKey);
+    if (
+      (source.platform !== "slack" && source.platform !== "whatsapp") ||
+      (source.targetType !== "channel" && source.targetType !== "group") ||
+      !source.targetId
+    ) {
+      continue;
+    }
+    const key = sourceKeyForTarget(source);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(key);
+  }
+  return result;
+}
+
+function normalizeRoutesFromValue(value: unknown): AgentRoute[] | null {
+  if (!Array.isArray(value)) return null;
+  const routes: AgentRoute[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const raw = entry as Record<string, unknown>;
+    const sources = normalizeRouteSources(raw.sources);
+    if (sources.length === 0) continue;
+    const destination = isAgentRouteDestination(raw.destination) ? raw.destination : { kind: "off" as const };
+    const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : routeIdForSources(sources);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    routes.push({
+      id,
+      sources,
+      focus: typeof raw.focus === "string" && raw.focus.trim() ? raw.focus.trim() : null,
+      sections: normalizeRouteSections(raw.sections),
+      maxItemsPerSection:
+        Number.isInteger(raw.maxItemsPerSection) && Number(raw.maxItemsPerSection) > 0
+          ? Number(raw.maxItemsPerSection)
+          : null,
+      schedule: normalizeRouteSchedule(raw.schedule),
+      destination,
+      enabled: raw.enabled !== false,
+    });
+  }
+  return routes;
+}
+
+function synthesizeRoutesFromDeliveryModel(
+  deliveryModel: AgentDeliveryModel,
+  sources: AgentSourceConfig[],
+  prefs: AgentUserPrefs,
+  maxItemsPerSection: number,
+): AgentRoute[] {
+  const content = {
+    focus: prefs.focus?.trim() ? prefs.focus.trim() : null,
+    sections: prefs.sections ?? null,
+    maxItemsPerSection,
+    schedule: null,
+    enabled: true,
+  };
+
+  if (deliveryModel.mode === "combined") {
+    const routeSources = sources.map(sourceKeyForTarget);
+    if (routeSources.length === 0) return [];
+    return [
+      {
+        id: routeIdForSources(routeSources),
+        sources: routeSources,
+        ...content,
+        destination: { kind: "off" },
+      },
+    ];
+  }
+
+  return sources.map((source) => {
+    const sourceKey = sourceKeyForTarget(source);
+    const delivery = normalizePerSourceDelivery(deliveryModel.perSource[sourceKey], deliveryModel.defaultRoute);
+    return {
+      id: sourceKey,
+      sources: [sourceKey],
+      ...content,
+      destination: delivery.kind === "self" ? { kind: "self" } : { kind: "off" },
+    };
+  });
+}
+
+function enabledSectionsForRoute(def: AgentDefinition, route: AgentRoute | undefined): Record<string, boolean> {
+  const sections: Record<string, boolean> = {};
+  for (const section of def.sections) {
+    sections[section.key] = route?.sections?.[section.key] ?? section.enabledByDefault;
+  }
+  return sections;
+}
+
+function maxItemsPerSectionForRoute(def: AgentDefinition, route: AgentRoute | undefined): number {
+  return route?.maxItemsPerSection ?? def.defaults.maxItemsPerSection;
 }
 
 function whatsappNumberToJid(whatsappNumber: string): string {
@@ -416,17 +583,24 @@ export class AgentRunService {
     const deliveryModel =
       normalizeDeliveryModelFromValue(prefs.deliveryModel, sources) ??
       normalizeLegacyDeliveryModel(prefs.delivery ?? null, sources);
+    const maxItemsPerSection = raw.maxItemsPerSection ?? def.defaults.maxItemsPerSection;
+    const configuredRoutes =
+      normalizeRoutesFromValue(prefs.routes) ??
+      synthesizeRoutesFromDeliveryModel(deliveryModel, sources, prefs, maxItemsPerSection);
+    const routes = await this.resolveRoutesForRun(def, userId, configuredRoutes, sources);
     return {
       enabled: raw.exists ? raw.enabled : def.defaults.enabled,
       scheduleHour: raw.scheduleHour ?? def.defaults.scheduleHour,
       scheduleMinute: raw.scheduleMinute ?? def.defaults.scheduleMinute,
       timezone: raw.timezone,
-      maxItemsPerSection: raw.maxItemsPerSection ?? def.defaults.maxItemsPerSection,
+      maxItemsPerSection,
       enabledSections,
       focus: prefs.focus ?? null,
       delivery: projectLegacyDelivery(deliveryModel, sources),
       deliveryModel,
       sources,
+      routes,
+      configuredRoutes,
     };
   }
 
@@ -473,6 +647,7 @@ export class AgentRunService {
       deliveryModel: config.deliveryModel,
       sourceConfig: def.sourceConfig ?? null,
       sources: config.sources,
+      routes: config.configuredRoutes,
       sections: def.sections.map((section) => ({
         key: section.key,
         title: section.title,
@@ -494,6 +669,7 @@ export class AgentRunService {
       delivery?: AgentDeliveryConfig | null;
       deliveryModel?: AgentDeliveryModel;
       sources?: AgentSourceConfig[];
+      routes?: AgentRoute[];
     },
   ): Promise<AgentConfigView | null> {
     const def = getAgentDefinition(agentKey);
@@ -508,11 +684,16 @@ export class AgentRunService {
 
     let prefs: AgentUserPrefs | undefined;
     if (
+      patch.enabled !== undefined ||
+      patch.scheduleHour !== undefined ||
+      patch.scheduleMinute !== undefined ||
       patch.sections !== undefined ||
       patch.focus !== undefined ||
       patch.delivery !== undefined ||
       patch.deliveryModel !== undefined ||
-      patch.sources !== undefined
+      patch.sources !== undefined ||
+      patch.routes !== undefined ||
+      maxItemsPerSection !== undefined
     ) {
       const sections: Record<string, boolean> = { ...current.enabledSections };
       if (patch.sections) {
@@ -525,15 +706,41 @@ export class AgentRunService {
         patch.sources !== undefined
           ? await this.resolveSourceConfigsForUser(def, userId, patch.sources)
           : current.sources;
-      const deliveryModel = this.resolveDeliveryModelForUser(
+      const deliveryModel =
+        patch.deliveryModel !== undefined || patch.delivery !== undefined || patch.sources !== undefined
+          ? this.resolveDeliveryModelForUser(
+              sources,
+              patch.deliveryModel !== undefined
+                ? patch.deliveryModel
+                : patch.delivery !== undefined
+                  ? normalizeLegacyDeliveryModel(patch.delivery, sources)
+                  : reconcileDeliveryModel(current.deliveryModel, sources),
+            )
+          : current.deliveryModel;
+      const routes =
+        patch.routes !== undefined
+          ? this.resolveRoutesForUser(def, sources, patch.routes)
+          : patch.deliveryModel !== undefined || patch.delivery !== undefined || patch.sources !== undefined
+            ? synthesizeRoutesFromDeliveryModel(
+                deliveryModel,
+                sources,
+                { sections, focus },
+                maxItemsPerSection ?? current.maxItemsPerSection,
+              )
+            : current.configuredRoutes.map((route) => ({
+                ...route,
+                ...(patch.sections !== undefined ? { sections } : {}),
+                ...(patch.focus !== undefined ? { focus } : {}),
+                ...(maxItemsPerSection !== undefined ? { maxItemsPerSection } : {}),
+              }));
+      prefs = {
+        sections,
+        focus,
+        delivery: projectLegacyDelivery(deliveryModel, sources),
+        deliveryModel,
         sources,
-        patch.deliveryModel !== undefined
-          ? patch.deliveryModel
-          : patch.delivery !== undefined
-            ? normalizeLegacyDeliveryModel(patch.delivery, sources)
-            : reconcileDeliveryModel(current.deliveryModel, sources),
-      );
-      prefs = { sections, focus, delivery: projectLegacyDelivery(deliveryModel, sources), deliveryModel, sources };
+        routes,
+      };
     }
 
     await this.repo.upsertConfig(
@@ -572,6 +779,56 @@ export class AgentRunService {
     }
 
     return reconciled;
+  }
+
+  private resolveRoutesForUser(def: AgentDefinition, sources: AgentSourceConfig[], routes: AgentRoute[]): AgentRoute[] {
+    const sourceKeys = new Set(sources.map(sourceKeyForTarget));
+    const sectionKeys = new Set(def.sections.map((section) => section.key));
+    const range = def.itemsPerSectionRange;
+    const seenScopeKeys = new Set<string>();
+
+    return routes.map((route) => {
+      if (def.sourceConfig && route.sources.length !== 1) {
+        throw new AgentSourceTargetError("Arc 2 routes must include exactly one source");
+      }
+      if (route.destination.kind === "member") {
+        throw new AgentDeliveryTargetError("Member route destinations are not supported until Arc 1b");
+      }
+      for (const sourceKey of route.sources) {
+        if (!sourceKeys.has(sourceKey)) {
+          throw new AgentSourceTargetError("Route source must be one of the selected sources");
+        }
+      }
+      for (const sectionKey of Object.keys(route.sections ?? {})) {
+        if (!sectionKeys.has(sectionKey)) throw new AgentSourceTargetError(`Unknown route section: ${sectionKey}`);
+      }
+      if (
+        route.schedule &&
+        (!Number.isInteger(route.schedule.hour) ||
+          route.schedule.hour < 0 ||
+          route.schedule.hour > 23 ||
+          !Number.isInteger(route.schedule.minute) ||
+          route.schedule.minute < 0 ||
+          route.schedule.minute > 59)
+      ) {
+        throw new AgentSourceTargetError("Route schedule must be a valid hour and minute");
+      }
+      const scopeKey = route.sources.length === 1 ? route.sources[0] : `route:${stableRouteHash(route.sources)}`;
+      if (seenScopeKeys.has(scopeKey)) {
+        throw new AgentSourceTargetError("Routes must not duplicate the same output scope");
+      }
+      seenScopeKeys.add(scopeKey);
+
+      return {
+        ...route,
+        id: route.id.trim() || routeIdForSources(route.sources),
+        focus: route.focus?.trim() ? route.focus.trim() : null,
+        sections: route.sections ? { ...route.sections } : null,
+        maxItemsPerSection:
+          route.maxItemsPerSection === null ? null : Math.min(range.max, Math.max(range.min, route.maxItemsPerSection)),
+        enabled: route.enabled !== false,
+      };
+    });
   }
 
   async resolveDeliveryConfigForUser(
@@ -835,6 +1092,28 @@ export class AgentRunService {
     return resolved;
   }
 
+  private async resolveRoutesForRun(
+    def: AgentDefinition,
+    userId: string,
+    routes: AgentRoute[],
+    sources: AgentSourceConfig[],
+  ): Promise<ResolvedRoute[]> {
+    if (!def.sourceConfig) return routes.map((route) => ({ ...route, resolvedSources: [] }));
+    const resolvedSources = await this.resolveSourcesForRun(def, userId, sources);
+    const byKey = new Map(resolvedSources.map((source) => [sourceKeyForTarget(source), source]));
+    const resolvedRoutes: ResolvedRoute[] = [];
+
+    for (const route of routes) {
+      const routeSources = route.sources
+        .map((sourceKey) => byKey.get(sourceKey))
+        .filter((source) => source !== undefined);
+      if (routeSources.length !== route.sources.length) continue;
+      resolvedRoutes.push({ ...route, resolvedSources: routeSources });
+    }
+
+    return resolvedRoutes;
+  }
+
   private toApiOutput(
     def: AgentDefinition,
     value: Awaited<ReturnType<ReturnType<typeof createAgentOutputRepository>["findLatestCompletedForScope"]>>,
@@ -914,25 +1193,24 @@ export class AgentRunService {
 
   private async resolveExpectedScopesForUser(
     def: AgentDefinition,
-    user: UserRow,
+    _user: UserRow,
     config: ResolvedAgentConfig,
   ): Promise<AgentExpectedScope[]> {
     if (!def.sourceConfig) {
       return [{ kind: "combined", sourceKey: "", sourceLabel: null, sources: [] }];
     }
 
-    const sources = await this.resolveSourcesForRun(def, user.id, config.sources);
-    if (config.deliveryModel.mode === "combined") {
-      return [{ kind: "combined", sourceKey: "", sourceLabel: null, sources }];
-    }
-
-    return sources.map((source) => ({
-      kind: "source",
-      source,
-      sourceKey: sourceKeyForTarget(source),
-      sourceLabel: source.label,
-      sources: [source],
-    }));
+    return config.routes
+      .filter((route) => route.enabled)
+      .map((route): AgentExpectedScope => {
+        const sourceKey = scopeKeyForRoute(route, route.resolvedSources);
+        const sourceLabel = labelForRoute(route, route.resolvedSources);
+        if (route.resolvedSources.length === 1) {
+          const [source] = route.resolvedSources;
+          return { kind: "source", source, sourceKey, sourceLabel, route, sources: route.resolvedSources };
+        }
+        return { kind: "combined", sourceKey, sourceLabel, route, sources: route.resolvedSources };
+      });
   }
 
   async requestGenerationForUser(params: RequestAgentGenerationParams): Promise<AgentOutputRow[]> {
@@ -944,9 +1222,10 @@ export class AgentRunService {
     const outputDate = params.outputDate || localDateInTimezone(new Date(), timezone);
     const now = new Date();
     const scopes = await this.resolveExpectedScopesForUser(def, user, config);
+    const scopeKeys = params.scopeKeys ? new Set(params.scopeKeys) : null;
     const rows: AgentOutputRow[] = [];
 
-    for (const scope of scopes) {
+    for (const scope of scopeKeys ? scopes.filter((candidate) => scopeKeys.has(candidate.sourceKey)) : scopes) {
       let recoveredStaleRunning = false;
       const existingRunning = await this.repo.findRunning(def.key, user.id, outputDate, scope.sourceKey);
       if (existingRunning) {
@@ -996,9 +1275,9 @@ export class AgentRunService {
     def: AgentDefinition,
     user: UserRow,
     now = new Date(),
-  ): Promise<{ outputDate: string } | null> {
+  ): Promise<{ outputDate: string; scopeKeys: string[] } | null> {
     const config = await this.resolveConfig(def, user.id);
-    if (def.sourceConfig && config.sources.length === 0) return null;
+    if (def.sourceConfig && config.routes.length === 0) return null;
     if (!config.enabled) return null;
     const timezone = config.timezone || user.timezone || "UTC";
     const parts = new Intl.DateTimeFormat("en-US", {
@@ -1009,12 +1288,14 @@ export class AgentRunService {
     }).formatToParts(now);
     const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0");
     const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
-    if (hour !== config.scheduleHour || minute < config.scheduleMinute) return null;
     const outputDate = localDateInTimezone(now, timezone);
     const scopes = await this.resolveExpectedScopesForUser(def, user, config);
     if (scopes.length === 0) return null;
+    const dueScopeKeys: string[] = [];
 
     for (const scope of scopes) {
+      const schedule = scope.route?.schedule ?? { hour: config.scheduleHour, minute: config.scheduleMinute };
+      if (hour !== schedule.hour || minute < schedule.minute) continue;
       const [running, completed] = await Promise.all([
         this.repo.findRunning(def.key, user.id, outputDate, scope.sourceKey),
         this.repo.findLatestCompletedForScope(def.key, user.id, scope.sourceKey, outputDate),
@@ -1023,10 +1304,10 @@ export class AgentRunService {
       if (running && !this.isRunningStale(running, now)) continue;
       const latest = await this.repo.findLatestAny(def.key, user.id, outputDate, scope.sourceKey);
       if (latest && this.isRecentScheduledFailure(latest, now)) continue;
-      return { outputDate };
+      dueScopeKeys.push(scope.sourceKey);
     }
 
-    return null;
+    return dueScopeKeys.length > 0 ? { outputDate, scopeKeys: dueScopeKeys } : null;
   }
 
   private isRunningStale(output: AgentOutputRow, now: Date): boolean {
@@ -1078,7 +1359,7 @@ export class AgentRunService {
 
   private async resolveScopeForOutput(
     def: AgentDefinition,
-    user: UserRow,
+    _user: UserRow,
     config: ResolvedAgentConfig,
     output: AgentOutputRow,
   ): Promise<AgentExpectedScope | null> {
@@ -1086,20 +1367,17 @@ export class AgentRunService {
       return { kind: "combined", sourceKey: "", sourceLabel: null, sources: [] };
     }
 
-    const sources = await this.resolveSourcesForRun(def, user.id, config.sources);
-    if (output.source_key === "") {
-      return { kind: "combined", sourceKey: "", sourceLabel: null, sources };
+    const route = config.routes.find(
+      (candidate) => scopeKeyForRoute(candidate, candidate.resolvedSources) === output.source_key,
+    );
+    if (!route) return null;
+    const sourceKey = scopeKeyForRoute(route, route.resolvedSources);
+    const sourceLabel = output.source_label ?? labelForRoute(route, route.resolvedSources);
+    if (route.resolvedSources.length === 1) {
+      const [source] = route.resolvedSources;
+      return { kind: "source", source, sourceKey, sourceLabel, route, sources: route.resolvedSources };
     }
-
-    const source = sources.find((candidate) => sourceKeyForTarget(candidate) === output.source_key);
-    if (!source) return null;
-    return {
-      kind: "source",
-      source,
-      sourceKey: output.source_key,
-      sourceLabel: output.source_label ?? source.label,
-      sources: [source],
-    };
+    return { kind: "combined", sourceKey, sourceLabel, route, sources: route.resolvedSources };
   }
 
   private async getPreviousOutputForContext(
@@ -1125,10 +1403,13 @@ export class AgentRunService {
     const config = await this.resolveConfig(def, user.id);
     const scope = await this.resolveScopeForOutput(def, user, config, output);
     if (!scope) {
-      await this.repo.markFailed(outputId, "Generation source is no longer available.");
+      await this.repo.markFailed(outputId, "Generation route was removed.");
       return;
     }
-    const enabledSections = def.sections.filter((s) => config.enabledSections[s.key]).map((s) => s.key);
+    const routeSections = enabledSectionsForRoute(def, scope.route);
+    const routeMaxItemsPerSection = maxItemsPerSectionForRoute(def, scope.route);
+    const routeFocus = scope.route ? scope.route.focus : config.focus;
+    const enabledSections = def.sections.filter((s) => routeSections[s.key]).map((s) => s.key);
 
     try {
       const now = new Date();
@@ -1151,9 +1432,9 @@ export class AgentRunService {
               adminCanReadAllFiles,
               contentUserEmails,
               agentConfig: {
-                enabledSections: config.enabledSections,
-                maxItemsPerSection: config.maxItemsPerSection,
-                focus: config.focus,
+                enabledSections: routeSections,
+                maxItemsPerSection: routeMaxItemsPerSection,
+                focus: routeFocus,
                 delivery: config.delivery,
                 sources: scope.sources,
                 sourceKey: scope.sourceKey,
@@ -1169,8 +1450,8 @@ export class AgentRunService {
         timezone: output.timezone,
         user: { id: user.id, name: user.name, email: user.email },
         sections: enabledSections,
-        maxItemsPerSection: config.maxItemsPerSection,
-        focus: config.focus,
+        maxItemsPerSection: routeMaxItemsPerSection,
+        focus: routeFocus,
         sources: scope.sources,
         sameDayPreviousOutput: this.formatOutputForContext(sameDayPrevious),
         previousDayOutput: this.formatOutputForContext(previousDay),
@@ -1253,7 +1534,7 @@ export class AgentRunService {
       const config = await this.resolveConfig(def, userId);
       const scope = await this.resolveScopeForOutput(def, user, config, output);
       if (!scope) return;
-      const configuredDelivery = this.deliveryForScope(config.deliveryModel, scope);
+      const configuredDelivery = scope.route ? this.deliveryForRoute(scope.route, scope.sources) : config.delivery;
       if (!configuredDelivery) return;
       const delivery = await this.resolveDeliveryConfigForUser(userId, configuredDelivery);
       if (!delivery) return;
@@ -1265,19 +1546,11 @@ export class AgentRunService {
     }
   }
 
-  private deliveryForScope(deliveryModel: AgentDeliveryModel, scope: AgentExpectedScope): AgentDeliveryConfig | null {
-    if (scope.kind === "combined") {
-      if (deliveryModel.mode !== "combined") return null;
-      if (!isDmDelivery(deliveryModel.combined) && deliveryModel.combined.ackNonDm !== true) return null;
-      const deliveryKey = deliveryKeyForTarget(deliveryModel.combined);
-      if (scope.sources.some((source) => sourceKeyForTarget(source) === deliveryKey)) return null;
-      return deliveryModel.combined;
-    }
-
-    const route = perSourceDeliveryFor(deliveryModel, scope.sourceKey);
-    if (!route || route.kind === "off") return null;
-    if (route.kind === "target") return null;
-    return sourceAsDelivery(scope.source);
+  private deliveryForRoute(route: AgentRoute, resolvedSources: AgentSourceConfig[]): AgentDeliveryConfig | null {
+    if (route.destination.kind === "off") return null;
+    if (route.destination.kind === "member") throw new Error("Arc 1b");
+    if (resolvedSources.length !== 1) return null;
+    return sourceAsDelivery(resolvedSources[0]);
   }
 
   private createWriter(

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -119,6 +119,12 @@ export interface AgentConfigView {
   sections: AgentSectionView[];
 }
 
+export interface AgentRouteMember {
+  userId: string;
+  name: string;
+  slackUserId: string;
+}
+
 export interface AgentOutputApi {
   id: string;
   agentKey: string;
@@ -310,11 +316,13 @@ function projectLegacyDelivery(model: AgentDeliveryModel, sources: AgentSourceCo
   return selfSources.length === 1 ? sourceAsDelivery(selfSources[0]) : null;
 }
 
-function isAgentRouteDestination(value: unknown): value is AgentRouteDestination {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+function normalizeRouteDestination(value: unknown): AgentRouteDestination | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const raw = value as Record<string, unknown>;
-  if (raw.kind === "self" || raw.kind === "off") return true;
-  return raw.kind === "member" && raw.platform === "slack" && typeof raw.memberUserId === "string";
+  if (raw.kind === "self" || raw.kind === "off") return { kind: raw.kind };
+  if (raw.kind !== "member" || raw.platform !== "slack") return null;
+  const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
+  return memberUserId ? { kind: "member", platform: "slack", memberUserId } : null;
 }
 
 function normalizeRouteSchedule(value: unknown): AgentRoute["schedule"] {
@@ -368,7 +376,7 @@ function normalizeRoutesFromValue(value: unknown): AgentRoute[] | null {
     const raw = entry as Record<string, unknown>;
     const sources = normalizeRouteSources(raw.sources);
     if (sources.length === 0) continue;
-    const destination = isAgentRouteDestination(raw.destination) ? raw.destination : { kind: "off" as const };
+    const destination = normalizeRouteDestination(raw.destination) ?? { kind: "off" as const };
     const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : routeIdForSources(sources);
     if (seen.has(id)) continue;
     seen.add(id);
@@ -788,13 +796,23 @@ export class AgentRunService {
     const seenScopeKeys = new Set<string>();
 
     return routes.map((route) => {
-      if (def.sourceConfig && route.sources.length !== 1) {
-        throw new AgentSourceTargetError("Arc 2 routes must include exactly one source");
+      const sources = [...new Set(route.sources)];
+      if (sources.length === 0) {
+        throw new AgentSourceTargetError("Route must include at least one source");
       }
+      if (sources.length > 1 && route.destination.kind === "self") {
+        throw new AgentDeliveryTargetError("Combined routes cannot use self destination");
+      }
+      let destination = route.destination;
       if (route.destination.kind === "member") {
-        throw new AgentDeliveryTargetError("Member route destinations are not supported until Arc 1b");
+        const raw = route.destination as Record<string, unknown>;
+        const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
+        if (raw.platform !== "slack" || !memberUserId) {
+          throw new AgentDeliveryTargetError("Member route destination must include a Slack member");
+        }
+        destination = { kind: "member", platform: "slack", memberUserId };
       }
-      for (const sourceKey of route.sources) {
+      for (const sourceKey of sources) {
         if (!sourceKeys.has(sourceKey)) {
           throw new AgentSourceTargetError("Route source must be one of the selected sources");
         }
@@ -813,7 +831,7 @@ export class AgentRunService {
       ) {
         throw new AgentSourceTargetError("Route schedule must be a valid hour and minute");
       }
-      const scopeKey = route.sources.length === 1 ? route.sources[0] : `route:${stableRouteHash(route.sources)}`;
+      const scopeKey = sources.length === 1 ? sources[0] : `route:${stableRouteHash(sources)}`;
       if (seenScopeKeys.has(scopeKey)) {
         throw new AgentSourceTargetError("Routes must not duplicate the same output scope");
       }
@@ -821,11 +839,13 @@ export class AgentRunService {
 
       return {
         ...route,
-        id: route.id.trim() || routeIdForSources(route.sources),
+        id: route.id.trim() || routeIdForSources(sources),
+        sources,
         focus: route.focus?.trim() ? route.focus.trim() : null,
         sections: route.sections ? { ...route.sections } : null,
         maxItemsPerSection:
           route.maxItemsPerSection === null ? null : Math.min(range.max, Math.max(range.min, route.maxItemsPerSection)),
+        destination,
         enabled: route.enabled !== false,
       };
     });
@@ -913,6 +933,35 @@ export class AgentRunService {
       ...normalized,
       ...withMentions(await this.resolveDeliveryMentions(normalized, { whatsappGroup: groupMetadata })),
     };
+  }
+
+  async listEligibleRouteMembers(userId: string, sourceKeys: string[]): Promise<AgentRouteMember[]> {
+    const sources = [...new Set(sourceKeys)].map((sourceKey) => parseSourceKey(sourceKey as AgentSourceKey));
+    if (sources.length === 0 || sources.some((source) => source.platform !== "slack")) return [];
+    const slack = this.deps.getSlack?.() ?? null;
+    if (!slack) return [];
+    const requester = await this.deps.users.findById(userId);
+    if (!requester?.slack_user_id) return [];
+    for (const source of sources) {
+      if (source.targetType !== "channel" || !(await slack.isUserInChannel(source.targetId, requester.slack_user_id))) {
+        return [];
+      }
+    }
+
+    const members: AgentRouteMember[] = [];
+    for (const user of await this.deps.users.list()) {
+      if (!user.slack_user_id) continue;
+      let eligible = true;
+      for (const source of sources) {
+        if (source.targetType !== "channel" || !(await slack.isUserInChannel(source.targetId, user.slack_user_id))) {
+          eligible = false;
+          break;
+        }
+      }
+      if (eligible) members.push({ userId: user.id, name: user.name, slackUserId: user.slack_user_id });
+    }
+
+    return members;
   }
 
   private async resolveDeliveryMentions(
@@ -1527,6 +1576,7 @@ export class AgentRunService {
 
   private async deliverCompletedOutput(def: AgentDefinition, outputId: string, userId: string): Promise<void> {
     if (!this.deps.outputDelivery) return;
+    let markFailedOnRouteTargetError = false;
     try {
       const output = await this.repo.findById(def.key, outputId);
       const user = await this.deps.users.findById(userId);
@@ -1534,23 +1584,69 @@ export class AgentRunService {
       const config = await this.resolveConfig(def, userId);
       const scope = await this.resolveScopeForOutput(def, user, config, output);
       if (!scope) return;
-      const configuredDelivery = scope.route ? this.deliveryForRoute(scope.route, scope.sources) : config.delivery;
-      if (!configuredDelivery) return;
-      const delivery = await this.resolveDeliveryConfigForUser(userId, configuredDelivery);
+      let delivery: AgentDeliveryConfig | null;
+      if (scope.route) {
+        markFailedOnRouteTargetError = true;
+        delivery = await this.deliveryForRoute(userId, scope.route, scope.sources);
+      } else {
+        delivery = await this.resolveDeliveryConfigForUser(userId, config.delivery);
+      }
       if (!delivery) return;
       const completed = await this.getByIdForUser(def.key, outputId, userId);
       if (!completed) return;
       await this.deps.outputDelivery.deliver({ definition: def, output: completed, delivery });
     } catch (err) {
+      if (markFailedOnRouteTargetError && err instanceof AgentDeliveryTargetError) {
+        await this.repo.markDeliveryFailed(outputId, err.message);
+      }
       this.deps.logger.warn({ err, agentKey: def.key, outputId, userId }, "Agent: output delivery failed");
     }
   }
 
-  private deliveryForRoute(route: AgentRoute, resolvedSources: AgentSourceConfig[]): AgentDeliveryConfig | null {
+  private async deliveryForRoute(
+    userId: string,
+    route: AgentRoute,
+    resolvedSources: AgentSourceConfig[],
+  ): Promise<AgentDeliveryConfig | null> {
     if (route.destination.kind === "off") return null;
-    if (route.destination.kind === "member") throw new Error("Arc 1b");
-    if (resolvedSources.length !== 1) return null;
-    return sourceAsDelivery(resolvedSources[0]);
+    if (route.destination.kind === "member") {
+      return this.resolveMemberRouteDelivery(route.destination, resolvedSources);
+    }
+    if (resolvedSources.length !== 1) {
+      throw new AgentDeliveryTargetError("Combined routes cannot use self destination");
+    }
+    return this.resolveDeliveryConfigForUser(userId, sourceAsDelivery(resolvedSources[0]));
+  }
+
+  private async resolveMemberRouteDelivery(
+    destination: Extract<AgentRouteDestination, { kind: "member" }>,
+    resolvedSources: AgentSourceConfig[],
+  ): Promise<AgentDeliveryConfig> {
+    const member = await this.deps.users.findById(destination.memberUserId);
+    if (!member?.slack_user_id) {
+      throw new AgentDeliveryTargetError("Recipient is not available for Slack delivery");
+    }
+
+    const slack = this.deps.getSlack?.() ?? null;
+    if (!slack) throw new AgentDeliveryTargetError("Slack is not connected");
+
+    for (const source of resolvedSources) {
+      if (
+        source.platform !== "slack" ||
+        source.targetType !== "channel" ||
+        !(await slack.isUserInChannel(source.targetId, member.slack_user_id))
+      ) {
+        throw new AgentDeliveryTargetError("Recipient is not a member of every source");
+      }
+    }
+
+    return {
+      enabled: true,
+      platform: "slack",
+      targetType: "dm",
+      targetId: member.slack_user_id,
+      label: member.name,
+    };
   }
 
   private createWriter(

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -182,14 +182,22 @@ function stableRouteHash(parts: readonly string[]): string {
   return createHash("sha256").update(parts.join("|")).digest("hex").slice(0, 12);
 }
 
-function routeIdForSources(sources: readonly AgentSourceKey[]): string {
+function canonicalRouteSources(sources: readonly AgentSourceKey[]): AgentSourceKey[] {
+  return [...sources].sort();
+}
+
+function routeScopeKeyForSources(sources: readonly AgentSourceKey[]): string {
   if (sources.length === 1) return sources[0];
-  return `route:${stableRouteHash(sources)}`;
+  return `route:${stableRouteHash(canonicalRouteSources(sources))}`;
+}
+
+function routeIdForSources(sources: readonly AgentSourceKey[]): string {
+  return routeScopeKeyForSources(sources);
 }
 
 export function scopeKeyForRoute(route: Pick<AgentRoute, "sources">, resolvedSources: AgentSourceConfig[]): string {
   if (route.sources.length === 1) return sourceKeyForTarget(resolvedSources[0] ?? parseSourceKey(route.sources[0]));
-  return `route:${stableRouteHash(route.sources)}`;
+  return routeScopeKeyForSources(route.sources);
 }
 
 export function labelForRoute(route: Pick<AgentRoute, "sources">, resolvedSources: AgentSourceConfig[]): string | null {
@@ -444,8 +452,24 @@ function enabledSectionsForRoute(def: AgentDefinition, route: AgentRoute | undef
   return sections;
 }
 
+function enabledSectionsForScope(
+  def: AgentDefinition,
+  config: Pick<ResolvedAgentConfig, "enabledSections">,
+  route: AgentRoute | undefined,
+): Record<string, boolean> {
+  return route ? enabledSectionsForRoute(def, route) : config.enabledSections;
+}
+
 function maxItemsPerSectionForRoute(def: AgentDefinition, route: AgentRoute | undefined): number {
   return route?.maxItemsPerSection ?? def.defaults.maxItemsPerSection;
+}
+
+function maxItemsPerSectionForScope(
+  def: AgentDefinition,
+  config: Pick<ResolvedAgentConfig, "maxItemsPerSection">,
+  route: AgentRoute | undefined,
+): number {
+  return route ? maxItemsPerSectionForRoute(def, route) : config.maxItemsPerSection;
 }
 
 function whatsappNumberToJid(whatsappNumber: string): string {
@@ -831,7 +855,7 @@ export class AgentRunService {
       ) {
         throw new AgentSourceTargetError("Route schedule must be a valid hour and minute");
       }
-      const scopeKey = sources.length === 1 ? sources[0] : `route:${stableRouteHash(sources)}`;
+      const scopeKey = routeScopeKeyForSources(sources);
       if (seenScopeKeys.has(scopeKey)) {
         throw new AgentSourceTargetError("Routes must not duplicate the same output scope");
       }
@@ -1455,8 +1479,8 @@ export class AgentRunService {
       await this.repo.markFailed(outputId, "Generation route was removed.");
       return;
     }
-    const routeSections = enabledSectionsForRoute(def, scope.route);
-    const routeMaxItemsPerSection = maxItemsPerSectionForRoute(def, scope.route);
+    const routeSections = enabledSectionsForScope(def, config, scope.route);
+    const routeMaxItemsPerSection = maxItemsPerSectionForScope(def, config, scope.route);
     const routeFocus = scope.route ? scope.route.focus : config.focus;
     const enabledSections = def.sections.filter((s) => routeSections[s.key]).map((s) => s.key);
 

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -90,6 +90,24 @@ export interface AgentSourceConfig {
   label: string | null;
 }
 
+export type AgentRouteId = string;
+
+export type AgentRouteDestination =
+  | { kind: "self" }
+  | { kind: "off" }
+  | { kind: "member"; platform: "slack"; memberUserId: string };
+
+export interface AgentRoute {
+  id: AgentRouteId;
+  sources: AgentSourceKey[];
+  focus: string | null;
+  sections: Record<string, boolean> | null;
+  maxItemsPerSection: number | null;
+  schedule: { hour: number; minute: number } | null;
+  destination: AgentRouteDestination;
+  enabled: boolean;
+}
+
 /**
  * Per-user reconfiguration of a prebuilt agent. `prefs` carries the additive,
  * structured preferences (section toggles + plain-language focus); agent behavior
@@ -101,6 +119,7 @@ export interface AgentUserPrefs {
   delivery?: AgentDeliveryConfig | null;
   deliveryModel?: AgentDeliveryModel;
   sources?: AgentSourceConfig[];
+  routes?: AgentRoute[];
 }
 
 export interface AgentUserConfig {

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -590,6 +590,15 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
         .execute();
     },
 
+    async markDeliveryFailed(outputId: string, message: string): Promise<void> {
+      await db
+        .updateTable("agent_outputs")
+        .set({ status: "failed", error_message: message, updated_at: new Date().toISOString() })
+        .where("id", "=", outputId)
+        .where("status", "=", "completed")
+        .execute();
+    },
+
     async countKnownEntities(ids: string[]): Promise<number> {
       if (ids.length === 0) return 0;
       const row = await db

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -7,15 +7,16 @@ import {
   type AgentConfig,
   type AgentDeliveryConfig,
   type AgentDeliveryMention,
-  type AgentDeliveryModel,
   type AgentDetailResponse,
   type AgentOutput,
   type AgentOutputsResponse,
+  type AgentRoute,
   type AgentSourceConfig,
   api,
 } from "@/lib/api";
 import {
   ArrowLeftIcon,
+  CaretDownIcon,
   CheckCircleIcon,
   HashIcon,
   PencilSimpleIcon,
@@ -43,7 +44,7 @@ import { toast } from "sonner";
 type Tab = "outputs" | "config";
 type EditField = "schedule" | "focus" | "volume" | "delivery" | "sources" | "routing" | null;
 
-type PerSourceRoute = "self" | "off";
+type RouteDestKind = "self" | "off";
 
 function detailKey(agentKey: string) {
   return ["agents", "detail", agentKey];
@@ -69,39 +70,63 @@ function deliverySummary(delivery: AgentDeliveryConfig | null): string {
 }
 
 /**
- * Reads the per-source route for a source from the delivery model. A source
- * summarizes on its own and either posts back to itself ("self") or stays
- * web-only ("off"). A legacy combined model is shown as "self" in this
- * per-source view; saving migrates it to explicit per-source routes.
+ * A default route for a newly added source: summarize on its own, post back to
+ * the source, inheriting the agent-level focus/sections/volume/schedule (all
+ * null = inherit). The id is the source key — stable and unique per source in
+ * the single-source (Arc 2) model.
  */
-function routeForSource(model: AgentDeliveryModel, source: AgentSourceConfig): PerSourceRoute {
-  if (model.mode !== "per_source") return "self";
-  return model.perSource[sourceKey(source)]?.kind === "self" ? "self" : "off";
+function makeRoute(source: AgentSourceConfig): AgentRoute {
+  return {
+    id: sourceKey(source),
+    sources: [sourceKey(source)] as AgentRoute["sources"],
+    focus: null,
+    sections: null,
+    maxItemsPerSection: null,
+    schedule: null,
+    destination: { kind: "self" },
+    enabled: true,
+  };
 }
 
-function buildDeliveryModel(routes: Record<string, PerSourceRoute>, sources: AgentSourceConfig[]): AgentDeliveryModel {
-  const perSource: Record<string, { kind: PerSourceRoute }> = {};
-  for (const source of sources) {
-    const key = sourceKey(source);
-    perSource[key] = { kind: routes[key] ?? "self" };
-  }
-  return { mode: "per_source", defaultRoute: "off", perSource, combined: null };
+function isRouteCustomized(route: AgentRoute): boolean {
+  return (
+    route.focus !== null || route.sections !== null || route.maxItemsPerSection !== null || route.schedule !== null
+  );
 }
 
 function routingSummary(agent: AgentConfig): string {
-  if (agent.sources.length === 0) return "No sources selected";
-  const posted = agent.sources.filter((source) => routeForSource(agent.deliveryModel, source) === "self").length;
-  const webOnly = agent.sources.length - posted;
-  const parts = [`${agent.sources.length} ${agent.sources.length === 1 ? "source" : "sources"}`];
-  if (posted > 0) parts.push(`${posted} post back`);
+  const routes = agent.routes;
+  if (routes.length === 0) return "No sources selected";
+  const postBack = routes.filter((route) => route.destination.kind === "self").length;
+  const dm = routes.filter((route) => route.destination.kind === "member").length;
+  const webOnly = routes.filter((route) => route.destination.kind === "off").length;
+  const parts = [`${routes.length} ${routes.length === 1 ? "source" : "sources"}`];
+  if (postBack > 0) parts.push(`${postBack} post back`);
+  if (dm > 0) parts.push(`${dm} DM`);
   if (webOnly > 0) parts.push(`${webOnly} web only`);
+  if (routes.some(isRouteCustomized)) parts.push("customized");
   return parts.join(" · ");
 }
 
-function initRoutes(model: AgentDeliveryModel, sources: AgentSourceConfig[]): Record<string, PerSourceRoute> {
-  const out: Record<string, PerSourceRoute> = {};
-  for (const source of sources) out[sourceKey(source)] = routeForSource(model, source);
-  return out;
+/** One-line summary of a route's overrides for the collapsed card. */
+function describeRoute(route: AgentRoute, agent: AgentConfig): string {
+  const parts: string[] = [];
+  if (route.sections) {
+    const on = agent.sections.filter((section) => route.sections?.[section.key] ?? section.enabled);
+    parts.push(
+      on.length === agent.sections.length ? "All sections" : on.map((s) => s.title).join(", ") || "No sections",
+    );
+  }
+  if (route.schedule) parts.push(formatTime(route.schedule.hour, route.schedule.minute));
+  if (route.maxItemsPerSection !== null) parts.push(`up to ${route.maxItemsPerSection}`);
+  if (route.focus) parts.push(`focus: ${route.focus}`);
+  return parts.length === 0 ? "Default settings" : parts.join(" · ");
+}
+
+function destinationLabel(destination: AgentRoute["destination"], sourceLabel: string): string {
+  if (destination.kind === "self") return `Post back to ${sourceLabel}`;
+  if (destination.kind === "member") return "DM a member";
+  return "Web only";
 }
 
 export function AgentDetail({ agentKey }: { agentKey: string }) {
@@ -509,7 +534,7 @@ const EDIT_META: Record<Exclude<EditField, null>, { title: string; hint: string 
   sources: { title: "Sources", hint: "Shared conversations this agent summarizes." },
   routing: {
     title: "Sources & delivery",
-    hint: "Each source is summarized on its own. Choose where its digest goes.",
+    hint: "Each source is its own summary. Open one to tune its focus, sections, schedule, and where it goes.",
   },
   volume: { title: "Volume", hint: "How many items each section can hold." },
   delivery: { title: "Deliver to", hint: "Where completed outputs are sent after generation finishes." },
@@ -533,9 +558,7 @@ function EditDrawer({
   const [minute, setMinute] = useState(agent.scheduleMinute);
   const [focus, setFocus] = useState(agent.focus ?? "");
   const [sources, setSources] = useState<AgentSourceConfig[]>(agent.sources);
-  const [routes, setRoutes] = useState<Record<string, PerSourceRoute>>(() =>
-    initRoutes(agent.deliveryModel, agent.sources),
-  );
+  const [routes, setRoutes] = useState<AgentRoute[]>(agent.routes);
   const [volume, setVolume] = useState(agent.maxItemsPerSection);
   const [delivery, setDelivery] = useState<AgentDeliveryConfig | null>(agent.delivery);
 
@@ -545,7 +568,7 @@ function EditDrawer({
       setMinute(agent.scheduleMinute);
       setFocus(agent.focus ?? "");
       setSources(agent.sources);
-      setRoutes(initRoutes(agent.deliveryModel, agent.sources));
+      setRoutes(agent.routes);
       setVolume(agent.maxItemsPerSection);
       setDelivery(agent.delivery);
     }
@@ -555,7 +578,7 @@ function EditDrawer({
     agent.scheduleMinute,
     agent.focus,
     agent.sources,
-    agent.deliveryModel,
+    agent.routes,
     agent.maxItemsPerSection,
     agent.delivery,
   ]);
@@ -566,8 +589,7 @@ function EditDrawer({
         return api.agents.updateConfig(agentKey, { scheduleHour: hour, scheduleMinute: minute });
       if (field === "focus") return api.agents.updateConfig(agentKey, { focus: focus.trim() ? focus.trim() : null });
       if (field === "sources") return api.agents.updateConfig(agentKey, { sources });
-      if (field === "routing")
-        return api.agents.updateConfig(agentKey, { sources, deliveryModel: buildDeliveryModel(routes, sources) });
+      if (field === "routing") return api.agents.updateConfig(agentKey, { sources, routes });
       if (field === "volume") return api.agents.updateConfig(agentKey, { maxItemsPerSection: volume });
       if (field === "delivery") return api.agents.updateConfig(agentKey, { delivery });
       return Promise.resolve({ agent });
@@ -622,13 +644,12 @@ function EditDrawer({
           ) : field === "sources" && agent.sourceConfig ? (
             <SourceEditor agent={agent} value={sources} onChange={setSources} />
           ) : field === "routing" && agent.sourceConfig ? (
-            <SourcesDeliveryEditor
+            <RoutesEditor
               agent={agent}
-              sources={sources}
               routes={routes}
-              onChange={(nextSources, nextRoutes) => {
-                setSources(nextSources);
+              onChange={(nextRoutes, nextSources) => {
                 setRoutes(nextRoutes);
+                setSources(nextSources);
               }}
             />
           ) : field === "delivery" ? (
@@ -791,40 +812,25 @@ function SourceEditor({
   );
 }
 
-function SourcesDeliveryEditor({
+/**
+ * Routes editor (Arc 2). Each selected source is one route — an independent
+ * digest that can override the agent's focus, sections, volume, and schedule
+ * and choose where its summary is delivered (post back to the source or stay
+ * web-only). Sources and routes are kept in lockstep (one route per source).
+ */
+function RoutesEditor({
   agent,
-  sources,
   routes,
   onChange,
 }: {
   agent: AgentConfig;
-  sources: AgentSourceConfig[];
-  routes: Record<string, PerSourceRoute>;
-  onChange: (sources: AgentSourceConfig[], routes: Record<string, PerSourceRoute>) => void;
+  routes: AgentRoute[];
+  onChange: (routes: AgentRoute[], sources: AgentSourceConfig[]) => void;
 }) {
   const slackChannels = useQuery({ queryKey: ["slack-channels"], queryFn: () => api.channels.listSlack() });
   const whatsappGroups = useQuery({ queryKey: ["whatsapp-groups"], queryFn: () => api.channels.listWhatsAppGroups() });
-  const selected = new Set(sources.map(sourceKey));
+  const [expanded, setExpanded] = useState<string | null>(null);
   const maxSources = agent.sourceConfig?.maxSources ?? 0;
-
-  const toggle = (source: AgentSourceConfig) => {
-    const key = sourceKey(source);
-    if (selected.has(key)) {
-      const nextRoutes = { ...routes };
-      delete nextRoutes[key];
-      onChange(
-        sources.filter((item) => sourceKey(item) !== key),
-        nextRoutes,
-      );
-      return;
-    }
-    if (sources.length >= maxSources) return;
-    onChange([...sources, source], { ...routes, [key]: "self" });
-  };
-
-  const setRoute = (source: AgentSourceConfig, route: PerSourceRoute) => {
-    onChange(sources, { ...routes, [sourceKey(source)]: route });
-  };
 
   const slackOptions = (slackChannels.data?.channels ?? [])
     .filter((channel) => channel.isMember)
@@ -845,58 +851,58 @@ function SourcesDeliveryEditor({
     }),
   );
 
+  const sourceByKey = new Map<string, AgentSourceConfig>();
+  for (const source of [...agent.sources, ...slackOptions, ...whatsappOptions])
+    sourceByKey.set(sourceKey(source), source);
+
+  const routedKeys = new Set<string>(routes.map((route) => route.sources[0]));
+
+  const emit = (next: AgentRoute[]) => {
+    const sources = next
+      .map((route) => sourceByKey.get(route.sources[0]))
+      .filter((source): source is AgentSourceConfig => Boolean(source));
+    onChange(next, sources);
+  };
+
+  const toggleSource = (source: AgentSourceConfig) => {
+    const key = sourceKey(source);
+    if (routedKeys.has(key)) {
+      emit(routes.filter((route) => route.sources[0] !== key));
+      return;
+    }
+    if (routes.length >= maxSources) return;
+    setExpanded(key);
+    emit([...routes, makeRoute(source)]);
+  };
+
+  const updateRoute = (id: string, patch: Partial<AgentRoute>) => {
+    emit(routes.map((route) => (route.id === id ? { ...route, ...patch } : route)));
+  };
+
   return (
     <div className="space-y-5">
       <div>
-        <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Selected</span>
-        {sources.length === 0 ? (
+        <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Routes</span>
+        {routes.length === 0 ? (
           <p className="mt-2 rounded-lg border-[0.5px] border-dashed border-border px-3 py-3 text-[12px] text-muted-foreground">
-            Add a source below. Each source is summarized on its own.
+            Add a source below. Each source becomes its own summary, delivered on its own.
           </p>
         ) : (
           <div className="mt-2 flex flex-col gap-2">
-            {sources.map((source) => {
-              const route = routes[sourceKey(source)] ?? "self";
+            {routes.map((route) => {
+              const source = sourceByKey.get(route.sources[0]) ?? null;
               return (
-                <div key={sourceKey(source)} className="rounded-lg border-[0.5px] border-border px-3 py-2.5">
-                  <div className="flex items-center gap-2">
-                    <span className="shrink-0">
-                      {source.platform === "slack" ? (
-                        <HashIcon size={14} aria-hidden />
-                      ) : (
-                        <UsersThreeIcon size={14} aria-hidden />
-                      )}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-foreground">
-                      {source.label ?? source.targetId}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => toggle(source)}
-                      aria-label={`Remove ${source.label ?? source.targetId}`}
-                      className="shrink-0 text-muted-foreground/50 transition-colors hover:text-foreground"
-                    >
-                      <XIcon size={13} weight="bold" aria-hidden />
-                    </button>
-                  </div>
-                  <div className="mt-2 grid grid-cols-2 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1">
-                    {(["self", "off"] as const).map((option) => (
-                      <button
-                        key={option}
-                        type="button"
-                        onClick={() => setRoute(source, option)}
-                        className={cn(
-                          "rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-colors",
-                          route === option
-                            ? "bg-background text-foreground shadow-sm"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
-                      >
-                        {option === "self" ? "Post back" : "Web only"}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+                <RouteCard
+                  key={route.id}
+                  agent={agent}
+                  route={route}
+                  source={source}
+                  label={source?.label ?? route.sources[0]}
+                  open={expanded === route.id}
+                  onToggleOpen={() => setExpanded(expanded === route.id ? null : route.id)}
+                  onChange={(patch) => updateRoute(route.id, patch)}
+                  onRemove={() => emit(routes.filter((item) => item.id !== route.id))}
+                />
               );
             })}
           </div>
@@ -908,9 +914,9 @@ function SourcesDeliveryEditor({
           title="Add Slack channels"
           loading={slackChannels.isLoading}
           empty="No Slack channels available."
-          selected={selected}
+          selected={routedKeys}
           options={slackOptions}
-          onToggle={toggle}
+          onToggle={toggleSource}
         />
       ) : null}
       {agent.sourceConfig?.supportsWhatsAppGroups ? (
@@ -918,15 +924,233 @@ function SourcesDeliveryEditor({
           title="Add WhatsApp groups"
           loading={whatsappGroups.isLoading}
           empty="No WhatsApp groups available."
-          selected={selected}
+          selected={routedKeys}
           options={whatsappOptions}
-          onToggle={toggle}
+          onToggle={toggleSource}
         />
       ) : null}
       <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
-        {sources.length} selected{maxSources > 0 ? ` · limit ${maxSources}` : ""} · post back = to the source · web only
-        = not posted
+        {routes.length} {routes.length === 1 ? "source" : "sources"}
+        {maxSources > 0 ? ` · limit ${maxSources}` : ""} · open a source to tune its focus, sections, schedule, and
+        delivery
       </p>
+    </div>
+  );
+}
+
+function RouteField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">{label}</span>
+      <div className="mt-1.5">{children}</div>
+    </div>
+  );
+}
+
+const SEGMENT_BASE = "rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-colors";
+const SEGMENT_WRAP = "grid grid-cols-2 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1";
+function segmentClass(active: boolean): string {
+  return cn(
+    SEGMENT_BASE,
+    active ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
+  );
+}
+
+function RouteCard({
+  agent,
+  route,
+  source,
+  label,
+  open,
+  onToggleOpen,
+  onChange,
+  onRemove,
+}: {
+  agent: AgentConfig;
+  route: AgentRoute;
+  source: AgentSourceConfig | null;
+  label: string;
+  open: boolean;
+  onToggleOpen: () => void;
+  onChange: (patch: Partial<AgentRoute>) => void;
+  onRemove: () => void;
+}) {
+  const destKind: RouteDestKind = route.destination.kind === "self" ? "self" : "off";
+  const customSchedule = route.schedule !== null;
+
+  const toggleSection = (key: string, checked: boolean) => {
+    const next: Record<string, boolean> = {};
+    for (const section of agent.sections) next[section.key] = route.sections?.[section.key] ?? section.enabled;
+    next[key] = checked;
+    onChange({ sections: next });
+  };
+
+  return (
+    <div className={cn("rounded-lg border-[0.5px] border-border", !route.enabled && "opacity-60")}>
+      <div className="flex items-center gap-2 px-3 py-2.5">
+        <span className="shrink-0">
+          {source?.platform === "slack" ? <HashIcon size={14} aria-hidden /> : <UsersThreeIcon size={14} aria-hidden />}
+        </span>
+        <button type="button" onClick={onToggleOpen} className="min-w-0 flex-1 text-left">
+          <span className="block truncate text-[12.5px] font-medium text-foreground">{label}</span>
+          <span className="block truncate text-[11px] text-muted-foreground">
+            {destinationLabel(route.destination, label)}
+            {route.enabled ? "" : " · paused"} · {describeRoute(route, agent)}
+          </span>
+        </button>
+        <CaretDownIcon
+          size={13}
+          weight="bold"
+          aria-hidden
+          className={cn("shrink-0 text-muted-foreground/50 transition-transform", open && "rotate-180")}
+        />
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${label}`}
+          className="shrink-0 text-muted-foreground/50 transition-colors hover:text-foreground"
+        >
+          <XIcon size={13} weight="bold" aria-hidden />
+        </button>
+      </div>
+
+      {open ? (
+        <div className="space-y-4 border-t border-border/60 px-3 py-3.5">
+          <RouteField label="Deliver to">
+            <div className={SEGMENT_WRAP}>
+              <button
+                type="button"
+                onClick={() => onChange({ destination: { kind: "self" } })}
+                className={segmentClass(destKind === "self")}
+              >
+                Post back
+              </button>
+              <button
+                type="button"
+                onClick={() => onChange({ destination: { kind: "off" } })}
+                className={segmentClass(destKind === "off")}
+              >
+                Web only
+              </button>
+            </div>
+          </RouteField>
+
+          <RouteField label="Runs on">
+            <div className={SEGMENT_WRAP}>
+              <button
+                type="button"
+                onClick={() => onChange({ schedule: null })}
+                className={segmentClass(!customSchedule)}
+              >
+                Default ({formatTime(agent.scheduleHour, agent.scheduleMinute)})
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  onChange({ schedule: route.schedule ?? { hour: agent.scheduleHour, minute: agent.scheduleMinute } })
+                }
+                className={segmentClass(customSchedule)}
+              >
+                Custom time
+              </button>
+            </div>
+            {route.schedule ? (
+              <div className="mt-2 flex items-center gap-2">
+                <NumberField
+                  label="Hour"
+                  min={0}
+                  max={23}
+                  value={route.schedule.hour}
+                  onChange={(hour) => onChange({ schedule: { hour, minute: route.schedule?.minute ?? 0 } })}
+                />
+                <span className="mt-5 text-muted-foreground">:</span>
+                <NumberField
+                  label="Minute"
+                  min={0}
+                  max={59}
+                  value={route.schedule.minute}
+                  onChange={(minute) => onChange({ schedule: { hour: route.schedule?.hour ?? 0, minute } })}
+                />
+                <span className="mt-5 ml-2 text-[12.5px] text-muted-foreground">
+                  {formatTime(route.schedule.hour, route.schedule.minute)}
+                </span>
+              </div>
+            ) : null}
+          </RouteField>
+
+          <RouteField label="Sections">
+            <div className="flex flex-col gap-1.5">
+              {agent.sections.map((section) => {
+                const checked = route.sections?.[section.key] ?? section.enabled;
+                return (
+                  <label
+                    key={section.key}
+                    className="flex cursor-pointer items-center gap-2 text-[12.5px] text-foreground/90"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => toggleSection(section.key, e.target.checked)}
+                      className="h-3.5 w-3.5 accent-foreground"
+                    />
+                    {section.title}
+                  </label>
+                );
+              })}
+            </div>
+            {route.sections !== null ? (
+              <button
+                type="button"
+                onClick={() => onChange({ sections: null })}
+                className="mt-2 text-[11px] text-muted-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
+              >
+                Reset to default sections
+              </button>
+            ) : null}
+          </RouteField>
+
+          <RouteField label="Focus">
+            <textarea
+              rows={2}
+              value={route.focus ?? ""}
+              onChange={(e) => onChange({ focus: e.target.value.length ? e.target.value : null })}
+              placeholder="e.g. anything blocking delivery for this group"
+              className="w-full resize-none rounded-lg border-[0.5px] border-border bg-background px-3 py-2 text-[12.5px] leading-relaxed text-foreground/90 placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none"
+            />
+          </RouteField>
+
+          <RouteField label="Volume">
+            <div className="flex items-end gap-3">
+              <NumberField
+                label="Items per section"
+                min={agent.itemsPerSectionRange.min}
+                max={agent.itemsPerSectionRange.max}
+                value={route.maxItemsPerSection ?? agent.maxItemsPerSection}
+                onChange={(value) => onChange({ maxItemsPerSection: value })}
+              />
+              {route.maxItemsPerSection !== null ? (
+                <button
+                  type="button"
+                  onClick={() => onChange({ maxItemsPerSection: null })}
+                  className="mb-2 text-[11px] text-muted-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
+                >
+                  Reset to default
+                </button>
+              ) : null}
+            </div>
+          </RouteField>
+
+          <div className="flex items-center gap-3 border-t border-border/50 pt-3">
+            <span className="flex-1 text-[12.5px] font-medium text-foreground">Active</span>
+            <Switch
+              checked={route.enabled}
+              onCheckedChange={(checked) => onChange({ enabled: checked })}
+              aria-label={`${label} active`}
+              className="data-[state=checked]:bg-emerald-500"
+            />
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -11,15 +11,17 @@ import {
   type AgentOutput,
   type AgentOutputsResponse,
   type AgentRoute,
+  type AgentRouteDestination,
   type AgentSourceConfig,
+  type AgentSourceKey,
   api,
 } from "@/lib/api";
 import {
   ArrowLeftIcon,
-  CaretDownIcon,
   CheckCircleIcon,
   HashIcon,
   PencilSimpleIcon,
+  PlusIcon,
   SlackLogoIcon,
   UserIcon,
   UsersThreeIcon,
@@ -42,9 +44,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 type Tab = "outputs" | "config";
-type EditField = "schedule" | "focus" | "volume" | "delivery" | "sources" | "routing" | null;
-
-type RouteDestKind = "self" | "off";
+type EditField = "schedule" | "focus" | "volume" | "delivery" | "sources" | null;
 
 function detailKey(agentKey: string) {
   return ["agents", "detail", agentKey];
@@ -69,66 +69,6 @@ function deliverySummary(delivery: AgentDeliveryConfig | null): string {
   return `WhatsApp ${delivery.label ?? delivery.targetId}${tagged}`;
 }
 
-/**
- * A default route for a newly added source: summarize on its own, post back to
- * the source, inheriting the agent-level focus/sections/volume/schedule (all
- * null = inherit). The id is the source key — stable and unique per source in
- * the single-source (Arc 2) model.
- */
-function makeRoute(source: AgentSourceConfig): AgentRoute {
-  return {
-    id: sourceKey(source),
-    sources: [sourceKey(source)] as AgentRoute["sources"],
-    focus: null,
-    sections: null,
-    maxItemsPerSection: null,
-    schedule: null,
-    destination: { kind: "self" },
-    enabled: true,
-  };
-}
-
-function isRouteCustomized(route: AgentRoute): boolean {
-  return (
-    route.focus !== null || route.sections !== null || route.maxItemsPerSection !== null || route.schedule !== null
-  );
-}
-
-function routingSummary(agent: AgentConfig): string {
-  const routes = agent.routes;
-  if (routes.length === 0) return "No sources selected";
-  const postBack = routes.filter((route) => route.destination.kind === "self").length;
-  const dm = routes.filter((route) => route.destination.kind === "member").length;
-  const webOnly = routes.filter((route) => route.destination.kind === "off").length;
-  const parts = [`${routes.length} ${routes.length === 1 ? "source" : "sources"}`];
-  if (postBack > 0) parts.push(`${postBack} post back`);
-  if (dm > 0) parts.push(`${dm} DM`);
-  if (webOnly > 0) parts.push(`${webOnly} web only`);
-  if (routes.some(isRouteCustomized)) parts.push("customized");
-  return parts.join(" · ");
-}
-
-/** One-line summary of a route's overrides for the collapsed card. */
-function describeRoute(route: AgentRoute, agent: AgentConfig): string {
-  const parts: string[] = [];
-  if (route.sections) {
-    const on = agent.sections.filter((section) => route.sections?.[section.key] ?? section.enabled);
-    parts.push(
-      on.length === agent.sections.length ? "All sections" : on.map((s) => s.title).join(", ") || "No sections",
-    );
-  }
-  if (route.schedule) parts.push(formatTime(route.schedule.hour, route.schedule.minute));
-  if (route.maxItemsPerSection !== null) parts.push(`up to ${route.maxItemsPerSection}`);
-  if (route.focus) parts.push(`focus: ${route.focus}`);
-  return parts.length === 0 ? "Default settings" : parts.join(" · ");
-}
-
-function destinationLabel(destination: AgentRoute["destination"], sourceLabel: string): string {
-  if (destination.kind === "self") return `Post back to ${sourceLabel}`;
-  if (destination.kind === "member") return "DM a member";
-  return "Web only";
-}
-
 export function AgentDetail({ agentKey }: { agentKey: string }) {
   const queryClient = useQueryClient();
   const detailQuery = useQuery({
@@ -143,6 +83,7 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
   });
   const [tab, setTab] = useState<Tab>("outputs");
   const [editing, setEditing] = useState<EditField>(null);
+  const [editingSummariser, setEditingSummariser] = useState<{ route: AgentRoute | null } | null>(null);
   const [selectedOutputId, setSelectedOutputId] = useState<string | null>(null);
 
   const invalidate = () => {
@@ -228,7 +169,13 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
             runPending={runMutation.isPending}
           />
         ) : (
-          <ConfigTab agentKey={agentKey} agent={agent} onEdit={setEditing} onChanged={invalidate} />
+          <ConfigTab
+            agentKey={agentKey}
+            agent={agent}
+            onEdit={setEditing}
+            onEditSummariser={(route) => setEditingSummariser({ route })}
+            onChanged={invalidate}
+          />
         )}
       </div>
 
@@ -239,6 +186,15 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
         onClose={() => setEditing(null)}
         onSaved={invalidate}
       />
+      {editingSummariser ? (
+        <SummariserDrawer
+          agentKey={agentKey}
+          agent={agent}
+          editing={editingSummariser}
+          onClose={() => setEditingSummariser(null)}
+          onSaved={invalidate}
+        />
+      ) : null}
     </Shell>
   );
 }
@@ -397,13 +353,20 @@ function ConfigTab({
   agentKey,
   agent,
   onEdit,
+  onEditSummariser,
   onChanged,
 }: {
   agentKey: string;
   agent: AgentConfig;
   onEdit: (field: EditField) => void;
+  onEditSummariser: (route: AgentRoute | null) => void;
   onChanged: () => void;
 }) {
+  if (agent.sourceConfig) {
+    return (
+      <SummariserConfig agentKey={agentKey} agent={agent} onEditSummariser={onEditSummariser} onChanged={onChanged} />
+    );
+  }
   return (
     <>
       <div className="rounded-xl border-[0.5px] border-border bg-card px-4">
@@ -420,19 +383,12 @@ function ConfigTab({
             {agent.focus ? agent.focus : <span className="text-muted-foreground">None — add what to emphasize.</span>}
           </p>
         </Row>
-        {agent.sourceConfig ? (
-          <Row label="Sources & delivery" onEdit={() => onEdit("routing")}>
-            <p className="line-clamp-2 text-[12.5px] leading-relaxed text-foreground/85">{routingSummary(agent)}</p>
-          </Row>
-        ) : null}
         <Row label="Volume" onEdit={() => onEdit("volume")}>
           <p className="text-[12.5px] text-foreground/85">Up to {agent.maxItemsPerSection} items per section</p>
         </Row>
-        {agent.sourceConfig ? null : (
-          <Row label="Deliver to" onEdit={() => onEdit("delivery")}>
-            <p className="text-[12.5px] text-foreground/85">{deliverySummary(agent.delivery)}</p>
-          </Row>
-        )}
+        <Row label="Deliver to" onEdit={() => onEdit("delivery")}>
+          <p className="text-[12.5px] text-foreground/85">{deliverySummary(agent.delivery)}</p>
+        </Row>
       </div>
 
       <div className="mb-3 mt-7 flex items-baseline justify-between border-b border-border/60 pb-2">
@@ -452,6 +408,183 @@ function ConfigTab({
         ))}
       </div>
     </>
+  );
+}
+
+function routesToSources(routes: AgentRoute[], lookup: Map<string, AgentSourceConfig>): AgentSourceConfig[] {
+  const out: AgentSourceConfig[] = [];
+  const seen = new Set<string>();
+  for (const route of routes) {
+    for (const key of route.sources) {
+      if (seen.has(key)) continue;
+      const source = lookup.get(key);
+      if (source) {
+        seen.add(key);
+        out.push(source);
+      }
+    }
+  }
+  return out;
+}
+
+function deliversLabel(route: AgentRoute): string {
+  if (route.destination.kind === "self") return "Post back";
+  if (route.destination.kind === "member") return "Direct message";
+  return "Web only";
+}
+
+function sectionsLabel(route: AgentRoute, agent: AgentConfig): string {
+  const on = agent.sections.filter((section) => route.sections?.[section.key] ?? section.enabled);
+  if (on.length === agent.sections.length) return "All sections";
+  if (on.length === 0) return "No sections";
+  return on.map((section) => section.title).join(", ");
+}
+
+/**
+ * Summariser config surface for source-backed agents: a shared "what it does"
+ * plus a table of independent summarisers (routes). Each row maps input
+ * conversations to a delivery, schedule, and sections; editing opens the drawer.
+ */
+function SummariserConfig({
+  agentKey,
+  agent,
+  onEditSummariser,
+  onChanged,
+}: {
+  agentKey: string;
+  agent: AgentConfig;
+  onEditSummariser: (route: AgentRoute | null) => void;
+  onChanged: () => void;
+}) {
+  const lookup = new Map(agent.sources.map((source) => [sourceKey(source), source] as const));
+  const maxSources = agent.sourceConfig?.maxSources ?? 0;
+  const save = useMutation({
+    mutationFn: (routes: AgentRoute[]) =>
+      api.agents.updateConfig(agentKey, { sources: routesToSources(routes, lookup), routes }),
+    onSuccess: onChanged,
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to update"),
+  });
+
+  return (
+    <>
+      <div className="rounded-xl border-[0.5px] border-border bg-card px-4">
+        <Row label="What it does">
+          <p className="text-[12.5px] leading-relaxed text-foreground/85">{agent.description}</p>
+        </Row>
+      </div>
+
+      <div className="mb-3 mt-7 flex items-center justify-between border-b border-border/60 pb-2">
+        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Summarisers</span>
+        <button
+          type="button"
+          onClick={() => onEditSummariser(null)}
+          className="inline-flex items-center gap-1.5 rounded-full border-[0.5px] border-border px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted/50"
+        >
+          <PlusIcon size={13} weight="bold" aria-hidden />
+          New summariser
+        </button>
+      </div>
+
+      {agent.routes.length === 0 ? (
+        <EmptyCard>No summarisers yet. Add one to start delivering digests.</EmptyCard>
+      ) : (
+        <div className="overflow-hidden rounded-xl border-[0.5px] border-border">
+          <div className="flex items-center gap-3 border-b-[0.5px] border-border bg-muted/20 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground/70">
+            <span className="flex-[2]">Input</span>
+            <span className="flex-[2]">Delivers to</span>
+            <span className="w-14">Runs</span>
+            <span className="hidden flex-[2] sm:block">Sections</span>
+            <span className="w-16 text-right">&nbsp;</span>
+          </div>
+          {agent.routes.map((route) => (
+            <SummariserRow
+              key={route.id}
+              agent={agent}
+              route={route}
+              lookup={lookup}
+              busy={save.isPending}
+              onEdit={() => onEditSummariser(route)}
+              onToggle={(enabled) => save.mutate(agent.routes.map((r) => (r.id === route.id ? { ...r, enabled } : r)))}
+              onRemove={() => save.mutate(agent.routes.filter((r) => r.id !== route.id))}
+            />
+          ))}
+        </div>
+      )}
+      <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
+        {agent.routes.length} {agent.routes.length === 1 ? "summariser" : "summarisers"}
+        {maxSources > 0 ? ` · limit ${maxSources} inputs` : ""}
+      </p>
+    </>
+  );
+}
+
+function SummariserRow({
+  agent,
+  route,
+  lookup,
+  busy,
+  onEdit,
+  onToggle,
+  onRemove,
+}: {
+  agent: AgentConfig;
+  route: AgentRoute;
+  lookup: Map<string, AgentSourceConfig>;
+  busy: boolean;
+  onEdit: () => void;
+  onToggle: (enabled: boolean) => void;
+  onRemove: () => void;
+}) {
+  const first = lookup.get(route.sources[0]);
+  const inputLabel = first?.label ?? route.sources[0];
+  const combined = route.sources.length > 1;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 border-b-[0.5px] border-border px-4 py-3 last:border-0",
+        !route.enabled && "opacity-55",
+      )}
+    >
+      <button type="button" onClick={onEdit} className="flex min-w-0 flex-1 items-center gap-3 text-left">
+        <span className="flex min-w-0 flex-[2] items-center gap-1.5">
+          {first?.platform === "slack" ? (
+            <HashIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
+          ) : (
+            <UsersThreeIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
+          )}
+          <span className="truncate text-[12.5px] font-medium text-foreground">{inputLabel}</span>
+          {combined ? (
+            <span className="shrink-0 text-[11px] text-muted-foreground">+{route.sources.length - 1}</span>
+          ) : null}
+        </span>
+        <span className="flex-[2] truncate text-[12px] text-muted-foreground">{deliversLabel(route)}</span>
+        <span className="w-14 shrink-0 text-[12px] text-muted-foreground">
+          {formatTime(route.schedule?.hour ?? agent.scheduleHour, route.schedule?.minute ?? agent.scheduleMinute)}
+        </span>
+        <span className="hidden flex-[2] truncate text-[12px] text-muted-foreground sm:block">
+          {sectionsLabel(route, agent)}
+        </span>
+      </button>
+      <div className="flex w-16 shrink-0 items-center justify-end gap-2.5">
+        <Switch
+          checked={route.enabled}
+          disabled={busy}
+          onCheckedChange={onToggle}
+          aria-label={`${inputLabel} active`}
+          className="scale-90 data-[state=checked]:bg-emerald-500"
+        />
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={busy}
+          aria-label={`Remove ${inputLabel}`}
+          className="text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-40"
+        >
+          <XIcon size={13} weight="bold" aria-hidden />
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -532,10 +665,6 @@ const EDIT_META: Record<Exclude<EditField, null>, { title: string; hint: string 
   schedule: { title: "Runs on", hint: "When the agent runs each day, in your timezone." },
   focus: { title: "Focus", hint: "Plain-language emphasis. Added as a hint — it never overrides what the agent does." },
   sources: { title: "Sources", hint: "Shared conversations this agent summarizes." },
-  routing: {
-    title: "Sources & delivery",
-    hint: "Each source is its own summary. Open one to tune its focus, sections, schedule, and where it goes.",
-  },
   volume: { title: "Volume", hint: "How many items each section can hold." },
   delivery: { title: "Deliver to", hint: "Where completed outputs are sent after generation finishes." },
 };
@@ -558,7 +687,6 @@ function EditDrawer({
   const [minute, setMinute] = useState(agent.scheduleMinute);
   const [focus, setFocus] = useState(agent.focus ?? "");
   const [sources, setSources] = useState<AgentSourceConfig[]>(agent.sources);
-  const [routes, setRoutes] = useState<AgentRoute[]>(agent.routes);
   const [volume, setVolume] = useState(agent.maxItemsPerSection);
   const [delivery, setDelivery] = useState<AgentDeliveryConfig | null>(agent.delivery);
 
@@ -568,7 +696,6 @@ function EditDrawer({
       setMinute(agent.scheduleMinute);
       setFocus(agent.focus ?? "");
       setSources(agent.sources);
-      setRoutes(agent.routes);
       setVolume(agent.maxItemsPerSection);
       setDelivery(agent.delivery);
     }
@@ -578,7 +705,6 @@ function EditDrawer({
     agent.scheduleMinute,
     agent.focus,
     agent.sources,
-    agent.routes,
     agent.maxItemsPerSection,
     agent.delivery,
   ]);
@@ -589,7 +715,6 @@ function EditDrawer({
         return api.agents.updateConfig(agentKey, { scheduleHour: hour, scheduleMinute: minute });
       if (field === "focus") return api.agents.updateConfig(agentKey, { focus: focus.trim() ? focus.trim() : null });
       if (field === "sources") return api.agents.updateConfig(agentKey, { sources });
-      if (field === "routing") return api.agents.updateConfig(agentKey, { sources, routes });
       if (field === "volume") return api.agents.updateConfig(agentKey, { maxItemsPerSection: volume });
       if (field === "delivery") return api.agents.updateConfig(agentKey, { delivery });
       return Promise.resolve({ agent });
@@ -643,15 +768,6 @@ function EditDrawer({
             />
           ) : field === "sources" && agent.sourceConfig ? (
             <SourceEditor agent={agent} value={sources} onChange={setSources} />
-          ) : field === "routing" && agent.sourceConfig ? (
-            <RoutesEditor
-              agent={agent}
-              routes={routes}
-              onChange={(nextRoutes, nextSources) => {
-                setRoutes(nextRoutes);
-                setSources(nextSources);
-              }}
-            />
           ) : field === "delivery" ? (
             <DeliveryEditor value={delivery} sources={agent.sources} onChange={setDelivery} />
           ) : null}
@@ -813,24 +929,41 @@ function SourceEditor({
 }
 
 /**
- * Routes editor (Arc 2). Each selected source is one route — an independent
- * digest that can override the agent's focus, sections, volume, and schedule
- * and choose where its summary is delivered (post back to the source or stay
- * web-only). Sources and routes are kept in lockstep (one route per source).
+ * Editor drawer for a single summariser (route). Pick one or more input
+ * conversations, where the finished summary goes (post it back to a single
+ * source, keep it web-only, or DM a member who belongs to every source), and
+ * the schedule, sections, focus, and volume for that summariser alone. Each
+ * summariser is self-contained: it always stores explicit values, never
+ * inheriting the agent's defaults.
  */
-function RoutesEditor({
+function SummariserDrawer({
+  agentKey,
   agent,
-  routes,
-  onChange,
+  editing,
+  onClose,
+  onSaved,
 }: {
+  agentKey: string;
   agent: AgentConfig;
-  routes: AgentRoute[];
-  onChange: (routes: AgentRoute[], sources: AgentSourceConfig[]) => void;
+  editing: { route: AgentRoute | null };
+  onClose: () => void;
+  onSaved: () => void;
 }) {
   const slackChannels = useQuery({ queryKey: ["slack-channels"], queryFn: () => api.channels.listSlack() });
   const whatsappGroups = useQuery({ queryKey: ["whatsapp-groups"], queryFn: () => api.channels.listWhatsAppGroups() });
-  const [expanded, setExpanded] = useState<string | null>(null);
   const maxSources = agent.sourceConfig?.maxSources ?? 0;
+
+  const route = editing.route;
+  const [sources, setSources] = useState<AgentSourceKey[]>(route?.sources ?? []);
+  const [destKind, setDestKind] = useState<AgentRouteDestination["kind"]>(route?.destination.kind ?? "off");
+  const [memberUserId, setMemberUserId] = useState<string | null>(
+    route?.destination.kind === "member" ? route.destination.memberUserId : null,
+  );
+  const [hour, setHour] = useState(route?.schedule?.hour ?? agent.scheduleHour);
+  const [minute, setMinute] = useState(route?.schedule?.minute ?? agent.scheduleMinute);
+  const [sections, setSections] = useState<Record<string, boolean>>(defaultSections(agent, route));
+  const [focus, setFocus] = useState(route?.focus ?? "");
+  const [volume, setVolume] = useState(route?.maxItemsPerSection ?? agent.maxItemsPerSection);
 
   const slackOptions = (slackChannels.data?.channels ?? [])
     .filter((channel) => channel.isMember)
@@ -850,309 +983,251 @@ function RoutesEditor({
       label: group.name,
     }),
   );
+  const lookup = new Map<string, AgentSourceConfig>();
+  for (const source of [...agent.sources, ...slackOptions, ...whatsappOptions]) lookup.set(sourceKey(source), source);
 
-  const sourceByKey = new Map<string, AgentSourceConfig>();
-  for (const source of [...agent.sources, ...slackOptions, ...whatsappOptions])
-    sourceByKey.set(sourceKey(source), source);
+  const selectedKeys = new Set<string>(sources);
+  const combined = sources.length > 1;
+  const hasWhatsApp = sources.some((key) => key.startsWith("whatsapp:"));
 
-  const routedKeys = new Set<string>(routes.map((route) => route.sources[0]));
-
-  const emit = (next: AgentRoute[]) => {
-    const sources = next
-      .map((route) => sourceByKey.get(route.sources[0]))
-      .filter((source): source is AgentSourceConfig => Boolean(source));
-    onChange(next, sources);
-  };
+  useEffect(() => {
+    if (destKind === "self" && sources.length !== 1) setDestKind("off");
+  }, [destKind, sources.length]);
 
   const toggleSource = (source: AgentSourceConfig) => {
-    const key = sourceKey(source);
-    if (routedKeys.has(key)) {
-      emit(routes.filter((route) => route.sources[0] !== key));
+    const key = sourceKey(source) as AgentSourceKey;
+    if (selectedKeys.has(key)) {
+      setSources(sources.filter((item) => item !== key));
       return;
     }
-    if (routes.length >= maxSources) return;
-    setExpanded(key);
-    emit([...routes, makeRoute(source)]);
+    if (maxSources > 0 && sources.length >= maxSources) return;
+    setSources([...sources, key]);
   };
 
-  const updateRoute = (id: string, patch: Partial<AgentRoute>) => {
-    emit(routes.map((route) => (route.id === id ? { ...route, ...patch } : route)));
-  };
+  const memberQuery = useQuery({
+    queryKey: ["route-members", agentKey, sources],
+    queryFn: () => api.agents.routeMembers(agentKey, sources),
+    enabled: destKind === "member" && sources.length > 0 && !hasWhatsApp,
+  });
+
+  const save = useMutation({
+    mutationFn: () => {
+      const destination: AgentRouteDestination =
+        destKind === "self"
+          ? { kind: "self" }
+          : destKind === "member" && memberUserId
+            ? { kind: "member", platform: "slack", memberUserId }
+            : { kind: "off" };
+      const next: AgentRoute = {
+        id: route?.id ?? crypto.randomUUID(),
+        sources,
+        focus: focus.trim() ? focus.trim() : null,
+        sections,
+        maxItemsPerSection: volume,
+        schedule: { hour, minute },
+        destination,
+        enabled: route?.enabled ?? true,
+      };
+      const routes = route ? agent.routes.map((item) => (item.id === route.id ? next : item)) : [...agent.routes, next];
+      return api.agents.updateConfig(agentKey, { sources: routesToSources(routes, lookup), routes });
+    },
+    onSuccess: () => {
+      onSaved();
+      toast.success("Saved");
+      onClose();
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to save"),
+  });
+
+  const saveDisabled =
+    save.isPending ||
+    sources.length === 0 ||
+    (destKind === "self" && sources.length !== 1) ||
+    (destKind === "member" && (!memberUserId || hasWhatsApp));
+
+  const destOptions: Array<{ value: AgentRouteDestination["kind"]; label: string; disabled: boolean; hint?: string }> =
+    [
+      { value: "self", label: "Post back", disabled: combined, hint: combined ? "single input only" : undefined },
+      { value: "off", label: "Web only", disabled: false },
+      {
+        value: "member",
+        label: "DM a member",
+        disabled: !agent.sourceConfig?.supportsSlackChannels || hasWhatsApp,
+        hint: hasWhatsApp ? "Slack only" : undefined,
+      },
+    ];
 
   return (
-    <div className="space-y-5">
-      <div>
-        <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Routes</span>
-        {routes.length === 0 ? (
-          <p className="mt-2 rounded-lg border-[0.5px] border-dashed border-border px-3 py-3 text-[12px] text-muted-foreground">
-            Add a source below. Each source becomes its own summary, delivered on its own.
-          </p>
-        ) : (
-          <div className="mt-2 flex flex-col gap-2">
-            {routes.map((route) => {
-              const source = sourceByKey.get(route.sources[0]) ?? null;
-              return (
-                <RouteCard
-                  key={route.id}
-                  agent={agent}
-                  route={route}
-                  source={source}
-                  label={source?.label ?? route.sources[0]}
-                  open={expanded === route.id}
-                  onToggleOpen={() => setExpanded(expanded === route.id ? null : route.id)}
-                  onChange={(patch) => updateRoute(route.id, patch)}
-                  onRemove={() => emit(routes.filter((item) => item.id !== route.id))}
-                />
-              );
-            })}
+    <Sheet open onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-y-auto sm:max-w-[480px]">
+        <SheetHeader>
+          <SheetTitle>{route ? "Edit summariser" : "New summariser"}</SheetTitle>
+          <SheetDescription>
+            Pick the conversations to summarise, where the summary goes, and when it runs.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-6 px-4 py-4">
+          <div className="space-y-4">
+            {agent.sourceConfig?.supportsSlackChannels ? (
+              <SourceGroup
+                title="Slack channels"
+                loading={slackChannels.isLoading}
+                empty="No Slack channels available."
+                selected={selectedKeys}
+                options={slackOptions}
+                onToggle={toggleSource}
+              />
+            ) : null}
+            {agent.sourceConfig?.supportsWhatsAppGroups ? (
+              <SourceGroup
+                title="WhatsApp groups"
+                loading={whatsappGroups.isLoading}
+                empty="No WhatsApp groups available."
+                selected={selectedKeys}
+                options={whatsappOptions}
+                onToggle={toggleSource}
+              />
+            ) : null}
+            <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
+              {sources.length} selected
+              {maxSources > 0 ? ` · limit ${maxSources}` : ""}
+              {combined ? " · combined into one summary" : ""}
+            </p>
           </div>
-        )}
-      </div>
 
-      {agent.sourceConfig?.supportsSlackChannels ? (
-        <SourceGroup
-          title="Add Slack channels"
-          loading={slackChannels.isLoading}
-          empty="No Slack channels available."
-          selected={routedKeys}
-          options={slackOptions}
-          onToggle={toggleSource}
-        />
-      ) : null}
-      {agent.sourceConfig?.supportsWhatsAppGroups ? (
-        <SourceGroup
-          title="Add WhatsApp groups"
-          loading={whatsappGroups.isLoading}
-          empty="No WhatsApp groups available."
-          selected={routedKeys}
-          options={whatsappOptions}
-          onToggle={toggleSource}
-        />
-      ) : null}
-      <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
-        {routes.length} {routes.length === 1 ? "source" : "sources"}
-        {maxSources > 0 ? ` · limit ${maxSources}` : ""} · open a source to tune its focus, sections, schedule, and
-        delivery
-      </p>
-    </div>
-  );
-}
-
-function RouteField({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">{label}</span>
-      <div className="mt-1.5">{children}</div>
-    </div>
-  );
-}
-
-const SEGMENT_BASE = "rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-colors";
-const SEGMENT_WRAP = "grid grid-cols-2 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1";
-function segmentClass(active: boolean): string {
-  return cn(
-    SEGMENT_BASE,
-    active ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
-  );
-}
-
-function RouteCard({
-  agent,
-  route,
-  source,
-  label,
-  open,
-  onToggleOpen,
-  onChange,
-  onRemove,
-}: {
-  agent: AgentConfig;
-  route: AgentRoute;
-  source: AgentSourceConfig | null;
-  label: string;
-  open: boolean;
-  onToggleOpen: () => void;
-  onChange: (patch: Partial<AgentRoute>) => void;
-  onRemove: () => void;
-}) {
-  const destKind: RouteDestKind = route.destination.kind === "self" ? "self" : "off";
-  const customSchedule = route.schedule !== null;
-
-  const toggleSection = (key: string, checked: boolean) => {
-    const next: Record<string, boolean> = {};
-    for (const section of agent.sections) next[section.key] = route.sections?.[section.key] ?? section.enabled;
-    next[key] = checked;
-    onChange({ sections: next });
-  };
-
-  return (
-    <div className={cn("rounded-lg border-[0.5px] border-border", !route.enabled && "opacity-60")}>
-      <div className="flex items-center gap-2 px-3 py-2.5">
-        <span className="shrink-0">
-          {source?.platform === "slack" ? <HashIcon size={14} aria-hidden /> : <UsersThreeIcon size={14} aria-hidden />}
-        </span>
-        <button type="button" onClick={onToggleOpen} className="min-w-0 flex-1 text-left">
-          <span className="block truncate text-[12.5px] font-medium text-foreground">{label}</span>
-          <span className="block truncate text-[11px] text-muted-foreground">
-            {destinationLabel(route.destination, label)}
-            {route.enabled ? "" : " · paused"} · {describeRoute(route, agent)}
-          </span>
-        </button>
-        <CaretDownIcon
-          size={13}
-          weight="bold"
-          aria-hidden
-          className={cn("shrink-0 text-muted-foreground/50 transition-transform", open && "rotate-180")}
-        />
-        <button
-          type="button"
-          onClick={onRemove}
-          aria-label={`Remove ${label}`}
-          className="shrink-0 text-muted-foreground/50 transition-colors hover:text-foreground"
-        >
-          <XIcon size={13} weight="bold" aria-hidden />
-        </button>
-      </div>
-
-      {open ? (
-        <div className="space-y-4 border-t border-border/60 px-3 py-3.5">
-          <RouteField label="Deliver to">
-            <div className={SEGMENT_WRAP}>
-              <button
-                type="button"
-                onClick={() => onChange({ destination: { kind: "self" } })}
-                className={segmentClass(destKind === "self")}
-              >
-                Post back
-              </button>
-              <button
-                type="button"
-                onClick={() => onChange({ destination: { kind: "off" } })}
-                className={segmentClass(destKind === "off")}
-              >
-                Web only
-              </button>
+          <div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
+              Delivers to
+            </span>
+            <div className="mt-2 grid grid-cols-3 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1">
+              {destOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  disabled={option.disabled}
+                  onClick={() => setDestKind(option.value)}
+                  className={cn(
+                    "flex flex-col items-center justify-center rounded-md px-2 py-1.5 text-[12px] font-medium transition-colors",
+                    destKind === option.value
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                    option.disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+                  )}
+                >
+                  {option.label}
+                  {option.hint ? <span className="text-[9px] text-muted-foreground/70">{option.hint}</span> : null}
+                </button>
+              ))}
             </div>
-          </RouteField>
-
-          <RouteField label="Runs on">
-            <div className={SEGMENT_WRAP}>
-              <button
-                type="button"
-                onClick={() => onChange({ schedule: null })}
-                className={segmentClass(!customSchedule)}
-              >
-                Default ({formatTime(agent.scheduleHour, agent.scheduleMinute)})
-              </button>
-              <button
-                type="button"
-                onClick={() =>
-                  onChange({ schedule: route.schedule ?? { hour: agent.scheduleHour, minute: agent.scheduleMinute } })
-                }
-                className={segmentClass(customSchedule)}
-              >
-                Custom time
-              </button>
-            </div>
-            {route.schedule ? (
-              <div className="mt-2 flex items-center gap-2">
-                <NumberField
-                  label="Hour"
-                  min={0}
-                  max={23}
-                  value={route.schedule.hour}
-                  onChange={(hour) => onChange({ schedule: { hour, minute: route.schedule?.minute ?? 0 } })}
-                />
-                <span className="mt-5 text-muted-foreground">:</span>
-                <NumberField
-                  label="Minute"
-                  min={0}
-                  max={59}
-                  value={route.schedule.minute}
-                  onChange={(minute) => onChange({ schedule: { hour: route.schedule?.hour ?? 0, minute } })}
-                />
-                <span className="mt-5 ml-2 text-[12.5px] text-muted-foreground">
-                  {formatTime(route.schedule.hour, route.schedule.minute)}
-                </span>
+            {destKind === "member" ? (
+              <div className="mt-2">
+                {hasWhatsApp ? (
+                  <p className="px-1 py-2 text-[12px] text-muted-foreground">
+                    Member DM works with Slack sources only. Remove the WhatsApp source to pick a member.
+                  </p>
+                ) : (
+                  <TargetList
+                    loading={memberQuery.isLoading}
+                    empty="No member is in every selected source."
+                    selectedId={memberUserId ?? ""}
+                    options={(memberQuery.data?.members ?? []).map((member) => ({
+                      id: member.userId,
+                      label: member.name,
+                      icon: <UserIcon size={14} aria-hidden />,
+                    }))}
+                    onSelect={(id) => setMemberUserId(id)}
+                  />
+                )}
+                <p className="mt-1.5 text-[11px] leading-relaxed text-muted-foreground/70">
+                  Only members of every selected source appear — the summary can never reach someone outside the inputs.
+                </p>
               </div>
             ) : null}
-          </RouteField>
+          </div>
 
-          <RouteField label="Sections">
-            <div className="flex flex-col gap-1.5">
-              {agent.sections.map((section) => {
-                const checked = route.sections?.[section.key] ?? section.enabled;
-                return (
-                  <label
-                    key={section.key}
-                    className="flex cursor-pointer items-center gap-2 text-[12.5px] text-foreground/90"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(e) => toggleSection(section.key, e.target.checked)}
-                      className="h-3.5 w-3.5 accent-foreground"
-                    />
-                    {section.title}
-                  </label>
-                );
-              })}
+          <div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Runs on</span>
+            <div className="mt-2 flex items-center gap-2">
+              <NumberField label="Hour" min={0} max={23} value={hour} onChange={setHour} />
+              <span className="mt-5 text-muted-foreground">:</span>
+              <NumberField label="Minute" min={0} max={59} value={minute} onChange={setMinute} />
+              <span className="mt-5 ml-2 text-[12.5px] text-muted-foreground">{formatTime(hour, minute)}</span>
             </div>
-            {route.sections !== null ? (
-              <button
-                type="button"
-                onClick={() => onChange({ sections: null })}
-                className="mt-2 text-[11px] text-muted-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
-              >
-                Reset to default sections
-              </button>
-            ) : null}
-          </RouteField>
+          </div>
 
-          <RouteField label="Focus">
+          <div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Sections</span>
+            <div className="mt-2 flex flex-col gap-1.5">
+              {agent.sections.map((section) => (
+                <label
+                  key={section.key}
+                  className="flex cursor-pointer items-center gap-2 text-[12.5px] text-foreground/90"
+                >
+                  <input
+                    type="checkbox"
+                    checked={sections[section.key] ?? section.enabled}
+                    onChange={(e) => setSections({ ...sections, [section.key]: e.target.checked })}
+                    className="h-3.5 w-3.5 accent-foreground"
+                  />
+                  {section.title}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Focus</span>
             <textarea
               rows={2}
-              value={route.focus ?? ""}
-              onChange={(e) => onChange({ focus: e.target.value.length ? e.target.value : null })}
+              value={focus}
+              onChange={(e) => setFocus(e.target.value)}
               placeholder="e.g. anything blocking delivery for this group"
-              className="w-full resize-none rounded-lg border-[0.5px] border-border bg-background px-3 py-2 text-[12.5px] leading-relaxed text-foreground/90 placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none"
+              className="mt-2 w-full resize-none rounded-lg border-[0.5px] border-border bg-background px-3 py-2 text-[12.5px] leading-relaxed text-foreground/90 placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none"
             />
-          </RouteField>
+          </div>
 
-          <RouteField label="Volume">
-            <div className="flex items-end gap-3">
+          <div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Volume</span>
+            <div className="mt-2">
               <NumberField
                 label="Items per section"
                 min={agent.itemsPerSectionRange.min}
                 max={agent.itemsPerSectionRange.max}
-                value={route.maxItemsPerSection ?? agent.maxItemsPerSection}
-                onChange={(value) => onChange({ maxItemsPerSection: value })}
+                value={volume}
+                onChange={setVolume}
               />
-              {route.maxItemsPerSection !== null ? (
-                <button
-                  type="button"
-                  onClick={() => onChange({ maxItemsPerSection: null })}
-                  className="mb-2 text-[11px] text-muted-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
-                >
-                  Reset to default
-                </button>
-              ) : null}
             </div>
-          </RouteField>
-
-          <div className="flex items-center gap-3 border-t border-border/50 pt-3">
-            <span className="flex-1 text-[12.5px] font-medium text-foreground">Active</span>
-            <Switch
-              checked={route.enabled}
-              onCheckedChange={(checked) => onChange({ enabled: checked })}
-              aria-label={`${label} active`}
-              className="data-[state=checked]:bg-emerald-500"
-            />
           </div>
         </div>
-      ) : null}
-    </div>
+
+        <SheetFooter className="flex-row justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border-[0.5px] border-border px-4 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => save.mutate()}
+            disabled={saveDisabled}
+            className="inline-flex items-center gap-1.5 rounded-full bg-foreground px-4 py-1.5 text-[12px] font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            <CheckCircleIcon size={13} weight="bold" aria-hidden />
+            Save
+          </button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   );
+}
+
+function defaultSections(agent: AgentConfig, route: AgentRoute | null): Record<string, boolean> {
+  const record: Record<string, boolean> = {};
+  for (const section of agent.sections) record[section.key] = route?.sections?.[section.key] ?? section.enabled;
+  return record;
 }
 
 function SourceGroup({

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1069,6 +1069,8 @@ export interface AgentSourceConfig {
   label: string | null;
 }
 
+export type AgentSourceKey = `${AgentSourceConfig["platform"]}:${AgentSourceConfig["targetType"]}:${string}`;
+
 export type AgentPerSourceDelivery =
   | { kind: "self" }
   | { kind: "off" }
@@ -1085,6 +1087,22 @@ export type AgentDeliveryModel =
       mode: "combined";
       combined: AgentCombinedDeliveryConfig;
     };
+
+export type AgentRouteDestination =
+  | { kind: "self" }
+  | { kind: "off" }
+  | { kind: "member"; platform: "slack"; memberUserId: string };
+
+export interface AgentRoute {
+  id: string;
+  sources: AgentSourceKey[];
+  focus: string | null;
+  sections: Record<string, boolean> | null;
+  maxItemsPerSection: number | null;
+  schedule: { hour: number; minute: number } | null;
+  destination: AgentRouteDestination;
+  enabled: boolean;
+}
 
 export interface AgentSourceConfigMeta {
   maxSources: number;
@@ -1105,9 +1123,9 @@ export interface AgentConfig {
   itemsPerSectionRange: { min: number; max: number };
   focus: string | null;
   delivery: AgentDeliveryConfig | null;
-  deliveryModel: AgentDeliveryModel;
   sourceConfig: AgentSourceConfigMeta | null;
   sources: AgentSourceConfig[];
+  routes: AgentRoute[];
   sections: AgentSectionConfig[];
 }
 
@@ -1163,8 +1181,8 @@ export interface AgentConfigPatch {
   sections?: Record<string, boolean>;
   focus?: string | null;
   delivery?: AgentDeliveryConfig | null;
-  deliveryModel?: AgentDeliveryModel;
   sources?: AgentSourceConfig[];
+  routes?: AgentRoute[];
 }
 
 export interface AgentOutputsResponse {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1104,6 +1104,12 @@ export interface AgentRoute {
   enabled: boolean;
 }
 
+export interface AgentRouteMember {
+  userId: string;
+  name: string;
+  slackUserId: string;
+}
+
 export interface AgentSourceConfigMeta {
   maxSources: number;
   supportsSlackChannels: boolean;
@@ -1298,6 +1304,12 @@ export const api = {
       return request<{ agent: AgentConfig }>(`/api/agents/${agentKey}/config`, {
         method: "PUT",
         body: JSON.stringify(patch),
+      });
+    },
+    routeMembers(agentKey: string, sources: AgentSourceKey[]) {
+      return request<{ members: AgentRouteMember[] }>(`/api/agents/${agentKey}/route-members`, {
+        method: "POST",
+        body: JSON.stringify({ sources }),
       });
     },
     run(agentKey: string) {


### PR DESCRIPTION
Stack: 2/7
Base: feat/summarizer-routing-core
Merge after: feat: per-source summariser routing core
Merge before: feat: add summariser destination setup UI

Summary:
- Add the routes model for combining sources and targeting member DMs.
- Add route-aware backend behavior for configured summary delivery.
- Replace the early config surface with a table-first add/edit drawer.

Verification:
- pnpm biome check
- pnpm typecheck
- pnpm test
- pnpm build

All stack tips were checked locally under Node v24.8.0; the pushed stack also passed the pre-push hook under Node v24.8.0.