### PR TITLE
Fix Microsoft admin consent connector scopes

### DIFF
--- a/packages/server/src/api/oauth.test.ts
+++ b/packages/server/src/api/oauth.test.ts
@@ -174,7 +174,7 @@ describe("Microsoft OAuth callback", () => {
 });
 
 describe("Microsoft admin consent route", () => {
-  it("builds a Teams admin consent URL with the configured tenant and Graph default scope", async () => {
+  it("builds a Teams admin consent URL with the configured tenant and connector scopes", async () => {
     const { app, userId } = createMicrosoftOauthTestApp();
 
     const res = await app.request("/microsoft/admin-consent?connector=teams", { redirect: "manual" });
@@ -185,7 +185,16 @@ describe("Microsoft admin consent route", () => {
     expect(`${url.origin}${url.pathname}`).toBe("https://login.microsoftonline.com/tenant-id/v2.0/adminconsent");
     expect(url.searchParams.get("client_id")).toBe("env-cid");
     expect(url.searchParams.get("redirect_uri")).toBe("http://localhost/api/oauth/microsoft/callback");
-    expect(url.searchParams.get("scope")).toBe("https://graph.microsoft.com/.default");
+    expect(url.searchParams.get("scope")?.split(" ").sort()).toEqual(
+      [
+        "offline_access",
+        "https://graph.microsoft.com/Calendars.Read",
+        "https://graph.microsoft.com/OnlineMeetingRecording.Read.All",
+        "https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",
+        "https://graph.microsoft.com/OnlineMeetings.Read",
+        "https://graph.microsoft.com/User.Read",
+      ].sort(),
+    );
     expect(url.searchParams.get("state")).toContain(`${userId}:teams:`);
   });
 
@@ -208,6 +217,9 @@ describe("Microsoft admin consent route", () => {
     expect(res.status).toBe(302);
     const url = new URL(res.headers.get("location") ?? "");
     expect(`${url.origin}${url.pathname}`).toBe("https://login.microsoftonline.com/tenant-id/v2.0/adminconsent");
+    expect(url.searchParams.get("scope")?.split(" ").sort()).toEqual(
+      ["offline_access", "https://graph.microsoft.com/Mail.Read", "https://graph.microsoft.com/User.Read"].sort(),
+    );
     expect(url.searchParams.get("state")).toContain(`${userId}:outlook:`);
   });
 

--- a/packages/server/src/api/oauth.ts
+++ b/packages/server/src/api/oauth.ts
@@ -95,7 +95,6 @@ const USERINFO_SCOPE = "https://www.googleapis.com/auth/userinfo.email";
 const GOOGLE_OAUTH_CONNECTORS = new Set<ConnectorType>(["google_drive", "google_calendar", "gmail"]);
 const MICROSOFT_OAUTH_CONNECTORS = new Set<ConnectorType>(["outlook", "teams"]);
 const ZOHO_SCOPE = "ZohoCRM.modules.ALL,ZohoCRM.users.READ,ZohoCRM.org.READ,ZohoCRM.settings.READ";
-const MICROSOFT_GRAPH_ADMIN_CONSENT_SCOPE = "https://graph.microsoft.com/.default";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 
@@ -165,6 +164,19 @@ function microsoftConnectorFromQuery(value: string | undefined): ConnectorType {
 
 function microsoftScopesFor(connectorType: ConnectorType): string {
   return connectorType === "teams" ? TEAMS_MICROSOFT_SCOPE : OUTLOOK_MICROSOFT_SCOPE;
+}
+
+function microsoftAdminConsentScopesFor(connectorType: ConnectorType): string {
+  return microsoftScopesFor(connectorType)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((scope) => {
+      if (scope.includes("://") || scope === "offline_access" || scope === "openid" || scope === "profile") {
+        return scope;
+      }
+      return `https://graph.microsoft.com/${scope}`;
+    })
+    .join(" ");
 }
 
 function microsoftConnectorName(connectorType: ConnectorType): string {
@@ -670,7 +682,7 @@ export function oauthRoutes(
       client_id: clientId,
       redirect_uri: redirectUri,
       state,
-      scope: MICROSOFT_GRAPH_ADMIN_CONSENT_SCOPE,
+      scope: microsoftAdminConsentScopesFor(connectorType),
     });
 
     return c.redirect(`${microsoftAdminConsentEndpoint(adminConsentTenant)}?${params.toString()}`);


### PR DESCRIPTION
## Summary
- Fix Microsoft admin consent for Outlook and Teams connectors by requesting the connector's actual delegated Graph permissions instead of `https://graph.microsoft.com/.default`.
- Preserve `offline_access` and already-qualified scopes while qualifying Microsoft Graph permission names for the admin-consent endpoint.

## Linear Scope
- Attempted to create a matching SKE Linear issue, but Linear returned `Linear GraphQL error: usage limit exceeded`.
- PR scope is derived from the branch diff and commit `219d118b`.

## Implementation Details
- Updated `packages/server/src/api/oauth.ts` to derive admin-consent scopes from the existing connector scope definitions used by the Microsoft OAuth flow.
- Updated `packages/server/src/api/oauth.test.ts` so Teams admin consent asserts `Calendars.Read`, `OnlineMeetings.Read`, transcript/recording scopes, `User.Read`, and `offline_access`.
- Added Outlook admin-consent coverage for `Mail.Read`, `User.Read`, and `offline_access`.
- No API shape, database, migration, config, background job, provider callback, or UI changes.

## Verification
- `npx -y -p node@24 -p pnpm@11.7.0 -c 'node -v && pnpm biome check'` - passed
- `npx -y -p node@24 -p pnpm@11.7.0 -c 'node -v && pnpm typecheck'` - passed
- `npx -y -p node@24 -p pnpm@11.7.0 -c 'node -v && pnpm test'` - passed
- `npx -y -p node@24 -p pnpm@11.7.0 -c 'node -v && pnpm build'` - passed

## Risk / Rollout
- Low-risk auth-route change limited to Microsoft admin-consent URL construction.
- Existing Microsoft OAuth callback handling and stored connector credentials are unchanged.
