### PR TITLE
feat: add summariser destination setup UI

### DIFF
--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -245,6 +245,113 @@ describe("agentRoutes", () => {
     );
   });
 
+  it("parses Slack channel route destinations and rejects invalid channel targets", async () => {
+    const service = createService({
+      updateConfigForUser: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, routes: [] })),
+    });
+    const app = createRoutesTestApp(service);
+    const configUrl = `/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`;
+    const route = {
+      id: "alpha-channel-route",
+      sources: ["slack:channel:C_ALPHA"],
+      focus: null,
+      sections: null,
+      maxItemsPerSection: null,
+      schedule: null,
+      enabled: true,
+    };
+
+    const valid = await app.request(configUrl, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [{ platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" }],
+        routes: [
+          {
+            ...route,
+            destination: {
+              kind: "channel",
+              platform: "slack",
+              targetType: "channel",
+              targetId: "  C_DEST  ",
+              label: "  Leadership  ",
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(valid.status).toBe(200);
+    expect(service.updateConfigForUser).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "user-1",
+      expect.objectContaining({
+        routes: [
+          expect.objectContaining({
+            destination: {
+              kind: "channel",
+              platform: "slack",
+              targetType: "channel",
+              targetId: "C_DEST",
+              label: "Leadership",
+            },
+          }),
+        ],
+      }),
+    );
+
+    const wrongTargetType = await app.request(configUrl, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [{ platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" }],
+        routes: [
+          {
+            ...route,
+            destination: {
+              kind: "channel",
+              platform: "slack",
+              targetType: "group",
+              targetId: "C_DEST",
+              label: null,
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(wrongTargetType.status).toBe(400);
+    await expect(wrongTargetType.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "Slack route destination targetType must be channel" },
+    });
+
+    const emptyTargetId = await app.request(configUrl, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [{ platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" }],
+        routes: [
+          {
+            ...route,
+            destination: {
+              kind: "channel",
+              platform: "slack",
+              targetType: "channel",
+              targetId: "  ",
+              label: null,
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(emptyTargetId.status).toBe(400);
+    await expect(emptyTargetId.json()).resolves.toMatchObject({
+      error: { code: "VALIDATION_ERROR", message: "route.destination.targetId is required" },
+    });
+    expect(service.updateConfigForUser).toHaveBeenCalledTimes(1);
+  });
+
   it("passes multi-source routes and Slack member destinations to the service for saving", async () => {
     const service = createService({
       updateConfigForUser: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, routes: [] })),
@@ -284,6 +391,63 @@ describe("agentRoutes", () => {
             id: "combined-route",
             sources: ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
             destination: { kind: "member", platform: "slack", memberUserId: "member-1" },
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("passes multi-source routes with channel destinations to the service for saving", async () => {
+    const service = createService({
+      updateConfigForUser: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, routes: [] })),
+    });
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: [
+          { platform: "slack", targetType: "channel", targetId: "C_ALPHA", label: "#alpha" },
+          { platform: "slack", targetType: "channel", targetId: "C_BETA", label: "#beta" },
+        ],
+        routes: [
+          {
+            id: "combined-channel-route",
+            sources: ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
+            focus: null,
+            sections: null,
+            maxItemsPerSection: null,
+            schedule: null,
+            destination: {
+              kind: "channel",
+              platform: "slack",
+              targetType: "channel",
+              targetId: "C_DEST",
+              label: "#leadership",
+            },
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.updateConfigForUser).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "user-1",
+      expect.objectContaining({
+        routes: [
+          expect.objectContaining({
+            id: "combined-channel-route",
+            sources: ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
+            destination: {
+              kind: "channel",
+              platform: "slack",
+              targetType: "channel",
+              targetId: "C_DEST",
+              label: "#leadership",
+            },
           }),
         ],
       }),

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -319,7 +319,28 @@ function parseRouteDestination(value: unknown): AgentRouteDestination {
     if (!memberUserId) throw new ConfigPatchError("route.destination.memberUserId is required");
     return { kind: "member", platform: "slack", memberUserId };
   }
-  throw new ConfigPatchError("route.destination.kind must be self, off, or member");
+  if (raw.kind === "channel") {
+    if (raw.platform === "slack") {
+      if (raw.targetType !== "channel") {
+        throw new ConfigPatchError("Slack route destination targetType must be channel");
+      }
+      const targetId = typeof raw.targetId === "string" ? raw.targetId.trim() : "";
+      if (!targetId) throw new ConfigPatchError("route.destination.targetId is required");
+      const label = typeof raw.label === "string" && raw.label.trim() ? raw.label.trim() : null;
+      return { kind: "channel", platform: "slack", targetType: "channel", targetId, label };
+    }
+    if (raw.platform === "whatsapp") {
+      if (raw.targetType !== "group") {
+        throw new ConfigPatchError("WhatsApp route destination targetType must be group");
+      }
+      const targetId = typeof raw.targetId === "string" ? raw.targetId.trim() : "";
+      if (!targetId) throw new ConfigPatchError("route.destination.targetId is required");
+      const label = typeof raw.label === "string" && raw.label.trim() ? raw.label.trim() : null;
+      return { kind: "channel", platform: "whatsapp", targetType: "group", targetId, label };
+    }
+    throw new ConfigPatchError("route.destination.platform must be slack or whatsapp");
+  }
+  throw new ConfigPatchError("route.destination.kind must be self, off, member, or channel");
 }
 
 function parseRoutes(value: unknown, def: AgentDefinition): AgentRoute[] | undefined {

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -1526,6 +1526,137 @@ describe("AgentRunService", () => {
     expect(isUserInChannel).toHaveBeenCalledWith("C_B", "U_MEMBER");
   });
 
+  it("delivers route summaries to Slack channel destinations only when the bot is a member", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    await seedSlackConversationMessage(db, sourceA, {
+      messageId: "channel-route-a-1",
+      text: "Alpha launch decision",
+      receivedAt: "2026-06-15T07:00:00.000Z",
+    });
+    await seedSlackConversationMessage(db, sourceB, {
+      messageId: "channel-route-b-1",
+      text: "Beta launch decision",
+      receivedAt: "2026-06-15T07:05:00.000Z",
+    });
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "Summary" },
+        rawPayload: {
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Summarizer", summary: "Summary" },
+          items: [],
+        },
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
+    const listChannels = vi.fn(
+      async (): Promise<Array<{ id: string; name: string; type: string; isMember: boolean }>> => [
+        { id: "C_A", name: "alpha", type: "public_channel", isMember: true },
+        { id: "C_DEST", name: "leadership", type: "private_channel", isMember: true },
+      ],
+    );
+    const isUserInChannel = vi.fn(async (channelId: string, slackUserId: string) => {
+      if (channelId === "C_DEST") throw new Error("Channel route destination should not check user membership");
+      return channelId === "C_A" && slackUserId === "U_AGENT";
+    });
+    const service = createService(db, tasks, {
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      outputDelivery,
+      getSlack: () => ({ listChannels, isUserInChannel }),
+    });
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [sourceA],
+      routes: [
+        sourceRoute(sourceA, {
+          destination: {
+            kind: "channel",
+            platform: "slack",
+            targetType: "channel",
+            targetId: "C_DEST",
+            label: "#spoofed",
+          },
+        }),
+      ],
+    });
+    const deliveredRows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(deliveredRows).toHaveLength(1);
+    expect(outputDelivery.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delivery: {
+          enabled: true,
+          platform: "slack",
+          targetType: "channel",
+          targetId: "C_DEST",
+          label: "#leadership",
+        },
+      }),
+    );
+    expect(isUserInChannel).not.toHaveBeenCalledWith("C_DEST", expect.any(String));
+
+    tasks.length = 0;
+    outputDelivery.deliver.mockClear();
+    listChannels.mockResolvedValue([
+      { id: "C_B", name: "beta", type: "public_channel", isMember: true },
+      { id: "C_BLOCKED", name: "blocked", type: "private_channel", isMember: false },
+    ]);
+    isUserInChannel.mockImplementation(async (channelId: string, slackUserId: string) => {
+      return channelId === "C_B" && slackUserId === "U_AGENT";
+    });
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [sourceB],
+      routes: [
+        sourceRoute(sourceB, {
+          destination: {
+            kind: "channel",
+            platform: "slack",
+            targetType: "channel",
+            targetId: "C_BLOCKED",
+            label: null,
+          },
+        }),
+      ],
+    });
+    const blockedRows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(outputDelivery.deliver).not.toHaveBeenCalled();
+    const blockedOutput = await db
+      .selectFrom("agent_outputs")
+      .select(["status", "error_message"])
+      .where("id", "=", blockedRows[0].id)
+      .executeTakeFirstOrThrow();
+    expect(blockedOutput).toEqual({
+      status: "failed",
+      error_message: "Slack channel is not available for delivery",
+    });
+  });
+
   it("guards member delivery by source intersection and lists only eligible route members", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -825,6 +825,39 @@ describe("AgentRunService", () => {
     expect(reread?.delivery?.targetId).toBe("C_DAILY");
   });
 
+  it("includes source config, sources, and routes on agent summaries", async () => {
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const source = slackSource("C_A", "alpha");
+    const route = sourceRoute(source, {
+      focus: "Alpha customers",
+      sections: { highlights: true, decisions: false },
+      maxItemsPerSection: 2,
+      schedule: { hour: 10, minute: 15 },
+    });
+    const service = createService(db, [], allowSlackDelivery([{ id: "C_A", name: "alpha" }]));
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      sources: [source],
+      routes: [route],
+    });
+
+    const summaries = await service.listForUser(user.id);
+    const dailyBrief = summaries.find((summary) => summary.key === DAILY_BRIEF_AGENT_KEY);
+    const conversationSummary = summaries.find((summary) => summary.key === CONVERSATION_SUMMARY_AGENT_KEY);
+
+    expect(dailyBrief).toMatchObject({
+      sourceConfig: null,
+      sources: [],
+      routes: [],
+    });
+    expect(conversationSummary).toMatchObject({
+      sourceConfig: conversationSummaryDefinition.sourceConfig,
+      sources: [source],
+      routes: [route],
+    });
+  });
+
   it("normalizes delivery models with defaultRoute and full-key legacy matching", async () => {
     const users = createUserRepository(db);
     const slackDelivery = allowSlackDelivery([

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -1897,6 +1897,43 @@ describe("AgentRunService", () => {
     ).rejects.toThrow("Routes must not duplicate the same output scope");
   });
 
+  it("rejects combined channel route destinations that match a selected source", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const user = await users.create({ name: "Agent User", email: "agent@example.com", slackUserId: "U_AGENT" });
+    const service = createService(
+      db,
+      tasks,
+      allowSlackDelivery([
+        { id: "C_A", name: "alpha" },
+        { id: "C_B", name: "beta" },
+      ]),
+    );
+
+    await expect(
+      service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+        enabled: true,
+        sources: [sourceA, sourceB],
+        routes: [
+          {
+            ...sourceRoute(sourceA),
+            id: "alpha-beta-to-alpha",
+            sources: ["slack:channel:C_A", "slack:channel:C_B"],
+            destination: {
+              kind: "channel",
+              platform: "slack",
+              targetType: "channel",
+              targetId: "C_A",
+              label: "#alpha",
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow("Combined routes cannot deliver to one of the selected sources");
+  });
+
   it("synthesizes legacy deliveryModel-only configs into equivalent routes", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -863,6 +863,9 @@ export class AgentRunService {
             "Channel route destination must include a valid Slack channel or WhatsApp group",
           );
         }
+        if (sources.length > 1 && sources.includes(deliveryKeyForTarget(normalized) as AgentSourceKey)) {
+          throw new AgentDeliveryTargetError("Combined routes cannot deliver to one of the selected sources");
+        }
         destination = normalized;
       }
       for (const sourceKey of sources) {

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -331,9 +331,23 @@ function normalizeRouteDestination(value: unknown): AgentRouteDestination | null
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const raw = value as Record<string, unknown>;
   if (raw.kind === "self" || raw.kind === "off") return { kind: raw.kind };
-  if (raw.kind !== "member" || raw.platform !== "slack") return null;
-  const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
-  return memberUserId ? { kind: "member", platform: "slack", memberUserId } : null;
+  if (raw.kind === "member") {
+    if (raw.platform !== "slack") return null;
+    const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
+    return memberUserId ? { kind: "member", platform: "slack", memberUserId } : null;
+  }
+  if (raw.kind === "channel") {
+    const targetId = typeof raw.targetId === "string" ? raw.targetId.trim() : "";
+    if (!targetId) return null;
+    const label = typeof raw.label === "string" && raw.label.trim() ? raw.label.trim() : null;
+    if (raw.platform === "slack" && raw.targetType === "channel") {
+      return { kind: "channel", platform: "slack", targetType: "channel", targetId, label };
+    }
+    if (raw.platform === "whatsapp" && raw.targetType === "group") {
+      return { kind: "channel", platform: "whatsapp", targetType: "group", targetId, label };
+    }
+  }
+  return null;
 }
 
 function normalizeRouteSchedule(value: unknown): AgentRoute["schedule"] {
@@ -841,6 +855,15 @@ export class AgentRunService {
           throw new AgentDeliveryTargetError("Member route destination must include a Slack member");
         }
         destination = { kind: "member", platform: "slack", memberUserId };
+      }
+      if (route.destination.kind === "channel") {
+        const normalized = normalizeRouteDestination(route.destination);
+        if (!normalized || normalized.kind !== "channel") {
+          throw new AgentDeliveryTargetError(
+            "Channel route destination must include a valid Slack channel or WhatsApp group",
+          );
+        }
+        destination = normalized;
       }
       for (const sourceKey of sources) {
         if (!sourceKeys.has(sourceKey)) {
@@ -1642,6 +1665,9 @@ export class AgentRunService {
     if (route.destination.kind === "member") {
       return this.resolveMemberRouteDelivery(route.destination, resolvedSources);
     }
+    if (route.destination.kind === "channel") {
+      return this.resolveChannelRouteDelivery(route.destination);
+    }
     if (resolvedSources.length !== 1) {
       throw new AgentDeliveryTargetError("Combined routes cannot use self destination");
     }
@@ -1676,6 +1702,45 @@ export class AgentRunService {
       targetType: "dm",
       targetId: member.slack_user_id,
       label: member.name,
+    };
+  }
+
+  private async resolveChannelRouteDelivery(
+    destination: Extract<AgentRouteDestination, { kind: "channel" }>,
+  ): Promise<AgentDeliveryConfig> {
+    if (destination.platform === "slack") {
+      const slack = this.deps.getSlack?.() ?? null;
+      if (!slack) throw new AgentDeliveryTargetError("Slack is not connected");
+
+      const channel = (await slack.listChannels()).find((candidate) => candidate.id === destination.targetId);
+      if (!channel?.isMember) {
+        throw new AgentDeliveryTargetError("Slack channel is not available for delivery");
+      }
+      return {
+        enabled: true,
+        platform: "slack",
+        targetType: "channel",
+        targetId: channel.id,
+        label: `#${channel.name}`,
+      };
+    }
+
+    const group = await this.deps.db
+      .selectFrom("whatsapp_groups")
+      .select(["jid", "name"])
+      .where("jid", "=", destination.targetId)
+      .executeTakeFirst();
+    if (!group) throw new AgentDeliveryTargetError("WhatsApp group is not available for delivery");
+
+    const whatsapp = this.deps.getWhatsApp?.() ?? null;
+    if (!whatsapp) throw new AgentDeliveryTargetError("WhatsApp is not connected");
+
+    return {
+      enabled: true,
+      platform: "whatsapp",
+      targetType: "group",
+      targetId: group.jid,
+      label: group.name ?? destination.label ?? null,
     };
   }
 

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -149,6 +149,9 @@ export interface AgentSummaryView {
   enabled: boolean;
   scheduleHour: number;
   scheduleMinute: number;
+  sourceConfig: AgentSourceConfigDef | null;
+  sources: AgentSourceConfig[];
+  routes: AgentRoute[];
 }
 
 export class AgentDeliveryTargetError extends Error {}
@@ -654,6 +657,9 @@ export class AgentRunService {
         enabled: config.enabled,
         scheduleHour: config.scheduleHour,
         scheduleMinute: config.scheduleMinute,
+        sourceConfig: def.sourceConfig ?? null,
+        sources: config.sources,
+        routes: config.configuredRoutes,
       });
     }
     return result;

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -95,7 +95,9 @@ export type AgentRouteId = string;
 export type AgentRouteDestination =
   | { kind: "self" }
   | { kind: "off" }
-  | { kind: "member"; platform: "slack"; memberUserId: string };
+  | { kind: "member"; platform: "slack"; memberUserId: string }
+  | { kind: "channel"; platform: "slack"; targetType: "channel"; targetId: string; label: string | null }
+  | { kind: "channel"; platform: "whatsapp"; targetType: "group"; targetId: string; label: string | null };
 
 export interface AgentRoute {
   id: AgentRouteId;

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -28,6 +28,7 @@ import {
   WhatsappLogoIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
 import {
   Sheet,
   SheetContent,
@@ -37,6 +38,8 @@ import {
   SheetTitle,
 } from "@sketch/ui/components/sheet";
 import { Switch } from "@sketch/ui/components/switch";
+import { TabButton } from "@sketch/ui/components/tab-button";
+import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
 import { cn } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
@@ -131,7 +134,7 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
     <Shell>
       <header className="mt-5 flex items-start gap-4">
         <div className="min-w-0 flex-1">
-          <h1 className="text-[19px] font-semibold text-foreground">{agent.title}</h1>
+          <h1 className="text-[22px] font-medium text-foreground">{agent.title}</h1>
           <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">{agent.tagline}</p>
         </div>
         <span className="flex shrink-0 items-center gap-2 text-[12px] font-medium text-muted-foreground">
@@ -146,16 +149,12 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
         </span>
       </header>
 
-      <div className="mt-6 flex items-center gap-1 border-b border-border/60">
-        <TabButton active={tab === "outputs"} onClick={() => setTab("outputs")}>
-          Outputs
-        </TabButton>
-        <TabButton active={tab === "config"} onClick={() => setTab("config")}>
-          Config
-        </TabButton>
+      <div className="mt-6 flex items-center gap-6 border-b border-border">
+        <TabButton label="Outputs" isActive={tab === "outputs"} onClick={() => setTab("outputs")} />
+        <TabButton label="Config" isActive={tab === "config"} onClick={() => setTab("config")} />
       </div>
 
-      <div className="pt-5">
+      <TabContentContainer className="pt-5">
         {tab === "outputs" ? (
           <OutputsTab
             data={data}
@@ -177,7 +176,7 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
             onChanged={invalidate}
           />
         )}
-      </div>
+      </TabContentContainer>
 
       <EditDrawer
         field={editing}
@@ -466,55 +465,85 @@ function SummariserConfig({
   });
 
   return (
-    <>
-      <div className="rounded-xl border-[0.5px] border-border bg-card px-4">
-        <Row label="What it does">
-          <p className="text-[12.5px] leading-relaxed text-foreground/85">{agent.description}</p>
-        </Row>
+    <div className="space-y-6">
+      <div className="rounded-lg border-[0.5px] border-border bg-card p-4 dark:bg-[#111110]">
+        <p className="font-mono text-[10px] uppercase tracking-[0.07em] text-muted-foreground">What it does</p>
+        <p className="mt-1.5 text-[13px] leading-relaxed text-foreground/85">{agent.description}</p>
       </div>
 
-      <div className="mb-3 mt-7 flex items-center justify-between border-b border-border/60 pb-2">
-        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Summarisers</span>
-        <button
-          type="button"
-          onClick={() => onEditSummariser(null)}
-          className="inline-flex items-center gap-1.5 rounded-full border-[0.5px] border-border px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted/50"
-        >
-          <PlusIcon size={13} weight="bold" aria-hidden />
-          New summariser
-        </button>
-      </div>
-
-      {agent.routes.length === 0 ? (
-        <EmptyCard>No summarisers yet. Add one to start delivering digests.</EmptyCard>
-      ) : (
-        <div className="overflow-hidden rounded-xl border-[0.5px] border-border">
-          <div className="flex items-center gap-3 border-b-[0.5px] border-border bg-muted/20 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground/70">
-            <span className="flex-[2]">Input</span>
-            <span className="flex-[2]">Delivers to</span>
-            <span className="w-14">Runs</span>
-            <span className="hidden flex-[2] sm:block">Sections</span>
-            <span className="w-16 text-right">&nbsp;</span>
+      <div className="overflow-hidden rounded-lg border-[0.5px] border-border bg-card">
+        <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+          <div className="flex items-baseline gap-2">
+            <span className="font-mono text-[11px] uppercase tracking-[0.07em] text-muted-foreground">Summarisers</span>
+            <span className="font-mono text-[10px] text-muted-foreground/60">
+              {agent.routes.length}
+              {maxSources > 0 ? ` · limit ${maxSources} inputs` : ""}
+            </span>
           </div>
-          {agent.routes.map((route) => (
-            <SummariserRow
-              key={route.id}
-              agent={agent}
-              route={route}
-              lookup={lookup}
-              busy={save.isPending}
-              onEdit={() => onEditSummariser(route)}
-              onToggle={(enabled) => save.mutate(agent.routes.map((r) => (r.id === route.id ? { ...r, enabled } : r)))}
-              onRemove={() => save.mutate(agent.routes.filter((r) => r.id !== route.id))}
-            />
-          ))}
+          <button
+            type="button"
+            onClick={() => onEditSummariser(null)}
+            className="inline-flex items-center gap-1.5 rounded-md border-[0.5px] border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:bg-[#111110] dark:hover:bg-[#1C1C1A]"
+          >
+            <PlusIcon size={12} weight="bold" aria-hidden />
+            New summariser
+          </button>
         </div>
-      )}
-      <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
-        {agent.routes.length} {agent.routes.length === 1 ? "summariser" : "summarisers"}
-        {maxSources > 0 ? ` · limit ${maxSources} inputs` : ""}
-      </p>
-    </>
+
+        <table className="w-full text-[13px]">
+          <colgroup>
+            <col />
+            <col className="w-[150px]" />
+            <col className="w-[92px]" />
+            <col className="w-[170px]" />
+            <col className="w-[96px]" />
+          </colgroup>
+          <thead>
+            <tr className="border-b border-border text-left">
+              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
+                Input
+              </th>
+              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
+                Delivers to
+              </th>
+              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
+                Runs
+              </th>
+              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
+                Sections
+              </th>
+              <th className="px-4 py-2.5 text-right font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
+                &nbsp;
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {agent.routes.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-12 text-center text-[13px] text-muted-foreground">
+                  No summarisers yet. Add one to start delivering digests.
+                </td>
+              </tr>
+            ) : (
+              agent.routes.map((route) => (
+                <SummariserRow
+                  key={route.id}
+                  agent={agent}
+                  route={route}
+                  lookup={lookup}
+                  busy={save.isPending}
+                  onEdit={() => onEditSummariser(route)}
+                  onToggle={(enabled) =>
+                    save.mutate(agent.routes.map((r) => (r.id === route.id ? { ...r, enabled } : r)))
+                  }
+                  onRemove={() => save.mutate(agent.routes.filter((r) => r.id !== route.id))}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 }
 
@@ -540,51 +569,63 @@ function SummariserRow({
   const combined = route.sources.length > 1;
 
   return (
-    <div
+    <tr
       className={cn(
-        "flex items-center gap-3 border-b-[0.5px] border-border px-4 py-3 last:border-0",
+        "border-b border-border transition-colors last:border-b-0 hover:bg-secondary/50 dark:hover:bg-muted/30",
         !route.enabled && "opacity-55",
       )}
     >
-      <button type="button" onClick={onEdit} className="flex min-w-0 flex-1 items-center gap-3 text-left">
-        <span className="flex min-w-0 flex-[2] items-center gap-1.5">
+      <td className="px-4 py-2.5">
+        <button type="button" onClick={onEdit} className="flex max-w-full items-center gap-2 text-left">
           {first?.platform === "slack" ? (
             <HashIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
           ) : (
             <UsersThreeIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
           )}
-          <span className="truncate text-[12.5px] font-medium text-foreground">{inputLabel}</span>
+          <span className="truncate font-medium text-foreground">{inputLabel}</span>
           {combined ? (
-            <span className="shrink-0 text-[11px] text-muted-foreground">+{route.sources.length - 1}</span>
+            <Badge variant="secondary" className="shrink-0 rounded-[4px] px-1.5 py-0 text-[9px]">
+              +{route.sources.length - 1}
+            </Badge>
           ) : null}
-        </span>
-        <span className="flex-[2] truncate text-[12px] text-muted-foreground">{deliversLabel(route)}</span>
-        <span className="w-14 shrink-0 text-[12px] text-muted-foreground">
-          {formatTime(route.schedule?.hour ?? agent.scheduleHour, route.schedule?.minute ?? agent.scheduleMinute)}
-        </span>
-        <span className="hidden flex-[2] truncate text-[12px] text-muted-foreground sm:block">
-          {sectionsLabel(route, agent)}
-        </span>
-      </button>
-      <div className="flex w-16 shrink-0 items-center justify-end gap-2.5">
-        <Switch
-          checked={route.enabled}
-          disabled={busy}
-          onCheckedChange={onToggle}
-          aria-label={`${inputLabel} active`}
-          className="scale-90 data-[state=checked]:bg-emerald-500"
-        />
-        <button
-          type="button"
-          onClick={onRemove}
-          disabled={busy}
-          aria-label={`Remove ${inputLabel}`}
-          className="text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-40"
-        >
-          <XIcon size={13} weight="bold" aria-hidden />
+          {!route.enabled ? (
+            <Badge
+              variant="secondary"
+              className="shrink-0 rounded-[4px] bg-muted px-1.5 py-0 text-[9px] text-muted-foreground"
+            >
+              Paused
+            </Badge>
+          ) : null}
         </button>
-      </div>
-    </div>
+      </td>
+      <td className="px-4 py-2.5 text-muted-foreground">{deliversLabel(route)}</td>
+      <td className="px-4 py-2.5 tabular-nums text-muted-foreground">
+        {formatTime(route.schedule?.hour ?? agent.scheduleHour, route.schedule?.minute ?? agent.scheduleMinute)}
+      </td>
+      <td className="px-4 py-2.5 text-muted-foreground">
+        <span className="block truncate">{sectionsLabel(route, agent)}</span>
+      </td>
+      <td className="px-4 py-2.5">
+        <div className="flex items-center justify-end gap-2.5">
+          <Switch
+            checked={route.enabled}
+            disabled={busy}
+            onCheckedChange={onToggle}
+            aria-label={`${inputLabel} active`}
+            className="scale-90 data-[state=checked]:bg-emerald-500"
+          />
+          <button
+            type="button"
+            onClick={onRemove}
+            disabled={busy}
+            aria-label={`Remove ${inputLabel}`}
+            className="text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-40"
+          >
+            <XIcon size={13} weight="bold" aria-hidden />
+          </button>
+        </div>
+      </td>
+    </tr>
   );
 }
 
@@ -642,21 +683,6 @@ function Row({ label, children, onEdit }: { label: string; children: React.React
   return (
     <button type="button" onClick={onEdit} className={className}>
       {inner}
-    </button>
-  );
-}
-
-function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "-mb-px inline-flex items-center gap-1.5 border-b-2 px-3 py-2 text-[13px] font-medium transition-colors",
-        active ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground",
-      )}
-    >
-      {children}
     </button>
   );
 }

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -10,14 +10,12 @@ import {
   type AgentDetailResponse,
   type AgentOutput,
   type AgentOutputsResponse,
-  type AgentRoute,
-  type AgentRouteDestination,
   type AgentSourceConfig,
-  type AgentSourceKey,
   api,
 } from "@/lib/api";
 import {
   ArrowLeftIcon,
+  CaretRightIcon,
   CheckCircleIcon,
   HashIcon,
   PencilSimpleIcon,
@@ -26,9 +24,7 @@ import {
   UserIcon,
   UsersThreeIcon,
   WhatsappLogoIcon,
-  XIcon,
 } from "@phosphor-icons/react";
-import { Badge } from "@sketch/ui/components/badge";
 import {
   Sheet,
   SheetContent,
@@ -45,6 +41,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { SummariserSetupModal } from "./summariser-setup-modal";
+import { InputIcon, deliversLabel, routeInput } from "./summariser-shared";
 
 type Tab = "outputs" | "config";
 type EditField = "schedule" | "focus" | "volume" | "delivery" | "sources" | null;
@@ -86,7 +84,6 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
   });
   const [tab, setTab] = useState<Tab>("outputs");
   const [editing, setEditing] = useState<EditField>(null);
-  const [editingSummariser, setEditingSummariser] = useState<{ route: AgentRoute | null } | null>(null);
   const [selectedOutputId, setSelectedOutputId] = useState<string | null>(null);
 
   const invalidate = () => {
@@ -168,13 +165,7 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
             runPending={runMutation.isPending}
           />
         ) : (
-          <ConfigTab
-            agentKey={agentKey}
-            agent={agent}
-            onEdit={setEditing}
-            onEditSummariser={(route) => setEditingSummariser({ route })}
-            onChanged={invalidate}
-          />
+          <ConfigTab agentKey={agentKey} agent={agent} onEdit={setEditing} onChanged={invalidate} />
         )}
       </TabContentContainer>
 
@@ -185,15 +176,6 @@ export function AgentDetail({ agentKey }: { agentKey: string }) {
         onClose={() => setEditing(null)}
         onSaved={invalidate}
       />
-      {editingSummariser ? (
-        <SummariserDrawer
-          agentKey={agentKey}
-          agent={agent}
-          editing={editingSummariser}
-          onClose={() => setEditingSummariser(null)}
-          onSaved={invalidate}
-        />
-      ) : null}
     </Shell>
   );
 }
@@ -352,19 +334,15 @@ function ConfigTab({
   agentKey,
   agent,
   onEdit,
-  onEditSummariser,
   onChanged,
 }: {
   agentKey: string;
   agent: AgentConfig;
   onEdit: (field: EditField) => void;
-  onEditSummariser: (route: AgentRoute | null) => void;
   onChanged: () => void;
 }) {
   if (agent.sourceConfig) {
-    return (
-      <SummariserConfig agentKey={agentKey} agent={agent} onEditSummariser={onEditSummariser} onChanged={onChanged} />
-    );
+    return <SummariserIndex agentKey={agentKey} agent={agent} onChanged={onChanged} />;
   }
   return (
     <>
@@ -410,59 +388,22 @@ function ConfigTab({
   );
 }
 
-function routesToSources(routes: AgentRoute[], lookup: Map<string, AgentSourceConfig>): AgentSourceConfig[] {
-  const out: AgentSourceConfig[] = [];
-  const seen = new Set<string>();
-  for (const route of routes) {
-    for (const key of route.sources) {
-      if (seen.has(key)) continue;
-      const source = lookup.get(key);
-      if (source) {
-        seen.add(key);
-        out.push(source);
-      }
-    }
-  }
-  return out;
-}
-
-function deliversLabel(route: AgentRoute): string {
-  if (route.destination.kind === "self") return "Post back";
-  if (route.destination.kind === "member") return "Direct message";
-  return "Web only";
-}
-
-function sectionsLabel(route: AgentRoute, agent: AgentConfig): string {
-  const on = agent.sections.filter((section) => route.sections?.[section.key] ?? section.enabled);
-  if (on.length === agent.sections.length) return "All sections";
-  if (on.length === 0) return "No sections";
-  return on.map((section) => section.title).join(", ");
-}
-
 /**
- * Summariser config surface for source-backed agents: a shared "what it does"
- * plus a table of independent summarisers (routes). Each row maps input
- * conversations to a delivery, schedule, and sections; editing opens the drawer.
+ * Source-backed agents manage their summarisers as sub-rows in the roster and on
+ * per-summariser config pages. The agent's Config tab is a lightweight index:
+ * what it does, plus links into each summariser and a New-summariser modal.
  */
-function SummariserConfig({
+function SummariserIndex({
   agentKey,
   agent,
-  onEditSummariser,
   onChanged,
 }: {
   agentKey: string;
   agent: AgentConfig;
-  onEditSummariser: (route: AgentRoute | null) => void;
   onChanged: () => void;
 }) {
+  const [modalOpen, setModalOpen] = useState(false);
   const lookup = new Map(agent.sources.map((source) => [sourceKey(source), source] as const));
-  const maxSources = agent.sourceConfig?.maxSources ?? 0;
-  const save = useMutation({
-    mutationFn: (routes: AgentRoute[]) =>
-      api.agents.updateConfig(agentKey, { sources: routesToSources(routes, lookup), routes }),
-    onSuccess: onChanged,
-    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to update"),
-  });
 
   return (
     <div className="space-y-6">
@@ -475,14 +416,11 @@ function SummariserConfig({
         <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
           <div className="flex items-baseline gap-2">
             <span className="font-mono text-[11px] uppercase tracking-[0.07em] text-muted-foreground">Summarisers</span>
-            <span className="font-mono text-[10px] text-muted-foreground/60">
-              {agent.routes.length}
-              {maxSources > 0 ? ` · limit ${maxSources} inputs` : ""}
-            </span>
+            <span className="font-mono text-[10px] text-muted-foreground/60">{agent.routes.length}</span>
           </div>
           <button
             type="button"
-            onClick={() => onEditSummariser(null)}
+            onClick={() => setModalOpen(true)}
             className="inline-flex items-center gap-1.5 rounded-md border-[0.5px] border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:bg-[#111110] dark:hover:bg-[#1C1C1A]"
           >
             <PlusIcon size={12} weight="bold" aria-hidden />
@@ -490,142 +428,57 @@ function SummariserConfig({
           </button>
         </div>
 
-        <table className="w-full text-[13px]">
-          <colgroup>
-            <col />
-            <col className="w-[150px]" />
-            <col className="w-[92px]" />
-            <col className="w-[170px]" />
-            <col className="w-[96px]" />
-          </colgroup>
-          <thead>
-            <tr className="border-b border-border text-left">
-              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
-                Input
-              </th>
-              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
-                Delivers to
-              </th>
-              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
-                Runs
-              </th>
-              <th className="px-4 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
-                Sections
-              </th>
-              <th className="px-4 py-2.5 text-right font-mono text-[10px] font-normal uppercase tracking-[0.05em] text-muted-foreground">
-                &nbsp;
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {agent.routes.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="px-4 py-12 text-center text-[13px] text-muted-foreground">
-                  No summarisers yet. Add one to start delivering digests.
-                </td>
-              </tr>
-            ) : (
-              agent.routes.map((route) => (
-                <SummariserRow
+        {agent.routes.length === 0 ? (
+          <p className="px-4 py-10 text-center text-[13px] text-muted-foreground">
+            No summarisers yet. Add one to start delivering digests.
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {agent.routes.map((route) => {
+              const input = routeInput(route, lookup);
+              return (
+                <Link
                   key={route.id}
-                  agent={agent}
-                  route={route}
-                  lookup={lookup}
-                  busy={save.isPending}
-                  onEdit={() => onEditSummariser(route)}
-                  onToggle={(enabled) =>
-                    save.mutate(agent.routes.map((r) => (r.id === route.id ? { ...r, enabled } : r)))
-                  }
-                  onRemove={() => save.mutate(agent.routes.filter((r) => r.id !== route.id))}
-                />
-              ))
-            )}
-          </tbody>
-        </table>
+                  to="/agents/$agentKey/summarisers/$routeId"
+                  params={{ agentKey, routeId: route.id }}
+                  className={cn(
+                    "group flex items-center gap-3 border-b border-border px-4 py-3 transition-colors last:border-b-0 hover:bg-secondary/50 dark:hover:bg-muted/30",
+                    !route.enabled && "opacity-55",
+                  )}
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-2">
+                    <InputIcon platform={input.platform} />
+                    <span className="truncate text-[12.5px] font-medium text-foreground">{input.label}</span>
+                    {input.extra > 0 ? (
+                      <span className="shrink-0 text-[11px] text-muted-foreground">+{input.extra}</span>
+                    ) : null}
+                  </span>
+                  <span className="text-[12px] text-muted-foreground">{deliversLabel(route)}</span>
+                  <span className="w-16 text-right text-[12px] tabular-nums text-muted-foreground">
+                    {formatTime(
+                      route.schedule?.hour ?? agent.scheduleHour,
+                      route.schedule?.minute ?? agent.scheduleMinute,
+                    )}
+                  </span>
+                  <CaretRightIcon
+                    size={13}
+                    aria-hidden
+                    className="shrink-0 text-muted-foreground/30 group-hover:text-muted-foreground"
+                  />
+                </Link>
+              );
+            })}
+          </div>
+        )}
       </div>
+
+      <SummariserSetupModal
+        agentKey={agentKey}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onCreated={onChanged}
+      />
     </div>
-  );
-}
-
-function SummariserRow({
-  agent,
-  route,
-  lookup,
-  busy,
-  onEdit,
-  onToggle,
-  onRemove,
-}: {
-  agent: AgentConfig;
-  route: AgentRoute;
-  lookup: Map<string, AgentSourceConfig>;
-  busy: boolean;
-  onEdit: () => void;
-  onToggle: (enabled: boolean) => void;
-  onRemove: () => void;
-}) {
-  const first = lookup.get(route.sources[0]);
-  const inputLabel = first?.label ?? route.sources[0];
-  const combined = route.sources.length > 1;
-
-  return (
-    <tr
-      className={cn(
-        "border-b border-border transition-colors last:border-b-0 hover:bg-secondary/50 dark:hover:bg-muted/30",
-        !route.enabled && "opacity-55",
-      )}
-    >
-      <td className="px-4 py-2.5">
-        <button type="button" onClick={onEdit} className="flex max-w-full items-center gap-2 text-left">
-          {first?.platform === "slack" ? (
-            <HashIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
-          ) : (
-            <UsersThreeIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
-          )}
-          <span className="truncate font-medium text-foreground">{inputLabel}</span>
-          {combined ? (
-            <Badge variant="secondary" className="shrink-0 rounded-[4px] px-1.5 py-0 text-[9px]">
-              +{route.sources.length - 1}
-            </Badge>
-          ) : null}
-          {!route.enabled ? (
-            <Badge
-              variant="secondary"
-              className="shrink-0 rounded-[4px] bg-muted px-1.5 py-0 text-[9px] text-muted-foreground"
-            >
-              Paused
-            </Badge>
-          ) : null}
-        </button>
-      </td>
-      <td className="px-4 py-2.5 text-muted-foreground">{deliversLabel(route)}</td>
-      <td className="px-4 py-2.5 tabular-nums text-muted-foreground">
-        {formatTime(route.schedule?.hour ?? agent.scheduleHour, route.schedule?.minute ?? agent.scheduleMinute)}
-      </td>
-      <td className="px-4 py-2.5 text-muted-foreground">
-        <span className="block truncate">{sectionsLabel(route, agent)}</span>
-      </td>
-      <td className="px-4 py-2.5">
-        <div className="flex items-center justify-end gap-2.5">
-          <Switch
-            checked={route.enabled}
-            disabled={busy}
-            onCheckedChange={onToggle}
-            aria-label={`${inputLabel} active`}
-            className="scale-90 data-[state=checked]:bg-emerald-500"
-          />
-          <button
-            type="button"
-            onClick={onRemove}
-            disabled={busy}
-            aria-label={`Remove ${inputLabel}`}
-            className="text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-40"
-          >
-            <XIcon size={13} weight="bold" aria-hidden />
-          </button>
-        </div>
-      </td>
-    </tr>
   );
 }
 
@@ -952,308 +805,6 @@ function SourceEditor({
       <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">{countSummary}</p>
     </div>
   );
-}
-
-/**
- * Editor drawer for a single summariser (route). Pick one or more input
- * conversations, where the finished summary goes (post it back to a single
- * source, keep it web-only, or DM a member who belongs to every source), and
- * the schedule, sections, focus, and volume for that summariser alone. Each
- * summariser is self-contained: it always stores explicit values, never
- * inheriting the agent's defaults.
- */
-function SummariserDrawer({
-  agentKey,
-  agent,
-  editing,
-  onClose,
-  onSaved,
-}: {
-  agentKey: string;
-  agent: AgentConfig;
-  editing: { route: AgentRoute | null };
-  onClose: () => void;
-  onSaved: () => void;
-}) {
-  const slackChannels = useQuery({ queryKey: ["slack-channels"], queryFn: () => api.channels.listSlack() });
-  const whatsappGroups = useQuery({ queryKey: ["whatsapp-groups"], queryFn: () => api.channels.listWhatsAppGroups() });
-  const maxSources = agent.sourceConfig?.maxSources ?? 0;
-
-  const route = editing.route;
-  const [sources, setSources] = useState<AgentSourceKey[]>(route?.sources ?? []);
-  const [destKind, setDestKind] = useState<AgentRouteDestination["kind"]>(route?.destination.kind ?? "off");
-  const [memberUserId, setMemberUserId] = useState<string | null>(
-    route?.destination.kind === "member" ? route.destination.memberUserId : null,
-  );
-  const [hour, setHour] = useState(route?.schedule?.hour ?? agent.scheduleHour);
-  const [minute, setMinute] = useState(route?.schedule?.minute ?? agent.scheduleMinute);
-  const [sections, setSections] = useState<Record<string, boolean>>(defaultSections(agent, route));
-  const [focus, setFocus] = useState(route?.focus ?? "");
-  const [volume, setVolume] = useState(route?.maxItemsPerSection ?? agent.maxItemsPerSection);
-
-  const slackOptions = (slackChannels.data?.channels ?? [])
-    .filter((channel) => channel.isMember)
-    .map(
-      (channel): AgentSourceConfig => ({
-        platform: "slack",
-        targetType: "channel",
-        targetId: channel.id,
-        label: `#${channel.name}`,
-      }),
-    );
-  const whatsappOptions = (whatsappGroups.data?.groups ?? []).map(
-    (group): AgentSourceConfig => ({
-      platform: "whatsapp",
-      targetType: "group",
-      targetId: group.jid,
-      label: group.name,
-    }),
-  );
-  const lookup = new Map<string, AgentSourceConfig>();
-  for (const source of [...agent.sources, ...slackOptions, ...whatsappOptions]) lookup.set(sourceKey(source), source);
-
-  const selectedKeys = new Set<string>(sources);
-  const combined = sources.length > 1;
-  const hasWhatsApp = sources.some((key) => key.startsWith("whatsapp:"));
-
-  useEffect(() => {
-    if (destKind === "self" && sources.length !== 1) setDestKind("off");
-  }, [destKind, sources.length]);
-
-  const toggleSource = (source: AgentSourceConfig) => {
-    const key = sourceKey(source) as AgentSourceKey;
-    if (selectedKeys.has(key)) {
-      setSources(sources.filter((item) => item !== key));
-      return;
-    }
-    if (maxSources > 0 && sources.length >= maxSources) return;
-    setSources([...sources, key]);
-  };
-
-  const memberQuery = useQuery({
-    queryKey: ["route-members", agentKey, sources],
-    queryFn: () => api.agents.routeMembers(agentKey, sources),
-    enabled: destKind === "member" && sources.length > 0 && !hasWhatsApp,
-  });
-
-  const save = useMutation({
-    mutationFn: () => {
-      const destination: AgentRouteDestination =
-        destKind === "self"
-          ? { kind: "self" }
-          : destKind === "member" && memberUserId
-            ? { kind: "member", platform: "slack", memberUserId }
-            : { kind: "off" };
-      const next: AgentRoute = {
-        id: route?.id ?? crypto.randomUUID(),
-        sources,
-        focus: focus.trim() ? focus.trim() : null,
-        sections,
-        maxItemsPerSection: volume,
-        schedule: { hour, minute },
-        destination,
-        enabled: route?.enabled ?? true,
-      };
-      const routes = route ? agent.routes.map((item) => (item.id === route.id ? next : item)) : [...agent.routes, next];
-      return api.agents.updateConfig(agentKey, { sources: routesToSources(routes, lookup), routes });
-    },
-    onSuccess: () => {
-      onSaved();
-      toast.success("Saved");
-      onClose();
-    },
-    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to save"),
-  });
-
-  const saveDisabled =
-    save.isPending ||
-    sources.length === 0 ||
-    (destKind === "self" && sources.length !== 1) ||
-    (destKind === "member" && (!memberUserId || hasWhatsApp));
-
-  const destOptions: Array<{ value: AgentRouteDestination["kind"]; label: string; disabled: boolean; hint?: string }> =
-    [
-      { value: "self", label: "Post back", disabled: combined, hint: combined ? "single input only" : undefined },
-      { value: "off", label: "Web only", disabled: false },
-      {
-        value: "member",
-        label: "DM a member",
-        disabled: !agent.sourceConfig?.supportsSlackChannels || hasWhatsApp,
-        hint: hasWhatsApp ? "Slack only" : undefined,
-      },
-    ];
-
-  return (
-    <Sheet open onOpenChange={(open) => !open && onClose()}>
-      <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-y-auto sm:max-w-[480px]">
-        <SheetHeader>
-          <SheetTitle>{route ? "Edit summariser" : "New summariser"}</SheetTitle>
-          <SheetDescription>
-            Pick the conversations to summarise, where the summary goes, and when it runs.
-          </SheetDescription>
-        </SheetHeader>
-
-        <div className="flex-1 space-y-6 px-4 py-4">
-          <div className="space-y-4">
-            {agent.sourceConfig?.supportsSlackChannels ? (
-              <SourceGroup
-                title="Slack channels"
-                loading={slackChannels.isLoading}
-                empty="No Slack channels available."
-                selected={selectedKeys}
-                options={slackOptions}
-                onToggle={toggleSource}
-              />
-            ) : null}
-            {agent.sourceConfig?.supportsWhatsAppGroups ? (
-              <SourceGroup
-                title="WhatsApp groups"
-                loading={whatsappGroups.isLoading}
-                empty="No WhatsApp groups available."
-                selected={selectedKeys}
-                options={whatsappOptions}
-                onToggle={toggleSource}
-              />
-            ) : null}
-            <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
-              {sources.length} selected
-              {maxSources > 0 ? ` · limit ${maxSources}` : ""}
-              {combined ? " · combined into one summary" : ""}
-            </p>
-          </div>
-
-          <div>
-            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
-              Delivers to
-            </span>
-            <div className="mt-2 grid grid-cols-3 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1">
-              {destOptions.map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  disabled={option.disabled}
-                  onClick={() => setDestKind(option.value)}
-                  className={cn(
-                    "flex flex-col items-center justify-center rounded-md px-2 py-1.5 text-[12px] font-medium transition-colors",
-                    destKind === option.value
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:text-foreground",
-                    option.disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground",
-                  )}
-                >
-                  {option.label}
-                  {option.hint ? <span className="text-[9px] text-muted-foreground/70">{option.hint}</span> : null}
-                </button>
-              ))}
-            </div>
-            {destKind === "member" ? (
-              <div className="mt-2">
-                {hasWhatsApp ? (
-                  <p className="px-1 py-2 text-[12px] text-muted-foreground">
-                    Member DM works with Slack sources only. Remove the WhatsApp source to pick a member.
-                  </p>
-                ) : (
-                  <TargetList
-                    loading={memberQuery.isLoading}
-                    empty="No member is in every selected source."
-                    selectedId={memberUserId ?? ""}
-                    options={(memberQuery.data?.members ?? []).map((member) => ({
-                      id: member.userId,
-                      label: member.name,
-                      icon: <UserIcon size={14} aria-hidden />,
-                    }))}
-                    onSelect={(id) => setMemberUserId(id)}
-                  />
-                )}
-                <p className="mt-1.5 text-[11px] leading-relaxed text-muted-foreground/70">
-                  Only members of every selected source appear — the summary can never reach someone outside the inputs.
-                </p>
-              </div>
-            ) : null}
-          </div>
-
-          <div>
-            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Runs on</span>
-            <div className="mt-2 flex items-center gap-2">
-              <NumberField label="Hour" min={0} max={23} value={hour} onChange={setHour} />
-              <span className="mt-5 text-muted-foreground">:</span>
-              <NumberField label="Minute" min={0} max={59} value={minute} onChange={setMinute} />
-              <span className="mt-5 ml-2 text-[12.5px] text-muted-foreground">{formatTime(hour, minute)}</span>
-            </div>
-          </div>
-
-          <div>
-            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Sections</span>
-            <div className="mt-2 flex flex-col gap-1.5">
-              {agent.sections.map((section) => (
-                <label
-                  key={section.key}
-                  className="flex cursor-pointer items-center gap-2 text-[12.5px] text-foreground/90"
-                >
-                  <input
-                    type="checkbox"
-                    checked={sections[section.key] ?? section.enabled}
-                    onChange={(e) => setSections({ ...sections, [section.key]: e.target.checked })}
-                    className="h-3.5 w-3.5 accent-foreground"
-                  />
-                  {section.title}
-                </label>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Focus</span>
-            <textarea
-              rows={2}
-              value={focus}
-              onChange={(e) => setFocus(e.target.value)}
-              placeholder="e.g. anything blocking delivery for this group"
-              className="mt-2 w-full resize-none rounded-lg border-[0.5px] border-border bg-background px-3 py-2 text-[12.5px] leading-relaxed text-foreground/90 placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none"
-            />
-          </div>
-
-          <div>
-            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">Volume</span>
-            <div className="mt-2">
-              <NumberField
-                label="Items per section"
-                min={agent.itemsPerSectionRange.min}
-                max={agent.itemsPerSectionRange.max}
-                value={volume}
-                onChange={setVolume}
-              />
-            </div>
-          </div>
-        </div>
-
-        <SheetFooter className="flex-row justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full border-[0.5px] border-border px-4 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={() => save.mutate()}
-            disabled={saveDisabled}
-            className="inline-flex items-center gap-1.5 rounded-full bg-foreground px-4 py-1.5 text-[12px] font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
-          >
-            <CheckCircleIcon size={13} weight="bold" aria-hidden />
-            Save
-          </button>
-        </SheetFooter>
-      </SheetContent>
-    </Sheet>
-  );
-}
-
-function defaultSections(agent: AgentConfig, route: AgentRoute | null): Record<string, boolean> {
-  const record: Record<string, boolean> = {};
-  for (const section of agent.sections) record[section.key] = route?.sections?.[section.key] ?? section.enabled;
-  return record;
 }
 
 function SourceGroup({

--- a/packages/web/src/components/agents/agent-roster.tsx
+++ b/packages/web/src/components/agents/agent-roster.tsx
@@ -20,8 +20,8 @@ export function AgentRoster() {
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <header className="mb-6">
-        <h1 className="text-[22px] font-semibold tracking-tight text-foreground">Agents</h1>
-        <p className="mt-1 text-[13.5px] text-muted-foreground">
+        <h1 className="text-[22px] font-medium text-foreground">Agents</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">
           Prebuilt agents that run in the background on their own. Switch on what you need and tune it to your taste.
         </p>
       </header>

--- a/packages/web/src/components/agents/agent-roster.tsx
+++ b/packages/web/src/components/agents/agent-roster.tsx
@@ -1,15 +1,20 @@
 /**
- * The agents landing — the curated catalog of prebuilt agents. Each is a single,
- * code-owned, opt-in job rendered as one row with an on/off switch and a
- * click-through to its detail + config. Users switch them on and tune them; they
- * cannot author new ones. Design ported from the `feat/demo-mask-pii` roster.
+ * The agents landing — the curated catalog of prebuilt agents. Most are a single
+ * code-owned, opt-in job rendered as one row with an on/off switch. A
+ * source-backed agent (the summariser) instead expands into one sub-row per
+ * summariser it owns, each linking to its own config page, with a "New
+ * summariser" action that opens the first-time-setup modal.
  */
-import { type AgentSummary, api } from "@/lib/api";
-import { CaretRightIcon } from "@phosphor-icons/react";
+import { type AgentRoute, type AgentSourceConfig, type AgentSummary, api } from "@/lib/api";
+import { CaretRightIcon, PlusIcon } from "@phosphor-icons/react";
 import { Switch } from "@sketch/ui/components/switch";
+import { cn } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { useState } from "react";
 import { toast } from "sonner";
+import { SummariserSetupModal } from "./summariser-setup-modal";
+import { InputIcon, deliversLabel, routeInput, sourceKey } from "./summariser-shared";
 
 const AGENTS_LIST_KEY = ["agents", "list"];
 
@@ -34,10 +39,14 @@ export function AgentRoster() {
         groupByCategory(agents).map((group) => (
           <div key={group.category} className="mb-6 last:mb-0">
             <GroupHeader title={group.category} note="switch on what you need" />
-            <div className="flex flex-col">
-              {group.items.map((agent) => (
-                <BackgroundRow key={agent.key} agent={agent} />
-              ))}
+            <div className="flex flex-col gap-1">
+              {group.items.map((agent) =>
+                agent.sourceConfig ? (
+                  <SummariserGroup key={agent.key} agent={agent} />
+                ) : (
+                  <BackgroundRow key={agent.key} agent={agent} />
+                ),
+              )}
             </div>
           </div>
         ))
@@ -60,27 +69,32 @@ function groupByCategory(agents: AgentSummary[]): { category: string; items: Age
   return groups;
 }
 
-function GroupHeader({ title, note, className }: { title: string; note: string; className?: string }) {
+function GroupHeader({ title, note }: { title: string; note: string }) {
   return (
-    <div className={`mb-2 flex items-baseline justify-between border-b border-border/60 pb-2 ${className ?? ""}`}>
+    <div className="mb-2 flex items-baseline justify-between border-b border-border/60 pb-2">
       <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">{title}</span>
       <span className="text-[11px] text-muted-foreground/70">{note}</span>
     </div>
   );
 }
 
-function BackgroundRow({ agent }: { agent: AgentSummary }) {
+function useAgentInvalidate() {
   const queryClient = useQueryClient();
+  return (key: string) => {
+    void queryClient.invalidateQueries({ queryKey: AGENTS_LIST_KEY });
+    void queryClient.invalidateQueries({ queryKey: ["agents", "detail", key] });
+  };
+}
+
+function BackgroundRow({ agent }: { agent: AgentSummary }) {
+  const invalidate = useAgentInvalidate();
   const toggleMutation = useMutation({
     mutationFn: (enabled: boolean) => api.agents.updateConfig(agent.key, { enabled }),
     onSuccess: (_data, enabled) => {
-      void queryClient.invalidateQueries({ queryKey: AGENTS_LIST_KEY });
-      void queryClient.invalidateQueries({ queryKey: ["agents", "detail", agent.key] });
+      invalidate(agent.key);
       toast.success(`${agent.title} ${enabled ? "switched on" : "switched off"}`);
     },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to update agent");
-    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to update agent"),
   });
 
   return (
@@ -103,6 +117,113 @@ function BackgroundRow({ agent }: { agent: AgentSummary }) {
           className="shrink-0 text-muted-foreground/30 group-hover:text-muted-foreground"
         />
       </Link>
+    </div>
+  );
+}
+
+function SummariserGroup({ agent }: { agent: AgentSummary }) {
+  const invalidate = useAgentInvalidate();
+  const [modalOpen, setModalOpen] = useState(false);
+  const lookup = new Map<string, AgentSourceConfig>(agent.sources.map((source) => [sourceKey(source), source]));
+
+  const toggleAgent = useMutation({
+    mutationFn: (enabled: boolean) => api.agents.updateConfig(agent.key, { enabled }),
+    onSuccess: (_data, enabled) => {
+      invalidate(agent.key);
+      toast.success(`${agent.title} ${enabled ? "switched on" : "switched off"}`);
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to update agent"),
+  });
+
+  const toggleRoute = useMutation({
+    mutationFn: (next: AgentRoute) =>
+      api.agents.updateConfig(agent.key, { routes: agent.routes.map((r) => (r.id === next.id ? next : r)) }),
+    onSuccess: () => invalidate(agent.key),
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to update summariser"),
+  });
+
+  return (
+    <div className="rounded-xl">
+      <div className="group flex items-center gap-3 rounded-xl px-4 py-3.5 transition-colors hover:bg-muted/40">
+        <Link to="/agents/$agentKey" params={{ agentKey: agent.key }} className="min-w-0 flex-1">
+          <span className="text-[14px] font-medium text-foreground">{agent.title}</span>
+          <p className="mt-0.5 text-[12.5px] text-muted-foreground">{agent.tagline}</p>
+        </Link>
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-md border-[0.5px] border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:bg-[#111110] dark:hover:bg-[#1C1C1A]"
+        >
+          <PlusIcon size={12} weight="bold" aria-hidden />
+          New summariser
+        </button>
+        <Switch
+          checked={agent.enabled}
+          disabled={toggleAgent.isPending}
+          onCheckedChange={(checked) => toggleAgent.mutate(checked)}
+          aria-label={`${agent.title} on`}
+          className="data-[state=checked]:bg-emerald-500"
+        />
+      </div>
+
+      <div className="ml-6 flex flex-col gap-0.5 border-l border-border/60 pb-1 pl-3">
+        {agent.routes.length === 0 ? (
+          <p className="px-3 py-2.5 text-[12px] text-muted-foreground">
+            No summarisers yet. Add one to start delivering digests.
+          </p>
+        ) : (
+          agent.routes.map((route) => {
+            const input = routeInput(route, lookup);
+            return (
+              <div
+                key={route.id}
+                className={cn(
+                  "group/sub flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/40",
+                  !route.enabled && "opacity-55",
+                )}
+              >
+                <Link
+                  to="/agents/$agentKey/summarisers/$routeId"
+                  params={{ agentKey: agent.key, routeId: route.id }}
+                  className="flex min-w-0 flex-1 items-center gap-2"
+                >
+                  <InputIcon platform={input.platform} />
+                  <span className="truncate text-[12.5px] font-medium text-foreground">{input.label}</span>
+                  {input.extra > 0 ? (
+                    <span className="shrink-0 text-[11px] text-muted-foreground">+{input.extra}</span>
+                  ) : null}
+                  <span className="shrink-0 text-[11.5px] text-muted-foreground">→ {deliversLabel(route)}</span>
+                </Link>
+                <Switch
+                  checked={route.enabled}
+                  disabled={toggleRoute.isPending}
+                  onCheckedChange={(checked) => toggleRoute.mutate({ ...route, enabled: checked })}
+                  aria-label={`${input.label} on`}
+                  className="scale-90 data-[state=checked]:bg-emerald-500"
+                />
+                <Link
+                  to="/agents/$agentKey/summarisers/$routeId"
+                  params={{ agentKey: agent.key, routeId: route.id }}
+                  aria-label={`Open ${input.label}`}
+                >
+                  <CaretRightIcon
+                    size={13}
+                    aria-hidden
+                    className="shrink-0 text-muted-foreground/30 group-hover/sub:text-muted-foreground"
+                  />
+                </Link>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      <SummariserSetupModal
+        agentKey={agent.key}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onCreated={() => invalidate(agent.key)}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/agents/agent-roster.tsx
+++ b/packages/web/src/components/agents/agent-roster.tsx
@@ -126,15 +126,6 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
   const [modalOpen, setModalOpen] = useState(false);
   const lookup = new Map<string, AgentSourceConfig>(agent.sources.map((source) => [sourceKey(source), source]));
 
-  const toggleAgent = useMutation({
-    mutationFn: (enabled: boolean) => api.agents.updateConfig(agent.key, { enabled }),
-    onSuccess: (_data, enabled) => {
-      invalidate(agent.key);
-      toast.success(`${agent.title} ${enabled ? "switched on" : "switched off"}`);
-    },
-    onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to update agent"),
-  });
-
   const toggleRoute = useMutation({
     mutationFn: (next: AgentRoute) =>
       api.agents.updateConfig(agent.key, { routes: agent.routes.map((r) => (r.id === next.id ? next : r)) }),
@@ -143,8 +134,8 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
   });
 
   return (
-    <div className="rounded-xl">
-      <div className="group flex items-center gap-3 rounded-xl px-4 py-3.5 transition-colors hover:bg-muted/40">
+    <div>
+      <div className="flex items-center gap-3 px-4 py-2.5">
         <Link to="/agents/$agentKey" params={{ agentKey: agent.key }} className="min-w-0 flex-1">
           <span className="text-[14px] font-medium text-foreground">{agent.title}</span>
           <p className="mt-0.5 text-[12.5px] text-muted-foreground">{agent.tagline}</p>
@@ -152,24 +143,17 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
         <button
           type="button"
           onClick={() => setModalOpen(true)}
-          className="inline-flex items-center gap-1.5 rounded-md border-[0.5px] border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:bg-[#111110] dark:hover:bg-[#1C1C1A]"
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
         >
           <PlusIcon size={12} weight="bold" aria-hidden />
-          New summariser
+          New
         </button>
-        <Switch
-          checked={agent.enabled}
-          disabled={toggleAgent.isPending}
-          onCheckedChange={(checked) => toggleAgent.mutate(checked)}
-          aria-label={`${agent.title} on`}
-          className="data-[state=checked]:bg-emerald-500"
-        />
       </div>
 
-      <div className="ml-6 flex flex-col gap-0.5 border-l border-border/60 pb-1 pl-3">
+      <div className="ml-4 flex flex-col">
         {agent.routes.length === 0 ? (
-          <p className="px-3 py-2.5 text-[12px] text-muted-foreground">
-            No summarisers yet. Add one to start delivering digests.
+          <p className="px-4 py-2 text-[12px] text-muted-foreground/80">
+            No summarisers yet — add one to start delivering digests.
           </p>
         ) : (
           agent.routes.map((route) => {
@@ -178,7 +162,7 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
               <div
                 key={route.id}
                 className={cn(
-                  "group/sub flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/40",
+                  "group/sub flex items-center gap-3 rounded-lg px-4 py-2 transition-colors hover:bg-muted/40",
                   !route.enabled && "opacity-55",
                 )}
               >
@@ -188,7 +172,7 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
                   className="flex min-w-0 flex-1 items-center gap-2"
                 >
                   <InputIcon platform={input.platform} />
-                  <span className="truncate text-[12.5px] font-medium text-foreground">{input.label}</span>
+                  <span className="truncate text-[12.5px] text-foreground">{input.label}</span>
                   {input.extra > 0 ? (
                     <span className="shrink-0 text-[11px] text-muted-foreground">+{input.extra}</span>
                   ) : null}
@@ -201,17 +185,11 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
                   aria-label={`${input.label} on`}
                   className="scale-90 data-[state=checked]:bg-emerald-500"
                 />
-                <Link
-                  to="/agents/$agentKey/summarisers/$routeId"
-                  params={{ agentKey: agent.key, routeId: route.id }}
-                  aria-label={`Open ${input.label}`}
-                >
-                  <CaretRightIcon
-                    size={13}
-                    aria-hidden
-                    className="shrink-0 text-muted-foreground/30 group-hover/sub:text-muted-foreground"
-                  />
-                </Link>
+                <CaretRightIcon
+                  size={13}
+                  aria-hidden
+                  className="shrink-0 text-muted-foreground/20 transition-colors group-hover/sub:text-muted-foreground/60"
+                />
               </div>
             );
           })

--- a/packages/web/src/components/agents/summariser-config.tsx
+++ b/packages/web/src/components/agents/summariser-config.tsx
@@ -1,0 +1,319 @@
+/**
+ * Per-summariser config page. One summariser (an AgentRoute) shown as the rich
+ * row layout — Input, Runs on, Focus, Volume, Delivers to — plus inline section
+ * toggles. Each row opens a focused side drawer that edits just that field of
+ * the route; sections toggle in place.
+ */
+import { type AgentConfig, type AgentRoute, api } from "@/lib/api";
+import { ArrowLeftIcon, CheckCircleIcon, PencilSimpleIcon } from "@phosphor-icons/react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@sketch/ui/components/sheet";
+import { Switch } from "@sketch/ui/components/switch";
+import { cn } from "@sketch/ui/lib/utils";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  DestinationField,
+  FocusField,
+  InputIcon,
+  ScheduleField,
+  SourcesField,
+  VolumeField,
+  deliversLabel,
+  formatTime,
+  routeInput,
+  saveRoutes,
+  useRouteDraft,
+  useSourceOptions,
+} from "./summariser-shared";
+
+type RouteField = "sources" | "schedule" | "focus" | "volume" | "delivery" | null;
+
+const FIELD_META: Record<Exclude<RouteField, null>, { title: string; hint: string }> = {
+  sources: { title: "Input", hint: "The conversations this summariser reads. Two or more combine into one summary." },
+  schedule: { title: "Runs on", hint: "When this summariser runs each day, in your timezone." },
+  focus: {
+    title: "Focus",
+    hint: "Plain-language emphasis for this summariser. A hint — it never overrides the sections.",
+  },
+  volume: { title: "Volume", hint: "How many items each section can hold." },
+  delivery: { title: "Delivers to", hint: "Where this summary goes once it is generated." },
+};
+
+export function SummariserConfigPage({ agentKey, routeId }: { agentKey: string; routeId: string }) {
+  const queryClient = useQueryClient();
+  const detailQuery = useQuery({ queryKey: ["agents", "detail", agentKey], queryFn: () => api.agents.get(agentKey) });
+  const [editing, setEditing] = useState<RouteField>(null);
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["agents", "detail", agentKey] });
+    void queryClient.invalidateQueries({ queryKey: ["agents", "list"] });
+  };
+
+  const agent = detailQuery.data?.agent ?? null;
+  const route = agent?.routes.find((r) => r.id === routeId) ?? null;
+
+  if (detailQuery.isLoading) return <Shell>{null}</Shell>;
+  if (!agent || !route) {
+    return (
+      <Shell>
+        <p className="mt-10 text-center text-[14px] text-muted-foreground">No such summariser.</p>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <SummariserBody agentKey={agentKey} agent={agent} route={route} onEdit={setEditing} onChanged={invalidate} />
+      {editing ? (
+        <RouteFieldDrawer
+          key={editing}
+          field={editing}
+          agentKey={agentKey}
+          agent={agent}
+          route={route}
+          onClose={() => setEditing(null)}
+          onSaved={invalidate}
+        />
+      ) : null}
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
+      <Link
+        to="/agents"
+        className="inline-flex items-center gap-1.5 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeftIcon size={13} weight="bold" aria-hidden />
+        Agents
+      </Link>
+      {children}
+    </div>
+  );
+}
+
+function SummariserBody({
+  agentKey,
+  agent,
+  route,
+  onEdit,
+  onChanged,
+}: {
+  agentKey: string;
+  agent: AgentConfig;
+  route: AgentRoute;
+  onEdit: (field: RouteField) => void;
+  onChanged: () => void;
+}) {
+  const { lookup } = useSourceOptions(agent);
+  const input = routeInput(route, lookup);
+
+  const save = useMutation({
+    mutationFn: (next: AgentRoute) =>
+      saveRoutes(
+        agentKey,
+        agent.routes.map((r) => (r.id === route.id ? next : r)),
+        lookup,
+      ),
+    onSuccess: onChanged,
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to update"),
+  });
+
+  return (
+    <>
+      <header className="mt-5 flex items-start gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <InputIcon platform={input.platform} />
+            <h1 className="truncate text-[22px] font-medium text-foreground">{input.label}</h1>
+            {input.extra > 0 ? (
+              <span className="shrink-0 text-[13px] text-muted-foreground">+{input.extra}</span>
+            ) : null}
+          </div>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            Summariser · delivers {deliversLabel(route).toLowerCase()}
+          </p>
+        </div>
+        <span className="flex shrink-0 items-center gap-2 text-[12px] font-medium text-muted-foreground">
+          <Switch
+            checked={route.enabled}
+            disabled={save.isPending}
+            onCheckedChange={(enabled) => save.mutate({ ...route, enabled })}
+            aria-label="Summariser active"
+            className="data-[state=checked]:bg-emerald-500"
+          />
+          {route.enabled ? "On" : "Off"}
+        </span>
+      </header>
+
+      <div className="mt-6 rounded-xl border-[0.5px] border-border bg-card px-4">
+        <Row label="Input" onEdit={() => onEdit("sources")}>
+          <span className="flex items-center gap-1.5 text-[12.5px] text-foreground/85">
+            {input.label}
+            {input.extra > 0 ? <span className="text-muted-foreground">+{input.extra} more</span> : null}
+          </span>
+        </Row>
+        <Row label="Runs on" onEdit={() => onEdit("schedule")}>
+          <p className="text-[12.5px] text-foreground/85">
+            Every day at{" "}
+            {formatTime(route.schedule?.hour ?? agent.scheduleHour, route.schedule?.minute ?? agent.scheduleMinute)}
+          </p>
+        </Row>
+        <Row label="Focus" onEdit={() => onEdit("focus")}>
+          <p className="line-clamp-2 text-[12.5px] leading-relaxed text-foreground/85">
+            {route.focus ? route.focus : <span className="text-muted-foreground">None — add what to emphasize.</span>}
+          </p>
+        </Row>
+        <Row label="Volume" onEdit={() => onEdit("volume")}>
+          <p className="text-[12.5px] text-foreground/85">
+            Up to {route.maxItemsPerSection ?? agent.maxItemsPerSection} items per section
+          </p>
+        </Row>
+        <Row label="Delivers to" onEdit={() => onEdit("delivery")}>
+          <p className="text-[12.5px] text-foreground/85">{deliversLabel(route)}</p>
+        </Row>
+      </div>
+
+      <div className="mb-3 mt-7 flex items-baseline justify-between border-b border-border/60 pb-2">
+        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Sections</span>
+        <span className="text-[11px] text-muted-foreground/70">turn on only what you want</span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {agent.sections.map((section) => {
+          const on = route.sections?.[section.key] ?? section.enabled;
+          return (
+            <div
+              key={section.key}
+              className="flex items-center gap-3 rounded-xl border-[0.5px] border-border bg-card px-4 py-3"
+            >
+              <p className="min-w-0 flex-1 text-[13px] font-medium text-foreground">{section.title}</p>
+              <Switch
+                checked={on}
+                disabled={save.isPending}
+                onCheckedChange={(next) => {
+                  const sections: Record<string, boolean> = {};
+                  for (const s of agent.sections) sections[s.key] = route.sections?.[s.key] ?? s.enabled;
+                  sections[section.key] = next;
+                  save.mutate({ ...route, sections });
+                }}
+                aria-label={section.title}
+                className="data-[state=checked]:bg-emerald-500"
+              />
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function Row({ label, children, onEdit }: { label: string; children: React.ReactNode; onEdit: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onEdit}
+      className="group flex w-full items-start gap-3 border-b border-border/50 py-3.5 text-left last:border-0"
+    >
+      <span className="mt-[1px] w-[88px] shrink-0 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70">
+        {label}
+      </span>
+      <div className="min-w-0 flex-1">{children}</div>
+      <PencilSimpleIcon
+        size={13}
+        weight="bold"
+        aria-hidden
+        className="mt-[1px] shrink-0 text-muted-foreground/30 transition-colors group-hover:text-foreground"
+      />
+    </button>
+  );
+}
+
+function RouteFieldDrawer({
+  field,
+  agentKey,
+  agent,
+  route,
+  onClose,
+  onSaved,
+}: {
+  field: Exclude<RouteField, null>;
+  agentKey: string;
+  agent: AgentConfig;
+  route: AgentRoute;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const controller = useRouteDraft(agent, route);
+  const { lookup } = useSourceOptions(agent);
+  const meta = FIELD_META[field];
+
+  const save = useMutation({
+    mutationFn: () =>
+      saveRoutes(
+        agentKey,
+        agent.routes.map((r) => (r.id === route.id ? controller.build(route) : r)),
+        lookup,
+      ),
+    onSuccess: () => {
+      onSaved();
+      toast.success("Saved");
+      onClose();
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to save"),
+  });
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-y-auto sm:max-w-[480px]">
+        <SheetHeader>
+          <SheetTitle>{meta.title}</SheetTitle>
+          <SheetDescription>{meta.hint}</SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 px-4 py-4">
+          {field === "sources" ? (
+            <SourcesField agent={agent} controller={controller} />
+          ) : field === "schedule" ? (
+            <ScheduleField controller={controller} />
+          ) : field === "focus" ? (
+            <FocusField controller={controller} />
+          ) : field === "volume" ? (
+            <VolumeField agent={agent} controller={controller} />
+          ) : (
+            <DestinationField agent={agent} agentKey={agentKey} controller={controller} />
+          )}
+        </div>
+
+        <SheetFooter className="flex-row justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border-[0.5px] border-border px-4 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => save.mutate()}
+            disabled={save.isPending || !controller.isValid}
+            className="inline-flex items-center gap-1.5 rounded-full bg-foreground px-4 py-1.5 text-[12px] font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            <CheckCircleIcon size={13} weight="bold" aria-hidden />
+            Save
+          </button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/web/src/components/agents/summariser-setup-modal.tsx
+++ b/packages/web/src/components/agents/summariser-setup-modal.tsx
@@ -4,6 +4,7 @@
  * also switches the agent on. Editing an existing summariser happens on its own
  * config page, not here.
  */
+import { ProgressIndicator } from "@/components/onboarding/progress-indicator";
 import { type AgentConfig, api } from "@/lib/api";
 import { Button } from "@sketch/ui/components/button";
 import {
@@ -14,7 +15,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@sketch/ui/components/dialog";
-import { cn } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -83,8 +83,14 @@ function SetupBody({
   onCreated: () => void;
 }) {
   const [step, setStep] = useState(0);
+  const [maxStep, setMaxStep] = useState(0);
   const controller = useRouteDraft(agent, null);
   const { lookup } = useSourceOptions(agent);
+
+  const goToStep = (next: number) => {
+    setStep(next);
+    setMaxStep((prev) => Math.max(prev, next));
+  };
 
   const create = useMutation({
     mutationFn: () => {
@@ -109,8 +115,15 @@ function SetupBody({
 
   return (
     <>
-      <Stepper step={step} />
-      <p className="px-1 pt-3 text-[12px] text-muted-foreground">{STEPS[step].hint}</p>
+      <div className="pt-3">
+        <ProgressIndicator
+          currentStep={step + 1}
+          maxStepReached={maxStep + 1}
+          steps={STEPS.map((s, i) => ({ number: i + 1, label: s.title }))}
+          onStepClick={(n) => setStep(n - 1)}
+        />
+      </div>
+      <p className="px-1 text-[12px] text-muted-foreground">{STEPS[step].hint}</p>
       <div className="flex-1 overflow-y-auto px-1 py-4">
         {step === 0 ? (
           <SourcesField agent={agent} controller={controller} />
@@ -134,38 +147,11 @@ function SetupBody({
             Create summariser
           </Button>
         ) : (
-          <Button size="sm" disabled={!canAdvance} onClick={() => setStep(step + 1)}>
+          <Button size="sm" disabled={!canAdvance} onClick={() => goToStep(step + 1)}>
             Next
           </Button>
         )}
       </DialogFooter>
     </>
-  );
-}
-
-function Stepper({ step }: { step: number }) {
-  return (
-    <div className="flex items-center gap-2 px-1 pt-1">
-      {STEPS.map((s, i) => (
-        <div key={s.title} className="flex items-center gap-2">
-          <span
-            className={cn(
-              "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium transition-colors",
-              i < step
-                ? "bg-emerald-500 text-white"
-                : i === step
-                  ? "bg-foreground text-background"
-                  : "bg-muted text-muted-foreground",
-            )}
-          >
-            {i + 1}
-          </span>
-          <span className={cn("text-[11.5px]", i === step ? "font-medium text-foreground" : "text-muted-foreground")}>
-            {s.title}
-          </span>
-          {i < STEPS.length - 1 ? <span className="h-px w-4 bg-border" /> : null}
-        </div>
-      ))}
-    </div>
   );
 }

--- a/packages/web/src/components/agents/summariser-setup-modal.tsx
+++ b/packages/web/src/components/agents/summariser-setup-modal.tsx
@@ -1,8 +1,8 @@
 /**
- * First-time setup for a new summariser. A single modal captures everything —
- * inputs, destination, schedule, sections, focus, and volume — then appends the
- * route to the agent and closes. Editing an existing summariser happens on its
- * own config page, not here.
+ * First-time setup for a new summariser, as a short multi-step wizard: choose
+ * inputs, then delivery, then schedule + content. Creating the first summariser
+ * also switches the agent on. Editing an existing summariser happens on its own
+ * config page, not here.
  */
 import { type AgentConfig, api } from "@/lib/api";
 import { Button } from "@sketch/ui/components/button";
@@ -14,7 +14,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@sketch/ui/components/dialog";
+import { cn } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { toast } from "sonner";
 import {
   DestinationField,
@@ -23,10 +25,16 @@ import {
   SectionsField,
   SourcesField,
   VolumeField,
-  saveRoutes,
+  routesToSources,
   useRouteDraft,
   useSourceOptions,
 } from "./summariser-shared";
+
+const STEPS = [
+  { title: "Inputs", hint: "Pick the conversations to summarise." },
+  { title: "Delivery", hint: "Choose where the summary goes." },
+  { title: "Schedule & content", hint: "Set when it runs and what it includes." },
+];
 
 export function SummariserSetupModal({
   agentKey,
@@ -51,9 +59,7 @@ export function SummariserSetupModal({
       <DialogContent className="flex max-h-[85vh] flex-col gap-0 overflow-hidden sm:max-w-[520px]">
         <DialogHeader>
           <DialogTitle>New summariser</DialogTitle>
-          <DialogDescription>
-            Pick the conversations to summarise, where the summary goes, and when it runs.
-          </DialogDescription>
+          <DialogDescription>Set up a new summariser in three quick steps.</DialogDescription>
         </DialogHeader>
         {agent ? (
           <SetupBody agentKey={agentKey} agent={agent} onClose={onClose} onCreated={onCreated} />
@@ -76,11 +82,16 @@ function SetupBody({
   onClose: () => void;
   onCreated: () => void;
 }) {
+  const [step, setStep] = useState(0);
   const controller = useRouteDraft(agent, null);
   const { lookup } = useSourceOptions(agent);
 
   const create = useMutation({
-    mutationFn: () => saveRoutes(agentKey, [...agent.routes, controller.build(null)], lookup),
+    mutationFn: () => {
+      const next = controller.build(null);
+      const routes = [...agent.routes, next];
+      return api.agents.updateConfig(agentKey, { enabled: true, sources: routesToSources(routes, lookup), routes });
+    },
     onSuccess: () => {
       onCreated();
       toast.success("Summariser created");
@@ -89,24 +100,72 @@ function SetupBody({
     onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to create"),
   });
 
+  const inputsValid = controller.sources.length > 0;
+  const deliveryValid =
+    !(controller.destKind === "self" && controller.sources.length !== 1) &&
+    !(controller.destKind === "member" && (!controller.memberUserId || controller.hasWhatsApp));
+  const canAdvance = step === 0 ? inputsValid : step === 1 ? deliveryValid : controller.isValid;
+  const isLast = step === STEPS.length - 1;
+
   return (
     <>
-      <div className="flex-1 space-y-6 overflow-y-auto px-1 py-4">
-        <SourcesField agent={agent} controller={controller} />
-        <DestinationField agent={agent} agentKey={agentKey} controller={controller} />
-        <ScheduleField controller={controller} />
-        <SectionsField agent={agent} controller={controller} />
-        <FocusField controller={controller} />
-        <VolumeField agent={agent} controller={controller} />
+      <Stepper step={step} />
+      <p className="px-1 pt-3 text-[12px] text-muted-foreground">{STEPS[step].hint}</p>
+      <div className="flex-1 overflow-y-auto px-1 py-4">
+        {step === 0 ? (
+          <SourcesField agent={agent} controller={controller} />
+        ) : step === 1 ? (
+          <DestinationField agent={agent} agentKey={agentKey} controller={controller} />
+        ) : (
+          <div className="space-y-6">
+            <ScheduleField controller={controller} />
+            <SectionsField agent={agent} controller={controller} />
+            <FocusField controller={controller} />
+            <VolumeField agent={agent} controller={controller} />
+          </div>
+        )}
       </div>
       <DialogFooter>
-        <Button variant="outline" size="sm" onClick={onClose}>
-          Cancel
+        <Button variant="ghost" size="sm" onClick={() => (step === 0 ? onClose() : setStep(step - 1))}>
+          {step === 0 ? "Cancel" : "Back"}
         </Button>
-        <Button size="sm" disabled={!controller.isValid || create.isPending} onClick={() => create.mutate()}>
-          Create summariser
-        </Button>
+        {isLast ? (
+          <Button size="sm" disabled={!controller.isValid || create.isPending} onClick={() => create.mutate()}>
+            Create summariser
+          </Button>
+        ) : (
+          <Button size="sm" disabled={!canAdvance} onClick={() => setStep(step + 1)}>
+            Next
+          </Button>
+        )}
       </DialogFooter>
     </>
+  );
+}
+
+function Stepper({ step }: { step: number }) {
+  return (
+    <div className="flex items-center gap-2 px-1 pt-1">
+      {STEPS.map((s, i) => (
+        <div key={s.title} className="flex items-center gap-2">
+          <span
+            className={cn(
+              "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium transition-colors",
+              i < step
+                ? "bg-emerald-500 text-white"
+                : i === step
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-muted-foreground",
+            )}
+          >
+            {i + 1}
+          </span>
+          <span className={cn("text-[11.5px]", i === step ? "font-medium text-foreground" : "text-muted-foreground")}>
+            {s.title}
+          </span>
+          {i < STEPS.length - 1 ? <span className="h-px w-4 bg-border" /> : null}
+        </div>
+      ))}
+    </div>
   );
 }

--- a/packages/web/src/components/agents/summariser-setup-modal.tsx
+++ b/packages/web/src/components/agents/summariser-setup-modal.tsx
@@ -1,8 +1,8 @@
 /**
- * First-time setup for a new summariser, as a short multi-step wizard: choose
- * inputs, then delivery, then schedule + content. Creating the first summariser
- * also switches the agent on. Editing an existing summariser happens on its own
- * config page, not here.
+ * First-time setup for a new summariser, as a short four-step wizard: choose
+ * inputs, then delivery, then schedule, then content (sections + focus).
+ * Creating the first summariser also switches the agent on. Editing an existing
+ * summariser happens on its own config page, not here.
  */
 import { ProgressIndicator } from "@/components/onboarding/progress-indicator";
 import { type AgentConfig, api } from "@/lib/api";
@@ -33,7 +33,8 @@ import {
 const STEPS = [
   { title: "Inputs", hint: "Pick the conversations to summarise." },
   { title: "Delivery", hint: "Choose where the summary goes." },
-  { title: "Schedule & content", hint: "Set when it runs and what it includes." },
+  { title: "Schedule", hint: "Set when it runs and how much it includes." },
+  { title: "Content", hint: "Choose the sections and any focus." },
 ];
 
 export function SummariserSetupModal({
@@ -59,7 +60,7 @@ export function SummariserSetupModal({
       <DialogContent className="flex max-h-[85vh] flex-col gap-0 overflow-hidden sm:max-w-[520px]">
         <DialogHeader>
           <DialogTitle>New summariser</DialogTitle>
-          <DialogDescription>Set up a new summariser in three quick steps.</DialogDescription>
+          <DialogDescription>Set up a new summariser in four quick steps.</DialogDescription>
         </DialogHeader>
         {agent ? (
           <SetupBody agentKey={agentKey} agent={agent} onClose={onClose} onCreated={onCreated} />
@@ -111,7 +112,7 @@ function SetupBody({
     !(controller.destKind === "self" && controller.sources.length !== 1) &&
     !(controller.destKind === "member" && (!controller.memberUserId || controller.hasWhatsApp)) &&
     !(controller.destKind === "channel" && !controller.channelTarget);
-  const canAdvance = step === 0 ? inputsValid : step === 1 ? deliveryValid : controller.isValid;
+  const canAdvance = step === 0 ? inputsValid : step === 1 ? deliveryValid : step === 2 ? true : controller.isValid;
   const isLast = step === STEPS.length - 1;
 
   return (
@@ -124,18 +125,24 @@ function SetupBody({
           onStepClick={(n) => setStep(n - 1)}
         />
       </div>
-      <p className="px-1 text-[12px] text-muted-foreground">{STEPS[step].hint}</p>
-      <div className="flex-1 overflow-y-auto px-1 py-4">
+      <div className="mt-3 px-1">
+        <h2 className="text-[15px] font-semibold text-foreground">{STEPS[step].title}</h2>
+        <p className="mt-0.5 text-[12.5px] text-muted-foreground">{STEPS[step].hint}</p>
+      </div>
+      <div className="mt-2 h-[340px] overflow-y-auto px-1 py-3">
         {step === 0 ? (
           <SourcesField agent={agent} controller={controller} />
         ) : step === 1 ? (
           <DestinationField agent={agent} agentKey={agentKey} controller={controller} />
-        ) : (
+        ) : step === 2 ? (
           <div className="space-y-6">
             <ScheduleField controller={controller} />
+            <VolumeField agent={agent} controller={controller} />
+          </div>
+        ) : (
+          <div className="space-y-6">
             <SectionsField agent={agent} controller={controller} />
             <FocusField controller={controller} />
-            <VolumeField agent={agent} controller={controller} />
           </div>
         )}
       </div>

--- a/packages/web/src/components/agents/summariser-setup-modal.tsx
+++ b/packages/web/src/components/agents/summariser-setup-modal.tsx
@@ -109,7 +109,8 @@ function SetupBody({
   const inputsValid = controller.sources.length > 0;
   const deliveryValid =
     !(controller.destKind === "self" && controller.sources.length !== 1) &&
-    !(controller.destKind === "member" && (!controller.memberUserId || controller.hasWhatsApp));
+    !(controller.destKind === "member" && (!controller.memberUserId || controller.hasWhatsApp)) &&
+    !(controller.destKind === "channel" && !controller.channelTarget);
   const canAdvance = step === 0 ? inputsValid : step === 1 ? deliveryValid : controller.isValid;
   const isLast = step === STEPS.length - 1;
 

--- a/packages/web/src/components/agents/summariser-setup-modal.tsx
+++ b/packages/web/src/components/agents/summariser-setup-modal.tsx
@@ -1,0 +1,112 @@
+/**
+ * First-time setup for a new summariser. A single modal captures everything —
+ * inputs, destination, schedule, sections, focus, and volume — then appends the
+ * route to the agent and closes. Editing an existing summariser happens on its
+ * own config page, not here.
+ */
+import { type AgentConfig, api } from "@/lib/api";
+import { Button } from "@sketch/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@sketch/ui/components/dialog";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  DestinationField,
+  FocusField,
+  ScheduleField,
+  SectionsField,
+  SourcesField,
+  VolumeField,
+  saveRoutes,
+  useRouteDraft,
+  useSourceOptions,
+} from "./summariser-shared";
+
+export function SummariserSetupModal({
+  agentKey,
+  open,
+  onClose,
+  onCreated,
+}: {
+  agentKey: string;
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const configQuery = useQuery({
+    queryKey: ["agents", "detail", agentKey],
+    queryFn: () => api.agents.get(agentKey),
+    enabled: open,
+  });
+  const agent = configQuery.data?.agent ?? null;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="flex max-h-[85vh] flex-col gap-0 overflow-hidden sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>New summariser</DialogTitle>
+          <DialogDescription>
+            Pick the conversations to summarise, where the summary goes, and when it runs.
+          </DialogDescription>
+        </DialogHeader>
+        {agent ? (
+          <SetupBody agentKey={agentKey} agent={agent} onClose={onClose} onCreated={onCreated} />
+        ) : (
+          <p className="px-1 py-10 text-center text-[13px] text-muted-foreground">Loading…</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SetupBody({
+  agentKey,
+  agent,
+  onClose,
+  onCreated,
+}: {
+  agentKey: string;
+  agent: AgentConfig;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const controller = useRouteDraft(agent, null);
+  const { lookup } = useSourceOptions(agent);
+
+  const create = useMutation({
+    mutationFn: () => saveRoutes(agentKey, [...agent.routes, controller.build(null)], lookup),
+    onSuccess: () => {
+      onCreated();
+      toast.success("Summariser created");
+      onClose();
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to create"),
+  });
+
+  return (
+    <>
+      <div className="flex-1 space-y-6 overflow-y-auto px-1 py-4">
+        <SourcesField agent={agent} controller={controller} />
+        <DestinationField agent={agent} agentKey={agentKey} controller={controller} />
+        <ScheduleField controller={controller} />
+        <SectionsField agent={agent} controller={controller} />
+        <FocusField controller={controller} />
+        <VolumeField agent={agent} controller={controller} />
+      </div>
+      <DialogFooter>
+        <Button variant="outline" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button size="sm" disabled={!controller.isValid || create.isPending} onClick={() => create.mutate()}>
+          Create summariser
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/lib/api";
 import { CheckCircleIcon, HashIcon, MagnifyingGlassIcon, UserIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { Switch } from "@sketch/ui/components/switch";
-import { TabButton } from "@sketch/ui/components/tab-button";
 import { cn } from "@sketch/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
@@ -267,6 +266,24 @@ export function SourcesField({ agent, controller }: { agent: AgentConfig; contro
   );
 }
 
+/** Pill-style delivery tab, matching the Team Adoption filter tabs on the usage page. */
+function DeliveryTab({ label, isActive, onClick }: { label: string; isActive: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-md px-2.5 py-1 text-xs transition-colors",
+        isActive
+          ? "bg-accent font-medium text-foreground dark:bg-[#1C1C1A]"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
 export function DestinationField({
   agent,
   agentKey,
@@ -298,15 +315,15 @@ export function DestinationField({
 
   return (
     <div>
-      <div className="flex items-center gap-6 border-b border-border">
-        <TabButton
+      <div className="inline-flex rounded-lg border-[0.5px] border-border bg-card p-0.5 dark:bg-[#111110]">
+        <DeliveryTab
           label="Groups"
           isActive={activeTab === "groups"}
           onClick={() => {
             if (destKind === "member") controller.setDestKind("channel");
           }}
         />
-        <TabButton label="DM" isActive={activeTab === "dm"} onClick={() => controller.setDestKind("member")} />
+        <DeliveryTab label="DM" isActive={activeTab === "dm"} onClick={() => controller.setDestKind("member")} />
       </div>
 
       {activeTab === "groups" ? (

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -1,0 +1,538 @@
+/**
+ * Shared building blocks for editing a summariser (an AgentRoute on a
+ * source-backed agent). A summariser maps one or more input conversations to a
+ * delivery, schedule, sections, focus, and volume. These primitives are reused
+ * by the roster sub-rows, the new-summariser modal, and the per-summariser
+ * config page so the vocabulary stays consistent everywhere.
+ */
+import {
+  type AgentConfig,
+  type AgentRoute,
+  type AgentRouteDestination,
+  type AgentSourceConfig,
+  type AgentSourceKey,
+  api,
+} from "@/lib/api";
+import { CheckCircleIcon, HashIcon, UserIcon, UsersThreeIcon } from "@phosphor-icons/react";
+import { cn } from "@sketch/ui/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+export function sourceKey(source: AgentSourceConfig): string {
+  return `${source.platform}:${source.targetType}:${source.targetId}`;
+}
+
+export function formatTime(hour: number, minute: number): string {
+  const period = hour < 12 ? "AM" : "PM";
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${h12}:${String(minute).padStart(2, "0")} ${period}`;
+}
+
+export function deliversLabel(route: AgentRoute): string {
+  if (route.destination.kind === "self") return "Post back";
+  if (route.destination.kind === "member") return "Direct message";
+  return "Web only";
+}
+
+export function sectionsLabel(route: AgentRoute, agent: AgentConfig): string {
+  const on = agent.sections.filter((section) => route.sections?.[section.key] ?? section.enabled);
+  if (on.length === agent.sections.length) return "All sections";
+  if (on.length === 0) return "No sections";
+  return on.map((section) => section.title).join(", ");
+}
+
+export function routesToSources(routes: AgentRoute[], lookup: Map<string, AgentSourceConfig>): AgentSourceConfig[] {
+  const out: AgentSourceConfig[] = [];
+  const seen = new Set<string>();
+  for (const route of routes) {
+    for (const key of route.sources) {
+      if (seen.has(key)) continue;
+      const source = lookup.get(key);
+      if (source) {
+        seen.add(key);
+        out.push(source);
+      }
+    }
+  }
+  return out;
+}
+
+export function defaultSections(agent: AgentConfig, route: AgentRoute | null): Record<string, boolean> {
+  const record: Record<string, boolean> = {};
+  for (const section of agent.sections) record[section.key] = route?.sections?.[section.key] ?? section.enabled;
+  return record;
+}
+
+/** Resolves a route's first source to a display label + platform, with a count of any combined extras. */
+export function routeInput(
+  route: Pick<AgentRoute, "sources">,
+  lookup: Map<string, AgentSourceConfig>,
+): { label: string; platform: "slack" | "whatsapp" | null; extra: number } {
+  const first = route.sources[0] ? lookup.get(route.sources[0]) : undefined;
+  return {
+    label: first?.label ?? route.sources[0] ?? "No input",
+    platform: first?.platform ?? null,
+    extra: Math.max(0, route.sources.length - 1),
+  };
+}
+
+/** Fetches the selectable Slack/WhatsApp inputs and builds a key→source lookup that also covers already-saved sources. */
+export function useSourceOptions(agent: AgentConfig) {
+  const slackChannels = useQuery({ queryKey: ["slack-channels"], queryFn: () => api.channels.listSlack() });
+  const whatsappGroups = useQuery({ queryKey: ["whatsapp-groups"], queryFn: () => api.channels.listWhatsAppGroups() });
+
+  const slackOptions = (slackChannels.data?.channels ?? [])
+    .filter((channel) => channel.isMember)
+    .map(
+      (channel): AgentSourceConfig => ({
+        platform: "slack",
+        targetType: "channel",
+        targetId: channel.id,
+        label: `#${channel.name}`,
+      }),
+    );
+  const whatsappOptions = (whatsappGroups.data?.groups ?? []).map(
+    (group): AgentSourceConfig => ({
+      platform: "whatsapp",
+      targetType: "group",
+      targetId: group.jid,
+      label: group.name,
+    }),
+  );
+
+  const lookup = new Map<string, AgentSourceConfig>();
+  for (const source of [...agent.sources, ...slackOptions, ...whatsappOptions]) lookup.set(sourceKey(source), source);
+
+  return {
+    slackLoading: slackChannels.isLoading,
+    whatsappLoading: whatsappGroups.isLoading,
+    slackOptions,
+    whatsappOptions,
+    lookup,
+  };
+}
+
+export interface RouteDraftController {
+  sources: AgentSourceKey[];
+  destKind: AgentRouteDestination["kind"];
+  memberUserId: string | null;
+  hour: number;
+  minute: number;
+  sections: Record<string, boolean>;
+  focus: string;
+  volume: number;
+  combined: boolean;
+  hasWhatsApp: boolean;
+  isValid: boolean;
+  toggleSource: (source: AgentSourceConfig) => void;
+  setDestKind: (kind: AgentRouteDestination["kind"]) => void;
+  setMemberUserId: (id: string | null) => void;
+  setHour: (v: number) => void;
+  setMinute: (v: number) => void;
+  setSection: (key: string, on: boolean) => void;
+  setFocus: (v: string) => void;
+  setVolume: (v: number) => void;
+  build: (base: AgentRoute | null) => AgentRoute;
+}
+
+/** Local editable state for one summariser, seeded from an existing route or blank for a new one. */
+export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): RouteDraftController {
+  const maxSources = agent.sourceConfig?.maxSources ?? 0;
+  const [sources, setSources] = useState<AgentSourceKey[]>(route?.sources ?? []);
+  const [destKind, setDestKind] = useState<AgentRouteDestination["kind"]>(route?.destination.kind ?? "off");
+  const [memberUserId, setMemberUserId] = useState<string | null>(
+    route?.destination.kind === "member" ? route.destination.memberUserId : null,
+  );
+  const [hour, setHour] = useState(route?.schedule?.hour ?? agent.scheduleHour);
+  const [minute, setMinute] = useState(route?.schedule?.minute ?? agent.scheduleMinute);
+  const [sections, setSections] = useState<Record<string, boolean>>(defaultSections(agent, route));
+  const [focus, setFocus] = useState(route?.focus ?? "");
+  const [volume, setVolume] = useState(route?.maxItemsPerSection ?? agent.maxItemsPerSection);
+
+  const combined = sources.length > 1;
+  const hasWhatsApp = sources.some((key) => key.startsWith("whatsapp:"));
+
+  useEffect(() => {
+    if (destKind === "self" && sources.length !== 1) setDestKind("off");
+  }, [destKind, sources.length]);
+
+  const toggleSource = (source: AgentSourceConfig) => {
+    const key = sourceKey(source) as AgentSourceKey;
+    if (sources.includes(key)) {
+      setSources(sources.filter((item) => item !== key));
+      return;
+    }
+    if (maxSources > 0 && sources.length >= maxSources) return;
+    setSources([...sources, key]);
+  };
+
+  const isValid =
+    sources.length > 0 &&
+    !(destKind === "self" && sources.length !== 1) &&
+    !(destKind === "member" && (!memberUserId || hasWhatsApp));
+
+  const build = (base: AgentRoute | null): AgentRoute => {
+    const destination: AgentRouteDestination =
+      destKind === "self"
+        ? { kind: "self" }
+        : destKind === "member" && memberUserId
+          ? { kind: "member", platform: "slack", memberUserId }
+          : { kind: "off" };
+    return {
+      id: base?.id ?? crypto.randomUUID(),
+      sources,
+      focus: focus.trim() ? focus.trim() : null,
+      sections,
+      maxItemsPerSection: volume,
+      schedule: { hour, minute },
+      destination,
+      enabled: base?.enabled ?? true,
+    };
+  };
+
+  return {
+    sources,
+    destKind,
+    memberUserId,
+    hour,
+    minute,
+    sections,
+    focus,
+    volume,
+    combined,
+    hasWhatsApp,
+    isValid,
+    toggleSource,
+    setDestKind,
+    setMemberUserId,
+    setHour,
+    setMinute,
+    setSection: (key, on) => setSections((prev) => ({ ...prev, [key]: on })),
+    setFocus,
+    setVolume,
+    build,
+  };
+}
+
+const LABEL = "font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70";
+
+export function SourcesField({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
+  const { slackLoading, whatsappLoading, slackOptions, whatsappOptions } = useSourceOptions(agent);
+  const selected = new Set<string>(controller.sources);
+  const maxSources = agent.sourceConfig?.maxSources ?? 0;
+  return (
+    <div className="space-y-4">
+      {agent.sourceConfig?.supportsSlackChannels ? (
+        <SourceGroup
+          title="Slack channels"
+          loading={slackLoading}
+          empty="No Slack channels available."
+          selected={selected}
+          options={slackOptions}
+          onToggle={controller.toggleSource}
+        />
+      ) : null}
+      {agent.sourceConfig?.supportsWhatsAppGroups ? (
+        <SourceGroup
+          title="WhatsApp groups"
+          loading={whatsappLoading}
+          empty="No WhatsApp groups available."
+          selected={selected}
+          options={whatsappOptions}
+          onToggle={controller.toggleSource}
+        />
+      ) : null}
+      <p className={LABEL}>
+        {controller.sources.length} selected
+        {maxSources > 0 ? ` · limit ${maxSources}` : ""}
+        {controller.combined ? " · combined into one summary" : ""}
+      </p>
+    </div>
+  );
+}
+
+export function DestinationField({
+  agent,
+  agentKey,
+  controller,
+}: {
+  agent: AgentConfig;
+  agentKey: string;
+  controller: RouteDraftController;
+}) {
+  const { destKind, memberUserId, combined, hasWhatsApp } = controller;
+  const memberQuery = useQuery({
+    queryKey: ["route-members", agentKey, controller.sources],
+    queryFn: () => api.agents.routeMembers(agentKey, controller.sources),
+    enabled: destKind === "member" && controller.sources.length > 0 && !hasWhatsApp,
+  });
+
+  const destOptions: Array<{ value: AgentRouteDestination["kind"]; label: string; disabled: boolean; hint?: string }> =
+    [
+      { value: "self", label: "Post back", disabled: combined, hint: combined ? "single input only" : undefined },
+      { value: "off", label: "Web only", disabled: false },
+      {
+        value: "member",
+        label: "DM a member",
+        disabled: !agent.sourceConfig?.supportsSlackChannels || hasWhatsApp,
+        hint: hasWhatsApp ? "Slack only" : undefined,
+      },
+    ];
+
+  return (
+    <div>
+      <span className={LABEL}>Delivers to</span>
+      <div className="mt-2 grid grid-cols-3 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1">
+        {destOptions.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            disabled={option.disabled}
+            onClick={() => controller.setDestKind(option.value)}
+            className={cn(
+              "flex flex-col items-center justify-center rounded-md px-2 py-1.5 text-[12px] font-medium transition-colors",
+              destKind === option.value
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+              option.disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+            )}
+          >
+            {option.label}
+            {option.hint ? <span className="text-[9px] text-muted-foreground/70">{option.hint}</span> : null}
+          </button>
+        ))}
+      </div>
+      {destKind === "member" ? (
+        <div className="mt-2">
+          {hasWhatsApp ? (
+            <p className="px-1 py-2 text-[12px] text-muted-foreground">
+              Member DM works with Slack sources only. Remove the WhatsApp source to pick a member.
+            </p>
+          ) : (
+            <TargetList
+              loading={memberQuery.isLoading}
+              empty="No member is in every selected source."
+              selectedId={memberUserId ?? ""}
+              options={(memberQuery.data?.members ?? []).map((member) => ({
+                id: member.userId,
+                label: member.name,
+                icon: <UserIcon size={14} aria-hidden />,
+              }))}
+              onSelect={(id) => controller.setMemberUserId(id)}
+            />
+          )}
+          <p className="mt-1.5 text-[11px] leading-relaxed text-muted-foreground/70">
+            Only members of every selected source appear — the summary can never reach someone outside the inputs.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ScheduleField({ controller }: { controller: RouteDraftController }) {
+  return (
+    <div>
+      <span className={LABEL}>Runs on</span>
+      <div className="mt-2 flex items-center gap-2">
+        <NumberField label="Hour" min={0} max={23} value={controller.hour} onChange={controller.setHour} />
+        <span className="mt-5 text-muted-foreground">:</span>
+        <NumberField label="Minute" min={0} max={59} value={controller.minute} onChange={controller.setMinute} />
+        <span className="mt-5 ml-2 text-[12.5px] text-muted-foreground">
+          {formatTime(controller.hour, controller.minute)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function SectionsField({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
+  return (
+    <div>
+      <span className={LABEL}>Sections</span>
+      <div className="mt-2 flex flex-col gap-1.5">
+        {agent.sections.map((section) => (
+          <label key={section.key} className="flex cursor-pointer items-center gap-2 text-[12.5px] text-foreground/90">
+            <input
+              type="checkbox"
+              checked={controller.sections[section.key] ?? section.enabled}
+              onChange={(e) => controller.setSection(section.key, e.target.checked)}
+              className="h-3.5 w-3.5 accent-foreground"
+            />
+            {section.title}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function FocusField({ controller }: { controller: RouteDraftController }) {
+  return (
+    <div>
+      <span className={LABEL}>Focus</span>
+      <textarea
+        rows={2}
+        value={controller.focus}
+        onChange={(e) => controller.setFocus(e.target.value)}
+        placeholder="e.g. anything blocking delivery for this group"
+        className="mt-2 w-full resize-none rounded-lg border-[0.5px] border-border bg-background px-3 py-2 text-[12.5px] leading-relaxed text-foreground/90 placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none"
+      />
+    </div>
+  );
+}
+
+export function VolumeField({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
+  return (
+    <div>
+      <span className={LABEL}>Volume</span>
+      <div className="mt-2">
+        <NumberField
+          label="Items per section"
+          min={agent.itemsPerSectionRange.min}
+          max={agent.itemsPerSectionRange.max}
+          value={controller.volume}
+          onChange={controller.setVolume}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function SourceGroup({
+  title,
+  loading,
+  empty,
+  selected,
+  options,
+  onToggle,
+}: {
+  title: string;
+  loading: boolean;
+  empty: string;
+  selected: Set<string>;
+  options: AgentSourceConfig[];
+  onToggle: (source: AgentSourceConfig) => void;
+}) {
+  return (
+    <div>
+      <span className={LABEL}>{title}</span>
+      <div className="mt-2 max-h-56 overflow-y-auto rounded-lg border-[0.5px] border-border p-1">
+        {loading ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading...</p>
+        ) : options.length === 0 ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">{empty}</p>
+        ) : (
+          <div className="flex flex-col">
+            {options.map((source) => {
+              const active = selected.has(sourceKey(source));
+              return (
+                <button
+                  key={sourceKey(source)}
+                  type="button"
+                  onClick={() => onToggle(source)}
+                  className={cn(
+                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+                    active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+                  )}
+                >
+                  <span className="shrink-0">
+                    {source.platform === "slack" ? (
+                      <HashIcon size={14} aria-hidden />
+                    ) : (
+                      <UsersThreeIcon size={14} aria-hidden />
+                    )}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{source.label ?? source.targetId}</span>
+                  {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function NumberField({
+  label,
+  min,
+  max,
+  value,
+  onChange,
+}: {
+  label: string;
+  min: number;
+  max: number;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className={LABEL}>{label}</span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => {
+          const next = Number(e.target.value);
+          if (Number.isFinite(next)) onChange(Math.min(max, Math.max(min, Math.trunc(next))));
+        }}
+        className="w-20 rounded-lg border-[0.5px] border-border bg-background px-3 py-2 text-[13px] text-foreground focus:border-foreground/30 focus:outline-none"
+      />
+    </label>
+  );
+}
+
+export function TargetList({
+  loading,
+  empty,
+  selectedId,
+  options,
+  onSelect,
+}: {
+  loading: boolean;
+  empty: string;
+  selectedId: string;
+  options: Array<{ id: string; label: string; icon: React.ReactNode }>;
+  onSelect: (id: string, label: string) => void;
+}) {
+  if (loading) return <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading...</p>;
+  if (options.length === 0) return <p className="px-2 py-2 text-[12px] text-muted-foreground">{empty}</p>;
+  return (
+    <div className="max-h-56 overflow-y-auto rounded-lg border-[0.5px] border-border p-1">
+      <div className="flex flex-col">
+        {options.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => onSelect(option.id, option.label)}
+            className={cn(
+              "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+              selectedId === option.id
+                ? "bg-emerald-500/10 text-foreground"
+                : "text-muted-foreground hover:bg-muted/60",
+            )}
+          >
+            <span className="shrink-0">{option.icon}</span>
+            <span className="min-w-0 flex-1 truncate">{option.label}</span>
+            {selectedId === option.id ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Persists a changed route into the agent's routes and recomputes the union of sources. */
+export function saveRoutes(agentKey: string, routes: AgentRoute[], lookup: Map<string, AgentSourceConfig>) {
+  return api.agents.updateConfig(agentKey, { sources: routesToSources(routes, lookup), routes });
+}
+
+export function InputIcon({ platform }: { platform: "slack" | "whatsapp" | null }) {
+  if (platform === "whatsapp")
+    return <UsersThreeIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />;
+  return <HashIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />;
+}

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -13,8 +13,9 @@ import {
   type AgentSourceKey,
   api,
 } from "@/lib/api";
-import { CheckCircleIcon, HashIcon, MagnifyingGlassIcon, UserIcon, UsersThreeIcon, XIcon } from "@phosphor-icons/react";
+import { CheckCircleIcon, HashIcon, MagnifyingGlassIcon, UserIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { Switch } from "@sketch/ui/components/switch";
+import { TabButton } from "@sketch/ui/components/tab-button";
 import { cn } from "@sketch/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
@@ -244,31 +245,19 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
 const LABEL = "font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70";
 
 export function SourcesField({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
-  const { slackLoading, whatsappLoading, slackOptions, whatsappOptions } = useSourceOptions(agent);
   const selected = new Set<string>(controller.sources);
   const maxSources = agent.sourceConfig?.maxSources ?? 0;
+  const atMax = maxSources > 0 && controller.sources.length >= maxSources;
   return (
-    <div className="space-y-4">
-      {agent.sourceConfig?.supportsSlackChannels ? (
-        <SourceGroup
-          title="Slack channels"
-          loading={slackLoading}
-          empty="No Slack channels available."
-          selected={selected}
-          options={slackOptions}
-          onToggle={controller.toggleSource}
-        />
-      ) : null}
-      {agent.sourceConfig?.supportsWhatsAppGroups ? (
-        <SourceGroup
-          title="WhatsApp groups"
-          loading={whatsappLoading}
-          empty="No WhatsApp groups available."
-          selected={selected}
-          options={whatsappOptions}
-          onToggle={controller.toggleSource}
-        />
-      ) : null}
+    <div className="space-y-2">
+      <ChannelPickerList
+        agent={agent}
+        selected={selected}
+        onToggle={controller.toggleSource}
+        showSlack={agent.sourceConfig?.supportsSlackChannels ?? false}
+        showWhatsapp={agent.sourceConfig?.supportsWhatsAppGroups ?? false}
+        isDisabled={atMax ? () => true : undefined}
+      />
       <p className={LABEL}>
         {controller.sources.length} selected
         {maxSources > 0 ? ` · limit ${maxSources}` : ""}
@@ -287,126 +276,100 @@ export function DestinationField({
   agentKey: string;
   controller: RouteDraftController;
 }) {
-  const { destKind, memberUserId, combined, hasWhatsApp } = controller;
+  const { destKind, memberUserId, hasWhatsApp } = controller;
+  const activeTab: "groups" | "dm" = destKind === "member" ? "dm" : "groups";
+  const dmAvailable = (agent.sourceConfig?.supportsSlackChannels ?? false) && !hasWhatsApp;
+
   const memberQuery = useQuery({
     queryKey: ["route-members", agentKey, controller.sources],
     queryFn: () => api.agents.routeMembers(agentKey, controller.sources),
-    enabled: destKind === "member" && controller.sources.length > 0 && !hasWhatsApp,
+    enabled: activeTab === "dm" && controller.sources.length > 0 && dmAvailable,
   });
 
-  const destOptions: Array<{
-    value: AgentRouteDestination["kind"];
-    label: string;
-    caption: string;
-    disabled: boolean;
-    hint?: string;
-  }> = [
-    {
-      value: "self",
-      label: "Post back",
-      caption: "To the source",
-      disabled: combined,
-      hint: combined ? "single input only" : undefined,
-    },
-    { value: "channel", label: "Another channel", caption: "Slack or WhatsApp", disabled: false },
-    {
-      value: "member",
-      label: "DM a member",
-      caption: "Direct message",
-      disabled: !agent.sourceConfig?.supportsSlackChannels || hasWhatsApp,
-      hint: hasWhatsApp ? "Slack only" : undefined,
-    },
-  ];
+  const channelSelected = controller.channelTarget
+    ? new Set<string>([sourceKey(controller.channelTarget)])
+    : new Set<string>();
+
+  const toggleChannel = (option: AgentSourceConfig) => {
+    const same = controller.channelTarget != null && sourceKey(controller.channelTarget) === sourceKey(option);
+    controller.setChannelTarget(same ? null : option);
+    if (!same) controller.setDestKind("channel");
+  };
 
   return (
     <div>
-      <span className={LABEL}>Delivers to</span>
-      <div className="mt-2 grid grid-cols-3 gap-2">
-        {destOptions.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            disabled={option.disabled}
-            onClick={() => controller.setDestKind(option.value)}
-            className={cn(
-              "flex flex-col items-start gap-0.5 rounded-xl border-[0.5px] px-3 py-2.5 text-left transition-colors",
-              destKind === option.value
-                ? "border-foreground/30 bg-card shadow-sm"
-                : "border-border bg-card/40 hover:bg-card",
-              option.disabled && "cursor-not-allowed opacity-40 hover:bg-card/40",
-            )}
-          >
-            <span className="text-[12.5px] font-medium text-foreground">{option.label}</span>
-            <span className="text-[10.5px] text-muted-foreground">{option.hint ?? option.caption}</span>
-          </button>
-        ))}
+      <div className="flex items-center gap-6 border-b border-border">
+        <TabButton
+          label="Groups"
+          isActive={activeTab === "groups"}
+          onClick={() => {
+            if (destKind === "member") controller.setDestKind("channel");
+          }}
+        />
+        <TabButton label="DM" isActive={activeTab === "dm"} onClick={() => controller.setDestKind("member")} />
       </div>
 
-      {destKind === "channel" ? <ChannelDestinationPicker agent={agent} controller={controller} /> : null}
-
-      {destKind === "member" ? (
+      {activeTab === "groups" ? (
         <div className="mt-3">
-          {hasWhatsApp ? (
-            <p className="px-1 py-2 text-[12px] text-muted-foreground">
-              Member DM works with Slack sources only. Remove the WhatsApp source to pick a member.
-            </p>
-          ) : (
-            <TargetList
-              loading={memberQuery.isLoading}
-              empty="No member is in every selected source."
-              selectedId={memberUserId ?? ""}
-              options={(memberQuery.data?.members ?? []).map((member) => ({
-                id: member.userId,
-                label: member.name,
-                icon: <UserIcon size={14} aria-hidden />,
-              }))}
-              onSelect={(id) => controller.setMemberUserId(id)}
-            />
-          )}
+          <ChannelPickerList agent={agent} selected={channelSelected} onToggle={toggleChannel} />
+          <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground/70">
+            Posts to any channel or group Sketch can reach — independent of the inputs above.
+          </p>
+        </div>
+      ) : !dmAvailable ? (
+        <p className="mt-3 px-1 py-2 text-[12px] text-muted-foreground">
+          Member DM works with Slack sources only. Remove the WhatsApp source to DM a member.
+        </p>
+      ) : (
+        <div className="mt-3">
+          <TargetList
+            loading={memberQuery.isLoading}
+            empty="No member is in every selected source."
+            selectedId={memberUserId ?? ""}
+            options={(memberQuery.data?.members ?? []).map((member) => ({
+              id: member.userId,
+              label: member.name,
+              icon: <UserIcon size={14} aria-hidden />,
+            }))}
+            onSelect={(id) => controller.setMemberUserId(id)}
+          />
           <p className="mt-1.5 text-[11px] leading-relaxed text-muted-foreground/70">
             Only members of every selected source appear — the summary can never reach someone outside the inputs.
           </p>
         </div>
-      ) : null}
+      )}
     </div>
   );
 }
 
 /**
- * Search-and-add single-select over the Slack channels and WhatsApp groups
- * Sketch can post to. The chosen target shows as a chip you can clear; the
- * search filters both platforms, each kept as its own always-visible section so
- * an empty WhatsApp list reads as "no groups yet" rather than silently missing.
+ * Shared search-and-add list over the Slack channels and WhatsApp groups Sketch
+ * can reach, split into a section per source. Used for both the multi-select
+ * inputs and the single-select delivery target — the caller owns the selection
+ * set (keyed by sourceKey) and the toggle handler.
  */
-function ChannelDestinationPicker({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
+export function ChannelPickerList({
+  agent,
+  selected,
+  onToggle,
+  showSlack = true,
+  showWhatsapp = true,
+  isDisabled,
+}: {
+  agent: AgentConfig;
+  selected: Set<string>;
+  onToggle: (option: AgentSourceConfig) => void;
+  showSlack?: boolean;
+  showWhatsapp?: boolean;
+  isDisabled?: (option: AgentSourceConfig) => boolean;
+}) {
   const { slackLoading, whatsappLoading, slackOptions, whatsappOptions } = useSourceOptions(agent);
   const [query, setQuery] = useState("");
   const q = query.trim().toLowerCase();
   const match = (o: AgentSourceConfig) => !q || (o.label ?? o.targetId).toLowerCase().includes(q);
-  const selected = controller.channelTarget;
-  const selectedId = selected?.targetId ?? "";
 
   return (
-    <div className="mt-3 space-y-2">
-      {selected ? (
-        <div className="flex items-center gap-2 rounded-lg border-[0.5px] border-emerald-500/40 bg-emerald-500/10 px-2.5 py-1.5 text-[12.5px] text-foreground">
-          {selected.platform === "slack" ? (
-            <HashIcon size={14} aria-hidden />
-          ) : (
-            <UsersThreeIcon size={14} aria-hidden />
-          )}
-          <span className="min-w-0 flex-1 truncate">{selected.label ?? selected.targetId}</span>
-          <button
-            type="button"
-            onClick={() => controller.setChannelTarget(null)}
-            aria-label="Clear channel"
-            className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <XIcon size={13} aria-hidden />
-          </button>
-        </div>
-      ) : null}
-
+    <div className="space-y-2">
       <div className="relative">
         <MagnifyingGlassIcon
           size={13}
@@ -423,49 +386,53 @@ function ChannelDestinationPicker({ agent, controller }: { agent: AgentConfig; c
       </div>
 
       <div className="max-h-56 space-y-3 overflow-y-auto rounded-lg border-[0.5px] border-border p-2">
-        <ChannelDestGroup
-          title="Slack channels"
-          loading={slackLoading}
-          total={slackOptions.length}
-          options={slackOptions.filter(match)}
-          selectedId={selectedId}
-          onSelect={controller.setChannelTarget}
-          empty="The bot isn't in any Slack channels yet."
-        />
-        <ChannelDestGroup
-          title="WhatsApp groups"
-          loading={whatsappLoading}
-          total={whatsappOptions.length}
-          options={whatsappOptions.filter(match)}
-          selectedId={selectedId}
-          onSelect={controller.setChannelTarget}
-          empty="The bot isn't in any WhatsApp groups yet — add it to a group and reload."
-        />
+        {showSlack ? (
+          <ChannelSection
+            title="Slack channels"
+            loading={slackLoading}
+            total={slackOptions.length}
+            options={slackOptions.filter(match)}
+            selected={selected}
+            onToggle={onToggle}
+            isDisabled={isDisabled}
+            empty="The bot isn't in any Slack channels yet."
+          />
+        ) : null}
+        {showWhatsapp ? (
+          <ChannelSection
+            title="WhatsApp groups"
+            loading={whatsappLoading}
+            total={whatsappOptions.length}
+            options={whatsappOptions.filter(match)}
+            selected={selected}
+            onToggle={onToggle}
+            isDisabled={isDisabled}
+            empty="The bot isn't in any WhatsApp groups yet — add it to a group and reload."
+          />
+        ) : null}
       </div>
-
-      <p className="text-[11px] leading-relaxed text-muted-foreground/70">
-        Posts to any channel or group Sketch can reach — independent of the inputs above.
-      </p>
     </div>
   );
 }
 
 /** One platform's rows inside the channel picker, always shown so an empty list carries its own explanation. */
-function ChannelDestGroup({
+function ChannelSection({
   title,
   loading,
   total,
   options,
-  selectedId,
-  onSelect,
+  selected,
+  onToggle,
+  isDisabled,
   empty,
 }: {
   title: string;
   loading: boolean;
   total: number;
   options: AgentSourceConfig[];
-  selectedId: string;
-  onSelect: (option: AgentSourceConfig) => void;
+  selected: Set<string>;
+  onToggle: (option: AgentSourceConfig) => void;
+  isDisabled?: (option: AgentSourceConfig) => boolean;
   empty: string;
 }) {
   return (
@@ -480,15 +447,19 @@ function ChannelDestGroup({
       ) : (
         <div className="mt-1 flex flex-col">
           {options.map((option) => {
-            const active = selectedId === option.targetId;
+            const key = sourceKey(option);
+            const active = selected.has(key);
+            const disabled = !active && (isDisabled?.(option) ?? false);
             return (
               <button
-                key={sourceKey(option)}
+                key={key}
                 type="button"
-                onClick={() => onSelect(option)}
+                disabled={disabled}
+                onClick={() => onToggle(option)}
                 className={cn(
                   "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
                   active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+                  disabled && "cursor-not-allowed opacity-40 hover:bg-transparent",
                 )}
               >
                 <span className="shrink-0">
@@ -579,89 +550,6 @@ export function VolumeField({ agent, controller }: { agent: AgentConfig; control
           value={controller.volume}
           onChange={controller.setVolume}
         />
-      </div>
-    </div>
-  );
-}
-
-export function SourceGroup({
-  title,
-  loading,
-  empty,
-  selected,
-  options,
-  onToggle,
-}: {
-  title: string;
-  loading: boolean;
-  empty: string;
-  selected: Set<string>;
-  options: AgentSourceConfig[];
-  onToggle: (source: AgentSourceConfig) => void;
-}) {
-  const [query, setQuery] = useState("");
-  const q = query.trim().toLowerCase();
-  const filtered = q ? options.filter((o) => (o.label ?? o.targetId).toLowerCase().includes(q)) : options;
-  const showSearch = options.length > 6;
-
-  return (
-    <div>
-      <span className={LABEL}>{title}</span>
-      <div className="mt-2 rounded-lg border-[0.5px] border-border p-1">
-        {loading ? (
-          <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading...</p>
-        ) : options.length === 0 ? (
-          <p className="px-2 py-2 text-[12px] text-muted-foreground">{empty}</p>
-        ) : (
-          <>
-            {showSearch ? (
-              <div className="relative mb-1">
-                <MagnifyingGlassIcon
-                  size={13}
-                  aria-hidden
-                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-                <input
-                  type="text"
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder={`Search ${title.toLowerCase()}…`}
-                  className="w-full rounded-md border-[0.5px] border-border bg-background py-1.5 pl-7 pr-2 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
-                />
-              </div>
-            ) : null}
-            <div className="flex max-h-56 flex-col overflow-y-auto">
-              {filtered.length === 0 ? (
-                <p className="px-2 py-2 text-[12px] text-muted-foreground">No matches.</p>
-              ) : (
-                filtered.map((source) => {
-                  const active = selected.has(sourceKey(source));
-                  return (
-                    <button
-                      key={sourceKey(source)}
-                      type="button"
-                      onClick={() => onToggle(source)}
-                      className={cn(
-                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
-                        active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
-                      )}
-                    >
-                      <span className="shrink-0">
-                        {source.platform === "slack" ? (
-                          <HashIcon size={14} aria-hidden />
-                        ) : (
-                          <UsersThreeIcon size={14} aria-hidden />
-                        )}
-                      </span>
-                      <span className="min-w-0 flex-1 truncate">{source.label ?? source.targetId}</span>
-                      {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
-                    </button>
-                  );
-                })
-              )}
-            </div>
-          </>
-        )}
       </div>
     </div>
   );

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -30,9 +30,18 @@ export function formatTime(hour: number, minute: number): string {
 }
 
 export function deliversLabel(route: AgentRoute): string {
-  if (route.destination.kind === "self") return "Post back";
-  if (route.destination.kind === "member") return "Direct message";
+  const dest = route.destination;
+  if (dest.kind === "self") return "Post back";
+  if (dest.kind === "member") return "Direct message";
+  if (dest.kind === "channel") return dest.label ?? (dest.platform === "slack" ? "Slack channel" : "WhatsApp group");
   return "Web only";
+}
+
+/** Narrows a selected input-shaped target into a channel destination, honoring the slack↔channel / whatsapp↔group pairing. */
+function channelDestination(target: AgentSourceConfig): AgentRouteDestination {
+  return target.platform === "slack"
+    ? { kind: "channel", platform: "slack", targetType: "channel", targetId: target.targetId, label: target.label }
+    : { kind: "channel", platform: "whatsapp", targetType: "group", targetId: target.targetId, label: target.label };
 }
 
 export function sectionsLabel(route: AgentRoute, agent: AgentConfig): string {
@@ -117,6 +126,7 @@ export interface RouteDraftController {
   sources: AgentSourceKey[];
   destKind: AgentRouteDestination["kind"];
   memberUserId: string | null;
+  channelTarget: AgentSourceConfig | null;
   hour: number;
   minute: number;
   sections: Record<string, boolean>;
@@ -128,6 +138,7 @@ export interface RouteDraftController {
   toggleSource: (source: AgentSourceConfig) => void;
   setDestKind: (kind: AgentRouteDestination["kind"]) => void;
   setMemberUserId: (id: string | null) => void;
+  setChannelTarget: (target: AgentSourceConfig | null) => void;
   setHour: (v: number) => void;
   setMinute: (v: number) => void;
   setSection: (key: string, on: boolean) => void;
@@ -140,9 +151,19 @@ export interface RouteDraftController {
 export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): RouteDraftController {
   const maxSources = agent.sourceConfig?.maxSources ?? 0;
   const [sources, setSources] = useState<AgentSourceKey[]>(route?.sources ?? []);
-  const [destKind, setDestKind] = useState<AgentRouteDestination["kind"]>(route?.destination.kind ?? "off");
+  const [destKind, setDestKind] = useState<AgentRouteDestination["kind"]>(route?.destination.kind ?? "self");
   const [memberUserId, setMemberUserId] = useState<string | null>(
     route?.destination.kind === "member" ? route.destination.memberUserId : null,
+  );
+  const [channelTarget, setChannelTarget] = useState<AgentSourceConfig | null>(
+    route?.destination.kind === "channel"
+      ? {
+          platform: route.destination.platform,
+          targetType: route.destination.targetType,
+          targetId: route.destination.targetId,
+          label: route.destination.label,
+        }
+      : null,
   );
   const [hour, setHour] = useState(route?.schedule?.hour ?? agent.scheduleHour);
   const [minute, setMinute] = useState(route?.schedule?.minute ?? agent.scheduleMinute);
@@ -154,7 +175,7 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
   const hasWhatsApp = sources.some((key) => key.startsWith("whatsapp:"));
 
   useEffect(() => {
-    if (destKind === "self" && sources.length !== 1) setDestKind("off");
+    if (destKind === "self" && sources.length > 1) setDestKind("channel");
   }, [destKind, sources.length]);
 
   const toggleSource = (source: AgentSourceConfig) => {
@@ -170,7 +191,8 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
   const isValid =
     sources.length > 0 &&
     !(destKind === "self" && sources.length !== 1) &&
-    !(destKind === "member" && (!memberUserId || hasWhatsApp));
+    !(destKind === "member" && (!memberUserId || hasWhatsApp)) &&
+    !(destKind === "channel" && !channelTarget);
 
   const build = (base: AgentRoute | null): AgentRoute => {
     const destination: AgentRouteDestination =
@@ -178,7 +200,9 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
         ? { kind: "self" }
         : destKind === "member" && memberUserId
           ? { kind: "member", platform: "slack", memberUserId }
-          : { kind: "off" };
+          : destKind === "channel" && channelTarget
+            ? channelDestination(channelTarget)
+            : { kind: "off" };
     return {
       id: base?.id ?? crypto.randomUUID(),
       sources,
@@ -195,6 +219,7 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
     sources,
     destKind,
     memberUserId,
+    channelTarget,
     hour,
     minute,
     sections,
@@ -206,6 +231,7 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
     toggleSource,
     setDestKind,
     setMemberUserId,
+    setChannelTarget,
     setHour,
     setMinute,
     setSection: (key, on) => setSections((prev) => ({ ...prev, [key]: on })),
@@ -268,22 +294,34 @@ export function DestinationField({
     enabled: destKind === "member" && controller.sources.length > 0 && !hasWhatsApp,
   });
 
-  const destOptions: Array<{ value: AgentRouteDestination["kind"]; label: string; disabled: boolean; hint?: string }> =
-    [
-      { value: "self", label: "Post back", disabled: combined, hint: combined ? "single input only" : undefined },
-      { value: "off", label: "Web only", disabled: false },
-      {
-        value: "member",
-        label: "DM a member",
-        disabled: !agent.sourceConfig?.supportsSlackChannels || hasWhatsApp,
-        hint: hasWhatsApp ? "Slack only" : undefined,
-      },
-    ];
+  const destOptions: Array<{
+    value: AgentRouteDestination["kind"];
+    label: string;
+    caption: string;
+    disabled: boolean;
+    hint?: string;
+  }> = [
+    {
+      value: "self",
+      label: "Post back",
+      caption: "To the source",
+      disabled: combined,
+      hint: combined ? "single input only" : undefined,
+    },
+    { value: "channel", label: "Another channel", caption: "Slack or WhatsApp", disabled: false },
+    {
+      value: "member",
+      label: "DM a member",
+      caption: "Direct message",
+      disabled: !agent.sourceConfig?.supportsSlackChannels || hasWhatsApp,
+      hint: hasWhatsApp ? "Slack only" : undefined,
+    },
+  ];
 
   return (
     <div>
       <span className={LABEL}>Delivers to</span>
-      <div className="mt-2 grid grid-cols-3 gap-1 rounded-lg border-[0.5px] border-border bg-muted/25 p-1">
+      <div className="mt-2 grid grid-cols-3 gap-2">
         {destOptions.map((option) => (
           <button
             key={option.value}
@@ -291,20 +329,23 @@ export function DestinationField({
             disabled={option.disabled}
             onClick={() => controller.setDestKind(option.value)}
             className={cn(
-              "flex flex-col items-center justify-center rounded-md px-2 py-1.5 text-[12px] font-medium transition-colors",
+              "flex flex-col items-start gap-0.5 rounded-xl border-[0.5px] px-3 py-2.5 text-left transition-colors",
               destKind === option.value
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-              option.disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+                ? "border-foreground/30 bg-card shadow-sm"
+                : "border-border bg-card/40 hover:bg-card",
+              option.disabled && "cursor-not-allowed opacity-40 hover:bg-card/40",
             )}
           >
-            {option.label}
-            {option.hint ? <span className="text-[9px] text-muted-foreground/70">{option.hint}</span> : null}
+            <span className="text-[12.5px] font-medium text-foreground">{option.label}</span>
+            <span className="text-[10.5px] text-muted-foreground">{option.hint ?? option.caption}</span>
           </button>
         ))}
       </div>
+
+      {destKind === "channel" ? <ChannelDestinationPicker agent={agent} controller={controller} /> : null}
+
       {destKind === "member" ? (
-        <div className="mt-2">
+        <div className="mt-3">
           {hasWhatsApp ? (
             <p className="px-1 py-2 text-[12px] text-muted-foreground">
               Member DM works with Slack sources only. Remove the WhatsApp source to pick a member.
@@ -327,6 +368,83 @@ export function DestinationField({
           </p>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/** Single-select picker over every Slack channel and WhatsApp group the workspace can post to. */
+function ChannelDestinationPicker({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
+  const { slackLoading, whatsappLoading, slackOptions, whatsappOptions } = useSourceOptions(agent);
+  const [query, setQuery] = useState("");
+  const q = query.trim().toLowerCase();
+
+  const options = [...slackOptions, ...whatsappOptions];
+  const filtered = q ? options.filter((o) => (o.label ?? o.targetId).toLowerCase().includes(q)) : options;
+  const loading = slackLoading || whatsappLoading;
+  const selectedId = controller.channelTarget?.targetId ?? "";
+  const showSearch = options.length > 6;
+
+  return (
+    <div className="mt-3">
+      <div className="rounded-lg border-[0.5px] border-border p-1">
+        {loading ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading channels…</p>
+        ) : options.length === 0 ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">No channels or groups available.</p>
+        ) : (
+          <>
+            {showSearch ? (
+              <div className="relative mb-1">
+                <MagnifyingGlassIcon
+                  size={13}
+                  aria-hidden
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+                />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search channels & groups…"
+                  className="w-full rounded-md border-[0.5px] border-border bg-background py-1.5 pl-7 pr-2 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+                />
+              </div>
+            ) : null}
+            <div className="flex max-h-56 flex-col overflow-y-auto">
+              {filtered.length === 0 ? (
+                <p className="px-2 py-2 text-[12px] text-muted-foreground">No matches.</p>
+              ) : (
+                filtered.map((option) => {
+                  const active = selectedId === option.targetId;
+                  return (
+                    <button
+                      key={sourceKey(option)}
+                      type="button"
+                      onClick={() => controller.setChannelTarget(option)}
+                      className={cn(
+                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+                        active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+                      )}
+                    >
+                      <span className="shrink-0">
+                        {option.platform === "slack" ? (
+                          <HashIcon size={14} aria-hidden />
+                        ) : (
+                          <UsersThreeIcon size={14} aria-hidden />
+                        )}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{option.label ?? option.targetId}</span>
+                      {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
+      </div>
+      <p className="mt-1.5 text-[11px] leading-relaxed text-muted-foreground/70">
+        The summary posts here, to any channel or group Sketch can reach — independent of the inputs above.
+      </p>
     </div>
   );
 }

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -13,7 +13,7 @@ import {
   type AgentSourceKey,
   api,
 } from "@/lib/api";
-import { CheckCircleIcon, HashIcon, MagnifyingGlassIcon, UserIcon, UsersThreeIcon } from "@phosphor-icons/react";
+import { CheckCircleIcon, HashIcon, MagnifyingGlassIcon, UserIcon, UsersThreeIcon, XIcon } from "@phosphor-icons/react";
 import { Switch } from "@sketch/ui/components/switch";
 import { cn } from "@sketch/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
@@ -372,79 +372,139 @@ export function DestinationField({
   );
 }
 
-/** Single-select picker over every Slack channel and WhatsApp group the workspace can post to. */
+/**
+ * Search-and-add single-select over the Slack channels and WhatsApp groups
+ * Sketch can post to. The chosen target shows as a chip you can clear; the
+ * search filters both platforms, each kept as its own always-visible section so
+ * an empty WhatsApp list reads as "no groups yet" rather than silently missing.
+ */
 function ChannelDestinationPicker({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
   const { slackLoading, whatsappLoading, slackOptions, whatsappOptions } = useSourceOptions(agent);
   const [query, setQuery] = useState("");
   const q = query.trim().toLowerCase();
-
-  const options = [...slackOptions, ...whatsappOptions];
-  const filtered = q ? options.filter((o) => (o.label ?? o.targetId).toLowerCase().includes(q)) : options;
-  const loading = slackLoading || whatsappLoading;
-  const selectedId = controller.channelTarget?.targetId ?? "";
-  const showSearch = options.length > 6;
+  const match = (o: AgentSourceConfig) => !q || (o.label ?? o.targetId).toLowerCase().includes(q);
+  const selected = controller.channelTarget;
+  const selectedId = selected?.targetId ?? "";
 
   return (
-    <div className="mt-3">
-      <div className="rounded-lg border-[0.5px] border-border p-1">
-        {loading ? (
-          <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading channels…</p>
-        ) : options.length === 0 ? (
-          <p className="px-2 py-2 text-[12px] text-muted-foreground">No channels or groups available.</p>
-        ) : (
-          <>
-            {showSearch ? (
-              <div className="relative mb-1">
-                <MagnifyingGlassIcon
-                  size={13}
-                  aria-hidden
-                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-                <input
-                  type="text"
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder="Search channels & groups…"
-                  className="w-full rounded-md border-[0.5px] border-border bg-background py-1.5 pl-7 pr-2 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
-                />
-              </div>
-            ) : null}
-            <div className="flex max-h-56 flex-col overflow-y-auto">
-              {filtered.length === 0 ? (
-                <p className="px-2 py-2 text-[12px] text-muted-foreground">No matches.</p>
-              ) : (
-                filtered.map((option) => {
-                  const active = selectedId === option.targetId;
-                  return (
-                    <button
-                      key={sourceKey(option)}
-                      type="button"
-                      onClick={() => controller.setChannelTarget(option)}
-                      className={cn(
-                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
-                        active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
-                      )}
-                    >
-                      <span className="shrink-0">
-                        {option.platform === "slack" ? (
-                          <HashIcon size={14} aria-hidden />
-                        ) : (
-                          <UsersThreeIcon size={14} aria-hidden />
-                        )}
-                      </span>
-                      <span className="min-w-0 flex-1 truncate">{option.label ?? option.targetId}</span>
-                      {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
-                    </button>
-                  );
-                })
-              )}
-            </div>
-          </>
-        )}
+    <div className="mt-3 space-y-2">
+      {selected ? (
+        <div className="flex items-center gap-2 rounded-lg border-[0.5px] border-emerald-500/40 bg-emerald-500/10 px-2.5 py-1.5 text-[12.5px] text-foreground">
+          {selected.platform === "slack" ? (
+            <HashIcon size={14} aria-hidden />
+          ) : (
+            <UsersThreeIcon size={14} aria-hidden />
+          )}
+          <span className="min-w-0 flex-1 truncate">{selected.label ?? selected.targetId}</span>
+          <button
+            type="button"
+            onClick={() => controller.setChannelTarget(null)}
+            aria-label="Clear channel"
+            className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <XIcon size={13} aria-hidden />
+          </button>
+        </div>
+      ) : null}
+
+      <div className="relative">
+        <MagnifyingGlassIcon
+          size={13}
+          aria-hidden
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search channels & groups…"
+          className="w-full rounded-md border-[0.5px] border-border bg-background py-1.5 pl-7 pr-2 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+        />
       </div>
-      <p className="mt-1.5 text-[11px] leading-relaxed text-muted-foreground/70">
-        The summary posts here, to any channel or group Sketch can reach — independent of the inputs above.
+
+      <div className="max-h-56 space-y-3 overflow-y-auto rounded-lg border-[0.5px] border-border p-2">
+        <ChannelDestGroup
+          title="Slack channels"
+          loading={slackLoading}
+          total={slackOptions.length}
+          options={slackOptions.filter(match)}
+          selectedId={selectedId}
+          onSelect={controller.setChannelTarget}
+          empty="The bot isn't in any Slack channels yet."
+        />
+        <ChannelDestGroup
+          title="WhatsApp groups"
+          loading={whatsappLoading}
+          total={whatsappOptions.length}
+          options={whatsappOptions.filter(match)}
+          selectedId={selectedId}
+          onSelect={controller.setChannelTarget}
+          empty="The bot isn't in any WhatsApp groups yet — add it to a group and reload."
+        />
+      </div>
+
+      <p className="text-[11px] leading-relaxed text-muted-foreground/70">
+        Posts to any channel or group Sketch can reach — independent of the inputs above.
       </p>
+    </div>
+  );
+}
+
+/** One platform's rows inside the channel picker, always shown so an empty list carries its own explanation. */
+function ChannelDestGroup({
+  title,
+  loading,
+  total,
+  options,
+  selectedId,
+  onSelect,
+  empty,
+}: {
+  title: string;
+  loading: boolean;
+  total: number;
+  options: AgentSourceConfig[];
+  selectedId: string;
+  onSelect: (option: AgentSourceConfig) => void;
+  empty: string;
+}) {
+  return (
+    <div>
+      <span className={LABEL}>{title}</span>
+      {loading ? (
+        <p className="px-1 py-1.5 text-[12px] text-muted-foreground">Loading…</p>
+      ) : total === 0 ? (
+        <p className="px-1 py-1.5 text-[11.5px] leading-relaxed text-muted-foreground">{empty}</p>
+      ) : options.length === 0 ? (
+        <p className="px-1 py-1.5 text-[11.5px] text-muted-foreground">No matches.</p>
+      ) : (
+        <div className="mt-1 flex flex-col">
+          {options.map((option) => {
+            const active = selectedId === option.targetId;
+            return (
+              <button
+                key={sourceKey(option)}
+                type="button"
+                onClick={() => onSelect(option)}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+                  active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+                )}
+              >
+                <span className="shrink-0">
+                  {option.platform === "slack" ? (
+                    <HashIcon size={14} aria-hidden />
+                  ) : (
+                    <UsersThreeIcon size={14} aria-hidden />
+                  )}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{option.label ?? option.targetId}</span>
+                {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -13,7 +13,8 @@ import {
   type AgentSourceKey,
   api,
 } from "@/lib/api";
-import { CheckCircleIcon, HashIcon, UserIcon, UsersThreeIcon } from "@phosphor-icons/react";
+import { CheckCircleIcon, HashIcon, MagnifyingGlassIcon, UserIcon, UsersThreeIcon } from "@phosphor-icons/react";
+import { Switch } from "@sketch/ui/components/switch";
 import { cn } from "@sketch/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
@@ -349,18 +350,24 @@ export function ScheduleField({ controller }: { controller: RouteDraftController
 export function SectionsField({ agent, controller }: { agent: AgentConfig; controller: RouteDraftController }) {
   return (
     <div>
-      <span className={LABEL}>Sections</span>
-      <div className="mt-2 flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className={LABEL}>Sections</span>
+        <span className="text-[11px] text-muted-foreground/70">turn on only what you want</span>
+      </div>
+      <div className="mt-2 flex flex-col gap-2">
         {agent.sections.map((section) => (
-          <label key={section.key} className="flex cursor-pointer items-center gap-2 text-[12.5px] text-foreground/90">
-            <input
-              type="checkbox"
+          <div
+            key={section.key}
+            className="flex items-center gap-3 rounded-xl border-[0.5px] border-border bg-card px-4 py-3"
+          >
+            <p className="min-w-0 flex-1 text-[13px] font-medium text-foreground">{section.title}</p>
+            <Switch
               checked={controller.sections[section.key] ?? section.enabled}
-              onChange={(e) => controller.setSection(section.key, e.target.checked)}
-              className="h-3.5 w-3.5 accent-foreground"
+              onCheckedChange={(on) => controller.setSection(section.key, on)}
+              aria-label={section.title}
+              className="data-[state=checked]:bg-emerald-500"
             />
-            {section.title}
-          </label>
+          </div>
         ))}
       </div>
     </div>
@@ -414,41 +421,68 @@ export function SourceGroup({
   options: AgentSourceConfig[];
   onToggle: (source: AgentSourceConfig) => void;
 }) {
+  const [query, setQuery] = useState("");
+  const q = query.trim().toLowerCase();
+  const filtered = q ? options.filter((o) => (o.label ?? o.targetId).toLowerCase().includes(q)) : options;
+  const showSearch = options.length > 6;
+
   return (
     <div>
       <span className={LABEL}>{title}</span>
-      <div className="mt-2 max-h-56 overflow-y-auto rounded-lg border-[0.5px] border-border p-1">
+      <div className="mt-2 rounded-lg border-[0.5px] border-border p-1">
         {loading ? (
           <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading...</p>
         ) : options.length === 0 ? (
           <p className="px-2 py-2 text-[12px] text-muted-foreground">{empty}</p>
         ) : (
-          <div className="flex flex-col">
-            {options.map((source) => {
-              const active = selected.has(sourceKey(source));
-              return (
-                <button
-                  key={sourceKey(source)}
-                  type="button"
-                  onClick={() => onToggle(source)}
-                  className={cn(
-                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
-                    active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
-                  )}
-                >
-                  <span className="shrink-0">
-                    {source.platform === "slack" ? (
-                      <HashIcon size={14} aria-hidden />
-                    ) : (
-                      <UsersThreeIcon size={14} aria-hidden />
-                    )}
-                  </span>
-                  <span className="min-w-0 flex-1 truncate">{source.label ?? source.targetId}</span>
-                  {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
-                </button>
-              );
-            })}
-          </div>
+          <>
+            {showSearch ? (
+              <div className="relative mb-1">
+                <MagnifyingGlassIcon
+                  size={13}
+                  aria-hidden
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+                />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder={`Search ${title.toLowerCase()}…`}
+                  className="w-full rounded-md border-[0.5px] border-border bg-background py-1.5 pl-7 pr-2 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+                />
+              </div>
+            ) : null}
+            <div className="flex max-h-56 flex-col overflow-y-auto">
+              {filtered.length === 0 ? (
+                <p className="px-2 py-2 text-[12px] text-muted-foreground">No matches.</p>
+              ) : (
+                filtered.map((source) => {
+                  const active = selected.has(sourceKey(source));
+                  return (
+                    <button
+                      key={sourceKey(source)}
+                      type="button"
+                      onClick={() => onToggle(source)}
+                      className={cn(
+                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+                        active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+                      )}
+                    >
+                      <span className="shrink-0">
+                        {source.platform === "slack" ? (
+                          <HashIcon size={14} aria-hidden />
+                        ) : (
+                          <UsersThreeIcon size={14} aria-hidden />
+                        )}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{source.label ?? source.targetId}</span>
+                      {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1094,7 +1094,9 @@ export type AgentDeliveryModel =
 export type AgentRouteDestination =
   | { kind: "self" }
   | { kind: "off" }
-  | { kind: "member"; platform: "slack"; memberUserId: string };
+  | { kind: "member"; platform: "slack"; memberUserId: string }
+  | { kind: "channel"; platform: "slack"; targetType: "channel"; targetId: string; label: string | null }
+  | { kind: "channel"; platform: "whatsapp"; targetType: "group"; targetId: string; label: string | null };
 
 export interface AgentRoute {
   id: string;

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1035,6 +1035,9 @@ export interface AgentSummary {
   enabled: boolean;
   scheduleHour: number;
   scheduleMinute: number;
+  sourceConfig: AgentSourceConfigMeta | null;
+  sources: AgentSourceConfig[];
+  routes: AgentRoute[];
 }
 
 export interface AgentSectionConfig {

--- a/packages/web/src/router.ts
+++ b/packages/web/src/router.ts
@@ -1,5 +1,5 @@
 import { createRouter } from "@tanstack/react-router";
-import { agentDetailRoute, agentsRoute } from "./routes/agents";
+import { agentDetailRoute, agentsRoute, summariserConfigRoute } from "./routes/agents";
 import { automationBuilderRoute } from "./routes/automation-builder";
 import { channelsRoute } from "./routes/channels";
 import { chatIndexRoute, chatRoute } from "./routes/chat";
@@ -27,6 +27,7 @@ const routeTree = rootRoute.addChildren([
     homeRoute,
     agentsRoute,
     agentDetailRoute,
+    summariserConfigRoute,
     chatIndexRoute,
     chatRoute,
     channelsRoute,

--- a/packages/web/src/routes/agents/index.tsx
+++ b/packages/web/src/routes/agents/index.tsx
@@ -4,6 +4,7 @@
  */
 import { AgentDetail } from "@/components/agents/agent-detail";
 import { AgentRoster } from "@/components/agents/agent-roster";
+import { SummariserConfigPage } from "@/components/agents/summariser-config";
 import { createRoute, useParams } from "@tanstack/react-router";
 import { dashboardRoute } from "../dashboard";
 
@@ -19,7 +20,18 @@ export const agentDetailRoute = createRoute({
   component: AgentDetailPage,
 });
 
+export const summariserConfigRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: "/agents/$agentKey/summarisers/$routeId",
+  component: SummariserConfigPageRoute,
+});
+
 function AgentDetailPage() {
   const { agentKey } = useParams({ from: agentDetailRoute.id });
   return <AgentDetail agentKey={agentKey} />;
+}
+
+function SummariserConfigPageRoute() {
+  const { agentKey, routeId } = useParams({ from: summariserConfigRoute.id });
+  return <SummariserConfigPage agentKey={agentKey} routeId={routeId} />;
 }


### PR DESCRIPTION
Stack: 3/7
Base: feat/summarizer-routes-config
Merge after: feat: add summariser route config model
Merge before: feat: add summariser run controls and teammate delivery

Summary:
- Promote summarisers into the agents roster and setup modal flow.
- Add Slack channel and WhatsApp group destination selection.
- Add searchable, tabbed input/output pickers and route setup polish.

Verification:
- pnpm biome check
- pnpm typecheck
- pnpm test
- pnpm build

All stack tips were checked locally under Node v24.8.0; the pushed stack also passed the pre-push hook under Node v24.8.0.