### PR TITLE
ci: one-click release cut, beta builds, and version reporting

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -1,0 +1,75 @@
+# Requires OIDC trust for refs/heads/* and an ECR lifecycle policy that expires beta-* images after 30 days.
+name: Beta Docker Build
+
+on:
+  push:
+    branches-ignore:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Guard non-main branch
+        run: |
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            echo "Beta builds are only allowed on non-main branches." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          aws-region: ap-south-1
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Compute beta tag
+        id: beta-tag
+        run: |
+          branch="$GITHUB_REF_NAME"
+          short_sha="${GITHUB_SHA::12}"
+          sanitized="$(printf '%s' "$branch" | sed -E 's/[^a-zA-Z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+          if [[ -z "$sanitized" ]]; then
+            sanitized="branch"
+          fi
+
+          max_branch_length=$((128 - 5 - 1 - ${#short_sha}))
+          sanitized="${sanitized:0:$max_branch_length}"
+          sanitized="$(printf '%s' "$sanitized" | sed -E 's/[.-]+$//')"
+          if [[ -z "$sanitized" ]]; then
+            sanitized="branch"
+          fi
+
+          tag="beta-${sanitized}-${short_sha}"
+          if (( ${#tag} > 128 )); then
+            echo "Computed Docker tag is too long: ${#tag} characters" >&2
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push beta image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.ecr-login.outputs.registry }}/sketch:${{ steps.beta-tag.outputs.tag }}
+          build-args: |
+            APP_VERSION=${{ steps.beta-tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -2,9 +2,6 @@
 name: Beta Docker Build
 
 on:
-  push:
-    branches-ignore:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -18,6 +15,11 @@ jobs:
     steps:
       - name: Guard non-main branch
         run: |
+          if [[ "$GITHUB_REF" != refs/heads/* ]]; then
+            echo "Beta builds are only allowed on branch refs. Current ref: $GITHUB_REF" >&2
+            exit 1
+          fi
+
           if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             echo "Beta builds are only allowed on non-main branches." >&2
             exit 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to rebuild and push, e.g. v0.46.0"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -15,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -26,9 +34,23 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Resolve release tag
+        id: release-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.tag }}"
+            git checkout "refs/tags/$tag"
+          else
+            tag="$GITHUB_REF_NAME"
+          fi
+
+          if [[ "$tag" != v* ]]; then
+            echo "Release tag must start with v: $tag" >&2
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -39,7 +61,9 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.ecr-login.outputs.registry }}/sketch:${{ steps.version.outputs.VERSION }}
+            ${{ steps.ecr-login.outputs.registry }}/sketch:${{ steps.release-tag.outputs.version }}
             ${{ steps.ecr-login.outputs.registry }}/sketch:latest
+          build-args: |
+            APP_VERSION=${{ steps.release-tag.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,29 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
+      - name: Resolve release tag
+        id: release-tag
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$DISPATCH_TAG"
+          else
+            tag="$GITHUB_REF_NAME"
+          fi
+
+          if [[ ! "$tag" =~ ^v[0-9] ]]; then
+            echo "Release tag must match ^v[0-9]: $tag" >&2
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ steps.release-tag.outputs.tag }}
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -33,24 +53,6 @@ jobs:
       - name: Login to Amazon ECR
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Resolve release tag
-        id: release-tag
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            tag="${{ inputs.tag }}"
-            git checkout "refs/tags/$tag"
-          else
-            tag="$GITHUB_REF_NAME"
-          fi
-
-          if [[ "$tag" != v* ]]; then
-            echo "Release tag must start with v: $tag" >&2
-            exit 1
-          fi
-
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,0 +1,461 @@
+# Source of truth: the git tag is canonical; package versions, image tag, APP_VERSION, and /api/health derive from this workflow.
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump to apply from the latest v* tag"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+      dry_run:
+        description: "Preview the release version and changelog without mutating main"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: release-cut
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release:
+    name: Cut release
+    runs-on: ubuntu-latest
+    outputs:
+      dry_run: ${{ steps.mode.outputs.dry_run }}
+      tag: ${{ steps.next-version.outputs.tag }}
+      version: ${{ steps.next-version.outputs.version }}
+
+    steps:
+      - name: Guard main branch
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Release cuts must run from main. Current ref: $GITHUB_REF" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve run mode
+        id: mode
+        run: echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version and preflight tag
+        id: next-version
+        run: |
+          git fetch --tags --force
+
+          latest_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+          if [[ -z "$latest_tag" ]]; then
+            current_version="0.0.0"
+          else
+            current_version="${latest_tag#v}"
+          fi
+
+          IFS=. read -r major minor patch <<< "$current_version"
+          if [[ -z "${major:-}" || -z "${minor:-}" || -z "${patch:-}" ]]; then
+            echo "Latest tag $latest_tag does not look like vX.Y.Z" >&2
+            exit 1
+          fi
+
+          case "${{ inputs.bump }}" in
+            patch)
+              patch=$((patch + 1))
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            *)
+              echo "Unsupported bump type: ${{ inputs.bump }}" >&2
+              exit 1
+              ;;
+          esac
+
+          version="${major}.${minor}.${patch}"
+          tag="v${version}"
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists. Refusing to continue." >&2
+            exit 1
+          fi
+
+          {
+            echo "latest_tag=$latest_tag"
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "date=$(date -u +%F)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Collect changelog source
+        id: changelog-source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LATEST_TAG: ${{ steps.next-version.outputs.latest_tag }}
+        run: |
+          mkdir -p .release
+          : > .release/prs.raw.jsonl
+          : > .release/direct.jsonl
+
+          if [[ -z "$LATEST_TAG" ]]; then
+            range="HEAD"
+          else
+            range="${LATEST_TAG}..HEAD"
+          fi
+
+          while IFS= read -r sha; do
+            [[ -z "$sha" ]] && continue
+            prs_json="$(gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls")"
+            if [[ "$(jq 'length' <<< "$prs_json")" -gt 0 ]]; then
+              jq -c '.[0] | {number, title, body: (.body // ""), url: .html_url}' <<< "$prs_json" >> .release/prs.raw.jsonl
+            else
+              subject="$(git log -1 --format=%s "$sha")"
+              jq -cn --arg sha "$sha" --arg subject "$subject" '{sha: $sha, subject: $subject}' >> .release/direct.jsonl
+            fi
+          done < <(git rev-list --reverse "$range")
+
+          jq -s 'unique_by(.number)[]' .release/prs.raw.jsonl > .release/prs.jsonl
+
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const limit = 50000;
+          const readJsonl = (path) =>
+            fs
+              .readFileSync(path, "utf8")
+              .split("\n")
+              .filter(Boolean)
+              .map((line) => JSON.parse(line));
+
+          const prs = readJsonl(".release/prs.jsonl");
+          const directCommits = readJsonl(".release/direct.jsonl");
+          const rawBullets = [
+            ...prs.map((pr) => `- #${pr.number}: ${pr.title}`),
+            ...directCommits.map((commit) => `- ${commit.subject} (${commit.sha.slice(0, 7)})`),
+          ];
+          const rawNotes = rawBullets.length > 0 ? rawBullets.join("\n") : "- No merged PRs or direct commits since the last release tag.";
+          fs.writeFileSync(".release/raw-notes.md", `${rawNotes}\n`);
+
+          const baseLines = [
+            "Merged pull requests since the last release tag:",
+            ...(prs.length > 0 ? prs.map((pr) => `- #${pr.number}: ${pr.title}`) : ["- None"]),
+            "",
+            "Direct commits since the last release tag:",
+            ...(directCommits.length > 0
+              ? directCommits.map((commit) => `- ${commit.subject} (${commit.sha.slice(0, 7)})`)
+              : ["- None"]),
+            "",
+            "Pull request bodies:",
+          ];
+
+          let remaining = limit - baseLines.join("\n").length - 500;
+          let truncated = false;
+          const bodyLines = [];
+
+          for (const pr of prs) {
+            bodyLines.push(`### PR #${pr.number}: ${pr.title}`);
+            const body = String(pr.body ?? "").trim();
+            if (body.length === 0) {
+              bodyLines.push("Body: (empty)");
+              continue;
+            }
+            if (remaining <= 0) {
+              bodyLines.push("Body: (omitted because the changelog source reached the 50000 character cap)");
+              truncated = true;
+              continue;
+            }
+            const prefix = "Body:\n";
+            const allowed = Math.max(0, remaining - prefix.length - 2);
+            const selected = body.length > allowed ? body.slice(0, allowed) : body;
+            bodyLines.push(`${prefix}${selected}`);
+            remaining -= prefix.length + selected.length + 2;
+            if (selected.length < body.length) truncated = true;
+          }
+
+          fs.writeFileSync(".release/changelog-input.md", `${[...baseLines, ...bodyLines].join("\n")}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `truncated=${truncated}\n`);
+          NODE
+
+      - name: Generate changelog entry
+        id: changelog
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          awk 'BEGIN { seen = 0 } /^## \[/ { seen++; if (seen > 3) exit } seen > 0 { print }' CHANGELOG.md > .release/changelog-examples.md
+
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const models = ["xiaomi/mimo-v2.5-pro", "deepseek/deepseek-v4-pro"];
+          const apiKey = process.env.OPENROUTER_API_KEY;
+          const input = fs.readFileSync(".release/changelog-input.md", "utf8");
+          const examples = fs.readFileSync(".release/changelog-examples.md", "utf8");
+          const fallback = fs.readFileSync(".release/raw-notes.md", "utf8").trim();
+          const errors = [];
+
+          async function generate(model) {
+            const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+                "HTTP-Referer": `https://github.com/${process.env.GITHUB_REPOSITORY}`,
+                "X-Title": "Sketch release changelog",
+              },
+              body: JSON.stringify({
+                model,
+                temperature: 0.2,
+                messages: [
+                  {
+                    role: "system",
+                    content:
+                      "Write concise release changelog notes for Sketch. Return markdown bullets only, no heading, no intro, no code fence. Match the style of the examples.",
+                  },
+                  {
+                    role: "user",
+                    content: `Recent CHANGELOG examples:\n\n${examples}\n\nSource material for this release:\n\n${input}`,
+                  },
+                ],
+              }),
+            });
+
+            if (!response.ok) {
+              const detail = await response.text();
+              throw new Error(`${response.status} ${response.statusText}: ${detail.slice(0, 500)}`);
+            }
+
+            const json = await response.json();
+            const content = json?.choices?.[0]?.message?.content?.trim();
+            if (!content) throw new Error("empty response content");
+            return content;
+          }
+
+          async function main() {
+            let entry = "";
+            let modelUsed = "";
+
+            if (!apiKey) {
+              errors.push("OPENROUTER_API_KEY is missing");
+            } else {
+              for (const model of models) {
+                try {
+                  entry = await generate(model);
+                  modelUsed = model;
+                  break;
+                } catch (error) {
+                  errors.push(`${model}: ${error instanceof Error ? error.message : String(error)}`);
+                }
+              }
+            }
+
+            const usedFallback = entry.length === 0;
+            if (usedFallback) {
+              entry = fallback;
+              process.stderr.write("::warning title=Changelog fallback::OpenRouter changelog generation failed for all configured models; using raw PR titles.\n");
+            }
+
+            fs.writeFileSync(".release/changelog.md", `${entry.trim()}\n`);
+            fs.writeFileSync(".release/changelog-errors.txt", `${errors.join("\n")}\n`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `used_fallback=${usedFallback}\n`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `model=${modelUsed}\n`);
+          }
+
+          main().catch((error) => {
+            process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+            process.exit(1);
+          });
+          NODE
+
+      - name: Write release summary
+        env:
+          VERSION: ${{ steps.next-version.outputs.version }}
+          TAG: ${{ steps.next-version.outputs.tag }}
+          LATEST_TAG: ${{ steps.next-version.outputs.latest_tag }}
+          DATE: ${{ steps.next-version.outputs.date }}
+          TRUNCATED: ${{ steps.changelog-source.outputs.truncated }}
+          USED_FALLBACK: ${{ steps.changelog.outputs.used_fallback }}
+          MODEL: ${{ steps.changelog.outputs.model }}
+        run: |
+          {
+            if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+              echo "## Release dry run"
+            else
+              echo "## Release cut"
+            fi
+            echo ""
+            echo "- Previous tag: ${LATEST_TAG:-none}"
+            echo "- Next tag: ${TAG}"
+            echo "- Version: ${VERSION}"
+            echo "- Date: ${DATE}"
+            if [[ "$TRUNCATED" == "true" ]]; then
+              echo "- Changelog source: truncated PR bodies to stay near the 50000 character cap"
+            else
+              echo "- Changelog source: not truncated"
+            fi
+            if [[ "$USED_FALLBACK" == "true" ]]; then
+              echo "- WARNING: OpenRouter changelog generation failed; raw PR-title notes were used"
+              echo ""
+              echo "### OpenRouter errors"
+              echo '```'
+              cat .release/changelog-errors.txt
+              echo '```'
+            else
+              echo "- Changelog model: ${MODEL}"
+            fi
+            echo ""
+            echo "### Changelog entry"
+            cat .release/changelog.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply release changes
+        if: ${{ inputs.dry_run == false }}
+        env:
+          VERSION: ${{ steps.next-version.outputs.version }}
+          TAG: ${{ steps.next-version.outputs.tag }}
+          DATE: ${{ steps.next-version.outputs.date }}
+          RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+        run: |
+          if [[ -z "${RELEASE_PUSH_TOKEN:-}" ]]; then
+            echo "RELEASE_PUSH_TOKEN is required for real release cuts." >&2
+            exit 1
+          fi
+
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} appeared after preflight. Refusing to mutate main." >&2
+            exit 1
+          fi
+
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const version = process.env.VERSION;
+          const date = process.env.DATE;
+          const packages = ["packages/server/package.json", "packages/web/package.json", "packages/shared/package.json"];
+
+          for (const path of packages) {
+            const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+            pkg.version = version;
+            fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
+          }
+
+          const entry = fs.readFileSync(".release/changelog.md", "utf8").trim() || "- No changes listed.";
+          const changelog = fs.readFileSync("CHANGELOG.md", "utf8");
+          const releaseEntry = `## [${version}] -- ${date}\n\n${entry}\n\n`;
+          const firstReleaseIndex = changelog.indexOf("\n## [");
+          const nextChangelog =
+            firstReleaseIndex === -1
+              ? `${changelog.trimEnd()}\n\n${releaseEntry}`
+              : `${changelog.slice(0, firstReleaseIndex + 1)}${releaseEntry}${changelog.slice(firstReleaseIndex + 1)}`;
+          fs.writeFileSync("CHANGELOG.md", nextChangelog);
+          NODE
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md packages/server/package.json packages/web/package.json packages/shared/package.json
+          git diff --cached --quiet && {
+            echo "No release changes were produced." >&2
+            exit 1
+          }
+          git commit -m "chore: release ${TAG}"
+          git tag -a "$TAG" -m "$TAG"
+          git remote set-url origin "https://x-access-token:${RELEASE_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:main
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          TAG: ${{ steps.next-version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TAG" --notes-file .release/changelog.md
+          else
+            gh release create "$TAG" --verify-tag --title "$TAG" --notes-file .release/changelog.md
+          fi
+
+  verify:
+    name: Verify release artifacts
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ needs.release.outputs.dry_run == 'false' }}
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          aws-region: ap-south-1
+
+      - name: Verify ECR image and latest tag
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          deadline=$((SECONDS + 900))
+          version_digest=""
+
+          while (( SECONDS < deadline )); do
+            if aws ecr describe-images --repository-name sketch --image-ids "imageTag=${VERSION}" --region ap-south-1 > .version-image.json 2>/dev/null; then
+              version_digest="$(jq -r '.imageDetails[0].imageDigest // ""' .version-image.json)"
+              [[ -n "$version_digest" ]] && break
+            fi
+            sleep 20
+          done
+
+          if [[ -z "$version_digest" ]]; then
+            echo "Timed out waiting for ECR image sketch:${VERSION}" >&2
+            exit 1
+          fi
+
+          deadline=$((SECONDS + 300))
+          latest_digest=""
+          while (( SECONDS < deadline )); do
+            if aws ecr describe-images --repository-name sketch --image-ids imageTag=latest --region ap-south-1 > .latest-image.json 2>/dev/null; then
+              latest_digest="$(jq -r '.imageDetails[0].imageDigest // ""' .latest-image.json)"
+              [[ "$latest_digest" == "$version_digest" ]] && break
+            fi
+            sleep 20
+          done
+
+          if [[ "$latest_digest" != "$version_digest" ]]; then
+            echo "ECR latest did not move to the sketch:${VERSION} digest within the timeout." >&2
+            exit 1
+          fi
+
+          {
+            echo "## Release verification"
+            echo ""
+            echo "- ECR image pushed: sketch:${VERSION}"
+            echo "- ECR latest updated to the same digest"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          deadline=$((SECONDS + 300))
+          until gh release view "$TAG" >/dev/null 2>&1; do
+            if (( SECONDS >= deadline )); then
+              echo "Timed out waiting for GitHub Release ${TAG}" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+
+          echo "- GitHub Release exists: ${TAG}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -29,6 +29,10 @@ jobs:
   release:
     name: Cut release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: read
     outputs:
       dry_run: ${{ steps.mode.outputs.dry_run }}
       tag: ${{ steps.next-version.outputs.tag }}
@@ -45,6 +49,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Resolve run mode
         id: mode
@@ -206,6 +211,7 @@ jobs:
           async function generate(model) {
             const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
               method: "POST",
+              signal: AbortSignal.timeout(60000),
               headers: {
                 Authorization: `Bearer ${apiKey}`,
                 "Content-Type": "application/json",
@@ -261,9 +267,10 @@ jobs:
             const usedFallback = entry.length === 0;
             if (usedFallback) {
               entry = fallback;
-              process.stderr.write("::warning title=Changelog fallback::OpenRouter changelog generation failed for all configured models; using raw PR titles.\n");
+              process.stdout.write("::warning title=Changelog fallback::OpenRouter changelog generation failed for all configured models; using raw PR titles.\n");
             }
 
+            entry = entry.replace(/^## \[[^\r\n]*(?:\r?\n)+/, "").trim();
             fs.writeFileSync(".release/changelog.md", `${entry.trim()}\n`);
             fs.writeFileSync(".release/changelog-errors.txt", `${errors.join("\n")}\n`);
             fs.appendFileSync(process.env.GITHUB_OUTPUT, `used_fallback=${usedFallback}\n`);
@@ -323,10 +330,10 @@ jobs:
           VERSION: ${{ steps.next-version.outputs.version }}
           TAG: ${{ steps.next-version.outputs.tag }}
           DATE: ${{ steps.next-version.outputs.date }}
-          RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          HAS_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY != '' }}
         run: |
-          if [[ -z "${RELEASE_PUSH_TOKEN:-}" ]]; then
-            echo "RELEASE_PUSH_TOKEN is required for real release cuts." >&2
+          if [[ "$HAS_DEPLOY_KEY" != "true" ]]; then
+            echo "RELEASE_DEPLOY_KEY is required for real release cuts." >&2
             exit 1
           fi
 
@@ -369,14 +376,12 @@ jobs:
           }
           git commit -m "chore: release ${TAG}"
           git tag -a "$TAG" -m "$TAG"
-          git remote set-url origin "https://x-access-token:${RELEASE_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin HEAD:main
-          git push origin "$TAG"
+          git push --atomic origin HEAD:main "refs/tags/$TAG"
 
       - name: Create GitHub Release
         if: ${{ inputs.dry_run == false }}
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.next-version.outputs.tag }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -388,6 +393,7 @@ jobs:
   verify:
     name: Verify release artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: release
     if: ${{ needs.release.outputs.dry_run == 'false' }}
     permissions:
@@ -409,9 +415,14 @@ jobs:
           version_digest=""
 
           while (( SECONDS < deadline )); do
-            if aws ecr describe-images --repository-name sketch --image-ids "imageTag=${VERSION}" --region ap-south-1 > .version-image.json 2>/dev/null; then
+            if aws ecr describe-images --repository-name sketch --image-ids "imageTag=${VERSION}" --region ap-south-1 > .version-image.json 2> .version-image.err; then
               version_digest="$(jq -r '.imageDetails[0].imageDigest // ""' .version-image.json)"
               [[ -n "$version_digest" ]] && break
+            elif grep -q "ImageNotFound" .version-image.err; then
+              true
+            else
+              cat .version-image.err >&2
+              exit 1
             fi
             sleep 20
           done
@@ -424,9 +435,14 @@ jobs:
           deadline=$((SECONDS + 300))
           latest_digest=""
           while (( SECONDS < deadline )); do
-            if aws ecr describe-images --repository-name sketch --image-ids imageTag=latest --region ap-south-1 > .latest-image.json 2>/dev/null; then
+            if aws ecr describe-images --repository-name sketch --image-ids imageTag=latest --region ap-south-1 > .latest-image.json 2> .latest-image.err; then
               latest_digest="$(jq -r '.imageDetails[0].imageDigest // ""' .latest-image.json)"
               [[ "$latest_digest" == "$version_digest" ]] && break
+            elif grep -q "ImageNotFound" .latest-image.err; then
+              true
+            else
+              cat .latest-image.err >&2
+              exit 1
             fi
             sleep 20
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN pnpm --filter @sketch/server deploy --prod --legacy /app/pruned
 # ── Stage 2: Runtime ──────────────────────────────────────────────
 FROM node:24-slim AS runtime
 
-ARG APP_VERSION=dev
 ARG GH_VERSION=2.92.0
 ARG GH_ARM64_DEB_SHA256=34d620b7c884774ed86236541535170889fda0b99aafbdab8b69c7d458b5ca6b
 ARG GH_AMD64_DEB_SHA256=8f8212b1a9cec261a8839e0893168f50d3fc70f095da257feef4229234cefdf8
@@ -66,6 +65,7 @@ RUN printf '%s\n' '#!/bin/sh' 'exec /app/node_modules/.bin/md-to-pdf "$@"' > /us
 RUN mkdir -p /app/data && chown 1000:1000 /app/data
 
 ENV NODE_ENV=production
+ARG APP_VERSION=dev
 ENV SKETCH_VERSION=$APP_VERSION
 ENV PATH=/app/node_modules/.bin:$PATH
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN pnpm --filter @sketch/server deploy --prod --legacy /app/pruned
 # ── Stage 2: Runtime ──────────────────────────────────────────────
 FROM node:24-slim AS runtime
 
+ARG APP_VERSION=dev
 ARG GH_VERSION=2.92.0
 ARG GH_ARM64_DEB_SHA256=34d620b7c884774ed86236541535170889fda0b99aafbdab8b69c7d458b5ca6b
 ARG GH_AMD64_DEB_SHA256=8f8212b1a9cec261a8839e0893168f50d3fc70f095da257feef4229234cefdf8
@@ -65,6 +66,7 @@ RUN printf '%s\n' '#!/bin/sh' 'exec /app/node_modules/.bin/md-to-pdf "$@"' > /us
 RUN mkdir -p /app/data && chown 1000:1000 /app/data
 
 ENV NODE_ENV=production
+ENV SKETCH_VERSION=$APP_VERSION
 ENV PATH=/app/node_modules/.bin:$PATH
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium

--- a/packages/server/src/api/health.ts
+++ b/packages/server/src/api/health.ts
@@ -6,11 +6,12 @@ export function healthRoutes(db: Kysely<DB>) {
   const routes = new Hono();
 
   routes.get("/", async (c) => {
+    const version = process.env.SKETCH_VERSION || "dev";
     try {
       await db.selectFrom("users").select("id").limit(1).execute();
-      return c.json({ status: "ok", db: "ok", uptime: process.uptime() });
+      return c.json({ status: "ok", db: "ok", uptime: process.uptime(), version });
     } catch {
-      return c.json({ status: "error", db: "error" }, 500);
+      return c.json({ status: "error", db: "error", version }, 500);
     }
   });
 

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -30,8 +30,10 @@ async function seedAdmin(db: Kysely<DB>, email = "admin@test.com", password = "t
 
 describe("HTTP health endpoint", () => {
   let db: Kysely<DB>;
+  const originalSketchVersion = process.env.SKETCH_VERSION;
 
   beforeEach(async () => {
+    process.env.SKETCH_VERSION = "test-version";
     db = await createTestDb();
   });
 
@@ -40,6 +42,11 @@ describe("HTTP health endpoint", () => {
       await db.destroy();
     } catch {
       // Already destroyed in some tests
+    }
+    if (originalSketchVersion === undefined) {
+      Reflect.deleteProperty(process.env, "SKETCH_VERSION");
+    } else {
+      process.env.SKETCH_VERSION = originalSketchVersion;
     }
   });
 
@@ -52,6 +59,7 @@ describe("HTTP health endpoint", () => {
       const body = await res.json();
       expect(body.status).toBe("ok");
       expect(body.db).toBe("ok");
+      expect(body.version).toBe("test-version");
       expect(typeof body.uptime).toBe("number");
     });
 
@@ -65,6 +73,7 @@ describe("HTTP health endpoint", () => {
       const body = await res.json();
       expect(body.status).toBe("error");
       expect(body.db).toBe("error");
+      expect(body.version).toBe("test-version");
     });
   });
 


### PR DESCRIPTION
## What changed

- **`release-cut.yml`**: one-click release from the Actions tab (main-only, enforced). Bumps server/web/shared versions in lockstep, generates the changelog from merged PR titles/bodies via OpenRouter (MiMo v2.5 Pro with DeepSeek V4 Pro fallback; falls back to a plain PR-title list if the API fails — a release never blocks on the LLM), commits, tags atomically, creates the GitHub Release, then a verification job confirms the ECR image and Release actually exist. `dry_run` (default) previews the version + changelog in the job summary without releasing.
- **`beta-build.yml`**: manual build of any feature branch into `sketch:beta-<branch>-<sha>` for pre-merge testing on beta tenants. Never touches `latest`, refuses to run on main.
- **`docker.yml`**: adds a manual retry dispatch (tag input, validated before checkout).
- **Version reporting**: `APP_VERSION` baked into the image (`SKETCH_VERSION`), and `/api/health` now returns `version` on both success and DB-failure paths — lets the platform verify what a tenant is actually running after a deploy.

## Notes

- Release pushes authenticate with a repo-owned write deploy key (`RELEASE_DEPLOY_KEY`): pushes made with the default `GITHUB_TOKEN` do not trigger the docker/macos tag workflows, and a deploy key is not tied to any individual account.
- `packages/ui` is intentionally excluded from the release lockstep (independently versioned).
- Beta builds need two AWS-side prereqs before first use (OIDC trust for branch refs + a `beta-*` ECR lifecycle policy); noted in the workflow header.

## Validation

- `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `actionlint` — all green.
- Plan + implementation both reviewed (independent review passes); findings fixed in the final commit.
- Functional verification after merge: dry-run release cut, then the next real release is cut with this workflow.

Linear: SKE-272