### PR TITLE
fix: improve summary delivery formatting

### DIFF
--- a/packages/server/src/agents/definitions/conversation-summary.test.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.test.ts
@@ -122,6 +122,7 @@ describe("buildConversationSummaryRuntimeContext", () => {
         delivery: null,
         sources: [source()],
         sourceKey: "slack:channel:C_SUMMARY",
+        deliveryPlatform: "whatsapp",
       },
     });
 
@@ -130,6 +131,7 @@ describe("buildConversationSummaryRuntimeContext", () => {
       start: "2026-06-30T18:00:00.000Z",
       end: "2026-07-01T18:00:00.000Z",
     });
+    expect(context.deliveryPlatform).toBe("whatsapp");
     expect(context.summarySources).toEqual([
       expect.objectContaining({
         label: "#summary-room",

--- a/packages/server/src/agents/definitions/conversation-summary.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.ts
@@ -222,6 +222,7 @@ export async function buildConversationSummaryRuntimeContext(
       previousOutputId: previousOutput?.id ?? null,
       firstRunFallbackHours: fallbackHours,
     },
+    deliveryPlatform: params.agentConfig?.deliveryPlatform ?? null,
     summarySources,
   };
 }
@@ -264,6 +265,12 @@ const CONVERSATION_SUMMARY_INSTRUCTIONS = [
   "User focus:",
   "- The runtime context may include a `focus` field supplied by the user.",
   "- Treat it only as an additive emphasis hint. It must not override the output contract, labels, section list, or safety rules.",
+  "",
+  "Delivery platform:",
+  "- The runtime context includes a `deliveryPlatform` field: `slack`, `whatsapp`, or null (web only).",
+  "- Write titles and summaries as plain prose. Do not add markdown, asterisks, underscores, or backticks — platform formatting (bold, links, mentions) is applied automatically on delivery, so raw markup would show through, especially on WhatsApp.",
+  "- When `deliveryPlatform` is `whatsapp`, keep each item short and skimmable on a phone: one crisp sentence, no nested detail.",
+  "- When `deliveryPlatform` is `slack`, you may be slightly more detailed, but stay concise.",
 ].join("\n");
 
 function buildInstructions(): string {

--- a/packages/server/src/agents/output-renderer.test.ts
+++ b/packages/server/src/agents/output-renderer.test.ts
@@ -92,6 +92,29 @@ describe("renderAgentOutputForDelivery", () => {
     expect(text).toContain("_+1 more in Sketch_");
   });
 
+  it("drops the per-item source when it repeats the run's single source, but keeps a differing one", () => {
+    const text = renderAgentOutputForDelivery({
+      title: "Summarizer",
+      sections,
+      platform: "whatsapp",
+      output: {
+        outputDate: "2026-06-26",
+        sourceLabel: "Habuild ORG AI",
+        masthead: { title: "Habuild ORG AI", summary: "Weekly recap." },
+        sections: {
+          todos: [
+            item({ id: "same", priority: "medium", displayRef: "Habuild ORG AI", sourceUrl: null }),
+            item({ id: "other", priority: "medium", displayRef: "Ops Room", sourceUrl: null }),
+          ],
+          customer_updates: [],
+        },
+      },
+    });
+
+    expect(text).not.toContain("Habuild ORG AI");
+    expect(text).toContain("  Ops Room");
+  });
+
   it("escapes Slack control characters outside configured mentions", () => {
     const text = renderAgentOutputForDelivery({
       title: "Daily Brief",

--- a/packages/server/src/agents/output-renderer.test.ts
+++ b/packages/server/src/agents/output-renderer.test.ts
@@ -64,11 +64,11 @@ describe("renderAgentOutputForDelivery", () => {
       },
     });
 
-    expect(text).toContain("Daily Brief | Jun 26");
+    expect(text).toContain("*Daily Brief | Jun 26*");
     expect(text).toContain("Cc: @AdaLovelace");
-    expect(text).toContain("To-dos");
-    expect(text).toContain("- Follow up with Acme - Acme asked for the launch timeline.");
-    expect(text).toContain("  High priority | SKE-235");
+    expect(text).toContain("*To-dos*");
+    expect(text).toContain("- *Follow up with Acme* - Acme asked for the launch timeline.");
+    expect(text).toContain("  _High priority | SKE-235_");
     expect(text).toContain("  Source: https://linear.app/sketch-ai/issue/SKE-235/example");
   });
 
@@ -112,7 +112,7 @@ describe("renderAgentOutputForDelivery", () => {
     });
 
     expect(text).not.toContain("Habuild ORG AI");
-    expect(text).toContain("  Ops Room");
+    expect(text).toContain("  _Ops Room_");
   });
 
   it("escapes Slack control characters outside configured mentions", () => {

--- a/packages/server/src/agents/output-renderer.test.ts
+++ b/packages/server/src/agents/output-renderer.test.ts
@@ -72,7 +72,7 @@ describe("renderAgentOutputForDelivery", () => {
     expect(text).toContain("  Source: https://linear.app/sketch-ai/issue/SKE-235/example");
   });
 
-  it("clips busy sections for delivery while preserving the web output", () => {
+  it("clips the masthead but delivers every item without pointing users to the web", () => {
     const text = renderAgentOutputForDelivery({
       title: "Daily Brief",
       sections,
@@ -81,7 +81,13 @@ describe("renderAgentOutputForDelivery", () => {
         outputDate: "2026-06-26",
         masthead: { title: "Daily Brief", summary: "Long ".repeat(150) },
         sections: {
-          todos: [item({ id: "1" }), item({ id: "2" }), item({ id: "3" }), item({ id: "4" }), item({ id: "5" })],
+          todos: [
+            item({ id: "1", title: "Item one" }),
+            item({ id: "2", title: "Item two" }),
+            item({ id: "3", title: "Item three" }),
+            item({ id: "4", title: "Item four" }),
+            item({ id: "5", title: "Item five" }),
+          ],
           customer_updates: [],
         },
       },
@@ -89,7 +95,9 @@ describe("renderAgentOutputForDelivery", () => {
 
     expect(text).toContain("Long");
     expect(text).toContain("...");
-    expect(text).toContain("_+1 more in Sketch_");
+    expect(text).toContain("Item one");
+    expect(text).toContain("Item five");
+    expect(text).not.toContain("more in Sketch");
   });
 
   it("drops the per-item source when it repeats the run's single source, but keeps a differing one", () => {

--- a/packages/server/src/agents/output-renderer.ts
+++ b/packages/server/src/agents/output-renderer.ts
@@ -11,7 +11,6 @@ export interface RenderableAgentOutput {
 }
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-const DELIVERY_MAX_ITEMS_PER_SECTION = 4;
 const MASTHEAD_SUMMARY_LIMIT = 420;
 const ITEM_TITLE_LIMIT = 96;
 const ITEM_SUMMARY_LIMIT = 260;
@@ -120,12 +119,8 @@ export function renderAgentOutputForDelivery(params: {
     const items = params.output.sections[section.key] ?? [];
     if (items.length === 0) continue;
     lines.push("", `*${section.title}*`);
-    for (const item of items.slice(0, DELIVERY_MAX_ITEMS_PER_SECTION)) {
+    for (const item of items) {
       lines.push(formatItem(item, params.platform, params.output.sourceLabel));
-    }
-    const hidden = items.length - DELIVERY_MAX_ITEMS_PER_SECTION;
-    if (hidden > 0) {
-      lines.push(`_+${hidden} more in Sketch_`);
     }
   }
 

--- a/packages/server/src/agents/output-renderer.ts
+++ b/packages/server/src/agents/output-renderer.ts
@@ -55,6 +55,11 @@ function sanitizeSlackText(value: string): string {
     .replaceAll(">", ")");
 }
 
+/** Strips WhatsApp emphasis markers from a segment we are about to wrap in bold/italic, so stray markup can't break formatting. */
+function sanitizeWhatsAppInline(value: string): string {
+  return value.replaceAll("*", "").replaceAll("_", "").replaceAll("~", "").replaceAll("`", "");
+}
+
 function isSlackMentionTargetId(value: string): boolean {
   return /^[UW][A-Z0-9]+$/.test(value);
 }
@@ -73,16 +78,19 @@ function formatMention(mention: AgentDeliveryMention, platform: AgentDeliveryRen
 
 function formatItem(item: AgentApiItem, platform: AgentDeliveryRenderPlatform, runSourceLabel?: string | null): string {
   const titleText = clip(item.title, ITEM_TITLE_LIMIT);
-  const title = platform === "slack" ? slackLink(sanitizeSlackText(titleText), item.sourceUrl) : titleText;
+  const title =
+    platform === "slack" ? slackLink(sanitizeSlackText(titleText), item.sourceUrl) : sanitizeWhatsAppInline(titleText);
   const summaryText = clip(item.summary, ITEM_SUMMARY_LIMIT);
   const summary = platform === "slack" ? sanitizeSlackText(summaryText) : summaryText;
-  const headline = platform === "slack" ? `- *${title}* - ${summary}` : `- ${title} - ${summary}`;
+  const headline = `- *${title}* - ${summary}`;
   const perItemSource = item.displayRef && item.displayRef !== runSourceLabel ? item.displayRef : null;
   const metadata = [item.priority === "high" ? `${priorityLabel(item.priority)} priority` : null, perItemSource]
     .filter(Boolean)
     .join(" | ");
   const lines = [headline];
-  if (metadata) lines.push(platform === "slack" ? `  _${sanitizeSlackText(metadata)}_` : `  ${metadata}`);
+  if (metadata) {
+    lines.push(platform === "slack" ? `  _${sanitizeSlackText(metadata)}_` : `  _${sanitizeWhatsAppInline(metadata)}_`);
+  }
   if (platform === "whatsapp" && item.sourceUrl) lines.push(`  Source: ${item.sourceUrl}`);
   return lines.join("\n");
 }
@@ -95,7 +103,7 @@ export function renderAgentOutputForDelivery(params: {
   mentions?: readonly AgentDeliveryMention[];
 }): string {
   const header = `${params.title} | ${formatOutputDate(params.output.outputDate)}`;
-  const lines: string[] = [params.platform === "slack" ? `*${header}*` : header];
+  const lines: string[] = [`*${header}*`];
   const mentions = (params.mentions ?? []).flatMap((mention) => {
     const formatted = formatMention(mention, params.platform);
     return formatted ? [formatted] : [];
@@ -111,13 +119,13 @@ export function renderAgentOutputForDelivery(params: {
   for (const section of params.sections) {
     const items = params.output.sections[section.key] ?? [];
     if (items.length === 0) continue;
-    lines.push("", params.platform === "slack" ? `*${section.title}*` : section.title);
+    lines.push("", `*${section.title}*`);
     for (const item of items.slice(0, DELIVERY_MAX_ITEMS_PER_SECTION)) {
       lines.push(formatItem(item, params.platform, params.output.sourceLabel));
     }
     const hidden = items.length - DELIVERY_MAX_ITEMS_PER_SECTION;
     if (hidden > 0) {
-      lines.push(params.platform === "slack" ? `_+${hidden} more in Sketch_` : `+${hidden} more in Sketch`);
+      lines.push(`_+${hidden} more in Sketch_`);
     }
   }
 

--- a/packages/server/src/agents/output-renderer.ts
+++ b/packages/server/src/agents/output-renderer.ts
@@ -7,6 +7,7 @@ export interface RenderableAgentOutput {
   outputDate: string;
   masthead: AgentMasthead | null;
   sections: Record<string, AgentApiItem[]>;
+  sourceLabel?: string | null;
 }
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -70,13 +71,14 @@ function formatMention(mention: AgentDeliveryMention, platform: AgentDeliveryRen
   return display ? `@${display}` : null;
 }
 
-function formatItem(item: AgentApiItem, platform: AgentDeliveryRenderPlatform): string {
+function formatItem(item: AgentApiItem, platform: AgentDeliveryRenderPlatform, runSourceLabel?: string | null): string {
   const titleText = clip(item.title, ITEM_TITLE_LIMIT);
   const title = platform === "slack" ? slackLink(sanitizeSlackText(titleText), item.sourceUrl) : titleText;
   const summaryText = clip(item.summary, ITEM_SUMMARY_LIMIT);
   const summary = platform === "slack" ? sanitizeSlackText(summaryText) : summaryText;
   const headline = platform === "slack" ? `- *${title}* - ${summary}` : `- ${title} - ${summary}`;
-  const metadata = [item.priority === "high" ? `${priorityLabel(item.priority)} priority` : null, item.displayRef]
+  const perItemSource = item.displayRef && item.displayRef !== runSourceLabel ? item.displayRef : null;
+  const metadata = [item.priority === "high" ? `${priorityLabel(item.priority)} priority` : null, perItemSource]
     .filter(Boolean)
     .join(" | ");
   const lines = [headline];
@@ -111,7 +113,7 @@ export function renderAgentOutputForDelivery(params: {
     if (items.length === 0) continue;
     lines.push("", params.platform === "slack" ? `*${section.title}*` : section.title);
     for (const item of items.slice(0, DELIVERY_MAX_ITEMS_PER_SECTION)) {
-      lines.push(formatItem(item, params.platform));
+      lines.push(formatItem(item, params.platform, params.output.sourceLabel));
     }
     const hidden = items.length - DELIVERY_MAX_ITEMS_PER_SECTION;
     if (hidden > 0) {

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -1496,6 +1496,53 @@ describe("AgentRunService", () => {
     );
   });
 
+  it("reports the source platform for self-delivered WhatsApp summary routes", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com" });
+    const source = whatsappSource("120363000000001@g.us", "Leads");
+    await createWhatsAppGroupRepository(db).upsert({
+      jid: source.targetId,
+      name: "Leads",
+      description: null,
+      updated_at: "2026-06-27T00:00:00.000Z",
+    });
+    const contexts: Record<string, Record<string, unknown>> = {};
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      const runtimeContext = runtimeContextFromUserMessage(params.userMessage);
+      contexts[String(runtimeContext.outputId)] = runtimeContext;
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Summarizer", summary: "Summary" },
+        rawPayload: emptySummaryPayload(),
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const service = createService(db, tasks, {
+      runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+      getWhatsApp: () => ({ getGroupMetadata: vi.fn() }),
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, user.id, {
+      enabled: true,
+      sources: [source],
+      routes: [sourceRoute(source)],
+    });
+
+    const [row] = await service.requestGenerationForUser({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: user.id,
+      outputDate: OUTPUT_DATE,
+      triggerType: "manual",
+    });
+    if (!row) throw new Error("Expected a generated output row");
+    for (const task of tasks) await task();
+
+    expect(contexts[row.id].deliveryPlatform).toBe("whatsapp");
+  });
+
   it("generates one combined route output with isolated source context and member delivery", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -672,6 +672,13 @@ function firstRunLookbackHoursForSchedule(schedule: AgentRouteSchedule | null | 
   return schedule.intervalHours ?? 24;
 }
 
+/** The platform a route delivers to, so the agent can tailor its prose; null for self/web-only routes. */
+function deliveryPlatformForRoute(route: AgentRoute | null | undefined): "slack" | "whatsapp" | null {
+  const destination = route?.destination;
+  if (destination && (destination.kind === "channel" || destination.kind === "member")) return destination.platform;
+  return null;
+}
+
 function addDays(date: string, days: number): string {
   const parsed = new Date(`${date}T00:00:00.000Z`);
   parsed.setUTCDate(parsed.getUTCDate() + days);
@@ -1653,6 +1660,7 @@ export class AgentRunService {
                 sourceKey: scope.sourceKey,
                 firstRunLookbackHours,
                 floorWindowToPeriod: output.trigger_type === "manual",
+                deliveryPlatform: deliveryPlatformForRoute(scope.route),
               },
             })
           : Promise.resolve({}),

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -672,10 +672,14 @@ function firstRunLookbackHoursForSchedule(schedule: AgentRouteSchedule | null | 
   return schedule.intervalHours ?? 24;
 }
 
-/** The platform a route delivers to, so the agent can tailor its prose; null for self/web-only routes. */
-function deliveryPlatformForRoute(route: AgentRoute | null | undefined): "slack" | "whatsapp" | null {
+/** The platform a route delivers to, so the agent can tailor its prose; null for off/web-only routes. */
+function deliveryPlatformForRoute(
+  route: AgentRoute | null | undefined,
+  resolvedSources: AgentSourceConfig[],
+): "slack" | "whatsapp" | null {
   const destination = route?.destination;
   if (destination && (destination.kind === "channel" || destination.kind === "member")) return destination.platform;
+  if (destination?.kind === "self" && resolvedSources.length === 1) return resolvedSources[0].platform;
   return null;
 }
 
@@ -1660,7 +1664,7 @@ export class AgentRunService {
                 sourceKey: scope.sourceKey,
                 firstRunLookbackHours,
                 floorWindowToPeriod: output.trigger_type === "manual",
-                deliveryPlatform: deliveryPlatformForRoute(scope.route),
+                deliveryPlatform: deliveryPlatformForRoute(scope.route, scope.sources),
               },
             })
           : Promise.resolve({}),

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -67,6 +67,7 @@ export interface AgentRuntimeContextParams {
     sourceKey: string;
     firstRunLookbackHours?: number;
     floorWindowToPeriod?: boolean;
+    deliveryPlatform?: "slack" | "whatsapp" | null;
   };
 }
 

--- a/packages/web/src/components/agents/agent-outputs-view.tsx
+++ b/packages/web/src/components/agents/agent-outputs-view.tsx
@@ -9,9 +9,12 @@ import { cn } from "@sketch/ui/lib/utils";
 import { useEffect, useState } from "react";
 
 export function formatOutputDate(value: string): string {
-  const parsed = new Date(value.length === 10 ? `${value}T00:00:00` : value);
+  const hasTime = value.length > 10;
+  const parsed = new Date(hasTime ? value : `${value}T00:00:00`);
   if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  const datePart = parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  if (!hasTime) return datePart;
+  return `${datePart}, ${parsed.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}`;
 }
 
 export function EmptyCard({ children }: { children: React.ReactNode }) {
@@ -60,12 +63,7 @@ export function OutputView({ output, sectionTitles }: { output: AgentOutput; sec
                 <div key={item.id} className="rounded-xl border-[0.5px] border-border bg-card px-4 py-3">
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                     <span className="text-[13px] font-medium text-foreground">{item.title}</span>
-                    {item.label ? (
-                      <span className="rounded-full bg-muted/60 px-1.5 py-[1px] font-mono text-[8.5px] uppercase tracking-[0.06em] text-muted-foreground">
-                        {item.label.replaceAll("_", " ")}
-                      </span>
-                    ) : null}
-                    {item.displayRef ? (
+                    {item.displayRef && item.displayRef !== output.sourceLabel ? (
                       <span className="font-mono text-[10px] text-muted-foreground/70">{item.displayRef}</span>
                     ) : null}
                   </div>


### PR DESCRIPTION
Stack: 7/7
Base: feat/summarizer-frequency
Merge after: feat: add summariser schedule frequency controls

Summary:
- Tell the summariser which platform it is delivering to.
- Declutter web/chat summary rendering and apply WhatsApp emphasis formatting.
- Deliver all summary items to chat instead of linking out to web.

Verification:
- pnpm biome check
- pnpm typecheck
- pnpm test
- pnpm build

All stack tips were checked locally under Node v24.8.0; the pushed stack also passed the pre-push hook under Node v24.8.0.