### PR TITLE
fix: allow three-year Gmail sync lookback

### DIFF
--- a/packages/server/src/connectors/gmail.test.ts
+++ b/packages/server/src/connectors/gmail.test.ts
@@ -175,6 +175,48 @@ describe("Gmail connector", () => {
     ]);
   });
 
+  it("caps initial lookback queries at three years", async () => {
+    const connector = createGmailConnector();
+    let initialQuery: string | null = null;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+      const url = new URL(input.toString());
+      const path = url.pathname;
+      const q = url.searchParams.get("q");
+
+      if (path === "/gmail/v1/users/me/profile") {
+        return jsonResponse({ historyId: "history-start" });
+      }
+
+      if (path === "/gmail/v1/users/me/messages" && q?.startsWith("newer_than")) {
+        initialQuery = q;
+        return jsonResponse({ messages: [] });
+      }
+
+      if (path === "/gmail/v1/users/me/messages" && q?.startsWith("in:sent")) {
+        return jsonResponse({ messages: [] });
+      }
+
+      throw new Error(`unexpected fetch ${url.toString()}`);
+    });
+
+    const credentials = validCredentials();
+    const items: EmailSyncedItem[] = [];
+    for await (const item of connector.sync({
+      connectorConfigId: "connector-gmail",
+      credentials,
+      scopeConfig: { initialDays: 3650, maxMessages: 10, maxReciprocitySent: 10 },
+      cursor: null,
+      logger,
+      ownerEmail: "owner@canvasx.ai",
+    })) {
+      items.push(item as EmailSyncedItem);
+    }
+
+    expect(items).toEqual([]);
+    expect(initialQuery).toBe("newer_than:1095d (in:inbox OR in:sent)");
+  });
+
   it("returns the history id snapshotted before incremental message processing", async () => {
     const connector = createGmailConnector();
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
@@ -332,6 +374,67 @@ describe("Gmail connector", () => {
       pageToken: "page-2",
     });
     expect(nextCursor.reciprocityEmails).toContain("jane@example.com");
+  });
+
+  it("normalizes legacy list cursor lookback queries before continuing", async () => {
+    const connector = createGmailConnector();
+    let continuedQuery: string | null = null;
+    let continuedPageToken: string | null = null;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+      const url = new URL(input.toString());
+      const path = url.pathname;
+
+      if (path === "/gmail/v1/users/me/messages") {
+        continuedQuery = url.searchParams.get("q");
+        continuedPageToken = url.searchParams.get("pageToken");
+        return jsonResponse({ messages: [{ id: "legacy-page" }], nextPageToken: "page-3" });
+      }
+
+      if (path.endsWith("/messages/legacy-page")) {
+        return jsonResponse(
+          gmailMessage("legacy-page", {
+            from: "Owner <owner@canvasx.ai>",
+            to: "Jane Doe <jane@example.com>",
+            labels: ["SENT"],
+          }),
+        );
+      }
+
+      throw new Error(`unexpected fetch ${url.toString()}`);
+    });
+
+    const credentials = validCredentials();
+    const items: EmailSyncedItem[] = [];
+    for await (const item of connector.sync({
+      connectorConfigId: "connector-gmail",
+      credentials,
+      scopeConfig: { maxMessages: 1 },
+      cursor: JSON.stringify({
+        mode: "list",
+        historyId: "history-start",
+        query: "newer_than:3650d (in:inbox OR in:sent)",
+        pageToken: "page-2",
+      }),
+      logger,
+      ownerEmail: "owner@canvasx.ai",
+    })) {
+      items.push(item as EmailSyncedItem);
+    }
+
+    const nextCursor = JSON.parse(
+      (await connector.getCursor({ credentials, scopeConfig: {}, currentCursor: null, logger })) ?? "{}",
+    );
+
+    expect(items).toHaveLength(1);
+    expect(continuedQuery).toBe("newer_than:1095d (in:inbox OR in:sent)");
+    expect(continuedPageToken).toBe("page-2");
+    expect(nextCursor).toMatchObject({
+      mode: "list",
+      historyId: "history-start",
+      query: "newer_than:1095d (in:inbox OR in:sent)",
+      pageToken: "page-3",
+    });
   });
 
   it("streams full bodies one page at a time instead of buffering the whole corpus", async () => {

--- a/packages/server/src/connectors/gmail.ts
+++ b/packages/server/src/connectors/gmail.ts
@@ -21,6 +21,7 @@ const DEFAULT_INITIAL_DAYS = 90;
 const DEFAULT_MAX_MESSAGES = 500;
 const DEFAULT_RECIPROCITY_DAYS = 365;
 const DEFAULT_MAX_RECIPROCITY_SENT = 250;
+const GMAIL_MAX_LOOKBACK_DAYS = 1095;
 const MESSAGE_FETCH_CONCURRENCY = 12;
 const MESSAGE_PAGE_SIZE = 100;
 const RECIPROCITY_METADATA_HEADERS = ["From", "To", "Cc", "Message-ID", "Subject", "Date"];
@@ -77,6 +78,14 @@ function assertOAuth(credentials: ConnectorCredentials): asserts credentials is 
 function parsePositiveInt(value: unknown, fallback: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(1, Math.min(Math.floor(value), max));
+}
+
+function normalizeLookbackQuery(query: string): string {
+  return query.replace(/\bnewer_than:(\d+)d\b/gi, (match, rawDays: string) => {
+    const days = Number.parseInt(rawDays, 10);
+    if (!Number.isFinite(days) || days <= GMAIL_MAX_LOOKBACK_DAYS) return match;
+    return `newer_than:${GMAIL_MAX_LOOKBACK_DAYS}d`;
+  });
 }
 
 function parseCursor(cursor: string | null): GmailCursor | null {
@@ -329,7 +338,7 @@ async function loadRecentSentMessages(
   scopeConfig: Record<string, unknown>,
   logger: Logger,
 ): Promise<NormalizedEmail[]> {
-  const days = parsePositiveInt(scopeConfig.reciprocityDays, DEFAULT_RECIPROCITY_DAYS, 3650);
+  const days = parsePositiveInt(scopeConfig.reciprocityDays, DEFAULT_RECIPROCITY_DAYS, GMAIL_MAX_LOOKBACK_DAYS);
   const maxMessages = parsePositiveInt(scopeConfig.maxReciprocitySent, DEFAULT_MAX_RECIPROCITY_SENT, 2000);
   const { refs, nextPageToken } = await listMessageRefs(accessToken, { q: `in:sent newer_than:${days}d` }, maxMessages);
   if (nextPageToken) {
@@ -462,13 +471,14 @@ async function* syncFullMailbox(
   setNextCursor: (cursor: GmailCursor) => void,
   opts?: { query?: string; pageToken?: string; bootstrapReciprocity?: boolean },
 ) {
-  const initialDays = parsePositiveInt(scopeConfig.initialDays, DEFAULT_INITIAL_DAYS, 3650);
+  const initialDays = parsePositiveInt(scopeConfig.initialDays, DEFAULT_INITIAL_DAYS, GMAIL_MAX_LOOKBACK_DAYS);
   const maxMessages = parsePositiveInt(scopeConfig.maxMessages, DEFAULT_MAX_MESSAGES, 5000);
-  const query =
+  const query = normalizeLookbackQuery(
     opts?.query ??
-    (typeof scopeConfig.query === "string" && scopeConfig.query.trim()
-      ? scopeConfig.query.trim()
-      : `newer_than:${initialDays}d (in:inbox OR in:sent)`);
+      (typeof scopeConfig.query === "string" && scopeConfig.query.trim()
+        ? scopeConfig.query.trim()
+        : `newer_than:${initialDays}d (in:inbox OR in:sent)`),
+  );
   const { refs, nextPageToken } = await listMessageRefs(
     accessToken,
     { q: query, pageToken: opts?.pageToken ?? "" },

--- a/packages/web/src/routes/files/manage-connector-dialog.isolated.test.tsx
+++ b/packages/web/src/routes/files/manage-connector-dialog.isolated.test.tsx
@@ -179,6 +179,35 @@ describe("ManageConnectorDialog connector capabilities", () => {
     expect(list).toHaveClass("max-h-72", "overflow-y-auto");
   });
 
+  it("offers Gmail lookback windows up to three years", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/connectors/:id/suppressed-emails", () =>
+        HttpResponse.json({ countsByReason: {}, recent: [], total: 0, hasMore: false }),
+      ),
+      http.get("/api/connectors/:id/email-threads", () => HttpResponse.json({ threads: [], total: 0, hasMore: false })),
+    );
+
+    renderWithProviders(
+      <ManageConnectorDialog
+        definition={gmail}
+        connector={connector({ connectorType: "gmail", authType: "oauth", scopeConfig: { initialDays: 180 } })}
+        open
+        onOpenChange={() => {}}
+        onDisconnected={() => {}}
+        onReconnect={() => {}}
+      />,
+    );
+
+    await user.click(await screen.findByRole("combobox", { name: /Lookback window/i }));
+
+    expect(await screen.findByRole("option", { name: "Last 1 year" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Last 2 years" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Last 3 years" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Last 12 months" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "All available" })).not.toBeInTheDocument();
+  });
+
   it("saves Google Calendar scope as selected calendarIds", async () => {
     const user = userEvent.setup();
     let patchedBody: unknown;

--- a/packages/web/src/routes/files/manage-connector-dialog.tsx
+++ b/packages/web/src/routes/files/manage-connector-dialog.tsx
@@ -507,9 +507,17 @@ const LOOKBACK_OPTIONS: Array<{ value: string; label: string }> = [
   { value: "30", label: "Last 30 days" },
   { value: "90", label: "Last 90 days" },
   { value: "180", label: "Last 6 months" },
-  { value: "365", label: "Last 12 months" },
-  { value: "3650", label: "All available" },
+  { value: "365", label: "Last 1 year" },
+  { value: "730", label: "Last 2 years" },
+  { value: "1095", label: "Last 3 years" },
 ];
+
+const EMAIL_MAX_LOOKBACK_DAYS = 1095;
+
+function normalizeEmailLookbackDays(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 90;
+  return Math.max(1, Math.min(Math.floor(value), EMAIL_MAX_LOOKBACK_DAYS));
+}
 
 function EmailScopeEditor({
   connectorId,
@@ -519,7 +527,7 @@ function EmailScopeEditor({
   scopeConfig: Record<string, unknown>;
 }) {
   const queryClient = useQueryClient();
-  const currentDays = typeof scopeConfig.initialDays === "number" ? scopeConfig.initialDays : 90;
+  const currentDays = normalizeEmailLookbackDays(scopeConfig.initialDays);
   const currentQuery = typeof scopeConfig.query === "string" ? scopeConfig.query : "";
   const [days, setDays] = useState(String(currentDays));
   const [query, setQuery] = useState(currentQuery);


### PR DESCRIPTION
## Summary
- Expands Gmail sync lookback support to a maximum of 3 years.
- Adds Gmail setup options for Last 1 year, Last 2 years, and Last 3 years while keeping the shorter windows.
- Normalizes legacy Gmail list-mode continuation cursor queries so stale `newer_than:<N>d` values above the cap are clamped before Gmail list requests continue.

## Implementation Details
- Raises the Gmail server-side max lookback from `730` to `1095` days.
- Applies query normalization to full-mailbox sync input, covering both new initial queries and saved continuation cursor queries passed through `opts.query`.
- Persists normalized continuation cursor queries when Gmail returns another page token, preventing old `newer_than:3650d` cursors from continuing past the advertised cap.
- Updates the connector management dialog lookback dropdown and its normalization cap to 3 years.

## Verification
- `pnpm --filter @sketch/server test src/connectors/gmail.test.ts` - passed.
- `pnpm --filter @sketch/web test src/routes/files/manage-connector-dialog.isolated.test.tsx` - passed.
- `pnpm biome check` - passed.
- `pnpm typecheck` - passed.
- `pnpm test` - passed.
- `pnpm build` - passed.
- Pre-push hook reran `pnpm biome check`, `pnpm typecheck`, `pnpm test`, and `pnpm build` - passed.

## Risk / Rollout
- No database migrations or config changes.
- Existing Gmail connectors with saved legacy list cursors will continue from their saved page token, but their stored query is clamped to the 3-year maximum before the next Gmail list call.
