### PR TITLE
fix: support managed whatsapp inbound media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [0.45.1] -- 2026-07-05
+
+- Managed WhatsApp DMs now preserve inbound media from the platform shared-number gateway: platform media references are accepted on `/api/system/whatsapp/managed/events`, downloaded with the tenant token, stored as normal workspace attachments, and passed into the agent. This fixes image+caption DMs being treated as text-only on managed tenants.
+- Managed media downloads are constrained to the platform media endpoint and retain the existing no-media-reference fallback for older platform events.
+
 ## [0.45.0] -- 2026-07-05
 
 - Summariser agents now route per source: each Slack channel or WhatsApp group can have its own route with an independent destination, schedule, focus, and sections, instead of one shared configuration. Existing single-destination summarisers are preserved.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sketch/server",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/server/src/whatsapp/providers/managed.test.ts
+++ b/packages/server/src/whatsapp/providers/managed.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Logger } from "pino";
 import { describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "../../test-utils";
@@ -26,6 +29,16 @@ function inboundPayload(overrides: Record<string, unknown> = {}) {
 }
 
 describe("managed WhatsApp provider", () => {
+  it("advertises managed inbound media support", () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+
+    expect(provider.dmProvider.capabilities.media).toBe(true);
+  });
+
   it("sends outbound DM text through the platform API", async () => {
     const requestFetch = vi.fn(
       async () =>
@@ -340,6 +353,138 @@ describe("managed WhatsApp provider", () => {
     });
   });
 
+  it("emits downloadable inbound media references through the runtime shape", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+
+    await provider.handleInboundEvent(
+      inboundPayload({
+        text: "what is in this image?",
+        mediaType: "image",
+        media: {
+          type: "image",
+          providerMessageId: "wamid.inbound",
+          downloadPath: "/api/whatsapp/media/wamid.inbound?senderPhoneE164=%2B15551234567",
+          fileName: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+      }),
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "what is in this image?",
+        mediaType: "image",
+        rawProviderPayload: expect.objectContaining({
+          media: {
+            type: "image",
+            providerMessageId: "wamid.inbound",
+            downloadPath: "/api/whatsapp/media/wamid.inbound?senderPhoneE164=%2B15551234567",
+            fileName: "photo.jpg",
+            mimeType: "image/jpeg",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("downloads managed inbound media into the workspace attachment directory", async () => {
+    const requestFetch = vi.fn(async () => {
+      return new Response("image-bytes", {
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-disposition": 'attachment; filename="ignored.bin"',
+        },
+      });
+    });
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai/",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+      fetch: requestFetch as typeof fetch,
+    });
+    let captured: WhatsAppInboundMessage | undefined;
+    provider.inboundProvider.onMessage(async (message) => {
+      captured = message;
+    });
+    await provider.handleInboundEvent(
+      inboundPayload({
+        text: "",
+        mediaType: "image",
+        media: {
+          type: "image",
+          providerMessageId: "wamid.inbound",
+          downloadPath: "/api/whatsapp/media/wamid.inbound?senderPhoneE164=%2B15551234567",
+          fileName: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+      }),
+    );
+    const workspaceDir = await mkdtemp(join(tmpdir(), "managed-download-"));
+
+    try {
+      if (!captured) throw new Error("expected inbound message");
+      const attachments = await provider.dmProvider.downloadMedia?.(captured, workspaceDir, { maxFileBytes: 1024 });
+
+      expect(attachments).toEqual([
+        expect.objectContaining({
+          originalName: "photo.jpg",
+          mimeType: "image/jpeg",
+          sizeBytes: "image-bytes".length,
+        }),
+      ]);
+      expect(await readFile(attachments?.[0]?.localPath ?? "", "utf8")).toBe("image-bytes");
+      const [url, init] = requestFetch.mock.calls[0] as unknown as [string, RequestInit];
+      expect(url).toBe("https://app.getsketch.ai/api/whatsapp/media/wamid.inbound?senderPhoneE164=%2B15551234567");
+      expect(init.headers).toEqual({
+        Authorization: "Bearer tenant-token",
+        Accept: "application/octet-stream",
+      });
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses managed media download paths outside the platform media endpoint", async () => {
+    const requestFetch = vi.fn();
+    const logger = { warn: vi.fn() } as unknown as Logger;
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger,
+      fetch: requestFetch as unknown as typeof fetch,
+    });
+    let captured: WhatsAppInboundMessage | undefined;
+    provider.inboundProvider.onMessage(async (message) => {
+      captured = message;
+    });
+    await provider.handleInboundEvent(
+      inboundPayload({
+        text: "",
+        mediaType: "image",
+        media: {
+          type: "image",
+          providerMessageId: "wamid.inbound",
+          downloadPath: "https://example.test/media/wamid.inbound",
+        },
+      }),
+    );
+
+    if (!captured) throw new Error("expected inbound message");
+    await expect(provider.dmProvider.downloadMedia?.(captured, "/tmp", { maxFileBytes: 1024 })).resolves.toEqual([]);
+    expect(requestFetch).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      { providerMessageId: "wamid.inbound", mediaType: "image" },
+      "Managed WhatsApp media message has no downloadable platform path",
+    );
+  });
+
   it("ignores non-message event types with metadata-only logging", async () => {
     const logger = { info: vi.fn(), warn: vi.fn() } as unknown as Logger;
     const provider = createManagedWhatsAppProvider({
@@ -399,6 +544,30 @@ describe("managed WhatsApp provider", () => {
         mediaType: "image",
       }),
     );
+  });
+
+  it("keeps media-only inbound messages empty when media is downloadable", async () => {
+    const provider = createManagedWhatsAppProvider({
+      platformUrl: "https://app.getsketch.ai",
+      tenantToken: "tenant-token",
+      logger: createTestLogger(),
+    });
+    const handler = vi.fn(async (_message: WhatsAppInboundMessage) => undefined);
+    provider.inboundProvider.onMessage(handler);
+
+    await provider.handleInboundEvent(
+      inboundPayload({
+        text: "",
+        mediaType: "image",
+        media: {
+          type: "image",
+          providerMessageId: "wamid.inbound",
+          downloadPath: "/api/whatsapp/media/wamid.inbound?senderPhoneE164=%2B15551234567",
+        },
+      }),
+    );
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ text: "", mediaType: "image" }));
   });
 
   it("rejects group sends", async () => {

--- a/packages/server/src/whatsapp/providers/managed.ts
+++ b/packages/server/src/whatsapp/providers/managed.ts
@@ -1,4 +1,7 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { z } from "zod";
+import { type Attachment, mimeToExtension } from "../../files";
 import type { Logger } from "../../logger";
 import {
   type WhatsAppCapabilities,
@@ -18,7 +21,7 @@ export const WHATSAPP_MANAGED_PROVIDER_ID = "managed";
 
 const MANAGED_CAPABILITIES: WhatsAppCapabilities = {
   text: true,
-  media: false,
+  media: true,
   quotedReply: true,
   templates: true,
   templateProvisioning: "manual",
@@ -46,6 +49,17 @@ const optionalTrimmedStringSchema = z
   .nullish()
   .transform((value) => value ?? undefined);
 
+const inboundMediaSchema = z
+  .object({
+    type: z.string().trim().min(1),
+    providerMessageId: z.string().trim().min(1),
+    downloadPath: z.string().trim().min(1),
+    fileName: optionalTrimmedStringSchema,
+    mimeType: optionalTrimmedStringSchema,
+  })
+  .nullish()
+  .transform((value) => value ?? undefined);
+
 const inboundEventEnvelopeSchema = z
   .object({
     eventId: z.string().trim().min(1),
@@ -66,6 +80,7 @@ const inboundMessageEventSchema = z.object({
   tenantUserEmail: optionalTrimmedStringSchema,
   text: optionalStringSchema,
   mediaType: optionalTrimmedStringSchema,
+  media: inboundMediaSchema,
   quotedMessage: z
     .object({
       providerMessageId: z.string().trim().min(1),
@@ -168,6 +183,82 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
     return sendResultFromManagedBody(body, target);
   };
 
+  const downloadMedia = async (
+    message: WhatsAppDmInboundMessage,
+    workspaceDir: string,
+    params: { maxFileBytes: number },
+  ): Promise<Attachment[]> => {
+    if (!message.mediaType) return [];
+
+    const media = managedMediaFromPayload(message.rawProviderPayload);
+    if (!media) return [];
+
+    const downloadUrl = managedMediaDownloadUrl(platformUrl, media.downloadPath);
+    if (!downloadUrl || !config.tenantToken) {
+      config.logger.warn(
+        { providerMessageId: message.providerMessageId, mediaType: message.mediaType },
+        "Managed WhatsApp media message has no downloadable platform path",
+      );
+      return [];
+    }
+
+    const response = await requestFetch(downloadUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${config.tenantToken}`,
+        Accept: "application/octet-stream",
+      },
+      signal: AbortSignal.timeout(OUTBOUND_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      config.logger.warn(
+        { status: response.status, providerMessageId: message.providerMessageId, mediaType: message.mediaType },
+        "Failed to download managed WhatsApp media",
+      );
+      return [];
+    }
+
+    const contentLength = Number(response.headers.get("content-length") ?? "0");
+    if (contentLength > params.maxFileBytes) {
+      config.logger.warn(
+        { sizeBytes: contentLength, maxFileBytes: params.maxFileBytes, mediaType: message.mediaType },
+        "Managed WhatsApp media exceeds size limit",
+      );
+      return [];
+    }
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.length > params.maxFileBytes) {
+      config.logger.warn(
+        { sizeBytes: bytes.length, maxFileBytes: params.maxFileBytes, mediaType: message.mediaType },
+        "Managed WhatsApp media exceeds size limit",
+      );
+      return [];
+    }
+
+    const mimeType =
+      media.mimeType ?? response.headers.get("content-type")?.split(";")[0]?.trim() ?? "application/octet-stream";
+    const originalName =
+      media.fileName ??
+      fileNameFromHeaders(response.headers) ??
+      `${media.providerMessageId}.${mimeToExtension(mimeType)}`;
+    const safeName = sanitizeFilename(originalName);
+    const attachmentsDir = join(workspaceDir, "attachments");
+    await mkdir(attachmentsDir, { recursive: true });
+    const localPath = join(attachmentsDir, `${Date.now()}_${safeName}`);
+    await writeFile(localPath, bytes);
+
+    return [
+      {
+        originalName: safeName,
+        mimeType,
+        localPath,
+        sizeBytes: bytes.length,
+      },
+    ];
+  };
+
   return {
     dmProvider: {
       id: WHATSAPP_MANAGED_PROVIDER_ID,
@@ -178,6 +269,8 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
       },
       sendText,
       sendTemplate,
+      downloadMedia: (message, workspaceDir, params) =>
+        message.kind === "dm" ? downloadMedia(message, workspaceDir, params) : Promise.resolve([]),
     },
     inboundProvider: {
       id: WHATSAPP_MANAGED_PROVIDER_ID,
@@ -210,7 +303,7 @@ export function createManagedWhatsAppProvider(config: ManagedWhatsAppConfig): Ma
       }
 
       const event = parsed.data;
-      const text = inboundMessageText(event.text, event.mediaType);
+      const text = inboundMessageText(event.text, event.mediaType, Boolean(event.media));
       const message: WhatsAppDmInboundMessage = {
         kind: "dm",
         providerId: WHATSAPP_MANAGED_PROVIDER_ID,
@@ -285,14 +378,51 @@ function assertValidE164Target(phoneE164: string, logger: Logger): void {
   throw new Error("Managed WhatsApp target phone number is invalid");
 }
 
-function inboundMessageText(text: string | undefined, mediaType: string | undefined): string {
+function inboundMessageText(
+  text: string | undefined,
+  mediaType: string | undefined,
+  hasDownloadableMedia = false,
+): string {
   if (text?.trim()) return text;
+  if (mediaType && hasDownloadableMedia) return "";
   if (mediaType) return `[WhatsApp media message (${mediaType}) - media content not available]`;
   return text ?? "";
 }
 
 function logicalTemplateParamRecord(params: Record<string, WhatsAppTemplateParamValue>): Record<string, string> {
   return Object.fromEntries(Object.entries(params).map(([key, value]) => [key, sanitizeTemplateParamValue(value)]));
+}
+
+function managedMediaFromPayload(payload: unknown): z.infer<typeof inboundMediaSchema> {
+  if (!isRecord(payload)) return undefined;
+  const parsed = inboundMediaSchema.safeParse(payload.media);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function managedMediaDownloadUrl(platformUrl: string, downloadPath: string): string | null {
+  if (!downloadPath.startsWith("/api/whatsapp/media/")) return null;
+
+  try {
+    return new URL(downloadPath, `${platformUrl}/`).toString();
+  } catch {
+    return null;
+  }
+}
+
+function fileNameFromHeaders(headers: Headers): string | null {
+  const value = headers.get("content-disposition");
+  const fileName = value?.match(/filename\*?=(?:UTF-8''|")?([^";]+)/iu)?.[1];
+  if (!fileName) return null;
+
+  try {
+    return decodeURIComponent(fileName).trim() || null;
+  } catch {
+    return fileName.trim() || null;
+  }
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/gu, "_");
 }
 
 function managedRequestError(status: number, text: string): ManagedWhatsAppRequestError {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sketch/shared",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sketch/web",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- enable managed WhatsApp inbound media capability in Sketch
- download managed media via the platform media proxy and persist it as normal message attachments
- cut release metadata for v0.45.1

## Verification
- pnpm typecheck
- pnpm build
- pnpm lint
- pnpm test

Linear: SKE-265