### PR TITLE
SKE-269: Let admins manage org Summarizer configs

### DIFF
--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -36,31 +36,50 @@ function createService(overrides: Record<string, unknown> = {}) {
     listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
     listForViewer: vi.fn(async () => []),
     getConfigView: vi.fn(async () => ({ agentKey: "daily-brief" })),
+    getConfigViewForViewer: vi.fn(async () => ({ agentKey: "daily-brief" })),
     getLatestForUser: vi.fn(async () => ({
       output: null,
       running: false,
       outputDate: "2026-07-06",
       timezone: "UTC",
     })),
+    getLatestForViewer: vi.fn(async () => ({
+      output: null,
+      running: false,
+      outputDate: "2026-07-06",
+      timezone: "UTC",
+    })),
     getByIdForUser: vi.fn(async () => null),
+    getByIdForViewer: vi.fn(async () => null),
     listOutputsForUser: vi.fn(async () => ({ outputs: [], nextCursor: null })),
+    listOutputsForViewer: vi.fn(async () => ({ outputs: [], nextCursor: null })),
     listEligibleRouteMembers: vi.fn(async () => []),
+    listEligibleRouteMembersForViewer: vi.fn(async () => []),
     listWhatsAppDmMembers: vi.fn(async () => []),
     requestGenerationForUser: vi.fn(async () => []),
+    requestGenerationForViewer: vi.fn(async () => []),
     updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
+    updateConfigForViewer: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
     ...overrides,
   } as unknown as AgentRunService & {
     resolveConfigControlUserId: ReturnType<typeof vi.fn>;
     resolveDeliveryConfigForUser: ReturnType<typeof vi.fn>;
     listForViewer: ReturnType<typeof vi.fn>;
     getConfigView: ReturnType<typeof vi.fn>;
+    getConfigViewForViewer: ReturnType<typeof vi.fn>;
     getLatestForUser: ReturnType<typeof vi.fn>;
+    getLatestForViewer: ReturnType<typeof vi.fn>;
     getByIdForUser: ReturnType<typeof vi.fn>;
+    getByIdForViewer: ReturnType<typeof vi.fn>;
     listOutputsForUser: ReturnType<typeof vi.fn>;
+    listOutputsForViewer: ReturnType<typeof vi.fn>;
     listEligibleRouteMembers: ReturnType<typeof vi.fn>;
+    listEligibleRouteMembersForViewer: ReturnType<typeof vi.fn>;
     listWhatsAppDmMembers: ReturnType<typeof vi.fn>;
     requestGenerationForUser: ReturnType<typeof vi.fn>;
+    requestGenerationForViewer: ReturnType<typeof vi.fn>;
     updateConfigForUser: ReturnType<typeof vi.fn>;
+    updateConfigForViewer: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -98,14 +117,13 @@ describe("agentRoutes", () => {
     expect(service.listForViewer).toHaveBeenCalledWith("user-1", "admin");
   });
 
-  it("reads admin Summarizer detail and latest output through the shared config owner", async () => {
+  it("reads admin Summarizer detail and latest output through the org-wide viewer methods", async () => {
     const service = createService({
-      resolveConfigControlUserId: vi.fn(async () => "admin-owner"),
-      getConfigView: vi.fn(async () => ({
+      getConfigViewForViewer: vi.fn(async () => ({
         agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
         routes: [{ id: "shared-route" }],
       })),
-      getLatestForUser: vi.fn(async () => ({
+      getLatestForViewer: vi.fn(async () => ({
         output: { id: "out-1" },
         running: false,
         outputDate: "2026-07-06",
@@ -117,15 +135,13 @@ describe("agentRoutes", () => {
     const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}`);
 
     expect(res.status).toBe(200);
-    expect(service.resolveConfigControlUserId).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "admin");
-    expect(service.getConfigView).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "admin-owner");
-    expect(service.getLatestForUser).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "admin-owner");
+    expect(service.getConfigViewForViewer).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "admin");
+    expect(service.getLatestForViewer).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "admin");
   });
 
-  it("saves admin Summarizer config through the shared config owner", async () => {
+  it("saves admin Summarizer config through the org-wide viewer method", async () => {
     const service = createService({
-      resolveConfigControlUserId: vi.fn(async () => "admin-owner"),
-      updateConfigForUser: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, delivery: null })),
+      updateConfigForViewer: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, delivery: null })),
     });
     const app = createRoutesTestApp(service, "admin-b-sub", "admin-b@example.com", "admin");
 
@@ -144,27 +160,22 @@ describe("agentRoutes", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(service.resolveConfigControlUserId).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "admin");
-    expect(service.resolveDeliveryConfigForUser).toHaveBeenCalledWith(
-      "admin-owner",
-      expect.objectContaining({ targetId: "U_OWNER" }),
-    );
-    expect(service.updateConfigForUser).toHaveBeenCalledWith(
+    expect(service.updateConfigForViewer).toHaveBeenCalledWith(
       CONVERSATION_SUMMARY_AGENT_KEY,
-      "admin-owner",
+      "user-1",
+      "admin",
       expect.objectContaining({ delivery: expect.objectContaining({ targetId: "U_OWNER" }) }),
     );
   });
 
-  it("uses the shared config owner for admin Summarizer route members, outputs, and runs", async () => {
+  it("uses org-wide viewer methods for admin Summarizer route members, outputs, and runs", async () => {
     const service = createService({
-      resolveConfigControlUserId: vi.fn(async () => "admin-owner"),
       listDefinitions: vi.fn(() => [{ key: CONVERSATION_SUMMARY_AGENT_KEY }]),
-      listEligibleRouteMembers: vi.fn(async () => [
+      listEligibleRouteMembersForViewer: vi.fn(async () => [
         { userId: "member-1", name: "Member One", slackUserId: "U_MEMBER_1" },
       ]),
-      listOutputsForUser: vi.fn(async () => ({ outputs: [{ id: "out-1" }], nextCursor: null })),
-      requestGenerationForUser: vi.fn(async () => [
+      listOutputsForViewer: vi.fn(async () => ({ outputs: [{ id: "out-1" }], nextCursor: null })),
+      requestGenerationForViewer: vi.fn(async () => [
         {
           id: "run-1",
           status: "running",
@@ -190,14 +201,21 @@ describe("agentRoutes", () => {
     expect(routeMembers.status).toBe(200);
     expect(outputs.status).toBe(200);
     expect(runs.status).toBe(202);
-    expect(service.listEligibleRouteMembers).toHaveBeenCalledWith("admin-owner", ["slack:channel:C_ALPHA"]);
-    expect(service.listOutputsForUser).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "admin-owner", {
+    expect(service.listEligibleRouteMembersForViewer).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "user-1",
+      "admin",
+      ["slack:channel:C_ALPHA"],
+      null,
+    );
+    expect(service.listOutputsForViewer).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "admin", {
       limit: 5,
       cursor: null,
     });
-    expect(service.requestGenerationForUser).toHaveBeenCalledWith({
+    expect(service.requestGenerationForViewer).toHaveBeenCalledWith({
       agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
-      userId: "admin-owner",
+      userId: "user-1",
+      viewerRole: "admin",
       triggerType: "manual",
       routeIds: ["shared-route"],
     });
@@ -761,7 +779,7 @@ describe("agentRoutes", () => {
 
   it("lists route members through the agent route-members endpoint", async () => {
     const service = createService({
-      listEligibleRouteMembers: vi.fn(async () => [
+      listEligibleRouteMembersForViewer: vi.fn(async () => [
         { userId: "member-1", name: "Member One", slackUserId: "U_MEMBER_1" },
       ]),
     });
@@ -779,10 +797,13 @@ describe("agentRoutes", () => {
     await expect(res.json()).resolves.toEqual({
       members: [{ userId: "member-1", name: "Member One", slackUserId: "U_MEMBER_1" }],
     });
-    expect(service.listEligibleRouteMembers).toHaveBeenCalledWith("user-1", [
-      "slack:channel:C_ALPHA",
-      "slack:channel:C_BETA",
-    ]);
+    expect(service.listEligibleRouteMembersForViewer).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "user-1",
+      "member",
+      ["slack:channel:C_ALPHA", "slack:channel:C_BETA"],
+      null,
+    );
   });
 
   it("lists WhatsApp DM members through the agent route-members endpoint", async () => {
@@ -828,7 +849,7 @@ describe("agentRoutes", () => {
   it("lists completed outputs for an agent", async () => {
     const service = createService({
       listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
-      listOutputsForUser: vi.fn(async () => ({ outputs: [{ id: "out-1" }], nextCursor: "out-1" })),
+      listOutputsForViewer: vi.fn(async () => ({ outputs: [{ id: "out-1" }], nextCursor: "out-1" })),
     });
     const app = createRoutesTestApp(service);
 
@@ -836,13 +857,16 @@ describe("agentRoutes", () => {
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ outputs: [{ id: "out-1" }], nextCursor: "out-1" });
-    expect(service.listOutputsForUser).toHaveBeenCalledWith("daily-brief", "user-1", { limit: 10, cursor: "old" });
+    expect(service.listOutputsForViewer).toHaveBeenCalledWith("daily-brief", "user-1", "member", {
+      limit: 10,
+      cursor: "old",
+    });
   });
 
   it("returns fan-out generations while keeping legacy generation", async () => {
     const service = createService({
       listDefinitions: vi.fn(() => [{ key: "conversation_summary" }]),
-      requestGenerationForUser: vi.fn(async () => [
+      requestGenerationForViewer: vi.fn(async () => [
         {
           id: "out-a",
           status: "running",
@@ -868,6 +892,12 @@ describe("agentRoutes", () => {
         { id: "out-a", sourceKey: "slack:channel:C_A", status: "running", outputDate: "2026-07-04" },
         { id: "out-b", sourceKey: "slack:channel:C_B", status: "running", outputDate: "2026-07-04" },
       ],
+    });
+    expect(service.requestGenerationForViewer).toHaveBeenCalledWith({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: "user-1",
+      viewerRole: "member",
+      triggerType: "manual",
     });
   });
 

--- a/packages/server/src/agents/routes.test.ts
+++ b/packages/server/src/agents/routes.test.ts
@@ -11,11 +11,17 @@ import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import { agentRoutes } from "./routes";
 import { AgentDeliveryTargetError, AgentRunService, type AgentRunServiceDeps, AgentSourceTargetError } from "./service";
 
-function createRoutesTestApp(service: AgentRunService, sub = "auth-user", email = "user@example.com") {
+function createRoutesTestApp(
+  service: AgentRunService,
+  sub = "auth-user",
+  email = "user@example.com",
+  role: "admin" | "member" = "member",
+) {
   const app = new Hono();
   app.use("*", async (c, next) => {
     c.set("sub", sub);
     c.set("email", email);
+    c.set("role", role);
     await next();
   });
   app.route("/api/agents", agentRoutes(service));
@@ -25,8 +31,18 @@ function createRoutesTestApp(service: AgentRunService, sub = "auth-user", email 
 function createService(overrides: Record<string, unknown> = {}) {
   return {
     resolveUserId: vi.fn(async () => "user-1"),
+    resolveConfigControlUserId: vi.fn(async (_agentKey, viewerUserId) => viewerUserId),
     resolveDeliveryConfigForUser: vi.fn(async (_userId, delivery) => delivery),
     listDefinitions: vi.fn(() => [{ key: "daily-brief" }]),
+    listForViewer: vi.fn(async () => []),
+    getConfigView: vi.fn(async () => ({ agentKey: "daily-brief" })),
+    getLatestForUser: vi.fn(async () => ({
+      output: null,
+      running: false,
+      outputDate: "2026-07-06",
+      timezone: "UTC",
+    })),
+    getByIdForUser: vi.fn(async () => null),
     listOutputsForUser: vi.fn(async () => ({ outputs: [], nextCursor: null })),
     listEligibleRouteMembers: vi.fn(async () => []),
     listWhatsAppDmMembers: vi.fn(async () => []),
@@ -34,7 +50,12 @@ function createService(overrides: Record<string, unknown> = {}) {
     updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),
     ...overrides,
   } as unknown as AgentRunService & {
+    resolveConfigControlUserId: ReturnType<typeof vi.fn>;
     resolveDeliveryConfigForUser: ReturnType<typeof vi.fn>;
+    listForViewer: ReturnType<typeof vi.fn>;
+    getConfigView: ReturnType<typeof vi.fn>;
+    getLatestForUser: ReturnType<typeof vi.fn>;
+    getByIdForUser: ReturnType<typeof vi.fn>;
     listOutputsForUser: ReturnType<typeof vi.fn>;
     listEligibleRouteMembers: ReturnType<typeof vi.fn>;
     listWhatsAppDmMembers: ReturnType<typeof vi.fn>;
@@ -62,6 +83,145 @@ function sourceRoute(source: AgentSourceConfig): AgentRoute {
 }
 
 describe("agentRoutes", () => {
+  it("lists agents through the viewer-aware service method", async () => {
+    const service = createService({
+      listForViewer: vi.fn(async () => [{ key: CONVERSATION_SUMMARY_AGENT_KEY, routes: [{ id: "shared-route" }] }]),
+    });
+    const app = createRoutesTestApp(service, "admin-b-sub", "admin-b@example.com", "admin");
+
+    const res = await app.request("/api/agents");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      agents: [{ key: CONVERSATION_SUMMARY_AGENT_KEY, routes: [{ id: "shared-route" }] }],
+    });
+    expect(service.listForViewer).toHaveBeenCalledWith("user-1", "admin");
+  });
+
+  it("reads admin Summarizer detail and latest output through the shared config owner", async () => {
+    const service = createService({
+      resolveConfigControlUserId: vi.fn(async () => "admin-owner"),
+      getConfigView: vi.fn(async () => ({
+        agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+        routes: [{ id: "shared-route" }],
+      })),
+      getLatestForUser: vi.fn(async () => ({
+        output: { id: "out-1" },
+        running: false,
+        outputDate: "2026-07-06",
+        timezone: "UTC",
+      })),
+    });
+    const app = createRoutesTestApp(service, "admin-b-sub", "admin-b@example.com", "admin");
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}`);
+
+    expect(res.status).toBe(200);
+    expect(service.resolveConfigControlUserId).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "admin");
+    expect(service.getConfigView).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "admin-owner");
+    expect(service.getLatestForUser).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "admin-owner");
+  });
+
+  it("saves admin Summarizer config through the shared config owner", async () => {
+    const service = createService({
+      resolveConfigControlUserId: vi.fn(async () => "admin-owner"),
+      updateConfigForUser: vi.fn(async () => ({ agentKey: CONVERSATION_SUMMARY_AGENT_KEY, delivery: null })),
+    });
+    const app = createRoutesTestApp(service, "admin-b-sub", "admin-b@example.com", "admin");
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        delivery: {
+          enabled: true,
+          platform: "slack",
+          targetType: "dm",
+          targetId: "U_OWNER",
+          label: "Owner",
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.resolveConfigControlUserId).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "admin");
+    expect(service.resolveDeliveryConfigForUser).toHaveBeenCalledWith(
+      "admin-owner",
+      expect.objectContaining({ targetId: "U_OWNER" }),
+    );
+    expect(service.updateConfigForUser).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "admin-owner",
+      expect.objectContaining({ delivery: expect.objectContaining({ targetId: "U_OWNER" }) }),
+    );
+  });
+
+  it("uses the shared config owner for admin Summarizer route members, outputs, and runs", async () => {
+    const service = createService({
+      resolveConfigControlUserId: vi.fn(async () => "admin-owner"),
+      listDefinitions: vi.fn(() => [{ key: CONVERSATION_SUMMARY_AGENT_KEY }]),
+      listEligibleRouteMembers: vi.fn(async () => [
+        { userId: "member-1", name: "Member One", slackUserId: "U_MEMBER_1" },
+      ]),
+      listOutputsForUser: vi.fn(async () => ({ outputs: [{ id: "out-1" }], nextCursor: null })),
+      requestGenerationForUser: vi.fn(async () => [
+        {
+          id: "run-1",
+          status: "running",
+          output_date: "2026-07-06",
+          source_key: "slack:channel:C_ALPHA",
+        },
+      ]),
+    });
+    const app = createRoutesTestApp(service, "admin-b-sub", "admin-b@example.com", "admin");
+
+    const routeMembers = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/route-members`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sources: ["slack:channel:C_ALPHA"] }),
+    });
+    const outputs = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/outputs?limit=5`);
+    const runs = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/runs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ routeId: "shared-route" }),
+    });
+
+    expect(routeMembers.status).toBe(200);
+    expect(outputs.status).toBe(200);
+    expect(runs.status).toBe(202);
+    expect(service.listEligibleRouteMembers).toHaveBeenCalledWith("admin-owner", ["slack:channel:C_ALPHA"]);
+    expect(service.listOutputsForUser).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "admin-owner", {
+      limit: 5,
+      cursor: null,
+    });
+    expect(service.requestGenerationForUser).toHaveBeenCalledWith({
+      agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+      userId: "admin-owner",
+      triggerType: "manual",
+      routeIds: ["shared-route"],
+    });
+  });
+
+  it("keeps member Summarizer config saves scoped to the viewer", async () => {
+    const service = createService();
+    const app = createRoutesTestApp(service);
+
+    const res = await app.request(`/api/agents/${CONVERSATION_SUMMARY_AGENT_KEY}/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.resolveConfigControlUserId).toHaveBeenCalledWith(CONVERSATION_SUMMARY_AGENT_KEY, "user-1", "member");
+    expect(service.updateConfigForUser).toHaveBeenCalledWith(
+      CONVERSATION_SUMMARY_AGENT_KEY,
+      "user-1",
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
   it("passes parsed delivery config to the service for saving", async () => {
     const service = createService({
       updateConfigForUser: vi.fn(async () => ({ agentKey: "daily-brief", delivery: null })),

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -15,13 +15,23 @@ import type {
 import type { DB } from "../db/schema";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import { getAgentDefinition } from "./registry";
-import { AgentDeliveryTargetError, type AgentOutputApi, type AgentRunService, AgentSourceTargetError } from "./service";
+import {
+  AgentDeliveryTargetError,
+  type AgentOutputApi,
+  type AgentRunService,
+  AgentSourceTargetError,
+  type AgentViewerRole,
+} from "./service";
 import type { AgentDefinition } from "./types";
 
 async function getCurrentUserId(c: { get: (key: "sub" | "email") => string | undefined }, service: AgentRunService) {
   const sub = c.get("sub");
   if (!sub) return null;
   return service.resolveUserId(sub, c.get("email"));
+}
+
+function getCurrentRole(c: { get: (key: "role") => string | undefined }): AgentViewerRole {
+  return c.get("role") === "admin" ? "admin" : "member";
 }
 
 /**
@@ -512,16 +522,17 @@ export function agentRoutes(service: AgentRunService) {
   routes.get("/", async (c) => {
     const userId = await getCurrentUserId(c, service);
     if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
-    return c.json({ agents: await service.listForUser(userId) });
+    return c.json({ agents: await service.listForViewer(userId, getCurrentRole(c)) });
   });
 
   routes.get("/:agentKey", async (c) => {
     const userId = await getCurrentUserId(c, service);
     if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
     const agentKey = c.req.param("agentKey");
-    const agent = await service.getConfigView(agentKey, userId);
+    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
+    const agent = await service.getConfigView(agentKey, configUserId);
     if (!agent) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
-    const latest = await service.getLatestForUser(agentKey, userId);
+    const latest = await service.getLatestForUser(agentKey, configUserId);
     return c.json({
       agent,
       output: latest.output,
@@ -542,8 +553,9 @@ export function agentRoutes(service: AgentRunService) {
     let agent: Awaited<ReturnType<AgentRunService["updateConfigForUser"]>>;
     try {
       patch = parseConfigPatch(body, def);
-      await validateDeliveryTargets(service, userId, patch);
-      agent = await service.updateConfigForUser(agentKey, userId, patch);
+      const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
+      await validateDeliveryTargets(service, configUserId, patch);
+      agent = await service.updateConfigForUser(agentKey, configUserId, patch);
     } catch (err) {
       if (
         err instanceof ConfigPatchError ||
@@ -567,7 +579,8 @@ export function agentRoutes(service: AgentRunService) {
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
     try {
       const sources = parseRouteMemberSources(body.sources);
-      return c.json({ members: await service.listEligibleRouteMembers(userId, sources) });
+      const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
+      return c.json({ members: await service.listEligibleRouteMembers(configUserId, sources) });
     } catch (err) {
       if (err instanceof ConfigPatchError) {
         return c.json({ error: { code: "VALIDATION_ERROR", message: err.message } }, 400);
@@ -595,7 +608,8 @@ export function agentRoutes(service: AgentRunService) {
     const rawLimit = Number(c.req.query("limit") ?? "20");
     const limit = Number.isInteger(rawLimit) ? rawLimit : 20;
     const cursor = c.req.query("cursor") || null;
-    return c.json(await service.listOutputsForUser(agentKey, userId, { limit, cursor }));
+    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
+    return c.json(await service.listOutputsForUser(agentKey, configUserId, { limit, cursor }));
   });
 
   routes.get("/:agentKey/outputs/:id", async (c) => {
@@ -605,7 +619,8 @@ export function agentRoutes(service: AgentRunService) {
     if (!service.listDefinitions().some((def) => def.key === agentKey)) {
       return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     }
-    const output = await service.getByIdForUser(agentKey, c.req.param("id"), userId);
+    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
+    const output = await service.getByIdForUser(agentKey, c.req.param("id"), configUserId);
     if (!output) return c.json({ error: { code: "NOT_FOUND", message: "Output not found" } }, 404);
     return c.json({ output });
   });
@@ -621,9 +636,10 @@ export function agentRoutes(service: AgentRunService) {
     const rawRouteId =
       body && typeof body === "object" && !Array.isArray(body) ? (body as { routeId?: unknown }).routeId : undefined;
     const routeId = typeof rawRouteId === "string" && rawRouteId.trim() ? rawRouteId.trim() : undefined;
+    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
     const rows = await service.requestGenerationForUser({
       agentKey,
-      userId,
+      userId: configUserId,
       triggerType: "manual",
       ...(routeId ? { routeIds: [routeId] } : {}),
     });

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -13,6 +13,7 @@ import type {
   AgentSourceKey,
 } from "../db/repositories/agent-outputs";
 import type { DB } from "../db/schema";
+import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import { getAgentDefinition } from "./registry";
 import {
@@ -529,10 +530,10 @@ export function agentRoutes(service: AgentRunService) {
     const userId = await getCurrentUserId(c, service);
     if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
     const agentKey = c.req.param("agentKey");
-    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
-    const agent = await service.getConfigView(agentKey, configUserId);
+    const role = getCurrentRole(c);
+    const agent = await service.getConfigViewForViewer(agentKey, userId, role);
     if (!agent) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
-    const latest = await service.getLatestForUser(agentKey, configUserId);
+    const latest = await service.getLatestForViewer(agentKey, userId, role);
     return c.json({
       agent,
       output: latest.output,
@@ -549,13 +550,18 @@ export function agentRoutes(service: AgentRunService) {
     const def = getAgentDefinition(agentKey);
     if (!def) return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+    const role = getCurrentRole(c);
     let patch: ReturnType<typeof parseConfigPatch>;
     let agent: Awaited<ReturnType<AgentRunService["updateConfigForUser"]>>;
     try {
       patch = parseConfigPatch(body, def);
-      const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
-      await validateDeliveryTargets(service, configUserId, patch);
-      agent = await service.updateConfigForUser(agentKey, configUserId, patch);
+      if (role === "admin" && agentKey === CONVERSATION_SUMMARY_AGENT_KEY) {
+        agent = await service.updateConfigForViewer(agentKey, userId, role, patch);
+      } else {
+        const configUserId = await service.resolveConfigControlUserId(agentKey, userId, role);
+        await validateDeliveryTargets(service, configUserId, patch);
+        agent = await service.updateConfigForUser(agentKey, configUserId, patch);
+      }
     } catch (err) {
       if (
         err instanceof ConfigPatchError ||
@@ -579,8 +585,10 @@ export function agentRoutes(service: AgentRunService) {
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
     try {
       const sources = parseRouteMemberSources(body.sources);
-      const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
-      return c.json({ members: await service.listEligibleRouteMembers(configUserId, sources) });
+      const routeId = typeof body.routeId === "string" && body.routeId.trim() ? body.routeId.trim() : null;
+      return c.json({
+        members: await service.listEligibleRouteMembersForViewer(agentKey, userId, getCurrentRole(c), sources, routeId),
+      });
     } catch (err) {
       if (err instanceof ConfigPatchError) {
         return c.json({ error: { code: "VALIDATION_ERROR", message: err.message } }, 400);
@@ -608,8 +616,7 @@ export function agentRoutes(service: AgentRunService) {
     const rawLimit = Number(c.req.query("limit") ?? "20");
     const limit = Number.isInteger(rawLimit) ? rawLimit : 20;
     const cursor = c.req.query("cursor") || null;
-    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
-    return c.json(await service.listOutputsForUser(agentKey, configUserId, { limit, cursor }));
+    return c.json(await service.listOutputsForViewer(agentKey, userId, getCurrentRole(c), { limit, cursor }));
   });
 
   routes.get("/:agentKey/outputs/:id", async (c) => {
@@ -619,8 +626,7 @@ export function agentRoutes(service: AgentRunService) {
     if (!service.listDefinitions().some((def) => def.key === agentKey)) {
       return c.json({ error: { code: "NOT_FOUND", message: "Agent not found" } }, 404);
     }
-    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
-    const output = await service.getByIdForUser(agentKey, c.req.param("id"), configUserId);
+    const output = await service.getByIdForViewer(agentKey, c.req.param("id"), userId, getCurrentRole(c));
     if (!output) return c.json({ error: { code: "NOT_FOUND", message: "Output not found" } }, 404);
     return c.json({ output });
   });
@@ -636,10 +642,10 @@ export function agentRoutes(service: AgentRunService) {
     const rawRouteId =
       body && typeof body === "object" && !Array.isArray(body) ? (body as { routeId?: unknown }).routeId : undefined;
     const routeId = typeof rawRouteId === "string" && rawRouteId.trim() ? rawRouteId.trim() : undefined;
-    const configUserId = await service.resolveConfigControlUserId(agentKey, userId, getCurrentRole(c));
-    const rows = await service.requestGenerationForUser({
+    const rows = await service.requestGenerationForViewer({
       agentKey,
-      userId: configUserId,
+      userId,
+      viewerRole: getCurrentRole(c),
       triggerType: "manual",
       ...(routeId ? { routeIds: [routeId] } : {}),
     });

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -866,6 +866,77 @@ describe("AgentRunService", () => {
     });
   });
 
+  it("resolves admin Summarizer control to the first admin-owned config", async () => {
+    const users = createUserRepository(db);
+    const adminA = await users.create({
+      name: "Admin A",
+      email: "admin-a@example.com",
+      slackUserId: "U_ADMIN_A",
+      authRole: "admin",
+    });
+    const adminB = await users.create({
+      name: "Admin B",
+      email: "admin-b@example.com",
+      slackUserId: "U_ADMIN_B",
+      authRole: "admin",
+    });
+    const source = slackSource("C_A", "alpha");
+    const route = sourceRoute(source);
+    const service = createService(db, [], allowSlackDelivery([{ id: "C_A", name: "alpha" }]));
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, adminA.id, {
+      sources: [source],
+      routes: [route],
+    });
+
+    await expect(service.resolveConfigControlUserId(CONVERSATION_SUMMARY_AGENT_KEY, adminB.id, "admin")).resolves.toBe(
+      adminA.id,
+    );
+
+    const summaries = await service.listForViewer(adminB.id, "admin");
+    expect(summaries.find((summary) => summary.key === CONVERSATION_SUMMARY_AGENT_KEY)).toMatchObject({
+      sources: [source],
+      routes: [route],
+    });
+  });
+
+  it("keeps admin Summarizer control on self when no admin config exists", async () => {
+    const users = createUserRepository(db);
+    const admin = await users.create({
+      name: "Admin",
+      email: "admin@example.com",
+      authRole: "admin",
+    });
+    const service = createService(db, []);
+
+    await expect(service.resolveConfigControlUserId(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, "admin")).resolves.toBe(
+      admin.id,
+    );
+  });
+
+  it("keeps members and non-Summarizer agents scoped to the viewer", async () => {
+    const users = createUserRepository(db);
+    const admin = await users.create({
+      name: "Admin",
+      email: "admin@example.com",
+      slackUserId: "U_ADMIN",
+      authRole: "admin",
+    });
+    const member = await users.create({ name: "Member", email: "member@example.com", authRole: "member" });
+    const source = slackSource("C_A", "alpha");
+    const service = createService(db, [], allowSlackDelivery([{ id: "C_A", name: "alpha" }]));
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, {
+      sources: [source],
+      routes: [sourceRoute(source)],
+    });
+
+    await expect(service.resolveConfigControlUserId(CONVERSATION_SUMMARY_AGENT_KEY, member.id, "member")).resolves.toBe(
+      member.id,
+    );
+    await expect(service.resolveConfigControlUserId(DAILY_BRIEF_AGENT_KEY, admin.id, "admin")).resolves.toBe(admin.id);
+  });
+
   it("resolves WhatsApp group sources by bot-known group membership without requiring a user WhatsApp number", async () => {
     const users = createUserRepository(db);
     const user = await users.create({ name: "Agent User", email: "user@example.com" });

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -866,7 +866,7 @@ describe("AgentRunService", () => {
     });
   });
 
-  it("resolves admin Summarizer control to the first admin-owned config", async () => {
+  it("keeps the legacy config-control resolver scoped to the viewer while admin lists aggregate Summarizer configs", async () => {
     const users = createUserRepository(db);
     const adminA = await users.create({
       name: "Admin A",
@@ -890,13 +890,19 @@ describe("AgentRunService", () => {
     });
 
     await expect(service.resolveConfigControlUserId(CONVERSATION_SUMMARY_AGENT_KEY, adminB.id, "admin")).resolves.toBe(
-      adminA.id,
+      adminB.id,
     );
 
     const summaries = await service.listForViewer(adminB.id, "admin");
     expect(summaries.find((summary) => summary.key === CONVERSATION_SUMMARY_AGENT_KEY)).toMatchObject({
       sources: [source],
-      routes: [route],
+      routes: [
+        expect.objectContaining({
+          ...route,
+          id: expect.stringMatching(/^org:/),
+          owner: expect.objectContaining({ userId: adminA.id, name: "Admin A", authRole: "admin" }),
+        }),
+      ],
     });
   });
 
@@ -935,6 +941,220 @@ describe("AgentRunService", () => {
       member.id,
     );
     await expect(service.resolveConfigControlUserId(DAILY_BRIEF_AGENT_KEY, admin.id, "admin")).resolves.toBe(admin.id);
+  });
+
+  it("lists org-wide Summarizer configs for admins across member and admin owners", async () => {
+    const users = createUserRepository(db);
+    const adminA = await users.create({
+      name: "Admin A",
+      email: "admin-a@example.com",
+      slackUserId: "U_ADMIN_A",
+      authRole: "admin",
+    });
+    const adminB = await users.create({
+      name: "Admin B",
+      email: "admin-b@example.com",
+      slackUserId: "U_ADMIN_B",
+      authRole: "admin",
+    });
+    const member = await users.create({
+      name: "Maya Member",
+      email: "maya@example.com",
+      slackUserId: "U_MAYA",
+      authRole: "member",
+    });
+    const adminSource = slackSource("C_ADMIN", "admin-source");
+    const memberSource = slackSource("C_MEMBER", "member-source");
+    const service = createService(
+      db,
+      [],
+      allowSlackDelivery([
+        { id: "C_ADMIN", name: "admin-source" },
+        { id: "C_MEMBER", name: "member-source" },
+      ]),
+    );
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, adminA.id, {
+      sources: [adminSource],
+      routes: [sourceRoute(adminSource, { focus: "Admin route" })],
+    });
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, member.id, {
+      sources: [memberSource],
+      routes: [sourceRoute(memberSource, { focus: "Member route" })],
+    });
+
+    const summaries = await service.listForViewer(adminB.id, "admin");
+    const summary = summaries.find((item) => item.key === CONVERSATION_SUMMARY_AGENT_KEY);
+
+    expect(summary?.sources).toHaveLength(2);
+    expect(summary?.sources).toEqual(expect.arrayContaining([adminSource, memberSource]));
+    expect(summary?.routes).toHaveLength(2);
+    expect(summary?.routes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.stringMatching(/^org:/),
+          sources: [`slack:channel:${adminSource.targetId}`],
+          focus: "Admin route",
+          owner: expect.objectContaining({ userId: adminA.id, name: "Admin A", authRole: "admin" }),
+        }),
+        expect.objectContaining({
+          id: expect.stringMatching(/^org:/),
+          sources: [`slack:channel:${memberSource.targetId}`],
+          focus: "Member route",
+          owner: expect.objectContaining({ userId: member.id, name: "Maya Member", authRole: "member" }),
+        }),
+      ]),
+    );
+  });
+
+  it("lets admins update a member-owned Summarizer route without moving ownership", async () => {
+    const users = createUserRepository(db);
+    const admin = await users.create({
+      name: "Admin",
+      email: "admin@example.com",
+      slackUserId: "U_ADMIN",
+      authRole: "admin",
+    });
+    const member = await users.create({
+      name: "Maya Member",
+      email: "maya@example.com",
+      slackUserId: "U_MAYA",
+      authRole: "member",
+    });
+    const source = slackSource("C_MEMBER", "member-source");
+    const service = createService(db, [], allowSlackDelivery([{ id: "C_MEMBER", name: "member-source" }]));
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, member.id, {
+      sources: [source],
+      routes: [sourceRoute(source)],
+    });
+    const adminView = await service.getConfigViewForViewer(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, "admin");
+    const disabledRoutes =
+      adminView?.routes.map((route) => (route.owner?.userId === member.id ? { ...route, enabled: false } : route)) ??
+      [];
+
+    await service.updateConfigForViewer(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, "admin", {
+      routes: disabledRoutes,
+    });
+
+    const memberView = await service.getConfigView(CONVERSATION_SUMMARY_AGENT_KEY, member.id);
+    const adminOwnConfig = await createAgentOutputRepository(db).getConfig(CONVERSATION_SUMMARY_AGENT_KEY, admin.id);
+    expect(memberView?.routes).toEqual([
+      expect.objectContaining({ id: `slack:channel:${source.targetId}`, enabled: false }),
+    ]);
+    expect(adminOwnConfig.exists).toBe(false);
+  });
+
+  it("stores new unowned routes created from an admin org-wide view under that admin", async () => {
+    const users = createUserRepository(db);
+    const admin = await users.create({
+      name: "Admin",
+      email: "admin@example.com",
+      slackUserId: "U_ADMIN",
+      authRole: "admin",
+    });
+    const member = await users.create({
+      name: "Maya Member",
+      email: "maya@example.com",
+      slackUserId: "U_MAYA",
+      authRole: "member",
+    });
+    const memberSource = slackSource("C_MEMBER", "member-source");
+    const adminSource = slackSource("C_ADMIN", "admin-source");
+    const service = createService(
+      db,
+      [],
+      allowSlackDelivery([
+        { id: "C_MEMBER", name: "member-source" },
+        { id: "C_ADMIN", name: "admin-source" },
+      ]),
+    );
+
+    await service.updateConfigForUser(CONVERSATION_SUMMARY_AGENT_KEY, member.id, {
+      sources: [memberSource],
+      routes: [sourceRoute(memberSource)],
+    });
+    const adminView = await service.getConfigViewForViewer(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, "admin");
+    const newAdminRoute = sourceRoute(adminSource, { focus: "Admin-created route" });
+
+    await service.updateConfigForViewer(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, "admin", {
+      sources: [memberSource, adminSource],
+      routes: [...(adminView?.routes ?? []), newAdminRoute],
+    });
+
+    const memberView = await service.getConfigView(CONVERSATION_SUMMARY_AGENT_KEY, member.id);
+    const adminViewAfterSave = await service.getConfigView(CONVERSATION_SUMMARY_AGENT_KEY, admin.id);
+    expect(memberView?.routes).toHaveLength(1);
+    expect(adminViewAfterSave?.routes).toEqual([
+      expect.objectContaining({ id: newAdminRoute.id, focus: "Admin-created route" }),
+    ]);
+  });
+
+  it("lists org-wide Summarizer outputs for admins", async () => {
+    const users = createUserRepository(db);
+    const admin = await users.create({ name: "Admin", email: "admin@example.com", authRole: "admin" });
+    const member = await users.create({ name: "Maya Member", email: "maya@example.com", authRole: "member" });
+    const service = createService(db, []);
+    const repo = createAgentOutputRepository(db);
+    const now = new Date().toISOString();
+    await db
+      .insertInto("agent_outputs")
+      .values([
+        {
+          id: "admin-output",
+          agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+          user_id: admin.id,
+          output_date: OUTPUT_DATE,
+          period_key: OUTPUT_DATE,
+          source_key: "slack:channel:C_ADMIN",
+          source_label: "#admin-source",
+          timezone: "UTC",
+          status: "completed",
+          trigger_type: "manual",
+          agent_version: conversationSummaryDefinition.version,
+          agent_run_id: null,
+          masthead_json: JSON.stringify({ title: "Admin", summary: "Admin summary" }),
+          raw_payload_json: "{}",
+          error_message: null,
+          generated_at: "2026-06-15T10:00:00.000Z",
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: "member-output",
+          agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+          user_id: member.id,
+          output_date: OUTPUT_DATE,
+          period_key: OUTPUT_DATE,
+          source_key: "slack:channel:C_MEMBER",
+          source_label: "#member-source",
+          timezone: "UTC",
+          status: "completed",
+          trigger_type: "manual",
+          agent_version: conversationSummaryDefinition.version,
+          agent_run_id: null,
+          masthead_json: JSON.stringify({ title: "Member", summary: "Member summary" }),
+          raw_payload_json: "{}",
+          error_message: null,
+          generated_at: "2026-06-15T11:00:00.000Z",
+          created_at: now,
+          updated_at: now,
+        },
+      ])
+      .execute();
+
+    const outputs = await service.listOutputsForViewer(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, "admin", {
+      limit: 10,
+    });
+    const memberOnlyOutputs = await service.listOutputsForViewer(CONVERSATION_SUMMARY_AGENT_KEY, member.id, "member", {
+      limit: 10,
+    });
+
+    expect(outputs.outputs.map((output) => output.id)).toEqual(["member-output", "admin-output"]);
+    expect(memberOnlyOutputs.outputs.map((output) => output.id)).toEqual(["member-output"]);
+    expect(
+      (await repo.listCompletedForUser(CONVERSATION_SUMMARY_AGENT_KEY, admin.id, { limit: 10 })).outputs,
+    ).toHaveLength(1);
   });
 
   it("resolves WhatsApp group sources by bot-known group membership without requiring a user WhatsApp number", async () => {

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -55,6 +55,8 @@ const WEEKDAY_INDEX = new Map([
 
 type UserRow = Selectable<UsersTable>;
 
+export type AgentViewerRole = "admin" | "member";
+
 export type AgentGenerationScope =
   | { kind: "combined"; sourceKey: string; sourceLabel: string | null }
   | { kind: "source"; source: AgentSourceConfig; sourceKey: string; sourceLabel: string | null };
@@ -780,10 +782,16 @@ export class AgentRunService {
     return listAgentDefinitions();
   }
 
-  async listForUser(userId: string): Promise<AgentSummaryView[]> {
+  async resolveConfigControlUserId(agentKey: string, viewerUserId: string, role: AgentViewerRole): Promise<string> {
+    if (role !== "admin" || agentKey !== CONVERSATION_SUMMARY_AGENT_KEY) return viewerUserId;
+    return (await this.repo.findFirstAdminConfigOwner(agentKey)) ?? viewerUserId;
+  }
+
+  async listForViewer(userId: string, role: AgentViewerRole): Promise<AgentSummaryView[]> {
     const result: AgentSummaryView[] = [];
     for (const def of listAgentDefinitions()) {
-      const config = await this.resolveConfig(def, userId);
+      const configUserId = await this.resolveConfigControlUserId(def.key, userId, role);
+      const config = await this.resolveConfig(def, configUserId);
       result.push({
         key: def.key,
         title: def.title,
@@ -800,6 +808,10 @@ export class AgentRunService {
       });
     }
     return result;
+  }
+
+  async listForUser(userId: string): Promise<AgentSummaryView[]> {
+    return this.listForViewer(userId, "member");
   }
 
   async getConfigView(agentKey: string, userId: string): Promise<AgentConfigView | null> {

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { areJidsSameUser } from "@whiskeysockets/baileys";
@@ -23,6 +24,7 @@ import {
   type AgentRouteSchedule,
   type AgentSourceConfig,
   type AgentSourceKey,
+  type AgentUserConfigWithOwner,
   type AgentUserPrefs,
   createAgentOutputRepository,
 } from "../db/repositories/agent-outputs";
@@ -138,9 +140,18 @@ export interface AgentConfigView {
   deliveryModel: AgentDeliveryModel;
   sourceConfig: AgentSourceConfigDef | null;
   sources: AgentSourceConfig[];
-  routes: AgentRoute[];
+  routes: AgentConfigRouteView[];
   sections: AgentSectionView[];
 }
+
+export interface AgentRouteOwnerView {
+  userId: string;
+  name: string;
+  email: string | null;
+  authRole: string;
+}
+
+export type AgentConfigRouteView = AgentRoute & { owner?: AgentRouteOwnerView };
 
 export interface AgentRouteMember {
   userId: string;
@@ -179,7 +190,20 @@ export interface AgentSummaryView {
   scheduleMinute: number;
   sourceConfig: AgentSourceConfigDef | null;
   sources: AgentSourceConfig[];
-  routes: AgentRoute[];
+  routes: AgentConfigRouteView[];
+}
+
+export interface AgentConfigUpdatePatch {
+  enabled?: boolean;
+  scheduleHour?: number;
+  scheduleMinute?: number;
+  maxItemsPerSection?: number;
+  sections?: Record<string, boolean>;
+  focus?: string | null;
+  delivery?: AgentDeliveryConfig | null;
+  deliveryModel?: AgentDeliveryModel;
+  sources?: AgentSourceConfig[];
+  routes?: AgentConfigRouteView[];
 }
 
 export class AgentDeliveryTargetError extends Error {}
@@ -224,6 +248,62 @@ function routeScopeKeyForSources(sources: readonly AgentSourceKey[]): string {
 
 function routeIdForSources(sources: readonly AgentSourceKey[]): string {
   return routeScopeKeyForSources(sources);
+}
+
+const ORG_ROUTE_ID_PREFIX = "org:";
+
+function encodeRouteIdSegment(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function decodeRouteIdSegment(value: string): string | null {
+  try {
+    return Buffer.from(value, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+function encodeOrgRouteId(ownerUserId: string, routeId: string): string {
+  return `${ORG_ROUTE_ID_PREFIX}${encodeRouteIdSegment(ownerUserId)}:${encodeRouteIdSegment(routeId)}`;
+}
+
+function decodeOrgRouteId(routeId: string): { ownerUserId: string; routeId: string } | null {
+  if (!routeId.startsWith(ORG_ROUTE_ID_PREFIX)) return null;
+  const [ownerSegment, routeSegment, ...extra] = routeId.slice(ORG_ROUTE_ID_PREFIX.length).split(":");
+  if (!ownerSegment || !routeSegment || extra.length > 0) return null;
+  const ownerUserId = decodeRouteIdSegment(ownerSegment);
+  const decodedRouteId = decodeRouteIdSegment(routeSegment);
+  return ownerUserId && decodedRouteId ? { ownerUserId, routeId: decodedRouteId } : null;
+}
+
+function routeOwnerView(owner: AgentUserConfigWithOwner): AgentRouteOwnerView {
+  return {
+    userId: owner.userId,
+    name: owner.name,
+    email: owner.email,
+    authRole: owner.authRole,
+  };
+}
+
+function routeWithOwner(route: AgentRoute, owner: AgentUserConfigWithOwner): AgentConfigRouteView {
+  return {
+    ...route,
+    id: encodeOrgRouteId(owner.userId, route.id),
+    owner: routeOwnerView(owner),
+  };
+}
+
+function stripOrgRouteOwner(route: AgentConfigRouteView): { ownerUserId: string | null; route: AgentRoute } {
+  const decoded = decodeOrgRouteId(route.id);
+  const { owner: _owner, ...rest } = route;
+  return {
+    ownerUserId: decoded?.ownerUserId ?? null,
+    route: {
+      ...rest,
+      id: decoded?.routeId ?? route.id,
+    },
+  };
 }
 
 export function scopeKeyForRoute(route: Pick<AgentRoute, "sources">, resolvedSources: AgentSourceConfig[]): string {
@@ -778,18 +858,123 @@ export class AgentRunService {
     };
   }
 
+  private usesOrgWideSummarizerView(agentKey: string, role: AgentViewerRole): boolean {
+    return role === "admin" && agentKey === CONVERSATION_SUMMARY_AGENT_KEY;
+  }
+
+  private async getOrgWideSummarizerConfigView(
+    def: AgentDefinition,
+    viewerUserId: string,
+  ): Promise<AgentConfigView | null> {
+    const [owners, viewerConfig] = await Promise.all([
+      this.repo.listHumanConfigs(def.key),
+      this.resolveConfig(def, viewerUserId),
+    ]);
+    if (owners.length === 0) return this.getConfigView(def.key, viewerUserId);
+
+    const sources: AgentSourceConfig[] = [];
+    const sourceKeys = new Set<string>();
+    const routes: AgentConfigRouteView[] = [];
+    let enabled = false;
+
+    for (const owner of owners) {
+      const config = await this.resolveConfig(def, owner.userId);
+      enabled = enabled || config.enabled;
+      for (const source of config.sources) {
+        const key = sourceKeyForTarget(source);
+        if (sourceKeys.has(key)) continue;
+        sourceKeys.add(key);
+        sources.push(source);
+      }
+      routes.push(...config.configuredRoutes.map((route) => routeWithOwner(route, owner)));
+    }
+
+    return {
+      agentKey: def.key,
+      title: def.title,
+      tagline: def.tagline,
+      description: def.description,
+      enabled,
+      scheduleHour: viewerConfig.scheduleHour,
+      scheduleMinute: viewerConfig.scheduleMinute,
+      timezone: viewerConfig.timezone,
+      maxItemsPerSection: viewerConfig.maxItemsPerSection,
+      itemsPerSectionRange: def.itemsPerSectionRange,
+      focus: viewerConfig.focus,
+      delivery: viewerConfig.delivery,
+      deliveryModel: viewerConfig.deliveryModel,
+      sourceConfig: def.sourceConfig ?? null,
+      sources,
+      routes,
+      sections: def.sections.map((section) => ({
+        key: section.key,
+        title: section.title,
+        enabled: viewerConfig.enabledSections[section.key] ?? section.enabledByDefault,
+      })),
+    };
+  }
+
+  private async sourceLookupForOwnerPatch(
+    def: AgentDefinition,
+    owners: AgentUserConfigWithOwner[],
+    patchSources: AgentSourceConfig[] | undefined,
+  ): Promise<Map<string, AgentSourceConfig>> {
+    const lookup = new Map<string, AgentSourceConfig>();
+    for (const source of patchSources ?? []) lookup.set(sourceKeyForTarget(source), source);
+    for (const owner of owners) {
+      const config = await this.resolveConfig(def, owner.userId);
+      for (const source of config.sources) {
+        const key = sourceKeyForTarget(source);
+        if (!lookup.has(key)) lookup.set(key, source);
+      }
+    }
+    return lookup;
+  }
+
+  private sourcesForRoutes(routes: AgentRoute[], lookup: Map<string, AgentSourceConfig>): AgentSourceConfig[] {
+    const sources: AgentSourceConfig[] = [];
+    const seen = new Set<string>();
+    for (const route of routes) {
+      for (const key of route.sources) {
+        if (seen.has(key)) continue;
+        const source = lookup.get(key) ?? parseSourceKey(key);
+        seen.add(key);
+        sources.push(source);
+      }
+    }
+    return sources;
+  }
+
   listDefinitions(): readonly AgentDefinition[] {
     return listAgentDefinitions();
   }
 
-  async resolveConfigControlUserId(agentKey: string, viewerUserId: string, role: AgentViewerRole): Promise<string> {
-    if (role !== "admin" || agentKey !== CONVERSATION_SUMMARY_AGENT_KEY) return viewerUserId;
-    return (await this.repo.findFirstAdminConfigOwner(agentKey)) ?? viewerUserId;
+  async resolveConfigControlUserId(_agentKey: string, viewerUserId: string, _role: AgentViewerRole): Promise<string> {
+    return viewerUserId;
   }
 
   async listForViewer(userId: string, role: AgentViewerRole): Promise<AgentSummaryView[]> {
     const result: AgentSummaryView[] = [];
     for (const def of listAgentDefinitions()) {
+      if (this.usesOrgWideSummarizerView(def.key, role)) {
+        const agent = await this.getOrgWideSummarizerConfigView(def, userId);
+        if (!agent) continue;
+        result.push({
+          key: def.key,
+          title: def.title,
+          tagline: def.tagline,
+          description: def.description,
+          category: def.category,
+          version: def.version,
+          enabled: agent.enabled,
+          scheduleHour: agent.scheduleHour,
+          scheduleMinute: agent.scheduleMinute,
+          sourceConfig: def.sourceConfig ?? null,
+          sources: agent.sources,
+          routes: agent.routes,
+        });
+        continue;
+      }
       const configUserId = await this.resolveConfigControlUserId(def.key, userId, role);
       const config = await this.resolveConfig(def, configUserId);
       result.push({
@@ -812,6 +997,18 @@ export class AgentRunService {
 
   async listForUser(userId: string): Promise<AgentSummaryView[]> {
     return this.listForViewer(userId, "member");
+  }
+
+  async getConfigViewForViewer(
+    agentKey: string,
+    userId: string,
+    role: AgentViewerRole,
+  ): Promise<AgentConfigView | null> {
+    const def = getAgentDefinition(agentKey);
+    if (!def) return null;
+    if (this.usesOrgWideSummarizerView(agentKey, role)) return this.getOrgWideSummarizerConfigView(def, userId);
+    const configUserId = await this.resolveConfigControlUserId(agentKey, userId, role);
+    return this.getConfigView(agentKey, configUserId);
   }
 
   async getConfigView(agentKey: string, userId: string): Promise<AgentConfigView | null> {
@@ -843,21 +1040,61 @@ export class AgentRunService {
     };
   }
 
+  async updateConfigForViewer(
+    agentKey: string,
+    userId: string,
+    role: AgentViewerRole,
+    patch: AgentConfigUpdatePatch,
+  ): Promise<AgentConfigView | null> {
+    const def = getAgentDefinition(agentKey);
+    if (!def) return null;
+    if (!this.usesOrgWideSummarizerView(agentKey, role)) {
+      const configUserId = await this.resolveConfigControlUserId(agentKey, userId, role);
+      return this.updateConfigForUser(agentKey, configUserId, patch);
+    }
+
+    const hasRoutePatch = patch.routes !== undefined;
+    const owners = await this.repo.listHumanConfigs(def.key);
+
+    if (!hasRoutePatch) {
+      const patchKeys = Object.keys(patch);
+      const isEnabledOnlyPatch = patch.enabled !== undefined && patchKeys.length === 1;
+      const targetUserIds = isEnabledOnlyPatch && owners.length > 0 ? owners.map((owner) => owner.userId) : [userId];
+      for (const targetUserId of targetUserIds) await this.updateConfigForUser(agentKey, targetUserId, patch);
+      return this.getOrgWideSummarizerConfigView(def, userId);
+    }
+
+    const routesByOwner = new Map<string, AgentRoute[]>();
+    if (patch.routes !== undefined) {
+      for (const owner of owners) routesByOwner.set(owner.userId, []);
+    }
+
+    for (const route of patch.routes ?? []) {
+      const stripped = stripOrgRouteOwner(route);
+      const ownerUserId = stripped.ownerUserId ?? userId;
+      const routes = routesByOwner.get(ownerUserId) ?? [];
+      routes.push(stripped.route);
+      routesByOwner.set(ownerUserId, routes);
+    }
+
+    const sourceLookup = await this.sourceLookupForOwnerPatch(def, owners, patch.sources);
+    for (const [ownerUserId, routes] of routesByOwner) {
+      const ownerPatch: AgentConfigUpdatePatch = { ...patch };
+      if (patch.routes !== undefined) ownerPatch.routes = routes;
+      if (patch.sources !== undefined) ownerPatch.sources = this.sourcesForRoutes(routes, sourceLookup);
+      if (patch.enabled !== undefined && ownerUserId !== userId && patch.routes !== undefined) {
+        ownerPatch.enabled = undefined;
+      }
+      await this.updateConfigForUser(agentKey, ownerUserId, ownerPatch);
+    }
+
+    return this.getOrgWideSummarizerConfigView(def, userId);
+  }
+
   async updateConfigForUser(
     agentKey: string,
     userId: string,
-    patch: {
-      enabled?: boolean;
-      scheduleHour?: number;
-      scheduleMinute?: number;
-      maxItemsPerSection?: number;
-      sections?: Record<string, boolean>;
-      focus?: string | null;
-      delivery?: AgentDeliveryConfig | null;
-      deliveryModel?: AgentDeliveryModel;
-      sources?: AgentSourceConfig[];
-      routes?: AgentRoute[];
-    },
+    patch: AgentConfigUpdatePatch,
   ): Promise<AgentConfigView | null> {
     const def = getAgentDefinition(agentKey);
     if (!def) return null;
@@ -1147,6 +1384,36 @@ export class AgentRunService {
     return members;
   }
 
+  async listEligibleRouteMembersForViewer(
+    agentKey: string,
+    userId: string,
+    role: AgentViewerRole,
+    sourceKeys: string[],
+    routeId?: string | null,
+  ): Promise<AgentRouteMember[]> {
+    if (!this.usesOrgWideSummarizerView(agentKey, role)) {
+      const configUserId = await this.resolveConfigControlUserId(agentKey, userId, role);
+      return this.listEligibleRouteMembers(configUserId, sourceKeys);
+    }
+    const decoded = routeId ? decodeOrgRouteId(routeId) : null;
+    if (decoded) return this.listEligibleRouteMembers(decoded.ownerUserId, sourceKeys);
+
+    const normalizedSourceKeys = [...new Set(sourceKeys)].sort();
+    const owners = await this.repo.listHumanConfigs(agentKey);
+    for (const owner of owners) {
+      const config = await this.resolveConfig(requireAgentDefinition(agentKey), owner.userId);
+      const match = config.configuredRoutes.find((route) => {
+        const routeSources = [...new Set(route.sources)].sort();
+        return (
+          routeSources.length === normalizedSourceKeys.length &&
+          routeSources.every((source, index) => source === normalizedSourceKeys[index])
+        );
+      });
+      if (match) return this.listEligibleRouteMembers(owner.userId, sourceKeys);
+    }
+    return this.listEligibleRouteMembers(userId, sourceKeys);
+  }
+
   async listWhatsAppDmMembers(): Promise<AgentWhatsAppDmMember[]> {
     const members: AgentWhatsAppDmMember[] = [];
     for (const user of await this.deps.users.list()) {
@@ -1399,9 +1666,59 @@ export class AgentRunService {
     };
   }
 
+  async getLatestForViewer(
+    agentKey: string,
+    userId: string,
+    role: AgentViewerRole,
+    outputDate?: string,
+  ): Promise<{
+    output: AgentOutputApi | null;
+    running: boolean;
+    outputDate: string;
+    timezone: string;
+    enabledSections: string[];
+  }> {
+    if (!this.usesOrgWideSummarizerView(agentKey, role)) {
+      const configUserId = await this.resolveConfigControlUserId(agentKey, userId, role);
+      return this.getLatestForUser(agentKey, configUserId, outputDate);
+    }
+
+    const def = requireAgentDefinition(agentKey);
+    const user = await this.deps.users.findById(userId);
+    if (!user) throw new Error("User not found");
+    const timezone = user.timezone || "UTC";
+    const date = outputDate || localDateInTimezone(new Date(), timezone);
+    const now = new Date();
+    const [completed, running] = await Promise.all([
+      this.repo.findLatestCompletedAcrossHumanUsers(def.key, date),
+      this.repo.findRunningAcrossHumanUsers(def.key, date),
+    ]);
+    return {
+      output: this.toApiOutput(def, completed),
+      running: Boolean(running && !this.isRunningStale(running, now)),
+      outputDate: date,
+      timezone,
+      enabledSections: def.sections.map((section) => section.key),
+    };
+  }
+
   async getByIdForUser(agentKey: string, id: string, userId: string): Promise<AgentOutputApi | null> {
     const def = requireAgentDefinition(agentKey);
     return this.toApiOutput(def, await this.repo.getByIdForUser(def.key, id, userId));
+  }
+
+  async getByIdForViewer(
+    agentKey: string,
+    id: string,
+    userId: string,
+    role: AgentViewerRole,
+  ): Promise<AgentOutputApi | null> {
+    const def = requireAgentDefinition(agentKey);
+    if (this.usesOrgWideSummarizerView(agentKey, role)) {
+      return this.toApiOutput(def, await this.repo.getByIdForHumanUser(def.key, id));
+    }
+    const configUserId = await this.resolveConfigControlUserId(agentKey, userId, role);
+    return this.getByIdForUser(agentKey, id, configUserId);
   }
 
   async listOutputsForUser(
@@ -1411,6 +1728,27 @@ export class AgentRunService {
   ): Promise<{ outputs: AgentOutputApi[]; nextCursor: string | null }> {
     const def = requireAgentDefinition(agentKey);
     const result = await this.repo.listCompletedForUser(def.key, userId, options);
+    return {
+      outputs: result.outputs.flatMap((output) => {
+        const api = this.toApiOutput(def, output);
+        return api ? [api] : [];
+      }),
+      nextCursor: result.nextCursor,
+    };
+  }
+
+  async listOutputsForViewer(
+    agentKey: string,
+    userId: string,
+    role: AgentViewerRole,
+    options: { limit?: number; cursor?: string | null } = {},
+  ): Promise<{ outputs: AgentOutputApi[]; nextCursor: string | null }> {
+    const def = requireAgentDefinition(agentKey);
+    if (!this.usesOrgWideSummarizerView(agentKey, role)) {
+      const configUserId = await this.resolveConfigControlUserId(agentKey, userId, role);
+      return this.listOutputsForUser(agentKey, configUserId, options);
+    }
+    const result = await this.repo.listCompletedForHumanUsers(def.key, options);
     return {
       outputs: result.outputs.flatMap((output) => {
         const api = this.toApiOutput(def, output);
@@ -1440,6 +1778,48 @@ export class AgentRunService {
         }
         return { kind: "combined", sourceKey, sourceLabel, route, sources: route.resolvedSources };
       });
+  }
+
+  async requestGenerationForViewer(
+    params: RequestAgentGenerationParams & { viewerRole: AgentViewerRole },
+  ): Promise<AgentOutputRow[]> {
+    const { viewerRole, ...requestParams } = params;
+    if (!this.usesOrgWideSummarizerView(requestParams.agentKey, viewerRole)) {
+      const configUserId = await this.resolveConfigControlUserId(
+        requestParams.agentKey,
+        requestParams.userId,
+        viewerRole,
+      );
+      return this.requestGenerationForUser({ ...requestParams, userId: configUserId });
+    }
+
+    const ownerRoutes = new Map<string, string[] | null>();
+    if (requestParams.routeIds?.length) {
+      for (const routeId of requestParams.routeIds) {
+        const decoded = decodeOrgRouteId(routeId);
+        const ownerUserId = decoded?.ownerUserId ?? requestParams.userId;
+        const plainRouteId = decoded?.routeId ?? routeId;
+        const routeIds = ownerRoutes.get(ownerUserId) ?? [];
+        routeIds.push(plainRouteId);
+        ownerRoutes.set(ownerUserId, routeIds);
+      }
+    } else {
+      const owners = await this.repo.listHumanConfigs(requestParams.agentKey);
+      for (const owner of owners) ownerRoutes.set(owner.userId, null);
+      if (ownerRoutes.size === 0) ownerRoutes.set(requestParams.userId, null);
+    }
+
+    const rows: AgentOutputRow[] = [];
+    for (const [ownerUserId, routeIds] of ownerRoutes) {
+      rows.push(
+        ...(await this.requestGenerationForUser({
+          ...requestParams,
+          userId: ownerUserId,
+          ...(routeIds ? { routeIds } : {}),
+        })),
+      );
+    }
+    return rows;
   }
 
   async requestGenerationForUser(params: RequestAgentGenerationParams): Promise<AgentOutputRow[]> {

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -210,6 +210,14 @@ export interface AgentOutputListResult {
   nextCursor: string | null;
 }
 
+export interface AgentUserConfigWithOwner {
+  userId: string;
+  name: string;
+  email: string | null;
+  authRole: string;
+  config: AgentUserConfig;
+}
+
 function withRefs(item: AgentOutputItemRow): AgentStoredItemRow {
   return {
     ...item,
@@ -232,6 +240,47 @@ export interface UpsertAgentConfigPatch {
  * `agent_key` so multiple agents share the same tables without cross-contamination.
  */
 export function createAgentOutputRepository(db: Kysely<DB>) {
+  async function outputWithItems(output: AgentOutputRow): Promise<AgentOutputWithItems> {
+    const items = await db
+      .selectFrom("agent_output_items")
+      .selectAll()
+      .where("agent_output_id", "=", output.id)
+      .orderBy("section_key", "asc")
+      .orderBy("sort_order", "asc")
+      .execute();
+    return {
+      output,
+      masthead: parseJson<AgentMasthead>(output.masthead_json),
+      items: items.map(withRefs),
+    };
+  }
+
+  async function outputsWithItems(rows: AgentOutputRow[]): Promise<AgentOutputWithItems[]> {
+    const ids = rows.map((row) => row.id);
+    const itemRows =
+      ids.length === 0
+        ? []
+        : await db
+            .selectFrom("agent_output_items")
+            .selectAll()
+            .where("agent_output_id", "in", ids)
+            .orderBy("agent_output_id", "asc")
+            .orderBy("section_key", "asc")
+            .orderBy("sort_order", "asc")
+            .execute();
+    const itemsByOutput = new Map<string, AgentStoredItemRow[]>();
+    for (const item of itemRows) {
+      const items = itemsByOutput.get(item.agent_output_id) ?? [];
+      items.push(withRefs(item));
+      itemsByOutput.set(item.agent_output_id, items);
+    }
+    return rows.map((output) => ({
+      output,
+      masthead: parseJson<AgentMasthead>(output.masthead_json),
+      items: itemsByOutput.get(output.id) ?? [],
+    }));
+  }
+
   return {
     async getConfig(agentKey: string, userId: string): Promise<AgentUserConfig> {
       const row = await db
@@ -243,17 +292,49 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
       return toConfig(row);
     },
 
-    async findFirstAdminConfigOwner(agentKey: string): Promise<string | null> {
-      const row = await db
+    async listHumanConfigs(agentKey: string): Promise<AgentUserConfigWithOwner[]> {
+      const rows = await db
         .selectFrom("agent_user_configs as c")
         .innerJoin("users as u", "u.id", "c.user_id")
-        .select(["c.user_id as userId"])
+        .select([
+          "c.agent_key as agentKey",
+          "c.user_id as userId",
+          "c.enabled as enabled",
+          "c.schedule_hour as scheduleHour",
+          "c.schedule_minute as scheduleMinute",
+          "c.timezone as timezone",
+          "c.max_items_per_section as maxItemsPerSection",
+          "c.prefs_json as prefsJson",
+          "c.created_at as createdAt",
+          "c.updated_at as updatedAt",
+          "u.name as name",
+          "u.email as email",
+          "u.auth_role as authRole",
+        ])
         .where("c.agent_key", "=", agentKey)
-        .where("u.auth_role", "=", "admin")
+        .where("u.type", "=", "human")
         .orderBy("c.created_at", "asc")
         .orderBy("c.user_id", "asc")
-        .executeTakeFirst();
-      return row?.userId ?? null;
+        .execute();
+
+      return rows.map((row) => ({
+        userId: row.userId,
+        name: row.name,
+        email: row.email,
+        authRole: row.authRole,
+        config: toConfig({
+          agent_key: row.agentKey,
+          user_id: row.userId,
+          enabled: row.enabled,
+          schedule_hour: row.scheduleHour,
+          schedule_minute: row.scheduleMinute,
+          timezone: row.timezone,
+          max_items_per_section: row.maxItemsPerSection,
+          prefs_json: row.prefsJson,
+          created_at: row.createdAt,
+          updated_at: row.updatedAt,
+        }),
+      }));
     },
 
     async upsertConfig(
@@ -522,6 +603,18 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
       };
     },
 
+    async getByIdForHumanUser(agentKey: string, id: string): Promise<AgentOutputWithItems | null> {
+      const output = await db
+        .selectFrom("agent_outputs as o")
+        .innerJoin("users as u", "u.id", "o.user_id")
+        .selectAll("o")
+        .where("o.agent_key", "=", agentKey)
+        .where("o.id", "=", id)
+        .where("u.type", "=", "human")
+        .executeTakeFirst();
+      return output ? outputWithItems(output) : null;
+    },
+
     async listCompletedForUser(
       agentKey: string,
       userId: string,
@@ -585,6 +678,79 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
         })),
         nextCursor: rows.length > limit ? (visibleRows[visibleRows.length - 1]?.id ?? null) : null,
       };
+    },
+
+    async listCompletedForHumanUsers(
+      agentKey: string,
+      options: { limit?: number; cursor?: string | null } = {},
+    ): Promise<AgentOutputListResult> {
+      const limit = Math.max(1, Math.min(options.limit ?? 20, 50));
+      let query = db
+        .selectFrom("agent_outputs as o")
+        .innerJoin("users as u", "u.id", "o.user_id")
+        .selectAll("o")
+        .where("o.agent_key", "=", agentKey)
+        .where("o.status", "=", "completed")
+        .where("u.type", "=", "human");
+
+      if (options.cursor) {
+        const cursorRow = await db
+          .selectFrom("agent_outputs")
+          .selectAll()
+          .where("agent_key", "=", agentKey)
+          .where("id", "=", options.cursor)
+          .executeTakeFirst();
+        if (cursorRow?.generated_at) {
+          query = query.where((eb) =>
+            eb.or([
+              eb("o.generated_at", "<", cursorRow.generated_at),
+              eb.and([eb("o.generated_at", "=", cursorRow.generated_at), eb("o.id", "<", cursorRow.id)]),
+            ]),
+          );
+        }
+      }
+
+      const rows = await query
+        .orderBy("o.generated_at", "desc")
+        .orderBy("o.id", "desc")
+        .limit(limit + 1)
+        .execute();
+      const visibleRows = rows.slice(0, limit);
+      return {
+        outputs: await outputsWithItems(visibleRows),
+        nextCursor: rows.length > limit ? (visibleRows[visibleRows.length - 1]?.id ?? null) : null,
+      };
+    },
+
+    async findLatestCompletedAcrossHumanUsers(
+      agentKey: string,
+      outputDate: string,
+    ): Promise<AgentOutputWithItems | null> {
+      const output = await db
+        .selectFrom("agent_outputs as o")
+        .innerJoin("users as u", "u.id", "o.user_id")
+        .selectAll("o")
+        .where("o.agent_key", "=", agentKey)
+        .where("o.output_date", "=", outputDate)
+        .where("o.status", "=", "completed")
+        .where("u.type", "=", "human")
+        .orderBy("o.generated_at", "desc")
+        .orderBy("o.id", "desc")
+        .executeTakeFirst();
+      return output ? outputWithItems(output) : null;
+    },
+
+    async findRunningAcrossHumanUsers(agentKey: string, outputDate: string): Promise<AgentOutputRow | undefined> {
+      return db
+        .selectFrom("agent_outputs as o")
+        .innerJoin("users as u", "u.id", "o.user_id")
+        .selectAll("o")
+        .where("o.agent_key", "=", agentKey)
+        .where("o.output_date", "=", outputDate)
+        .where("o.status", "=", "running")
+        .where("u.type", "=", "human")
+        .orderBy("o.created_at", "desc")
+        .executeTakeFirst();
     },
 
     async completeOutput(params: {

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -243,6 +243,19 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
       return toConfig(row);
     },
 
+    async findFirstAdminConfigOwner(agentKey: string): Promise<string | null> {
+      const row = await db
+        .selectFrom("agent_user_configs as c")
+        .innerJoin("users as u", "u.id", "c.user_id")
+        .select(["c.user_id as userId"])
+        .where("c.agent_key", "=", agentKey)
+        .where("u.auth_role", "=", "admin")
+        .orderBy("c.created_at", "asc")
+        .orderBy("c.user_id", "asc")
+        .executeTakeFirst();
+      return row?.userId ?? null;
+    },
+
     async upsertConfig(
       agentKey: string,
       userId: string,

--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -387,6 +387,11 @@ function SummariserIndex({
                     {input.extra > 0 ? (
                       <span className="shrink-0 text-[11px] text-muted-foreground">+{input.extra}</span>
                     ) : null}
+                    {route.owner ? (
+                      <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10.5px] text-muted-foreground">
+                        {route.owner.name}
+                      </span>
+                    ) : null}
                   </span>
                   <span className="text-[12px] text-muted-foreground">{deliversLabel(route)}</span>
                   <span className="w-16 text-right text-[12px] tabular-nums text-muted-foreground">

--- a/packages/web/src/components/agents/agent-roster.tsx
+++ b/packages/web/src/components/agents/agent-roster.tsx
@@ -176,6 +176,11 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
                   {input.extra > 0 ? (
                     <span className="shrink-0 text-[11px] text-muted-foreground">+{input.extra}</span>
                   ) : null}
+                  {route.owner ? (
+                    <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10.5px] text-muted-foreground">
+                      {route.owner.name}
+                    </span>
+                  ) : null}
                   <span className="shrink-0 text-[11.5px] text-muted-foreground">→ {deliversLabel(route)}</span>
                 </Link>
                 <Switch

--- a/packages/web/src/components/agents/summariser-config.tsx
+++ b/packages/web/src/components/agents/summariser-config.tsx
@@ -155,7 +155,7 @@ function SummariserContent({
             ) : null}
           </div>
           <p className="mt-1 text-[13px] text-muted-foreground">
-            Summariser · delivers {deliversLabel(route).toLowerCase()}
+            Summariser{route.owner ? ` · ${route.owner.name}` : ""} · delivers {deliversLabel(route).toLowerCase()}
           </p>
         </div>
         <span className="flex shrink-0 items-center gap-2 text-[12px] font-medium text-muted-foreground">

--- a/packages/web/src/components/agents/summariser-shared.tsx
+++ b/packages/web/src/components/agents/summariser-shared.tsx
@@ -154,6 +154,7 @@ export function useSourceOptions(agent: AgentConfig) {
 }
 
 export interface RouteDraftController {
+  routeId: string | null;
   sources: AgentSourceKey[];
   destKind: AgentRouteDestination["kind"];
   memberUserId: string | null;
@@ -266,6 +267,7 @@ export function useRouteDraft(agent: AgentConfig, route: AgentRoute | null): Rou
   };
 
   return {
+    routeId: route?.id ?? null,
     sources,
     destKind,
     memberUserId,
@@ -337,8 +339,8 @@ export function DestinationField({
   const slackDmSupported = agent.sourceConfig?.supportsSlackChannels ?? false;
 
   const slackMemberQuery = useQuery({
-    queryKey: ["route-members", agentKey, controller.sources],
-    queryFn: () => api.agents.routeMembers(agentKey, controller.sources),
+    queryKey: ["route-members", agentKey, controller.routeId, controller.sources],
+    queryFn: () => api.agents.routeMembers(agentKey, controller.sources, controller.routeId),
     enabled: activeTab === "dm" && dmPlatform === "slack" && slackDmSupported && controller.sources.length > 0,
   });
   const whatsappMemberQuery = useQuery({

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1117,6 +1117,12 @@ export interface AgentRoute {
   schedule: AgentRouteSchedule | null;
   destination: AgentRouteDestination;
   enabled: boolean;
+  owner?: {
+    userId: string;
+    name: string;
+    email: string | null;
+    authRole: string;
+  };
 }
 
 export interface AgentRouteMember {
@@ -1321,10 +1327,10 @@ export const api = {
         body: JSON.stringify(patch),
       });
     },
-    routeMembers(agentKey: string, sources: AgentSourceKey[]) {
+    routeMembers(agentKey: string, sources: AgentSourceKey[], routeId?: string | null) {
       return request<{ members: AgentRouteMember[] }>(`/api/agents/${agentKey}/route-members`, {
         method: "POST",
-        body: JSON.stringify({ sources }),
+        body: JSON.stringify({ sources, ...(routeId ? { routeId } : {}) }),
       });
     },
     whatsappDmMembers(agentKey: string) {


### PR DESCRIPTION
## Summary
- Show organization admins an aggregate Summarizer view containing every human user's Summarizer routes, whether created by admins or members.
- Keep member users self-scoped so they only see their own Summarizer config.
- Preserve route ownership with server-generated owner-prefixed route ids, so admin edits/toggles/runs write back to the route owner's config; new admin-created routes are stored under the acting admin.

## Linear Scope
- Linear: SKE-269, "Share Summarizer config across organization admins".
- Problem: Summarizer config was scoped to the creator user, so another admin could not see or manage org Summarizer routes in Sketch.

## Implementation Details
- Added repository helpers for listing human-owned Summarizer configs and aggregating human-owned outputs.
- Added viewer-aware Summarizer service methods for config views, config updates, route-member lookup, outputs, output detail, and manual runs.
- Added owner metadata to route responses and updated the Summarizer UI to display compact owner labels and include route ids in route-member lookup requests.
- Left non-Summarizer agents and member Summarizer views on existing self-scoped behavior.
- Removed the earlier first-admin-owner fallback so there is no dormant path with stale shared-owner semantics.

## Verification
- `npx -y -p node@24 -c 'pnpm biome check'` - passed.
- `npx -y -p node@24 -c 'pnpm --filter @sketch/server exec vitest run src/agents/service.isolated.test.ts src/agents/routes.test.ts --project unit --project unit-isolated --passWithNoTests'` - passed, 74 tests.
- `npx -y -p node@24 -c 'pnpm typecheck'` - passed.
- `npx -y -p node@24 -c 'pnpm test'` - passed. Server: 242 files / 3060 tests. Web: 43 files / 316 tests.
- `npx -y -p node@24 -c 'pnpm build'` - passed.
- Pre-push hook reran Biome, typecheck, full tests, and build successfully.
- Live API smoke on the QA DB: `codex-admin-b@example.test` sees 3 routes owned by Tanush Yadav, Codex Member Own Config, and Maya Patel; `maya.ui-seed@sketch.local` sees only 1 self-owned route.

## Risk / Rollout
- No schema migration.
- Admin aggregate route ids are synthetic `org:` ids; future route-level UI/API work must preserve them until the server decodes ownership.
- Existing build warnings remain unrelated: tsdown `define` option warnings and Vite chunk-size warning.
