### PR TITLE
feat: add summariser run controls and teammate delivery

### DIFF
--- a/packages/server/src/agents/output-delivery.test.ts
+++ b/packages/server/src/agents/output-delivery.test.ts
@@ -248,6 +248,63 @@ describe("createAgentOutputDeliveryService", () => {
     expect(attempt.message_refs_json).toBe(JSON.stringify(["wa-nudge-1"]));
   });
 
+  it("parks WhatsApp teammate DM deliveries for the teammate recipient", async () => {
+    await db
+      .insertInto("users")
+      .values({ id: "user-teammate", name: "Teammate", whatsapp_number: "+15557654321" })
+      .execute();
+    const whatsapp = createMockWhatsApp({
+      isConnected: true,
+      sendTemplate: vi.fn(async () => ({
+        providerMessageId: "wa-teammate-nudge-1",
+        providerConversationId: "dm:+15557654321",
+        providerTimestamp: "2024-06-04T07:20:00.000Z",
+      })),
+    });
+    const service = createAgentOutputDeliveryService({
+      db,
+      logger: createTestLogger(),
+      getSlack: () => null,
+      whatsapp,
+      settingsRepo: createSettingsRepository(db),
+    });
+
+    await service.deliver({
+      definition: dailyBriefDefinition,
+      delivery: {
+        enabled: true,
+        platform: "whatsapp",
+        targetType: "dm",
+        targetId: "dm:+15557654321",
+        label: "Teammate",
+        recipientUserId: "user-teammate",
+      },
+      output: {
+        id: "output-delivery",
+        userId: "user-delivery",
+        agentKey: dailyBriefDefinition.key,
+        outputDate: "2026-06-26",
+        masthead: { title: "Daily Brief", summary: "Start here." },
+        sections: {},
+      },
+    });
+
+    expect(whatsapp.sendTemplate).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+15557654321" },
+      expect.objectContaining({
+        key: "whatsapp.task_nudge",
+        params: { recipientName: "Teammate" },
+      }),
+    );
+    const inbox = await db.selectFrom("inbox_messages").selectAll().executeTakeFirstOrThrow();
+    expect(inbox).toMatchObject({
+      recipient_user_id: "user-teammate",
+      sender_user_id: "user-delivery",
+      kind: "workflow_output",
+      platform: "whatsapp",
+    });
+  });
+
   it("uses the recipient phone when a WhatsApp DM delivery target is an opaque Wati conversation id", async () => {
     await db.updateTable("users").set({ whatsapp_number: "+15551234567" }).where("id", "=", "user-delivery").execute();
     const sendText = vi.fn(async (target: unknown) => ({

--- a/packages/server/src/agents/output-delivery.ts
+++ b/packages/server/src/agents/output-delivery.ts
@@ -83,11 +83,12 @@ export function createAgentOutputDeliveryService(deps: AgentOutputDeliveryDeps):
     const target = whatsappTargetFromDeliveryTarget(delivery.targetId);
 
     if (target.kind === "dm") {
-      const recipient = await users.findById(output.userId);
+      const recipientUserId = delivery.recipientUserId ?? output.userId;
+      const recipient = await users.findById(recipientUserId);
       try {
         const result = await deliverProactiveDm({
           target,
-          recipientUserId: output.userId,
+          recipientUserId,
           senderUserId: output.userId,
           text,
           whatsapp: deps.whatsapp,

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
+import type { AgentRoute, AgentSourceConfig } from "../db/repositories/agent-outputs";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
@@ -35,6 +36,24 @@ function createService(overrides: Record<string, unknown> = {}) {
     listEligibleRouteMembers: ReturnType<typeof vi.fn>;
     requestGenerationForUser: ReturnType<typeof vi.fn>;
     updateConfigForUser: ReturnType<typeof vi.fn>;
+  };
+}
+
+function slackSource(id: string, name: string): AgentSourceConfig {
+  return { platform: "slack", targetType: "channel", targetId: id, label: `#${name}` };
+}
+
+function sourceRoute(source: AgentSourceConfig): AgentRoute {
+  const sourceKey = `${source.platform}:${source.targetType}:${source.targetId}` as AgentRoute["sources"][number];
+  return {
+    id: sourceKey,
+    sources: [sourceKey],
+    focus: null,
+    sections: null,
+    maxItemsPerSection: null,
+    schedule: null,
+    destination: { kind: "self" },
+    enabled: true,
   };
 }
 
@@ -589,6 +608,60 @@ describe("agentRoutes", () => {
         { id: "out-b", sourceKey: "slack:channel:C_B", status: "running", outputDate: "2026-07-04" },
       ],
     });
+  });
+
+  it("returns 404 for an unknown run routeId without creating generations", async () => {
+    const db = await createTestDb();
+    try {
+      const users = createUserRepository(db);
+      const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+      const sourceA = slackSource("C_A", "alpha");
+      const sourceB = slackSource("C_B", "beta");
+      const runAgent = vi.fn(async () => {
+        throw new Error("runAgent should not be called");
+      }) as unknown as AgentRunServiceDeps["runAgent"];
+      const service = new AgentRunService({
+        db,
+        config: createTestConfig(),
+        logger: createTestLogger(),
+        users,
+        settings: createSettingsRepository(db),
+        runAgent,
+        getSlack: () => ({
+          listChannels: vi.fn(async () => [
+            { id: "C_A", name: "alpha", type: "public_channel", isMember: true },
+            { id: "C_B", name: "beta", type: "public_channel", isMember: true },
+          ]),
+          isUserInChannel: vi.fn(async () => true),
+        }),
+      });
+      await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+        enabled: true,
+        sources: [sourceA, sourceB],
+        routes: [sourceRoute(sourceA), sourceRoute(sourceB)],
+      });
+      const app = createRoutesTestApp(service, user.id, user.email ?? undefined);
+
+      const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/runs`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ routeId: "missing-route" }),
+      });
+
+      const outputs = await db
+        .selectFrom("agent_outputs")
+        .select("id")
+        .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+        .where("user_id", "=", user.id)
+        .execute();
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: { code: "NOT_FOUND", message: "Route not found" } });
+      expect(outputs).toEqual([]);
+      expect(runAgent).not.toHaveBeenCalled();
+    } finally {
+      await db.destroy();
+    }
   });
 
   it("rejects combined delivery to a selected source through the public config route", async () => {

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import type { AgentRoute, AgentSourceConfig } from "../db/repositories/agent-outputs";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
+import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import type { WhatsAppBot } from "../whatsapp/bot";
 import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import { agentRoutes } from "./routes";
@@ -27,6 +29,7 @@ function createService(overrides: Record<string, unknown> = {}) {
     listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
     listOutputsForUser: vi.fn(async () => ({ outputs: [], nextCursor: null })),
     listEligibleRouteMembers: vi.fn(async () => []),
+    listWhatsAppDmMembers: vi.fn(async () => []),
     requestGenerationForUser: vi.fn(async () => []),
     updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
     ...overrides,
@@ -34,6 +37,7 @@ function createService(overrides: Record<string, unknown> = {}) {
     resolveDeliveryConfigForUser: ReturnType<typeof vi.fn>;
     listOutputsForUser: ReturnType<typeof vi.fn>;
     listEligibleRouteMembers: ReturnType<typeof vi.fn>;
+    listWhatsAppDmMembers: ReturnType<typeof vi.fn>;
     requestGenerationForUser: ReturnType<typeof vi.fn>;
     updateConfigForUser: ReturnType<typeof vi.fn>;
   };
@@ -507,35 +511,92 @@ describe("agentRoutes", () => {
     expect(service.updateConfigForUser).not.toHaveBeenCalled();
   });
 
-  it("rejects member route destinations with WhatsApp sources", async () => {
-    const service = createService();
-    const app = createRoutesTestApp(service);
+  it("round-trips WhatsApp member route destinations through the public config route", async () => {
+    const db = await createTestDb();
+    try {
+      const users = createUserRepository(db);
+      const user = await users.create({
+        name: "Agent User",
+        email: "user@example.com",
+        whatsappNumber: "+15550000000",
+      });
+      const member = await users.create({
+        name: "WhatsApp Recipient",
+        email: "recipient@example.com",
+        whatsappNumber: "+15551112222",
+      });
+      const groupJid = "120363000000001@g.us";
+      await createWhatsAppGroupRepository(db).upsert({
+        jid: groupJid,
+        name: "Leads",
+        description: null,
+        updated_at: "2026-06-27T00:00:00.000Z",
+      });
+      const getGroupMetadata = vi.fn(
+        async () =>
+          ({
+            subject: "Leads",
+            participants: [{ id: "15550000000@s.whatsapp.net" }],
+          }) as Awaited<ReturnType<WhatsAppBot["getGroupMetadata"]>>,
+      );
+      const service = new AgentRunService({
+        db,
+        config: createTestConfig(),
+        logger: createTestLogger(),
+        users,
+        settings: createSettingsRepository(db),
+        runAgent: vi.fn(async () => {
+          throw new Error("runAgent should not be called");
+        }) as unknown as AgentRunServiceDeps["runAgent"],
+        getWhatsApp: () => ({ getGroupMetadata }),
+      });
+      const app = createRoutesTestApp(service, user.id, user.email ?? undefined);
 
-    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sources: [{ platform: "whatsapp", targetType: "group", targetId: "120363000000001@g.us", label: "Leads" }],
-        routes: [
-          {
-            id: "whatsapp-member-route",
-            sources: ["whatsapp:group:120363000000001@g.us"],
-            focus: null,
-            sections: null,
-            maxItemsPerSection: null,
-            schedule: null,
-            destination: { kind: "member", platform: "slack", memberUserId: "member-1" },
-            enabled: true,
-          },
-        ],
-      }),
-    });
+      const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sources: [{ platform: "whatsapp", targetType: "group", targetId: groupJid, label: "Spoofed" }],
+          routes: [
+            {
+              id: "whatsapp-member-route",
+              sources: [`whatsapp:group:${groupJid}`],
+              focus: null,
+              sections: null,
+              maxItemsPerSection: null,
+              schedule: null,
+              destination: { kind: "member", platform: "whatsapp", memberUserId: member.id },
+              enabled: true,
+            },
+          ],
+        }),
+      });
+      const reread = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}`);
 
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toMatchObject({
-      error: { code: "VALIDATION_ERROR", message: "Member route destinations support Slack sources only" },
-    });
-    expect(service.updateConfigForUser).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        agent: {
+          routes: [
+            expect.objectContaining({
+              sources: [`whatsapp:group:${groupJid}`],
+              destination: { kind: "member", platform: "whatsapp", memberUserId: member.id },
+            }),
+          ],
+        },
+      });
+      expect(reread.status).toBe(200);
+      await expect(reread.json()).resolves.toMatchObject({
+        agent: {
+          routes: [
+            expect.objectContaining({
+              destination: { kind: "member", platform: "whatsapp", memberUserId: member.id },
+            }),
+          ],
+        },
+      });
+    } finally {
+      await db.destroy();
+    }
   });
 
   it("lists route members through the agent route-members endpoint", async () => {
@@ -562,6 +623,46 @@ describe("agentRoutes", () => {
       "slack:channel:C_ALPHA",
       "slack:channel:C_BETA",
     ]);
+  });
+
+  it("lists WhatsApp DM members through the agent route-members endpoint", async () => {
+    const db = await createTestDb();
+    try {
+      const users = createUserRepository(db);
+      const user = await users.create({ name: "Agent User", email: "user@example.com" });
+      const teammate = await users.create({
+        name: "Numbered Teammate",
+        email: "teammate@example.com",
+        whatsappNumber: "+15551112222",
+      });
+      await users.create({ name: "No Number", email: "no-number@example.com" });
+      await users.create({
+        name: "Agent Account",
+        email: "agent@example.com",
+        whatsappNumber: "+15553334444",
+        type: "agent",
+      });
+      const service = new AgentRunService({
+        db,
+        config: createTestConfig(),
+        logger: createTestLogger(),
+        users,
+        settings: createSettingsRepository(db),
+        runAgent: vi.fn(async () => {
+          throw new Error("runAgent should not be called");
+        }) as unknown as AgentRunServiceDeps["runAgent"],
+      });
+      const app = createRoutesTestApp(service, user.id, user.email ?? undefined);
+
+      const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/route-members/whatsapp`);
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({
+        members: [{ userId: teammate.id, name: "Numbered Teammate" }],
+      });
+    } finally {
+      await db.destroy();
+    }
   });
 
   it("lists completed outputs for an agent", async () => {

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -576,7 +576,19 @@ export function agentRoutes(service: AgentRunService) {
     if (!service.listDefinitions().some((def) => def.key === agentKey)) {
       return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     }
-    const rows = await service.requestGenerationForUser({ agentKey, userId, triggerType: "manual" });
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    const rawRouteId =
+      body && typeof body === "object" && !Array.isArray(body) ? (body as { routeId?: unknown }).routeId : undefined;
+    const routeId = typeof rawRouteId === "string" && rawRouteId.trim() ? rawRouteId.trim() : undefined;
+    const rows = await service.requestGenerationForUser({
+      agentKey,
+      userId,
+      triggerType: "manual",
+      ...(routeId ? { routeIds: [routeId] } : {}),
+    });
+    if (routeId && rows.length === 0) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Route not found" } }, 404);
+    }
     const generations = rows.map(toGenerationShape);
     return c.json({ generation: generations[0] ?? null, generations }, 202);
   });

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -314,10 +314,12 @@ function parseRouteDestination(value: unknown): AgentRouteDestination {
   const raw = value as Record<string, unknown>;
   if (raw.kind === "self" || raw.kind === "off") return { kind: raw.kind };
   if (raw.kind === "member") {
-    if (raw.platform !== "slack") throw new ConfigPatchError("route.destination.platform must be slack");
+    if (raw.platform !== "slack" && raw.platform !== "whatsapp") {
+      throw new ConfigPatchError("route.destination.platform must be slack or whatsapp");
+    }
     const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
     if (!memberUserId) throw new ConfigPatchError("route.destination.memberUserId is required");
-    return { kind: "member", platform: "slack", memberUserId };
+    return { kind: "member", platform: raw.platform, memberUserId };
   }
   if (raw.kind === "channel") {
     if (raw.platform === "slack") {
@@ -370,7 +372,11 @@ function parseRoutes(value: unknown, def: AgentDefinition): AgentRoute[] | undef
     if (sources.length > 1 && destination.kind === "self") {
       throw new ConfigPatchError("Combined routes cannot use self destination");
     }
-    if (destination.kind === "member" && sources.some((source) => source.startsWith("whatsapp:"))) {
+    if (
+      destination.kind === "member" &&
+      destination.platform === "slack" &&
+      sources.some((source) => source.startsWith("whatsapp:"))
+    ) {
       throw new ConfigPatchError("Member route destinations support Slack sources only");
     }
     const maxItemsPerSection =
@@ -542,6 +548,15 @@ export function agentRoutes(service: AgentRunService) {
       }
       throw err;
     }
+  });
+
+  routes.get("/:agentKey/route-members/whatsapp", async (c) => {
+    const userId = await getCurrentUserId(c, service);
+    if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
+    const agentKey = c.req.param("agentKey");
+    const def = getAgentDefinition(agentKey);
+    if (!def) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
+    return c.json({ members: await service.listWhatsAppDmMembers() });
   });
 
   routes.get("/:agentKey/outputs", async (c) => {

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -1845,6 +1845,7 @@ describe("AgentRunService", () => {
           targetType: "dm",
           targetId: "+15551112222",
           label: "WhatsApp Recipient",
+          recipientUserId: member.id,
         },
       }),
     );

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -1839,6 +1839,112 @@ describe("AgentRunService", () => {
     expect(tasks).toHaveLength(1);
   });
 
+  it("generates only the requested route scope when routeIds is provided", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const sourceC = slackSource("C_C", "gamma");
+    const combinedRoute: AgentRoute = {
+      id: "alpha-beta",
+      sources: ["slack:channel:C_A", "slack:channel:C_B"],
+      focus: null,
+      sections: null,
+      maxItemsPerSection: null,
+      schedule: null,
+      destination: { kind: "off" },
+      enabled: true,
+    };
+    const service = createService(db, tasks, {
+      ...allowSlackDelivery([
+        { id: "C_A", name: "alpha" },
+        { id: "C_B", name: "beta" },
+        { id: "C_C", name: "gamma" },
+      ]),
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [sourceA, sourceB, sourceC],
+      routes: [combinedRoute, sourceRoute(sourceC)],
+    });
+
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+      routeIds: ["alpha-beta"],
+    });
+
+    const expectedScopeKey = scopeKeyForRoute(combinedRoute, [sourceA, sourceB]);
+    const outputs = await db
+      .selectFrom("agent_outputs")
+      .select(["source_key", "status"])
+      .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+      .where("user_id", "=", user.id)
+      .where("output_date", "=", OUTPUT_DATE)
+      .orderBy("source_key", "asc")
+      .execute();
+
+    expect(rows.map((row) => row.source_key)).toEqual([expectedScopeKey]);
+    expect(outputs).toEqual([{ source_key: expectedScopeKey, status: "running" }]);
+    expect(tasks).toHaveLength(1);
+  });
+
+  it("generates every route scope when routeIds is omitted", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com", slackUserId: "U_AGENT" });
+    const sourceA = slackSource("C_A", "alpha");
+    const sourceB = slackSource("C_B", "beta");
+    const sourceC = slackSource("C_C", "gamma");
+    const combinedRoute: AgentRoute = {
+      id: "alpha-beta",
+      sources: ["slack:channel:C_A", "slack:channel:C_B"],
+      focus: null,
+      sections: null,
+      maxItemsPerSection: null,
+      schedule: null,
+      destination: { kind: "off" },
+      enabled: true,
+    };
+    const service = createService(db, tasks, {
+      ...allowSlackDelivery([
+        { id: "C_A", name: "alpha" },
+        { id: "C_B", name: "beta" },
+        { id: "C_C", name: "gamma" },
+      ]),
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [sourceA, sourceB, sourceC],
+      routes: [combinedRoute, sourceRoute(sourceC)],
+    });
+
+    const rows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+
+    const expectedScopeKeys = [scopeKeyForRoute(combinedRoute, [sourceA, sourceB]), "slack:channel:C_C"].sort();
+    const outputs = await db
+      .selectFrom("agent_outputs")
+      .select(["source_key", "status"])
+      .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+      .where("user_id", "=", user.id)
+      .where("output_date", "=", OUTPUT_DATE)
+      .orderBy("source_key", "asc")
+      .execute();
+
+    expect(rows.map((row) => row.source_key).sort()).toEqual(expectedScopeKeys);
+    expect(outputs.map((output) => output.source_key).sort()).toEqual(expectedScopeKeys);
+    expect(outputs.every((output) => output.status === "running")).toBe(true);
+    expect(tasks).toHaveLength(2);
+  });
+
   it("derives deterministic scope keys for source and combined routes", () => {
     const sourceA = slackSource("C_A", "alpha");
     const sourceB = slackSource("C_B", "beta");

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -145,6 +145,10 @@ function slackSource(id: string, name: string): AgentSourceConfig {
   return { platform: "slack", targetType: "channel", targetId: id, label: `#${name}` };
 }
 
+function whatsappSource(jid: string, name: string): AgentSourceConfig {
+  return { platform: "whatsapp", targetType: "group", targetId: jid, label: name };
+}
+
 function perSourceSelfModel(): AgentDeliveryModel {
   return { mode: "per_source", defaultRoute: "self", perSource: {}, combined: null };
 }
@@ -1755,6 +1759,126 @@ describe("AgentRunService", () => {
     expect(output).toEqual({
       status: "failed",
       error_message: "Recipient is not a member of every source",
+    });
+  });
+
+  it("delivers WhatsApp member routes by phone number without Slack membership checks", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({
+      name: "Agent User",
+      email: "user@example.com",
+      whatsappNumber: "+15550000000",
+    });
+    const member = await users.create({
+      name: "WhatsApp Recipient",
+      email: "recipient@example.com",
+      whatsappNumber: "+15551112222",
+    });
+    const noNumber = await users.create({ name: "No Number", email: "no-number@example.com" });
+    const groupJid = "120363000000001@g.us";
+    const source = whatsappSource(groupJid, "Leads");
+    await createWhatsAppGroupRepository(db).upsert({
+      jid: groupJid,
+      name: "Leads",
+      description: null,
+      updated_at: "2026-06-27T00:00:00.000Z",
+    });
+    const getGroupMetadata = vi.fn(
+      async () =>
+        ({
+          subject: "Leads",
+          participants: [{ id: "15550000000@s.whatsapp.net" }],
+        }) as Awaited<ReturnType<WhatsAppBot["getGroupMetadata"]>>,
+    );
+    const isUserInChannel = vi.fn(async () => {
+      throw new Error("Slack membership should not be checked");
+    });
+    const listChannels = vi.fn(async () => []);
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "Summary" },
+        rawPayload: {
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Summarizer", summary: "Summary" },
+          items: [],
+        },
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const outputDelivery = { deliver: vi.fn(async () => {}) } satisfies AgentOutputDeliveryPublisher;
+    const service = createService(db, tasks, {
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      outputDelivery,
+      getSlack: () => ({ listChannels, isUserInChannel }),
+      getWhatsApp: () => ({ getGroupMetadata }),
+    });
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [source],
+      routes: [
+        sourceRoute(source, {
+          destination: { kind: "member", platform: "whatsapp", memberUserId: member.id },
+        }),
+      ],
+    });
+    const deliveredRows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(deliveredRows).toHaveLength(1);
+    expect(outputDelivery.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delivery: {
+          enabled: true,
+          platform: "whatsapp",
+          targetType: "dm",
+          targetId: "+15551112222",
+          label: "WhatsApp Recipient",
+        },
+      }),
+    );
+    expect(isUserInChannel).not.toHaveBeenCalled();
+
+    tasks.length = 0;
+    outputDelivery.deliver.mockClear();
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [source],
+      routes: [
+        sourceRoute(source, {
+          destination: { kind: "member", platform: "whatsapp", memberUserId: noNumber.id },
+        }),
+      ],
+    });
+    const failedRows = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    for (const task of tasks) await task();
+
+    expect(outputDelivery.deliver).not.toHaveBeenCalled();
+    expect(isUserInChannel).not.toHaveBeenCalled();
+    const failedOutput = await db
+      .selectFrom("agent_outputs")
+      .select(["status", "error_message"])
+      .where("id", "=", failedRows[0].id)
+      .executeTakeFirstOrThrow();
+    expect(failedOutput).toEqual({
+      status: "failed",
+      error_message: "Recipient has no WhatsApp number",
     });
   });
 

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -76,6 +76,7 @@ export interface RequestAgentGenerationParams {
   triggerType: AgentOutputTriggerType;
   skipIfCompleted?: boolean;
   scopeKeys?: string[];
+  routeIds?: string[];
 }
 
 export interface ResolvedAgentConfig {
@@ -1328,9 +1329,14 @@ export class AgentRunService {
     const now = new Date();
     const scopes = await this.resolveExpectedScopesForUser(def, user, config);
     const scopeKeys = params.scopeKeys ? new Set(params.scopeKeys) : null;
+    const routeIds = params.routeIds ? new Set(params.routeIds) : null;
     const rows: AgentOutputRow[] = [];
 
-    for (const scope of scopeKeys ? scopes.filter((candidate) => scopeKeys.has(candidate.sourceKey)) : scopes) {
+    for (const scope of scopes.filter((candidate) => {
+      if (scopeKeys && !scopeKeys.has(candidate.sourceKey)) return false;
+      if (routeIds && (!candidate.route || !routeIds.has(candidate.route.id))) return false;
+      return true;
+    })) {
       let recoveredStaleRunning = false;
       const existingRunning = await this.repo.findRunning(def.key, user.id, outputDate, scope.sourceKey);
       if (existingRunning) {

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -1713,6 +1713,7 @@ export class AgentRunService {
         targetType: "dm",
         targetId: member.whatsapp_number,
         label: member.name,
+        recipientUserId: member.id,
       };
     }
 

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -126,6 +126,11 @@ export interface AgentRouteMember {
   slackUserId: string;
 }
 
+export interface AgentWhatsAppDmMember {
+  userId: string;
+  name: string;
+}
+
 export interface AgentOutputApi {
   id: string;
   agentKey: string;
@@ -333,9 +338,9 @@ function normalizeRouteDestination(value: unknown): AgentRouteDestination | null
   const raw = value as Record<string, unknown>;
   if (raw.kind === "self" || raw.kind === "off") return { kind: raw.kind };
   if (raw.kind === "member") {
-    if (raw.platform !== "slack") return null;
+    if (raw.platform !== "slack" && raw.platform !== "whatsapp") return null;
     const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
-    return memberUserId ? { kind: "member", platform: "slack", memberUserId } : null;
+    return memberUserId ? { kind: "member", platform: raw.platform, memberUserId } : null;
   }
   if (raw.kind === "channel") {
     const targetId = typeof raw.targetId === "string" ? raw.targetId.trim() : "";
@@ -852,10 +857,10 @@ export class AgentRunService {
       if (route.destination.kind === "member") {
         const raw = route.destination as Record<string, unknown>;
         const memberUserId = typeof raw.memberUserId === "string" ? raw.memberUserId.trim() : "";
-        if (raw.platform !== "slack" || !memberUserId) {
-          throw new AgentDeliveryTargetError("Member route destination must include a Slack member");
+        if ((raw.platform !== "slack" && raw.platform !== "whatsapp") || !memberUserId) {
+          throw new AgentDeliveryTargetError("Member route destination must include a Slack or WhatsApp member");
         }
-        destination = { kind: "member", platform: "slack", memberUserId };
+        destination = { kind: "member", platform: raw.platform, memberUserId };
       }
       if (route.destination.kind === "channel") {
         const normalized = normalizeRouteDestination(route.destination);
@@ -1018,6 +1023,15 @@ export class AgentRunService {
       if (eligible) members.push({ userId: user.id, name: user.name, slackUserId: user.slack_user_id });
     }
 
+    return members;
+  }
+
+  async listWhatsAppDmMembers(): Promise<AgentWhatsAppDmMember[]> {
+    const members: AgentWhatsAppDmMember[] = [];
+    for (const user of await this.deps.users.list()) {
+      if (user.type === "agent" || !user.whatsapp_number) continue;
+      members.push({ userId: user.id, name: user.name });
+    }
     return members;
   }
 
@@ -1688,6 +1702,20 @@ export class AgentRunService {
     resolvedSources: AgentSourceConfig[],
   ): Promise<AgentDeliveryConfig> {
     const member = await this.deps.users.findById(destination.memberUserId);
+
+    if (destination.platform === "whatsapp") {
+      if (!member?.whatsapp_number) {
+        throw new AgentDeliveryTargetError("Recipient has no WhatsApp number");
+      }
+      return {
+        enabled: true,
+        platform: "whatsapp",
+        targetType: "dm",
+        targetId: member.whatsapp_number,
+        label: member.name,
+      };
+    }
+
     if (!member?.slack_user_id) {
       throw new AgentDeliveryTargetError("Recipient is not available for Slack delivery");
     }

--- a/packages/server/src/api/channels.ts
+++ b/packages/server/src/api/channels.ts
@@ -97,6 +97,16 @@ export function channelRoutes(deps: ChannelDeps) {
     return c.json({ groups: await deps.whatsappGroups.list() });
   });
 
+  routes.post("/whatsapp/groups/sync", async (c) => {
+    await deps.whatsapp?.syncAllGroups({ force: true });
+
+    if (!deps.whatsappGroups) {
+      return c.json({ groups: [] });
+    }
+
+    return c.json({ groups: await deps.whatsappGroups.list() });
+  });
+
   routes.get("/whatsapp/templates/provider", async (c) => {
     const denied = denyIfNotAdmin(c);
     if (denied) return denied;

--- a/packages/server/src/api/middleware.ts
+++ b/packages/server/src/api/middleware.ts
@@ -65,6 +65,7 @@ function canUseSketchApiKey(path: string, method: string): boolean {
   if (method === "GET" && path === "/api/users") return true;
   if (method === "GET" && path === "/api/channels/slack") return true;
   if (method === "GET" && path === "/api/channels/whatsapp/groups") return true;
+  if (method === "POST" && path === "/api/channels/whatsapp/groups/sync") return true;
   if (method === "POST" && path === "/api/agent-runs") return true;
   if (method === "GET" && path.startsWith("/api/agent-sessions/") && path.endsWith("/messages")) return true;
   if (method === "GET" && (path === "/api/workflows" || path.startsWith("/api/workflows/"))) return true;

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -57,6 +57,7 @@ export interface AgentDeliveryConfig {
   targetType: AgentDeliveryTargetType;
   targetId: string;
   label: string | null;
+  recipientUserId?: string;
   mentions?: AgentDeliveryMention[];
 }
 

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -95,7 +95,7 @@ export type AgentRouteId = string;
 export type AgentRouteDestination =
   | { kind: "self" }
   | { kind: "off" }
-  | { kind: "member"; platform: "slack"; memberUserId: string }
+  | { kind: "member"; platform: "slack" | "whatsapp"; memberUserId: string }
   | { kind: "channel"; platform: "slack"; targetType: "channel"; targetId: string; label: string | null }
   | { kind: "channel"; platform: "whatsapp"; targetType: "group"; targetId: string; label: string | null };
 

--- a/packages/server/src/whatsapp/bot.isolated.test.ts
+++ b/packages/server/src/whatsapp/bot.isolated.test.ts
@@ -1,4 +1,4 @@
-import type { proto } from "@whiskeysockets/baileys";
+import type { GroupMetadata, proto } from "@whiskeysockets/baileys";
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
@@ -573,6 +573,130 @@ describe("WhatsAppBot group metadata persistence", () => {
     await expect(
       db.selectFrom("whatsapp_groups").selectAll().where("jid", "=", "group@g.us").executeTakeFirst(),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("WhatsAppBot syncAllGroups", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await db.destroy();
+  });
+
+  function metadata(id: string, subject: string, desc?: string): GroupMetadata {
+    return {
+      id,
+      owner: undefined,
+      subject,
+      desc,
+      participants: [],
+    };
+  }
+
+  function attachGroupSyncSocket(bot: WhatsAppBot, groups: Record<string, GroupMetadata>) {
+    const groupFetchAllParticipating = vi.fn().mockResolvedValue(groups);
+    (bot as unknown as { sock: { groupFetchAllParticipating: typeof groupFetchAllParticipating } }).sock = {
+      groupFetchAllParticipating,
+    };
+    return groupFetchAllParticipating;
+  }
+
+  it("upserts every fetched group while preserving agent bindings", async () => {
+    const repo = createWhatsAppGroupRepository(db);
+    const bot = new WhatsAppBot({
+      db,
+      logger: createTestLogger(),
+      groupMetadataStore: repo,
+    });
+
+    await db.insertInto("users").values({ id: "agent-1", name: "Agent One" }).execute();
+    await repo.upsert({
+      jid: "existing@g.us",
+      name: "Old Group",
+      description: "Old desc",
+      updated_at: "2026-03-13T10:00:00.000Z",
+    });
+    await db
+      .updateTable("whatsapp_groups")
+      .set({ agent_user_id: "agent-1" })
+      .where("jid", "=", "existing@g.us")
+      .execute();
+
+    attachGroupSyncSocket(bot, {
+      "existing@g.us": metadata("existing@g.us", "Renamed Group", "New desc"),
+      "new@g.us": metadata("new@g.us", "New Group"),
+    });
+
+    await expect(bot.syncAllGroups()).resolves.toBe(2);
+
+    const existing = await db
+      .selectFrom("whatsapp_groups")
+      .selectAll()
+      .where("jid", "=", "existing@g.us")
+      .executeTakeFirstOrThrow();
+    const inserted = await db
+      .selectFrom("whatsapp_groups")
+      .selectAll()
+      .where("jid", "=", "new@g.us")
+      .executeTakeFirstOrThrow();
+
+    expect(existing.name).toBe("Renamed Group");
+    expect(existing.description).toBe("New desc");
+    expect(existing.agent_user_id).toBe("agent-1");
+    expect(inserted.name).toBe("New Group");
+    expect(inserted.description).toBeNull();
+    await expect(bot.getGroupMetadata("new@g.us")).resolves.toMatchObject({ subject: "New Group" });
+  });
+
+  it("returns the synced count so far and warns when the socket fetch fails", async () => {
+    const logger = createTestLogger();
+    const warn = vi.spyOn(logger, "warn");
+    const bot = new WhatsAppBot({
+      db,
+      logger,
+      groupMetadataStore: createWhatsAppGroupRepository(db),
+    });
+    const groupFetchAllParticipating = vi.fn().mockRejectedValue(new Error("socket unavailable"));
+    (bot as unknown as { sock: { groupFetchAllParticipating: typeof groupFetchAllParticipating } }).sock = {
+      groupFetchAllParticipating,
+    };
+
+    await expect(bot.syncAllGroups()).resolves.toBe(0);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), syncedCount: 0 }),
+      "Failed to sync WhatsApp groups",
+    );
+  });
+
+  it("throttles repeated syncs and allows forced refreshes", async () => {
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(10_000);
+    const bot = new WhatsAppBot({
+      db,
+      logger: createTestLogger(),
+      groupMetadataStore: createWhatsAppGroupRepository(db),
+    });
+    const groupFetchAllParticipating = attachGroupSyncSocket(bot, {
+      "team@g.us": metadata("team@g.us", "Team"),
+    });
+
+    await expect(bot.syncAllGroups()).resolves.toBe(1);
+    await expect(bot.syncAllGroups()).resolves.toBe(0);
+    (bot as unknown as { activeSocketGeneration: number }).activeSocketGeneration = 2;
+    const nextGenerationFetch = attachGroupSyncSocket(bot, {
+      "next-team@g.us": metadata("next-team@g.us", "Next Team"),
+    });
+    await expect(bot.syncAllGroups()).resolves.toBe(1);
+    await expect(bot.syncAllGroups({ force: true })).resolves.toBe(1);
+
+    expect(groupFetchAllParticipating).toHaveBeenCalledTimes(1);
+    expect(nextGenerationFetch).toHaveBeenCalledTimes(2);
+    dateSpy.mockRestore();
   });
 });
 

--- a/packages/server/src/whatsapp/bot.ts
+++ b/packages/server/src/whatsapp/bot.ts
@@ -40,6 +40,7 @@ const RECONNECT_MAX_MS = 30_000;
 const RECONNECT_FACTOR = 1.8;
 const RECONNECT_JITTER = 0.25;
 const GROUP_META_TTL_MS = 5 * 60_000;
+const GROUP_SYNC_THROTTLE_MS = 5 * 60_000;
 
 /** Cached WA version — fetched once from GitHub, reused for all subsequent connections. */
 let cachedVersion: WAVersion | null = null;
@@ -110,6 +111,8 @@ export class WhatsAppBot {
   private stopping = false;
   private watchdogTimer: ReturnType<typeof setInterval> | null = null;
   private lastMessageAt = 0;
+  private lastGroupSyncAt = 0;
+  private lastGroupSyncSocketGeneration = 0;
   private authState: Awaited<ReturnType<typeof createDbAuthState>> | null = null;
   private composingTimers = new Map<
     string,
@@ -193,6 +196,7 @@ export class WhatsAppBot {
           this.reconnectAttempt = 0;
           this.registerMessageHandler();
           this.startWatchdog();
+          void this.syncAllGroups();
           await callbacks.onConnected(this.phoneNumber ?? "unknown");
           resolve();
         }
@@ -394,6 +398,60 @@ export class WhatsAppBot {
     return meta?.subject ?? "Unknown Group";
   }
 
+  async syncAllGroups(opts: { force?: boolean } = {}): Promise<number> {
+    const socket = this.sock;
+    const store = this.groupMetadataStore;
+    if (!socket || !store) return 0;
+
+    const now = Date.now();
+    const socketGeneration = this.activeSocketGeneration;
+    if (
+      !opts.force &&
+      this.lastGroupSyncSocketGeneration === socketGeneration &&
+      this.lastGroupSyncAt > 0 &&
+      now - this.lastGroupSyncAt < GROUP_SYNC_THROTTLE_MS
+    ) {
+      return 0;
+    }
+
+    this.lastGroupSyncAt = now;
+    this.lastGroupSyncSocketGeneration = socketGeneration;
+    let syncedCount = 0;
+
+    try {
+      const groups = await socket.groupFetchAllParticipating();
+      if (socketGeneration !== this.activeSocketGeneration || socket !== this.sock) {
+        if (this.lastGroupSyncAt === now && this.lastGroupSyncSocketGeneration === socketGeneration) {
+          this.lastGroupSyncAt = 0;
+          this.lastGroupSyncSocketGeneration = 0;
+        }
+        return 0;
+      }
+
+      for (const [jid, meta] of Object.entries(groups)) {
+        this.groupMetaCache.set(jid, { meta, expires: Date.now() + GROUP_META_TTL_MS });
+        await store.upsert({
+          jid,
+          name: meta.subject ?? "Unknown Group",
+          description: meta.desc ?? null,
+          updated_at: new Date().toISOString(),
+        });
+        syncedCount += 1;
+      }
+
+      return syncedCount;
+    } catch (err) {
+      if (socketGeneration !== this.activeSocketGeneration || socket !== this.sock) {
+        if (this.lastGroupSyncAt === now && this.lastGroupSyncSocketGeneration === socketGeneration) {
+          this.lastGroupSyncAt = 0;
+          this.lastGroupSyncSocketGeneration = 0;
+        }
+      }
+      this.logger.warn({ err, syncedCount }, "Failed to sync WhatsApp groups");
+      return syncedCount;
+    }
+  }
+
   async resolveJidToPhone(jid: string): Promise<string | null> {
     if (jid.endsWith("@lid")) return this.resolveLidToPhone(jid);
     if (jid.endsWith("@s.whatsapp.net")) return jidToPhoneNumber(jid);
@@ -454,6 +512,7 @@ export class WhatsAppBot {
         this.clearReconnectTimer();
         this.logger.info({ socketGeneration }, "WhatsApp connected");
         this.reconnectAttempt = 0;
+        void this.syncAllGroups();
       }
 
       if (connection === "close") {

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -41,6 +41,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { EmptyCard, OutputView, RunButton, formatOutputDate } from "./agent-outputs-view";
 import { SummariserSetupModal } from "./summariser-setup-modal";
 import { InputIcon, deliversLabel, routeInput } from "./summariser-shared";
 
@@ -223,7 +224,7 @@ function OutputsTab({
       <div className="mb-4 flex items-center justify-between">
         <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
           {selectedOutput
-            ? `Generated ${formatDate(selectedOutput.generatedAt ?? selectedOutput.outputDate)}`
+            ? `Generated ${formatOutputDate(selectedOutput.generatedAt ?? selectedOutput.outputDate)}`
             : "No output yet"}
         </span>
         <RunButton running={running} pending={runPending} onRun={onRun} />
@@ -252,7 +253,7 @@ function OutputsTab({
               >
                 <span className="block truncate text-[12.5px] font-medium">{output.sourceLabel ?? "Summary"}</span>
                 <span className="mt-0.5 block truncate font-mono text-[10px] uppercase tracking-[0.08em]">
-                  {formatDate(output.generatedAt ?? output.outputDate)}
+                  {formatOutputDate(output.generatedAt ?? output.outputDate)}
                 </span>
               </button>
             ))}
@@ -261,72 +262,6 @@ function OutputsTab({
         </div>
       )}
     </div>
-  );
-}
-
-function OutputView({ output, sectionTitles }: { output: AgentOutput; sectionTitles: Record<string, string> }) {
-  const sectionEntries = Object.entries(output.sections).filter(([, items]) => items.length > 0);
-  return (
-    <div className="flex flex-col gap-6">
-      {output.masthead ? (
-        <div className="rounded-xl border-[0.5px] border-border bg-gradient-to-b from-muted/50 to-card px-4 py-3.5">
-          <p className="text-[14px] font-semibold text-foreground">{output.masthead.title}</p>
-          <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">{output.masthead.summary}</p>
-        </div>
-      ) : null}
-      {sectionEntries.length === 0 ? (
-        <EmptyCard>No items in this run.</EmptyCard>
-      ) : (
-        sectionEntries.map(([sectionKey, items]) => (
-          <div key={sectionKey}>
-            <div className="mb-2 border-b border-border/60 pb-2">
-              <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
-                {sectionTitles[sectionKey] ?? sectionKey}
-              </span>
-            </div>
-            <div className="flex flex-col gap-2">
-              {items.map((item) => (
-                <div key={item.id} className="rounded-xl border-[0.5px] border-border bg-card px-4 py-3">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="text-[13px] font-medium text-foreground">{item.title}</span>
-                    {item.label ? (
-                      <span className="rounded-full bg-muted/60 px-1.5 py-[1px] font-mono text-[8.5px] uppercase tracking-[0.06em] text-muted-foreground">
-                        {item.label.replaceAll("_", " ")}
-                      </span>
-                    ) : null}
-                    {item.displayRef ? (
-                      <span className="font-mono text-[10px] text-muted-foreground/70">{item.displayRef}</span>
-                    ) : null}
-                  </div>
-                  <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">{item.summary}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))
-      )}
-    </div>
-  );
-}
-
-function RunButton({ running, pending, onRun }: { running: boolean; pending: boolean; onRun: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onRun}
-      disabled={running || pending}
-      className="inline-flex items-center gap-1.5 rounded-full bg-foreground px-3.5 py-1.5 text-[12px] font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
-    >
-      {running ? "Running…" : "Run now"}
-    </button>
-  );
-}
-
-function EmptyCard({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="rounded-xl border border-dashed border-border py-10 text-center text-[12.5px] text-muted-foreground">
-      {children}
-    </p>
   );
 }
 
@@ -1181,10 +1116,4 @@ function MentionList({
       })}
     </div>
   );
-}
-
-function formatDate(value: string): string {
-  const parsed = new Date(value.length === 10 ? `${value}T00:00:00` : value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }

--- a/packages/web/src/components/agents/agent-outputs-view.tsx
+++ b/packages/web/src/components/agents/agent-outputs-view.tsx
@@ -1,0 +1,151 @@
+/**
+ * Shared presentation for generated agent output — the "previous runs" list, a
+ * single run's rendered sections, the run-now button, and the empty/loading
+ * cards. Used by both the prebuilt-agent detail page (all routes) and the
+ * per-summariser page (one route), so the two surfaces stay visually identical.
+ */
+import type { AgentOutput } from "@/lib/api";
+import { cn } from "@sketch/ui/lib/utils";
+import { useEffect, useState } from "react";
+
+export function formatOutputDate(value: string): string {
+  const parsed = new Date(value.length === 10 ? `${value}T00:00:00` : value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function EmptyCard({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border py-10 text-center text-[12.5px] text-muted-foreground">
+      {children}
+    </p>
+  );
+}
+
+export function RunButton({ running, pending, onRun }: { running: boolean; pending: boolean; onRun: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onRun}
+      disabled={running || pending}
+      className="inline-flex items-center gap-1.5 rounded-full bg-foreground px-3.5 py-1.5 text-[12px] font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
+    >
+      {running ? "Running…" : "Run now"}
+    </button>
+  );
+}
+
+export function OutputView({ output, sectionTitles }: { output: AgentOutput; sectionTitles: Record<string, string> }) {
+  const sectionEntries = Object.entries(output.sections).filter(([, items]) => items.length > 0);
+  return (
+    <div className="flex flex-col gap-6">
+      {output.masthead ? (
+        <div className="rounded-xl border-[0.5px] border-border bg-gradient-to-b from-muted/50 to-card px-4 py-3.5">
+          <p className="text-[14px] font-semibold text-foreground">{output.masthead.title}</p>
+          <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">{output.masthead.summary}</p>
+        </div>
+      ) : null}
+      {sectionEntries.length === 0 ? (
+        <EmptyCard>No items in this run.</EmptyCard>
+      ) : (
+        sectionEntries.map(([sectionKey, items]) => (
+          <div key={sectionKey}>
+            <div className="mb-2 border-b border-border/60 pb-2">
+              <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+                {sectionTitles[sectionKey] ?? sectionKey}
+              </span>
+            </div>
+            <div className="flex flex-col gap-2">
+              {items.map((item) => (
+                <div key={item.id} className="rounded-xl border-[0.5px] border-border bg-card px-4 py-3">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="text-[13px] font-medium text-foreground">{item.title}</span>
+                    {item.label ? (
+                      <span className="rounded-full bg-muted/60 px-1.5 py-[1px] font-mono text-[8.5px] uppercase tracking-[0.06em] text-muted-foreground">
+                        {item.label.replaceAll("_", " ")}
+                      </span>
+                    ) : null}
+                    {item.displayRef ? (
+                      <span className="font-mono text-[10px] text-muted-foreground/70">{item.displayRef}</span>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">{item.summary}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+/**
+ * The full "runs" experience — a run-now header, the previous-runs rail, and the
+ * selected run's rendered sections. Manages its own selection; the caller owns
+ * fetching (and any refetch-while-running polling) and passes the outputs in.
+ */
+export function RunsPanel({
+  outputs,
+  loading,
+  running,
+  runPending,
+  onRun,
+  sectionTitles,
+  emptyHint,
+}: {
+  outputs: AgentOutput[];
+  loading: boolean;
+  running: boolean;
+  runPending: boolean;
+  onRun: () => void;
+  sectionTitles: Record<string, string>;
+  emptyHint: string;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!selectedId && outputs.length > 0) setSelectedId(outputs[0].id);
+  }, [outputs, selectedId]);
+  const selected = outputs.find((output) => output.id === selectedId) ?? outputs[0] ?? null;
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+          {selected ? `Generated ${formatOutputDate(selected.generatedAt ?? selected.outputDate)}` : "No output yet"}
+        </span>
+        <RunButton running={running} pending={runPending} onRun={onRun} />
+      </div>
+
+      {running && !selected ? (
+        <EmptyCard>Generating…</EmptyCard>
+      ) : loading && outputs.length === 0 ? (
+        <EmptyCard>Loading…</EmptyCard>
+      ) : !selected ? (
+        <EmptyCard>{emptyHint}</EmptyCard>
+      ) : (
+        <div className="grid gap-5 md:grid-cols-[220px_minmax(0,1fr)]">
+          <div className="flex flex-col gap-1">
+            {outputs.map((output) => (
+              <button
+                key={output.id}
+                type="button"
+                onClick={() => setSelectedId(output.id)}
+                className={cn(
+                  "rounded-lg px-3 py-2 text-left transition-colors",
+                  selected.id === output.id ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/50",
+                )}
+              >
+                <span className="block truncate text-[12.5px] font-medium">{output.sourceLabel ?? "Summary"}</span>
+                <span className="mt-0.5 block truncate font-mono text-[10px] uppercase tracking-[0.08em]">
+                  {formatOutputDate(output.generatedAt ?? output.outputDate)}
+                </span>
+              </button>
+            ))}
+          </div>
+          <OutputView output={selected} sectionTitles={sectionTitles} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/agents/summariser-config.tsx
+++ b/packages/web/src/components/agents/summariser-config.tsx
@@ -15,11 +15,13 @@ import {
   SheetTitle,
 } from "@sketch/ui/components/sheet";
 import { Switch } from "@sketch/ui/components/switch";
-import { cn } from "@sketch/ui/lib/utils";
+import { TabButton } from "@sketch/ui/components/tab-button";
+import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { RunsPanel } from "./agent-outputs-view";
 import {
   DestinationField,
   FocusField,
@@ -35,6 +37,40 @@ import {
   useSourceOptions,
 } from "./summariser-shared";
 
+type Tab = "config" | "runs";
+
+/**
+ * Reproduce the server's scope key for a route so we can match this route's
+ * generated outputs. A route's `id` is a UUID and does NOT equal the output
+ * `sourceKey`: single-source routes key on the source itself, combined routes on
+ * `route:${sha256(sources.join("|")).slice(0, 12)}` (see scopeKeyForRoute /
+ * stableRouteHash on the server). Kept in sync with that hashing.
+ */
+function useRouteScopeKey(route: AgentRoute): string | null {
+  const single = route.sources.length === 1 ? (route.sources[0] ?? null) : null;
+  const joined = route.sources.join("|");
+  const [key, setKey] = useState<string | null>(single);
+  useEffect(() => {
+    if (route.sources.length === 1) {
+      setKey(route.sources[0] ?? null);
+      return;
+    }
+    let cancelled = false;
+    void crypto.subtle.digest("SHA-256", new TextEncoder().encode(joined)).then((buf) => {
+      if (cancelled) return;
+      const hex = Array.from(new Uint8Array(buf))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")
+        .slice(0, 12);
+      setKey(`route:${hex}`);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [joined, route.sources]);
+  return key;
+}
+
 type RouteField = "sources" | "schedule" | "focus" | "volume" | "delivery" | null;
 
 const FIELD_META: Record<Exclude<RouteField, null>, { title: string; hint: string }> = {
@@ -49,14 +85,11 @@ const FIELD_META: Record<Exclude<RouteField, null>, { title: string; hint: strin
 };
 
 export function SummariserConfigPage({ agentKey, routeId }: { agentKey: string; routeId: string }) {
-  const queryClient = useQueryClient();
-  const detailQuery = useQuery({ queryKey: ["agents", "detail", agentKey], queryFn: () => api.agents.get(agentKey) });
-  const [editing, setEditing] = useState<RouteField>(null);
-
-  const invalidate = () => {
-    void queryClient.invalidateQueries({ queryKey: ["agents", "detail", agentKey] });
-    void queryClient.invalidateQueries({ queryKey: ["agents", "list"] });
-  };
+  const detailQuery = useQuery({
+    queryKey: ["agents", "detail", agentKey],
+    queryFn: () => api.agents.get(agentKey),
+    refetchInterval: (query) => (query.state.data?.running ? 3000 : false),
+  });
 
   const agent = detailQuery.data?.agent ?? null;
   const route = agent?.routes.find((r) => r.id === routeId) ?? null;
@@ -72,53 +105,33 @@ export function SummariserConfigPage({ agentKey, routeId }: { agentKey: string; 
 
   return (
     <Shell>
-      <SummariserBody agentKey={agentKey} agent={agent} route={route} onEdit={setEditing} onChanged={invalidate} />
-      {editing ? (
-        <RouteFieldDrawer
-          key={editing}
-          field={editing}
-          agentKey={agentKey}
-          agent={agent}
-          route={route}
-          onClose={() => setEditing(null)}
-          onSaved={invalidate}
-        />
-      ) : null}
+      <SummariserContent agentKey={agentKey} agent={agent} route={route} running={detailQuery.data?.running ?? false} />
     </Shell>
   );
 }
 
-function Shell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto box-content max-w-4xl px-10 py-8">
-      <Link
-        to="/agents"
-        className="inline-flex items-center gap-1.5 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ArrowLeftIcon size={13} weight="bold" aria-hidden />
-        Agents
-      </Link>
-      {children}
-    </div>
-  );
-}
-
-function SummariserBody({
+function SummariserContent({
   agentKey,
   agent,
   route,
-  onEdit,
-  onChanged,
+  running,
 }: {
   agentKey: string;
   agent: AgentConfig;
   route: AgentRoute;
-  onEdit: (field: RouteField) => void;
-  onChanged: () => void;
+  running: boolean;
 }) {
+  const queryClient = useQueryClient();
   const { lookup } = useSourceOptions(agent);
-  const input = routeInput(route, lookup);
+  const [editing, setEditing] = useState<RouteField>(null);
+  const [tab, setTab] = useState<Tab>("config");
 
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["agents", "detail", agentKey] });
+    void queryClient.invalidateQueries({ queryKey: ["agents", "list"] });
+  };
+
+  const input = routeInput(route, lookup);
   const save = useMutation({
     mutationFn: (next: AgentRoute) =>
       saveRoutes(
@@ -126,7 +139,7 @@ function SummariserBody({
         agent.routes.map((r) => (r.id === route.id ? next : r)),
         lookup,
       ),
-    onSuccess: onChanged,
+    onSuccess: invalidate,
     onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to update"),
   });
 
@@ -157,7 +170,111 @@ function SummariserBody({
         </span>
       </header>
 
-      <div className="mt-6 rounded-xl border-[0.5px] border-border bg-card px-4">
+      <div className="mt-6 flex items-center gap-6 border-b border-border">
+        <TabButton label="Runs" isActive={tab === "runs"} onClick={() => setTab("runs")} />
+        <TabButton label="Config" isActive={tab === "config"} onClick={() => setTab("config")} />
+      </div>
+
+      <TabContentContainer className="pt-5">
+        {tab === "runs" ? (
+          <RunsTab agentKey={agentKey} agent={agent} route={route} running={running} />
+        ) : (
+          <ConfigContent agent={agent} route={route} input={input} save={save} onEdit={setEditing} />
+        )}
+      </TabContentContainer>
+
+      {editing ? (
+        <RouteFieldDrawer
+          key={editing}
+          field={editing}
+          agentKey={agentKey}
+          agent={agent}
+          route={route}
+          onClose={() => setEditing(null)}
+          onSaved={invalidate}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function RunsTab({
+  agentKey,
+  agent,
+  route,
+  running,
+}: {
+  agentKey: string;
+  agent: AgentConfig;
+  route: AgentRoute;
+  running: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const outputsQuery = useQuery({
+    queryKey: ["agents", "outputs", agentKey],
+    queryFn: () => api.agents.outputs(agentKey, { limit: 50 }),
+    refetchInterval: () => (running ? 3000 : false),
+  });
+  const runMutation = useMutation({
+    mutationFn: () => api.agents.run(agentKey, { routeId: route.id }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["agents", "detail", agentKey] });
+      void queryClient.invalidateQueries({ queryKey: ["agents", "outputs", agentKey] });
+      toast.success("Run started");
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to start run"),
+  });
+
+  const scopeKey = useRouteScopeKey(route);
+  const outputs = (outputsQuery.data?.outputs ?? []).filter(
+    (output) => scopeKey != null && output.sourceKey === scopeKey,
+  );
+  const sectionTitles = Object.fromEntries(agent.sections.map((section) => [section.key, section.title]));
+
+  return (
+    <RunsPanel
+      outputs={outputs}
+      loading={outputsQuery.isLoading}
+      running={running || runMutation.isPending}
+      runPending={runMutation.isPending}
+      onRun={() => runMutation.mutate()}
+      sectionTitles={sectionTitles}
+      emptyHint="Nothing yet. Run it now or wait for its next scheduled run."
+    />
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
+      <Link
+        to="/agents"
+        className="inline-flex items-center gap-1.5 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeftIcon size={13} weight="bold" aria-hidden />
+        Agents
+      </Link>
+      {children}
+    </div>
+  );
+}
+
+function ConfigContent({
+  agent,
+  route,
+  input,
+  save,
+  onEdit,
+}: {
+  agent: AgentConfig;
+  route: AgentRoute;
+  input: ReturnType<typeof routeInput>;
+  save: { mutate: (next: AgentRoute) => void; isPending: boolean };
+  onEdit: (field: RouteField) => void;
+}) {
+  return (
+    <>
+      <div className="rounded-xl border-[0.5px] border-border bg-card px-4">
         <Row label="Input" onEdit={() => onEdit("sources")}>
           <span className="flex items-center gap-1.5 text-[12.5px] text-foreground/85">
             {input.label}

--- a/packages/web/src/components/agents/summariser-setup-modal.tsx
+++ b/packages/web/src/components/agents/summariser-setup-modal.tsx
@@ -110,7 +110,7 @@ function SetupBody({
   const inputsValid = controller.sources.length > 0;
   const deliveryValid =
     !(controller.destKind === "self" && controller.sources.length !== 1) &&
-    !(controller.destKind === "member" && (!controller.memberUserId || controller.hasWhatsApp)) &&
+    !(controller.destKind === "member" && !controller.memberUserId) &&
     !(controller.destKind === "channel" && !controller.channelTarget);
   const canAdvance = step === 0 ? inputsValid : step === 1 ? deliveryValid : step === 2 ? true : controller.isValid;
   const isLast = step === STEPS.length - 1;

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -192,7 +192,7 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
   const isValid =
     sources.length > 0 &&
     !(destKind === "self" && sources.length !== 1) &&
-    !(destKind === "member" && (!memberUserId || hasWhatsApp)) &&
+    !(destKind === "member" && !memberUserId) &&
     !(destKind === "channel" && !channelTarget);
 
   const build = (base: AgentRoute | null): AgentRoute => {
@@ -200,7 +200,7 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
       destKind === "self"
         ? { kind: "self" }
         : destKind === "member" && memberUserId
-          ? { kind: "member", platform: "slack", memberUserId }
+          ? { kind: "member", platform: hasWhatsApp ? "whatsapp" : "slack", memberUserId }
           : destKind === "channel" && channelTarget
             ? channelDestination(channelTarget)
             : { kind: "off" };
@@ -278,12 +278,18 @@ export function DestinationField({
 }) {
   const { destKind, memberUserId, hasWhatsApp } = controller;
   const activeTab: "groups" | "dm" = destKind === "member" ? "dm" : "groups";
-  const dmAvailable = (agent.sourceConfig?.supportsSlackChannels ?? false) && !hasWhatsApp;
+  const dmPlatform: "slack" | "whatsapp" = hasWhatsApp ? "whatsapp" : "slack";
+  const slackDmSupported = agent.sourceConfig?.supportsSlackChannels ?? false;
 
-  const memberQuery = useQuery({
+  const slackMemberQuery = useQuery({
     queryKey: ["route-members", agentKey, controller.sources],
     queryFn: () => api.agents.routeMembers(agentKey, controller.sources),
-    enabled: activeTab === "dm" && controller.sources.length > 0 && dmAvailable,
+    enabled: activeTab === "dm" && dmPlatform === "slack" && slackDmSupported && controller.sources.length > 0,
+  });
+  const whatsappMemberQuery = useQuery({
+    queryKey: ["whatsapp-dm-members", agentKey],
+    queryFn: () => api.agents.whatsappDmMembers(agentKey),
+    enabled: activeTab === "dm" && dmPlatform === "whatsapp",
   });
 
   const channelSelected = controller.channelTarget
@@ -316,17 +322,34 @@ export function DestinationField({
             Posts to any channel or group Sketch can reach — independent of the inputs above.
           </p>
         </div>
-      ) : !dmAvailable ? (
+      ) : dmPlatform === "whatsapp" ? (
+        <div className="mt-3">
+          <TargetList
+            loading={whatsappMemberQuery.isLoading}
+            empty="No teammate has a WhatsApp number yet. Add one on their profile and reload."
+            selectedId={memberUserId ?? ""}
+            options={(whatsappMemberQuery.data?.members ?? []).map((member) => ({
+              id: member.userId,
+              label: member.name,
+              icon: <UserIcon size={14} aria-hidden />,
+            }))}
+            onSelect={(id) => controller.setMemberUserId(id)}
+          />
+          <p className="mt-1.5 text-[11px] leading-relaxed text-muted-foreground/70">
+            DMs any teammate who has a WhatsApp number — independent of the inputs above.
+          </p>
+        </div>
+      ) : !slackDmSupported ? (
         <p className="mt-3 px-1 py-2 text-[12px] text-muted-foreground">
-          Member DM works with Slack sources only. Remove the WhatsApp source to DM a member.
+          Member DM isn't available for this summariser.
         </p>
       ) : (
         <div className="mt-3">
           <TargetList
-            loading={memberQuery.isLoading}
+            loading={slackMemberQuery.isLoading}
             empty="No member is in every selected source."
             selectedId={memberUserId ?? ""}
-            options={(memberQuery.data?.members ?? []).map((member) => ({
+            options={(slackMemberQuery.data?.members ?? []).map((member) => ({
               id: member.userId,
               label: member.name,
               icon: <UserIcon size={14} aria-hidden />,

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/api";
 import { CheckCircleIcon, HashIcon, MagnifyingGlassIcon, UserIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { Switch } from "@sketch/ui/components/switch";
+import { TabButton } from "@sketch/ui/components/tab-button";
 import { cn } from "@sketch/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
@@ -151,7 +152,7 @@ export interface RouteDraftController {
 export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): RouteDraftController {
   const maxSources = agent.sourceConfig?.maxSources ?? 0;
   const [sources, setSources] = useState<AgentSourceKey[]>(route?.sources ?? []);
-  const [destKind, setDestKind] = useState<AgentRouteDestination["kind"]>(route?.destination.kind ?? "self");
+  const [destKind, setDestKind] = useState<AgentRouteDestination["kind"]>(route?.destination.kind ?? "channel");
   const [memberUserId, setMemberUserId] = useState<string | null>(
     route?.destination.kind === "member" ? route.destination.memberUserId : null,
   );
@@ -266,24 +267,6 @@ export function SourcesField({ agent, controller }: { agent: AgentConfig; contro
   );
 }
 
-/** Pill-style delivery tab, matching the Team Adoption filter tabs on the usage page. */
-function DeliveryTab({ label, isActive, onClick }: { label: string; isActive: boolean; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "rounded-md px-2.5 py-1 text-xs transition-colors",
-        isActive
-          ? "bg-accent font-medium text-foreground dark:bg-[#1C1C1A]"
-          : "text-muted-foreground hover:text-foreground",
-      )}
-    >
-      {label}
-    </button>
-  );
-}
-
 export function DestinationField({
   agent,
   agentKey,
@@ -315,15 +298,15 @@ export function DestinationField({
 
   return (
     <div>
-      <div className="inline-flex rounded-lg border-[0.5px] border-border bg-card p-0.5 dark:bg-[#111110]">
-        <DeliveryTab
+      <div className="flex items-center gap-6 border-b border-border">
+        <TabButton
           label="Groups"
           isActive={activeTab === "groups"}
           onClick={() => {
             if (destKind === "member") controller.setDestKind("channel");
           }}
         />
-        <DeliveryTab label="DM" isActive={activeTab === "dm"} onClick={() => controller.setDestKind("member")} />
+        <TabButton label="DM" isActive={activeTab === "dm"} onClick={() => controller.setDestKind("member")} />
       </div>
 
       {activeTab === "groups" ? (
@@ -567,6 +550,89 @@ export function VolumeField({ agent, controller }: { agent: AgentConfig; control
           value={controller.volume}
           onChange={controller.setVolume}
         />
+      </div>
+    </div>
+  );
+}
+
+export function SourceGroup({
+  title,
+  loading,
+  empty,
+  selected,
+  options,
+  onToggle,
+}: {
+  title: string;
+  loading: boolean;
+  empty: string;
+  selected: Set<string>;
+  options: AgentSourceConfig[];
+  onToggle: (source: AgentSourceConfig) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const q = query.trim().toLowerCase();
+  const filtered = q ? options.filter((o) => (o.label ?? o.targetId).toLowerCase().includes(q)) : options;
+  const showSearch = options.length > 6;
+
+  return (
+    <div>
+      <span className={LABEL}>{title}</span>
+      <div className="mt-2 rounded-lg border-[0.5px] border-border p-1">
+        {loading ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">Loading...</p>
+        ) : options.length === 0 ? (
+          <p className="px-2 py-2 text-[12px] text-muted-foreground">{empty}</p>
+        ) : (
+          <>
+            {showSearch ? (
+              <div className="relative mb-1">
+                <MagnifyingGlassIcon
+                  size={13}
+                  aria-hidden
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+                />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder={`Search ${title.toLowerCase()}…`}
+                  className="w-full rounded-md border-[0.5px] border-border bg-background py-1.5 pl-7 pr-2 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+                />
+              </div>
+            ) : null}
+            <div className="flex max-h-56 flex-col overflow-y-auto">
+              {filtered.length === 0 ? (
+                <p className="px-2 py-2 text-[12px] text-muted-foreground">No matches.</p>
+              ) : (
+                filtered.map((source) => {
+                  const active = selected.has(sourceKey(source));
+                  return (
+                    <button
+                      key={sourceKey(source)}
+                      type="button"
+                      onClick={() => onToggle(source)}
+                      className={cn(
+                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors",
+                        active ? "bg-emerald-500/10 text-foreground" : "text-muted-foreground hover:bg-muted/60",
+                      )}
+                    >
+                      <span className="shrink-0">
+                        {source.platform === "slack" ? (
+                          <HashIcon size={14} aria-hidden />
+                        ) : (
+                          <UsersThreeIcon size={14} aria-hidden />
+                        )}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{source.label ?? source.targetId}</span>
+                      {active ? <CheckCircleIcon size={13} weight="fill" aria-hidden /> : null}
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1317,11 +1317,14 @@ export const api = {
         body: JSON.stringify({ sources }),
       });
     },
-    run(agentKey: string) {
+    run(agentKey: string, opts?: { routeId?: string }) {
       return request<{
         generation: { id: string; sourceKey: string; status: string; outputDate: string } | null;
         generations: Array<{ id: string; sourceKey: string; status: string; outputDate: string }>;
-      }>(`/api/agents/${agentKey}/runs`, { method: "POST", body: JSON.stringify({}) });
+      }>(`/api/agents/${agentKey}/runs`, {
+        method: "POST",
+        body: JSON.stringify(opts?.routeId ? { routeId: opts.routeId } : {}),
+      });
     },
     outputs(agentKey: string, opts?: { limit?: number; cursor?: string | null }) {
       const params = new URLSearchParams();

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1094,7 +1094,7 @@ export type AgentDeliveryModel =
 export type AgentRouteDestination =
   | { kind: "self" }
   | { kind: "off" }
-  | { kind: "member"; platform: "slack"; memberUserId: string }
+  | { kind: "member"; platform: "slack" | "whatsapp"; memberUserId: string }
   | { kind: "channel"; platform: "slack"; targetType: "channel"; targetId: string; label: string | null }
   | { kind: "channel"; platform: "whatsapp"; targetType: "group"; targetId: string; label: string | null };
 
@@ -1316,6 +1316,11 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ sources }),
       });
+    },
+    whatsappDmMembers(agentKey: string) {
+      return request<{ members: Array<{ userId: string; name: string }> }>(
+        `/api/agents/${agentKey}/route-members/whatsapp`,
+      );
     },
     run(agentKey: string, opts?: { routeId?: string }) {
       return request<{


### PR DESCRIPTION
Stack: 4/7
Base: feat/summarizer-destination-ui
Merge after: feat: add summariser destination setup UI
Merge before: feat(whatsapp): sync group history for summarisers

Summary:
- Sync WhatsApp groups on connect and expose manual refresh.
- Add per-summariser run-now controls and scoped history.
- Rework source/destination pickers and support teammate WhatsApp DM delivery.

Verification:
- pnpm biome check
- pnpm typecheck
- pnpm test
- pnpm build

All stack tips were checked locally under Node v24.8.0; the pushed stack also passed the pre-push hook under Node v24.8.0.