### PR TITLE
SKE-277: Fix managed member invite lifecycle after removal

### DIFF
--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -383,6 +383,18 @@ describe("Users API — agent fields", () => {
     });
     expect(create.status).toBe(201);
     const user = (await create.json()).user;
+    const connectorCredentials = JSON.stringify({ apiKey: "fireflies-test-key" });
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "managed-delete-failure-connector",
+        connector_type: "fireflies",
+        auth_type: "api_key",
+        credentials: connectorCredentials,
+        created_by: user.id,
+        sync_status: "active",
+      })
+      .execute();
 
     const res = await managedApp.request(`/api/users/${user.id}`, {
       method: "DELETE",
@@ -398,6 +410,18 @@ describe("Users API — agent fields", () => {
     });
     await expect(createUserRepository(db).findById(user.id)).resolves.toMatchObject({
       email: "managed.delete.failure@gmail.com",
+    });
+    await expect(
+      db
+        .selectFrom("connector_configs")
+        .select(["sync_status", "credentials", "credential_hint", "error_message"])
+        .where("id", "=", "managed-delete-failure-connector")
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({
+      sync_status: "active",
+      credentials: connectorCredentials,
+      credential_hint: null,
+      error_message: null,
     });
     fetchMock.mockRestore();
   });

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -300,6 +300,108 @@ describe("Users API — agent fields", () => {
     fetchMock.mockRestore();
   });
 
+  it("removes managed tenant members before deleting local human users", async () => {
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const create = await managedApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Managed Delete",
+        type: "human",
+        email: "managed.delete@gmail.com",
+        whatsappNumber: "+14155550110",
+      }),
+    });
+    expect(create.status).toBe(201);
+    const user = (await create.json()).user;
+
+    const res = await managedApp.request(`/api/users/${user.id}`, {
+      method: "DELETE",
+      headers: { Cookie: managedCookie },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://platform.test/api/tenant/members/managed.delete%40gmail.com",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          Authorization: "Bearer tenant-token",
+        }),
+      }),
+    );
+    await expect(createUserRepository(db).findById(user.id)).resolves.toBeUndefined();
+    fetchMock.mockRestore();
+  });
+
+  it("keeps local human users when managed tenant member removal fails", async () => {
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { code: "REMOVE_FAILED", message: "Could not remove managed member" } }), {
+          status: 502,
+        }),
+      );
+
+    const create = await managedApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Managed Delete Failure",
+        type: "human",
+        email: "managed.delete.failure@gmail.com",
+        whatsappNumber: "+14155550111",
+      }),
+    });
+    expect(create.status).toBe(201);
+    const user = (await create.json()).user;
+
+    const res = await managedApp.request(`/api/users/${user.id}`, {
+      method: "DELETE",
+      headers: { Cookie: managedCookie },
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "MANAGED_MEMBER_REGISTRATION_FAILED",
+        message: "Could not remove managed member",
+      },
+    });
+    await expect(createUserRepository(db).findById(user.id)).resolves.toMatchObject({
+      email: "managed.delete.failure@gmail.com",
+    });
+    fetchMock.mockRestore();
+  });
+
   it("rejects WhatsApp numbers without an international country code", async () => {
     const res = await app.request("/api/users", {
       method: "POST",

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -24,7 +24,11 @@ import type { createUserRepository } from "../db/repositories/users";
 import type { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
 import { createEmailTransport, sendVerificationEmail } from "../email";
-import { ManagedMemberRegistrationError, type ManagedMemberRegistrationInput } from "../managed-members";
+import {
+  ManagedMemberRegistrationError,
+  type ManagedMemberRegistrationInput,
+  type ManagedMemberRemovalInput,
+} from "../managed-members";
 import type { SlackBot } from "../slack/bot";
 
 import { getSmtpConfig, resolveBaseUrl } from "./shared";
@@ -44,6 +48,7 @@ interface UserRoutesDeps {
   whatsappGroups?: WhatsAppGroupRepo;
   getSlack?: () => SlackBot | null;
   registerManagedMember?: (input: ManagedMemberRegistrationInput) => Promise<unknown>;
+  removeManagedMember?: (input: ManagedMemberRemovalInput) => Promise<unknown>;
 }
 
 const allowedToolsSchema = z.array(z.string().refine(isKnownAgentToolName, "Unknown tool name")).nullable().optional();
@@ -813,6 +818,15 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     const result = await createConnectorRepository(deps.db, deps.config.ENCRYPTION_KEY).archiveConnectorsForOwner(id);
     if (result.archived > 0) {
       deps.logger.info({ userId: id, count: result.archived }, "Archived connectors after user removal");
+    }
+
+    if (existing.type === "human" && existing.email && deps.removeManagedMember) {
+      try {
+        await deps.removeManagedMember({ email: existing.email });
+      } catch (err) {
+        const response = managedRegistrationResponse(err);
+        return c.json(response.body, response.status as 400);
+      }
     }
 
     await users.remove(id);

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -810,16 +810,6 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
       return c.json({ error: { code: "FORBIDDEN", message: "Cannot delete your own account" } }, 403);
     }
 
-    // Archive any per-user connectors (Fireflies etc.) before removing the user.
-    // Scrubs credentials and disables future syncs; leaves indexed_files intact so
-    // other attendees still see previously-synced meetings via file_access.
-    // Fail-noisy: if archival throws we let the 500 surface so the admin retries
-    // rather than silently leaving credentials in DB after the user row is gone.
-    const result = await createConnectorRepository(deps.db, deps.config.ENCRYPTION_KEY).archiveConnectorsForOwner(id);
-    if (result.archived > 0) {
-      deps.logger.info({ userId: id, count: result.archived }, "Archived connectors after user removal");
-    }
-
     if (existing.type === "human" && existing.email && deps.removeManagedMember) {
       try {
         await deps.removeManagedMember({ email: existing.email });
@@ -827,6 +817,14 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
         const response = managedRegistrationResponse(err);
         return c.json(response.body, response.status as 400);
       }
+    }
+
+    // Archive any per-user connectors (Fireflies etc.) only after managed
+    // membership cleanup succeeds, so a transient platform failure leaves the
+    // local user and their integrations unchanged.
+    const result = await createConnectorRepository(deps.db, deps.config.ENCRYPTION_KEY).archiveConnectorsForOwner(id);
+    if (result.archived > 0) {
+      deps.logger.info({ userId: id, count: result.archived }, "Archived connectors after user removal");
     }
 
     await users.remove(id);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -72,7 +72,7 @@ import type { IntegrationProvider } from "./integrations/types";
 import { createLocalClaudeEventDispatcher } from "./local-devices/claude-event-dispatcher";
 import type { LocalClaudeSessionService } from "./local-devices/claude-sessions";
 import type { LocalDeviceGateway } from "./local-devices/gateway";
-import { registerManagedTenantMember } from "./managed-members";
+import { registerManagedTenantMember, removeManagedTenantMember } from "./managed-members";
 import { createManagedLoginUrl } from "./managed-url";
 import { mcpOAuthRoutes } from "./mcp/oauth/routes";
 import { mountPublicMcpServer } from "./mcp/server/transport";
@@ -349,6 +349,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       whatsappGroups,
       getSlack: deps?.getSlack,
       registerManagedMember: (input) => registerManagedTenantMember(config, input),
+      removeManagedMember: (input) => removeManagedTenantMember(config, input),
     }),
   );
   app.route(

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -8,6 +8,10 @@ export interface ManagedMemberRegistrationInput {
   sendInvite?: boolean;
 }
 
+export interface ManagedMemberRemovalInput {
+  email: string;
+}
+
 export interface ManagedMemberRegistrationResult {
   registered: boolean;
   emailSent?: boolean;
@@ -88,4 +92,36 @@ export async function registerManagedTenantMember(
     emailSent,
     whatsappSent,
   };
+}
+
+export async function removeManagedTenantMember(
+  config: Config,
+  input: ManagedMemberRemovalInput,
+  requestFetch: typeof fetch = fetch,
+): Promise<{ removed: boolean }> {
+  if (!shouldRegisterManagedMembers(config)) return { removed: false };
+
+  const platformUrl = managedPlatformUrl(config);
+  if (!platformUrl || !config.MANAGED_WHATSAPP_TENANT_TOKEN) {
+    throw new ManagedMemberRegistrationError(503, "UNCONFIGURED", "Managed member registration is not configured");
+  }
+
+  const email = input.email.trim().toLowerCase();
+  const response = await requestFetch(
+    `${platformUrl.replace(/\/+$/u, "")}/api/tenant/members/${encodeURIComponent(email)}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${config.MANAGED_WHATSAPP_TENANT_TOKEN}`,
+      },
+    },
+  );
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = errorFromBody(body);
+    throw new ManagedMemberRegistrationError(response.status, error.code, error.message);
+  }
+
+  return { removed: true };
 }


### PR DESCRIPTION
## Summary

- Fixes the Sketch side of the managed member lifecycle bug after member removal.
- Sketch now unregisters the platform tenant member before deleting a local human user.
- Local deletion is blocked if platform cleanup fails, preventing local/platform membership drift.
- Review follow-up: connector archival now runs only after platform cleanup succeeds, so failed managed removal leaves the user's integrations unchanged.

## Linear Scope

SKE-277: Fix managed member invite lifecycle after removal.

## Implementation Details

- Added `removeManagedTenantMember()` client support for `DELETE /api/tenant/members/:email`.
- Wired the Sketch HTTP app to pass `removeManagedMember` into user routes.
- The `DELETE /api/users/:id` path now disables platform tenant membership first, then archives owned connectors, then removes the local user.
- Added regression tests for successful platform cleanup on delete, failed platform cleanup preserving the local user, and failed platform cleanup preserving connector credentials/status.

## Verification

- Red check: focused `users.test.ts` regression failed before the route-order fix because the connector was already disabled/scrubbed.
- `pnpm exec vitest run src/api/users.test.ts -t "keeps local human users when managed tenant member removal fails"` - passed.
- `pnpm exec vitest run src/api/users.test.ts` - passed.
- `pnpm lint` - passed.
- `pnpm typecheck` - passed.
- Pre-push hook: lint, typecheck, root tests, build - passed.

## Risk / Rollout

- Deleting a managed human member now depends on the platform API when managed tenant registration is configured.
- If platform cleanup fails, the admin sees an error and the local member plus their integrations remain unchanged.
- Existing platform rows created before this patch may still need a one-time cleanup/backfill.
