### PR TITLE
Fix integration card resolution and simplify automation links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tmp/
 .worktrees/
 apps/macos/.build/
 apps/macos/.dist/
+
+# Local feature-design artifacts
+docs/superpowers/specs/

--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -351,6 +351,12 @@ describe("buildSystemContext", () => {
       expect(result).not.toContain("write URLs inline");
     });
 
+    it("uses plain-language automation link guidance", () => {
+      const result = buildSystemContext({ platform: "web" });
+      expect(result).toContain("automation link");
+      expect(result).not.toContain("builder URL");
+    });
+
     it("can mention delivery context without overriding web reply formatting", () => {
       const result = buildSystemContext({ platform: "web", deliveryPlatform: "slack" });
       expect(result).toContain("visible reply is rendered in web chat");

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -389,7 +389,7 @@ export function buildSystemContext(params: {
       "",
       "## Web Chat Automations",
       "",
-      "When ManageScheduledTasks creates or updates an automation in web chat, the client renders the automation card separately. Briefly introduce the card, but do not paste or link to the builder URL unless the user explicitly asks for the literal URL.",
+      "When ManageScheduledTasks creates or updates an automation in web chat, the client renders the automation card separately. Briefly introduce the card, but do not paste an automation link unless the user explicitly asks for the literal URL. If they do, provide it as an automation link and avoid internal product terminology in the user-facing response.",
     );
   }
 

--- a/packages/server/src/automation/artifact-links.test.ts
+++ b/packages/server/src/automation/artifact-links.test.ts
@@ -34,6 +34,20 @@ describe("appendAutomationBuilderLinks", () => {
     );
   });
 
+  it("uses a plural heading when one automation link is present and another is appended", () => {
+    const secondArtifact: AutomationArtifact = {
+      ...artifact,
+      taskId: "task-456",
+      title: "Weekly pipeline review",
+      builderUrl: "https://sketch.test/scheduled-tasks/task-456/edit",
+    };
+    const text = `First automation: ${artifact.builderUrl}`;
+
+    expect(appendAutomationBuilderLinks(text, [artifact, secondArtifact])).toBe(
+      `${text}\n\nOpen your automations:\n- Weekly pipeline review: https://sketch.test/scheduled-tasks/task-456/edit`,
+    );
+  });
+
   it("creates fallback text for artifact-only responses", () => {
     expect(appendAutomationBuilderLinks(null, [artifact])).toBe(
       "Your automation is ready.\n\nOpen your automation:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit",

--- a/packages/server/src/automation/artifact-links.test.ts
+++ b/packages/server/src/automation/artifact-links.test.ts
@@ -15,15 +15,28 @@ const artifact: AutomationArtifact = {
 };
 
 describe("appendAutomationBuilderLinks", () => {
-  it("appends missing builder links to final text", () => {
+  it("appends a missing automation link to final text", () => {
     expect(appendAutomationBuilderLinks("Done.", [artifact])).toBe(
-      "Done.\n\nBuilder link:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit",
+      "Done.\n\nOpen your automation:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit",
+    );
+  });
+
+  it("appends multiple missing automation links to final text", () => {
+    const secondArtifact: AutomationArtifact = {
+      ...artifact,
+      taskId: "task-456",
+      title: "Weekly pipeline review",
+      builderUrl: "https://sketch.test/scheduled-tasks/task-456/edit",
+    };
+
+    expect(appendAutomationBuilderLinks("Done.", [artifact, secondArtifact])).toBe(
+      "Done.\n\nOpen your automations:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit\n- Weekly pipeline review: https://sketch.test/scheduled-tasks/task-456/edit",
     );
   });
 
   it("creates fallback text for artifact-only responses", () => {
     expect(appendAutomationBuilderLinks(null, [artifact])).toBe(
-      "Automation created.\n\nBuilder link:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit",
+      "Your automation is ready.\n\nOpen your automation:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit",
     );
   });
 

--- a/packages/server/src/automation/artifact-links.ts
+++ b/packages/server/src/automation/artifact-links.ts
@@ -22,7 +22,13 @@ export function appendAutomationBuilderLinks(
   artifacts: AutomationArtifact[],
 ): string | null {
   const text = finalText?.trim() ?? "";
-  const missingLinks = artifacts
+  const artifactsByUrl = new Map<string, AutomationArtifact>();
+  for (const artifact of artifacts) {
+    const url = artifact.builderUrl.trim();
+    if (url && !artifactsByUrl.has(url)) artifactsByUrl.set(url, artifact);
+  }
+  const distinctArtifacts = Array.from(artifactsByUrl.values());
+  const missingLinks = distinctArtifacts
     .filter((artifact) => {
       const references = builderUrlReferences(artifact.builderUrl);
       return references.length > 0 && references.every((reference) => !text.includes(reference));
@@ -32,7 +38,7 @@ export function appendAutomationBuilderLinks(
 
   if (missingLinks.length === 0) return text || null;
 
-  const linkHeading = missingLinks.length === 1 ? "Open your automation:" : "Open your automations:";
+  const linkHeading = distinctArtifacts.length === 1 ? "Open your automation:" : "Open your automations:";
   const linkBlock = `${linkHeading}\n${missingLinks.join("\n")}`;
   const fallback = "Your automation is ready.";
   return text ? `${text}\n\n${linkBlock}` : `${fallback}\n\n${linkBlock}`;

--- a/packages/server/src/automation/artifact-links.ts
+++ b/packages/server/src/automation/artifact-links.ts
@@ -32,7 +32,8 @@ export function appendAutomationBuilderLinks(
 
   if (missingLinks.length === 0) return text || null;
 
-  const linkBlock =
-    missingLinks.length === 1 ? `Builder link:\n${missingLinks[0]}` : `Builder links:\n${missingLinks.join("\n")}`;
-  return text ? `${text}\n\n${linkBlock}` : `Automation created.\n\n${linkBlock}`;
+  const linkHeading = missingLinks.length === 1 ? "Open your automation:" : "Open your automations:";
+  const linkBlock = `${linkHeading}\n${missingLinks.join("\n")}`;
+  const fallback = "Your automation is ready.";
+  return text ? `${text}\n\n${linkBlock}` : `${fallback}\n\n${linkBlock}`;
 }

--- a/packages/server/src/integrations/cards.test.ts
+++ b/packages/server/src/integrations/cards.test.ts
@@ -351,6 +351,84 @@ describe("integration cards", () => {
     expect(cards).toEqual([]);
   });
 
+  it("collects a canonical app card when a healthy same-name connection has a different slug", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [
+        {
+          id: "conn-sheets",
+          providerId: "provider-1",
+          appId: "google-sheets",
+          appName: "Google Sheets",
+          app: { name: "Google Sheets", nameSlug: "google-sheets" },
+          healthy: true,
+          status: "active",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      listApps: async (query?: string) => ({
+        apps:
+          query === "google-sheets-oauth"
+            ? [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }]
+            : [],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
+  });
+
+  it("collects a reconnect card for an unhealthy exact canonical connection", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [
+        {
+          id: "conn-sheets",
+          providerId: "provider-1",
+          appId: "google-sheets-oauth",
+          appName: "Google Sheets",
+          healthy: false,
+          status: "error",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      listApps: async () => ({
+        apps: [],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
+  });
+
   it("collects a card for an unconnected canonical component app", async () => {
     const cards: unknown[] = [];
     const provider = {

--- a/packages/server/src/integrations/cards.test.ts
+++ b/packages/server/src/integrations/cards.test.ts
@@ -610,6 +610,43 @@ describe("integration cards", () => {
     expect(cards).toEqual([]);
   });
 
+  it("keeps explicit fuzzy-query and canonical component cards distinct across slug boundaries", async () => {
+    const cards: Array<{ appId: string }> = [];
+    const provider = {
+      listConnections: async () => [],
+      listApps: async (query?: string) => ({
+        apps:
+          query === "googlesheetsoauth"
+            ? [{ id: "googlesheetsoauth", name: "Google Sheets Compact", description: "Spreadsheets" }]
+            : query === "google-sheets-oauth"
+              ? [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }]
+              : [],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__search_apps",
+          input: { queries: ["googlesheetsoauth"] },
+        },
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards.map((card) => card.appId)).toEqual(["googlesheetsoauth", "google-sheets-oauth"]);
+  });
+
   it.each([
     "google--sheets-oauth-query-formula",
     "-google-sheets-oauth-query-formula",

--- a/packages/server/src/integrations/cards.test.ts
+++ b/packages/server/src/integrations/cards.test.ts
@@ -308,7 +308,7 @@ describe("integration cards", () => {
       collector: { collect: (card) => cards.push(card) },
     });
 
-    expect(queries).toEqual(["google-calendar-oauth-create", "google-calendar-oauth"]);
+    expect(queries).toEqual(["google-calendar-oauth-create", undefined, "google-calendar-oauth"]);
     expect(cards).toMatchObject([{ appId: "google-calendar-oauth", appName: "Google Calendar", state: "connect" }]);
   });
 
@@ -347,7 +347,7 @@ describe("integration cards", () => {
       collector: { collect: (card) => cards.push(card) },
     });
 
-    expect(listApps.mock.calls.map(([query]) => query)).toEqual(["google-sheets-oauth-query"]);
+    expect(listApps.mock.calls.map(([query]) => query)).toEqual(["google-sheets-oauth-query", undefined]);
     expect(cards).toEqual([]);
   });
 
@@ -361,6 +361,56 @@ describe("integration cards", () => {
           appId: "google-sheets",
           appName: "Google Sheets",
           app: { name: "Google Sheets", nameSlug: "google-sheets" },
+          healthy: true,
+          status: "active",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      listApps: async (query?: string) => ({
+        apps:
+          query === "google-sheets-oauth"
+            ? [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }]
+            : [],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
+  });
+
+  it("does not match separatorless or punctuation connection slugs to a canonical component app", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [
+        {
+          id: "conn-compact",
+          providerId: "provider-1",
+          appId: "googlesheetsoauth",
+          appName: "Google Sheets Compact",
+          healthy: true,
+          status: "active",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "conn-punctuation",
+          providerId: "provider-1",
+          appId: "google_sheets_oauth",
+          appName: "Google Sheets Punctuation",
+          app: { name: "Google Sheets Punctuation", nameSlug: "google.sheets.oauth" },
           healthy: true,
           status: "active",
           createdAt: "2026-01-01T00:00:00Z",
@@ -526,6 +576,73 @@ describe("integration cards", () => {
     expect(cards).toEqual([]);
   });
 
+  it("does not collect compact or punctuation app IDs for an exact canonical component candidate", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [],
+      listApps: async (query?: string) => ({
+        apps:
+          query === undefined
+            ? []
+            : [
+                { id: "googlesheetsoauth", name: "Google Sheets Compact", description: "Spreadsheets" },
+                { id: "google_sheets_oauth", name: "Google Sheets Underscore", description: "Spreadsheets" },
+                { id: "google.sheets.oauth", name: "Google Sheets Dotted", description: "Spreadsheets" },
+              ],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toEqual([]);
+  });
+
+  it.each([
+    "google--sheets-oauth-query-formula",
+    "-google-sheets-oauth-query-formula",
+    "google-sheets-oauth-query-formula-",
+  ])("does not collect a card for malformed component key %s", async (componentKey) => {
+    const cards: unknown[] = [];
+    const listApps = vi.fn(async () => ({
+      apps: [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }],
+      pageInfo: { endCursor: null, hasMore: false },
+    }));
+    const provider = {
+      listConnections: async () => [],
+      listApps,
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(listApps).not.toHaveBeenCalled();
+    expect(cards).toEqual([]);
+  });
+
   it("resolves a canonical app before an unknown action segment", async () => {
     const cards: unknown[] = [];
     const provider = {
@@ -553,6 +670,47 @@ describe("integration cards", () => {
       collector: { collect: (card) => cards.push(card) },
     });
 
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
+  });
+
+  it("falls back to a cached unfiltered catalog while preserving longest-prefix resolution", async () => {
+    const cards: unknown[] = [];
+    const listApps = vi.fn(async (query?: string) => ({
+      apps:
+        query === undefined
+          ? [
+              { id: "google", name: "Google", description: "Google" },
+              { id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" },
+            ]
+          : [],
+      pageInfo: { endCursor: null, hasMore: false },
+    }));
+    const provider = {
+      listConnections: async () => [],
+      listApps,
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-append-values" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(listApps.mock.calls.filter(([query]) => query === undefined)).toHaveLength(1);
+    expect(listApps.mock.calls.map(([query]) => query)).not.toContain("google");
     expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
   });
 
@@ -596,6 +754,7 @@ describe("integration cards", () => {
 
     expect(listApps.mock.calls.map(([query]) => query)).toEqual([
       "google-sheets-oauth-query",
+      undefined,
       "google-sheets-oauth",
       "google-sheets-oauth-frobnicate",
     ]);

--- a/packages/server/src/integrations/cards.test.ts
+++ b/packages/server/src/integrations/cards.test.ts
@@ -24,14 +24,17 @@ describe("integration cards", () => {
   it("extracts app lookups from Canvas CLI commands", () => {
     expect(extractCanvasIntegrationLookups('$CANVAS_CLI search-apps --queries "slack,gmail" --output json')).toEqual({
       queries: ["slack", "gmail"],
+      componentKeys: [],
       listConnected: false,
     });
     expect(extractCanvasIntegrationLookups("$CANVAS_CLI search-apps --queries=slack --output json")).toEqual({
       queries: ["slack"],
+      componentKeys: [],
       listConnected: false,
     });
     expect(extractCanvasIntegrationLookups("$CANVAS_CLI search-apps --output json")).toEqual({
       queries: [],
+      componentKeys: [],
       listConnected: true,
     });
     expect(
@@ -39,7 +42,8 @@ describe("integration cards", () => {
         "$CANVAS_CLI direct-execute-action --component-key github-create-issue --configured-props '{}' --output json",
       ),
     ).toEqual({
-      queries: ["github"],
+      queries: [],
+      componentKeys: ["github-create-issue"],
       listConnected: false,
     });
     expect(
@@ -47,7 +51,8 @@ describe("integration cards", () => {
         "$CANVAS_CLI direct-execute-action --component-key=google-calendar-oauth-create-event --output json",
       ),
     ).toEqual({
-      queries: ["google-calendar-oauth"],
+      queries: [],
+      componentKeys: ["google-calendar-oauth-create-event"],
       listConnected: false,
     });
     expect(
@@ -55,7 +60,17 @@ describe("integration cards", () => {
         "$CANVAS_CLI direct-execute-action --component-key microsoft-teams-send-message --output json",
       ),
     ).toEqual({
-      queries: ["microsoft-teams"],
+      queries: [],
+      componentKeys: ["microsoft-teams-send-message"],
+      listConnected: false,
+    });
+    expect(
+      extractCanvasIntegrationLookups(
+        "$CANVAS_CLI direct-execute-action --component-key=google-sheets-oauth-query-formula --output json",
+      ),
+    ).toEqual({
+      queries: [],
+      componentKeys: ["google-sheets-oauth-query-formula"],
       listConnected: false,
     });
     expect(
@@ -64,12 +79,14 @@ describe("integration cards", () => {
       ),
     ).toEqual({
       queries: ["linear"],
+      componentKeys: [],
       listConnected: false,
     });
     expect(
       extractCanvasIntegrationLookups("$CANVAS_CLI get-component-definition --key github-create-issue --output json"),
     ).toEqual({
-      queries: ["github"],
+      queries: [],
+      componentKeys: ["github-create-issue"],
       listConnected: false,
     });
   });
@@ -81,49 +98,56 @@ describe("integration cards", () => {
         toolName: "mcp__canvas__search_apps",
         input: { queries: ["slack", "gmail"] },
       }),
-    ).toEqual({ queries: ["slack", "gmail"], listConnected: false });
+    ).toEqual({ queries: ["slack", "gmail"], componentKeys: [], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_use",
         toolName: "searchApps",
         input: { queries: "notion" },
       }),
-    ).toEqual({ queries: ["notion"], listConnected: false });
+    ).toEqual({ queries: ["notion"], componentKeys: [], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_use",
         toolName: "mcp__canvas__search_apps",
         input: {},
       }),
-    ).toEqual({ queries: [], listConnected: true });
+    ).toEqual({ queries: [], componentKeys: [], listConnected: true });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_use",
         toolName: "mcp__canvas__direct_execute_action",
         input: { componentKey: "github-create-issue" },
       }),
-    ).toEqual({ queries: ["github"], listConnected: false });
+    ).toEqual({ queries: [], componentKeys: ["github-create-issue"], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_use",
         toolName: "mcp__canvas__direct_execute_action",
         input: { componentKey: "google-calendar-oauth-create-event" },
       }),
-    ).toEqual({ queries: ["google-calendar-oauth"], listConnected: false });
+    ).toEqual({ queries: [], componentKeys: ["google-calendar-oauth-create-event"], listConnected: false });
+    expect(
+      extractIntegrationLookupsFromProgressEvent({
+        kind: "tool_use",
+        toolName: "mcp__canvas__direct_execute_action",
+        input: { componentKey: "google-sheets-oauth-query-formula" },
+      }),
+    ).toEqual({ queries: [], componentKeys: ["google-sheets-oauth-query-formula"], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_use",
         toolName: "mcp__canvas__search_components",
         input: { queries: [{ app: "linear", query: "create issue" }] },
       }),
-    ).toEqual({ queries: ["linear"], listConnected: false });
+    ).toEqual({ queries: ["linear"], componentKeys: [], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_use",
         toolName: "mcp__canvas__get_component_definition",
         input: { key: "slack-send-message" },
       }),
-    ).toEqual({ queries: ["slack"], listConnected: false });
+    ).toEqual({ queries: [], componentKeys: ["slack-send-message"], listConnected: false });
   });
 
   it("extracts app lookups from missing-connection tool results only", () => {
@@ -134,7 +158,7 @@ describe("integration cards", () => {
         input: { app: "slack" },
         output: { code: "CONNECTION_NOT_CONNECTED", message: "Slack is not connected" },
       }),
-    ).toEqual({ queries: ["slack"], listConnected: false });
+    ).toEqual({ queries: ["slack"], componentKeys: ["slack-send-message"], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_result",
@@ -142,7 +166,7 @@ describe("integration cards", () => {
         input: {},
         output: [{ type: "text", text: "CONNECTION_NOT_CONNECTED" }],
       }),
-    ).toEqual({ queries: ["github"], listConnected: false });
+    ).toEqual({ queries: [], componentKeys: ["github-create-issue"], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_result",
@@ -150,7 +174,7 @@ describe("integration cards", () => {
         input: { app: "slack" },
         output: "Rate limit exceeded",
       }),
-    ).toEqual({ queries: [], listConnected: false });
+    ).toEqual({ queries: [], componentKeys: [], listConnected: false });
     expect(
       extractIntegrationLookupsFromProgressEvent({
         kind: "tool_result",
@@ -158,7 +182,7 @@ describe("integration cards", () => {
         input: {},
         output: { filler: "x".repeat(100_000), connectionStatus: "not_connected" },
       }),
-    ).toEqual({ queries: ["github"], listConnected: false });
+    ).toEqual({ queries: [], componentKeys: ["github-create-issue"], listConnected: false });
   });
 
   it("resolves exactly matched apps to connect or connected cards from provider state", async () => {
@@ -284,8 +308,220 @@ describe("integration cards", () => {
       collector: { collect: (card) => cards.push(card) },
     });
 
-    expect(queries).toEqual(["google-calendar-oauth"]);
+    expect(queries).toEqual(["google-calendar-oauth-create", "google-calendar-oauth"]);
     expect(cards).toMatchObject([{ appId: "google-calendar-oauth", appName: "Google Calendar", state: "connect" }]);
+  });
+
+  it("does not collect a card when the canonical component app has a healthy connection", async () => {
+    const cards: unknown[] = [];
+    const listApps = vi.fn(async (_query?: string) => ({
+      apps: [],
+      pageInfo: { endCursor: null, hasMore: false },
+    }));
+    const provider = {
+      listConnections: async () => [
+        {
+          id: "conn-sheets",
+          providerId: "provider-1",
+          appId: "google-sheets-oauth",
+          appName: "Google Sheets",
+          healthy: true,
+          status: "active",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      listApps,
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(listApps.mock.calls.map(([query]) => query)).toEqual(["google-sheets-oauth-query"]);
+    expect(cards).toEqual([]);
+  });
+
+  it("collects a card for an unconnected canonical component app", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [],
+      listApps: async (query?: string) => ({
+        apps:
+          query === "google-sheets-oauth"
+            ? [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }]
+            : [],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
+  });
+
+  it("collects the longest canonical app even when a shorter prefix is connected", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [
+        {
+          id: "conn-google",
+          providerId: "provider-1",
+          appId: "google",
+          appName: "Google",
+          healthy: true,
+          status: "active",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      listApps: async (query?: string) => ({
+        apps:
+          query === "google-sheets-oauth"
+            ? [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }]
+            : [],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
+  });
+
+  it("does not collect a fuzzy single app without an exact canonical candidate ID", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [],
+      listApps: async () => ({
+        apps: [{ id: "google-drive", name: "Google Drive", description: "Files" }],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toEqual([]);
+  });
+
+  it("resolves a canonical app before an unknown action segment", async () => {
+    const cards: unknown[] = [];
+    const provider = {
+      listConnections: async () => [],
+      listApps: async (query?: string) => ({
+        apps:
+          query === "google-sheets-oauth"
+            ? [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }]
+            : [],
+        pageInfo: { endCursor: null, hasMore: false },
+      }),
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-frobnicate-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
+  });
+
+  it("caches shared component-key candidates for the collection run", async () => {
+    const cards: unknown[] = [];
+    const listApps = vi.fn(async (query?: string) => ({
+      apps:
+        query === "google-sheets-oauth"
+          ? [{ id: "google-sheets-oauth", name: "Google Sheets", description: "Spreadsheets" }]
+          : [],
+      pageInfo: { endCursor: null, hasMore: false },
+    }));
+    const provider = {
+      listConnections: async () => [],
+      listApps,
+    } as Pick<IntegrationProvider, "listApps" | "listConnections"> as IntegrationProvider;
+
+    await collectIntegrationCardsFromProgressEvents({
+      events: [
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-frobnicate-formula" },
+        },
+        {
+          kind: "tool_use",
+          toolName: "mcp__canvas__direct_execute_action",
+          input: { componentKey: "google-sheets-oauth-query-formula" },
+        },
+      ],
+      loadIntegrationProvider: async () => provider,
+      userEmail: "alice@example.com",
+      userName: "Alice",
+      collector: { collect: (card) => cards.push(card) },
+    });
+
+    expect(listApps.mock.calls.map(([query]) => query)).toEqual([
+      "google-sheets-oauth-query",
+      "google-sheets-oauth",
+      "google-sheets-oauth-frobnicate",
+    ]);
+    expect(cards).toMatchObject([{ appId: "google-sheets-oauth", appName: "Google Sheets", state: "connect" }]);
   });
 
   it("collects missing app cards from observed Canvas MCP search_apps progress", async () => {

--- a/packages/server/src/integrations/cards.ts
+++ b/packages/server/src/integrations/cards.ts
@@ -56,6 +56,11 @@ export function normalizeIntegrationLookup(value: string | undefined): string {
     .replace(/[^a-z0-9]+/g, "");
 }
 
+function normalizeExactIntegrationSlug(value: string | undefined): string | null {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(normalized) ? normalized : null;
+}
+
 export function connectionMatchesApp(connection: IntegrationConnection, app: IntegrationApp): boolean {
   const appKeys = [app.id, app.name].map(normalizeIntegrationLookup);
   const connectionKeys = [connection.appId, connection.app?.nameSlug, connection.appName].map(
@@ -205,9 +210,21 @@ function uniqueQueries(queries: string[]): string[] {
   return result;
 }
 
+function uniqueComponentKeys(componentKeys: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const componentKey of componentKeys) {
+    const normalized = normalizeExactIntegrationSlug(componentKey);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
 function componentKeysFromValue(componentKey: string | null): string[] {
-  const value = componentKey?.trim();
-  return value ? [value] : [];
+  const normalized = normalizeExactIntegrationSlug(componentKey ?? undefined);
+  return normalized ? [normalized] : [];
 }
 
 function firstStringValue(record: Record<string, unknown> | undefined, keys: string[]): string | null {
@@ -471,7 +488,7 @@ function genericFailureLookups(
 
   return {
     queries: uniqueQueries(queries),
-    componentKeys: uniqueQueries(componentKeys),
+    componentKeys: uniqueComponentKeys(componentKeys),
   };
 }
 
@@ -497,7 +514,7 @@ export function extractIntegrationLookupsFromProgressEvent(
     const failureLookups = genericFailureLookups(event.toolName, event.input);
     return {
       queries: uniqueQueries([...lookup.queries, ...failureLookups.queries]),
-      componentKeys: uniqueQueries([...lookup.componentKeys, ...failureLookups.componentKeys]),
+      componentKeys: uniqueComponentKeys([...lookup.componentKeys, ...failureLookups.componentKeys]),
       listConnected: false,
     };
   }
@@ -506,12 +523,9 @@ export function extractIntegrationLookupsFromProgressEvent(
 }
 
 function componentKeyPrefixes(componentKey: string): string[] {
-  const parts = componentKey
-    .trim()
-    .toLowerCase()
-    .split("-")
-    .map((part) => part.trim())
-    .filter(Boolean);
+  const normalized = normalizeExactIntegrationSlug(componentKey);
+  if (!normalized) return [];
+  const parts = normalized.split("-");
   const prefixes: string[] = [];
   for (let length = parts.length - 1; length > 0; length -= 1) {
     prefixes.push(parts.slice(0, length).join("-"));
@@ -520,9 +534,10 @@ function componentKeyPrefixes(componentKey: string): string[] {
 }
 
 function connectionMatchesCandidateSlug(connection: IntegrationConnection, candidate: string): boolean {
-  const candidateKey = normalizeIntegrationLookup(candidate);
+  const candidateKey = normalizeExactIntegrationSlug(candidate);
+  if (!candidateKey) return false;
   return [connection.appId, connection.app?.nameSlug]
-    .map(normalizeIntegrationLookup)
+    .map(normalizeExactIntegrationSlug)
     .some((connectionKey) => connectionKey === candidateKey);
 }
 
@@ -540,6 +555,7 @@ async function resolveComponentKeyCard(
   connections: IntegrationConnection[],
   componentKey: string,
   appCache: Map<string, Promise<IntegrationApp | null>>,
+  loadAppCatalog: () => Promise<IntegrationApp[]>,
 ): Promise<WebChatIntegrationConnectionData | null> {
   for (const candidate of componentKeyPrefixes(componentKey)) {
     const exactConnections = connections.filter((connection) => connectionMatchesCandidateSlug(connection, candidate));
@@ -548,16 +564,20 @@ async function resolveComponentKeyCard(
       return healthyConnection ? null : cardFromApp(appFromConnection(exactConnections[0]), null);
     }
 
-    const candidateKey = normalizeIntegrationLookup(candidate);
+    const candidateKey = normalizeExactIntegrationSlug(candidate);
+    if (!candidateKey) continue;
     let appRequest = appCache.get(candidateKey);
     if (!appRequest) {
       appRequest = provider
         .listApps(candidate, 5, undefined)
-        .then((result) => result.apps.find((app) => normalizeIntegrationLookup(app.id) === candidateKey) ?? null);
+        .then((result) => result.apps.find((app) => normalizeExactIntegrationSlug(app.id) === candidateKey) ?? null);
       appCache.set(candidateKey, appRequest);
     }
 
-    const app = await appRequest;
+    const queriedApp = await appRequest;
+    const app =
+      queriedApp ??
+      (await loadAppCatalog()).find((catalogApp) => normalizeExactIntegrationSlug(catalogApp.id) === candidateKey);
     if (!app) continue;
     const healthyConnection = connections.find(
       (connection) => connectionMatchesCandidateSlug(connection, app.id) && isActiveIntegrationConnection(connection),
@@ -583,7 +603,7 @@ export async function collectIntegrationCardsFromProgressEvents(params: {
   for (const event of params.events) {
     const lookup = extractIntegrationLookupsFromProgressEvent(event);
     for (const query of lookup.queries) queries.add(query);
-    for (const componentKey of lookup.componentKeys) componentKeys.add(componentKey);
+    for (const componentKey of uniqueComponentKeys(lookup.componentKeys)) componentKeys.add(componentKey);
     listConnected ||= lookup.listConnected;
   }
 
@@ -601,8 +621,13 @@ export async function collectIntegrationCardsFromProgressEvents(params: {
     cards.push(...result.cards.filter((card) => (card.state ?? "connect") === "connect"));
   }
   const appCache = new Map<string, Promise<IntegrationApp | null>>();
+  let appCatalogRequest: Promise<IntegrationApp[]> | null = null;
+  const loadAppCatalog = () => {
+    appCatalogRequest ??= provider.listApps(undefined, 20, undefined).then((result) => result.apps);
+    return appCatalogRequest;
+  };
   for (const componentKey of componentKeys) {
-    const card = await resolveComponentKeyCard(provider, connections, componentKey, appCache);
+    const card = await resolveComponentKeyCard(provider, connections, componentKey, appCache, loadAppCatalog);
     if (card) cards.push(card);
   }
   for (const card of dedupeIntegrationCards(cards)) {

--- a/packages/server/src/integrations/cards.ts
+++ b/packages/server/src/integrations/cards.ts
@@ -31,6 +31,12 @@ export interface IntegrationProgressEventLike {
   isError?: boolean;
 }
 
+export interface ExtractedIntegrationLookups {
+  queries: string[];
+  componentKeys: string[];
+  listConnected: boolean;
+}
+
 const CONNECTED_ACCOUNTS_INQUIRY_PATTERNS = [
   /\b(list|show|display|view|see)\b.*\b(connected\s+(accounts|apps|integrations|connections)|connections|accounts)\b/i,
   /\b(what|which)\b.*\b(accounts|apps|integrations|connections)\b.*\bconnected\b/i,
@@ -199,66 +205,9 @@ function uniqueQueries(queries: string[]): string[] {
   return result;
 }
 
-const COMPONENT_ACTION_START_SEGMENTS = new Set([
-  "accept",
-  "add",
-  "append",
-  "archive",
-  "assign",
-  "cancel",
-  "close",
-  "complete",
-  "copy",
-  "create",
-  "custom",
-  "delete",
-  "download",
-  "execute",
-  "export",
-  "fetch",
-  "find",
-  "forward",
-  "generate",
-  "get",
-  "import",
-  "insert",
-  "invite",
-  "list",
-  "lookup",
-  "make",
-  "move",
-  "open",
-  "post",
-  "publish",
-  "quick",
-  "reject",
-  "remove",
-  "reply",
-  "run",
-  "schedule",
-  "search",
-  "send",
-  "set",
-  "share",
-  "submit",
-  "sync",
-  "trigger",
-  "unarchive",
-  "update",
-  "upload",
-  "upsert",
-]);
-
-function appFromComponentKey(componentKey: string | null): string[] {
+function componentKeysFromValue(componentKey: string | null): string[] {
   const value = componentKey?.trim();
-  if (!value) return [];
-  const parts = value
-    .split("-")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  const actionIndex = parts.findIndex((part, index) => index > 0 && COMPONENT_ACTION_START_SEGMENTS.has(part));
-  const app = (actionIndex > 0 ? parts.slice(0, actionIndex).join("-") : parts[0])?.trim();
-  return app ? [app] : [];
+  return value ? [value] : [];
 }
 
 function firstStringValue(record: Record<string, unknown> | undefined, keys: string[]): string | null {
@@ -299,27 +248,24 @@ function rawQueryApps(value: unknown): string[] {
   });
 }
 
-export function extractCanvasIntegrationLookups(command: string): {
-  queries: string[];
-  listConnected: boolean;
-} {
-  if (!/\$\{?CANVAS_CLI\}?/.test(command)) return { queries: [], listConnected: false };
+export function extractCanvasIntegrationLookups(command: string): ExtractedIntegrationLookups {
+  if (!/\$\{?CANVAS_CLI\}?/.test(command)) return { queries: [], componentKeys: [], listConnected: false };
   const raw = parseRawJson(command) as Record<string, unknown> | null;
 
   if (/\bsearch-apps\b/.test(command) || /\bsearch_apps\b/.test(command)) {
     const rawQueries = rawStringArray(raw?.queries);
     const queries = rawQueries.length > 0 ? rawQueries : splitQueryList(shellFlagValue(command, "--queries"));
-    return { queries, listConnected: queries.length === 0 };
+    return { queries, componentKeys: [], listConnected: queries.length === 0 };
   }
 
   if (/\bget-components\b/.test(command) || /\bget_components\b/.test(command)) {
     const rawApps = rawStringArray(raw?.apps);
     const queries = rawApps.length > 0 ? rawApps : splitQueryList(shellFlagValue(command, "--apps"));
-    return { queries, listConnected: false };
+    return { queries, componentKeys: [], listConnected: false };
   }
 
   if (/\bsearch-components\b/.test(command) || /\bsearch_components\b/.test(command)) {
-    return { queries: rawQueryApps(raw?.queries), listConnected: false };
+    return { queries: rawQueryApps(raw?.queries), componentKeys: [], listConnected: false };
   }
 
   if (/\bget-component-definition\b/.test(command) || /\bget_component_definition\b/.test(command)) {
@@ -327,7 +273,7 @@ export function extractCanvasIntegrationLookups(command: string): {
       typeof raw?.key === "string"
         ? raw.key
         : shellFlagValueAny(command, ["--key", "--component-key", "--componentKey"]);
-    return { queries: appFromComponentKey(componentKey), listConnected: false };
+    return { queries: [], componentKeys: componentKeysFromValue(componentKey), listConnected: false };
   }
 
   if (/\bdirect-execute-action\b/.test(command) || /\bdirect_execute_action\b/.test(command)) {
@@ -335,7 +281,7 @@ export function extractCanvasIntegrationLookups(command: string): {
       typeof raw?.componentKey === "string"
         ? raw.componentKey
         : shellFlagValueAny(command, ["--component-key", "--componentKey"]);
-    return { queries: appFromComponentKey(componentKey), listConnected: false };
+    return { queries: [], componentKeys: componentKeysFromValue(componentKey), listConnected: false };
   }
 
   if (/\bfetch-remote-options\b/.test(command) || /\bfetch_remote_options\b/.test(command)) {
@@ -343,31 +289,28 @@ export function extractCanvasIntegrationLookups(command: string): {
       typeof raw?.componentKey === "string"
         ? raw.componentKey
         : shellFlagValueAny(command, ["--component-key", "--componentKey"]);
-    return { queries: appFromComponentKey(componentKey), listConnected: false };
+    return { queries: [], componentKeys: componentKeysFromValue(componentKey), listConnected: false };
   }
 
   if (/\bcreate-sketch-trigger-workflow\b/.test(command) || /\bcreate_sketch_trigger_workflow\b/.test(command)) {
     const rawSlug = raw?.triggerAppSlug;
     const triggerAppSlug =
       typeof rawSlug === "string" ? rawSlug : shellFlagValueAny(command, ["--trigger-app-slug", "--triggerAppSlug"]);
-    if (triggerAppSlug) return { queries: [triggerAppSlug], listConnected: false };
+    if (triggerAppSlug) return { queries: [triggerAppSlug], componentKeys: [], listConnected: false };
     const triggerComponentKey =
       typeof raw?.triggerComponentKey === "string"
         ? raw.triggerComponentKey
         : shellFlagValueAny(command, ["--trigger-component-key", "--triggerComponentKey"]);
-    return { queries: appFromComponentKey(triggerComponentKey), listConnected: false };
+    return { queries: [], componentKeys: componentKeysFromValue(triggerComponentKey), listConnected: false };
   }
 
-  return { queries: [], listConnected: false };
+  return { queries: [], componentKeys: [], listConnected: false };
 }
 
 function extractMcpIntegrationLookups(
   toolName: string | undefined,
   input: Record<string, unknown> | undefined,
-): {
-  queries: string[];
-  listConnected: boolean;
-} {
+): ExtractedIntegrationLookups {
   const match = toolName?.match(/^mcp__(.+?)__(.+)$/);
   const normalizedToolName = (match?.[2] ?? toolName ?? "")
     .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
@@ -376,35 +319,35 @@ function extractMcpIntegrationLookups(
 
   if (normalizedToolName === "search-apps") {
     const queries = stringListValue(input?.queries);
-    return { queries, listConnected: queries.length === 0 };
+    return { queries, componentKeys: [], listConnected: queries.length === 0 };
   }
 
   if (normalizedToolName === "get-components") {
-    return { queries: stringListValue(input?.apps), listConnected: false };
+    return { queries: stringListValue(input?.apps), componentKeys: [], listConnected: false };
   }
 
   if (normalizedToolName === "search-components") {
-    return { queries: rawQueryApps(input?.queries), listConnected: false };
+    return { queries: rawQueryApps(input?.queries), componentKeys: [], listConnected: false };
   }
 
   if (normalizedToolName === "get-component-definition") {
     const componentKey = firstStringValue(input, ["key", "componentKey"]);
-    return { queries: appFromComponentKey(componentKey), listConnected: false };
+    return { queries: [], componentKeys: componentKeysFromValue(componentKey), listConnected: false };
   }
 
   if (normalizedToolName === "direct-execute-action" || normalizedToolName === "fetch-remote-options") {
     const componentKey = firstStringValue(input, ["componentKey", "key"]);
-    return { queries: appFromComponentKey(componentKey), listConnected: false };
+    return { queries: [], componentKeys: componentKeysFromValue(componentKey), listConnected: false };
   }
 
   if (normalizedToolName === "create-sketch-trigger-workflow") {
     const triggerAppSlug = typeof input?.triggerAppSlug === "string" ? input.triggerAppSlug : null;
-    if (triggerAppSlug) return { queries: [triggerAppSlug], listConnected: false };
+    if (triggerAppSlug) return { queries: [triggerAppSlug], componentKeys: [], listConnected: false };
     const triggerComponentKey = typeof input?.triggerComponentKey === "string" ? input.triggerComponentKey : null;
-    return { queries: appFromComponentKey(triggerComponentKey), listConnected: false };
+    return { queries: [], componentKeys: componentKeysFromValue(triggerComponentKey), listConnected: false };
   }
 
-  return { queries: [], listConnected: false };
+  return { queries: [], componentKeys: [], listConnected: false };
 }
 
 const TOOL_RESULT_TEXT_LIMIT = 30_000;
@@ -507,34 +450,42 @@ function normalizedMcpToolParts(toolName: string | undefined): { server: string 
   };
 }
 
-function genericFailureQueries(toolName: string | undefined, input: Record<string, unknown> | undefined): string[] {
+function genericFailureLookups(
+  toolName: string | undefined,
+  input: Record<string, unknown> | undefined,
+): Pick<ExtractedIntegrationLookups, "queries" | "componentKeys"> {
   const queries: string[] = [];
+  const componentKeys: string[] = [];
   const directApp = firstStringValue(input, ["app", "appSlug", "appId", "nameSlug", "triggerAppSlug"]);
   if (directApp) queries.push(directApp);
   const componentKey = firstStringValue(input, ["componentKey", "key", "triggerComponentKey"]);
-  queries.push(...appFromComponentKey(componentKey));
+  componentKeys.push(...componentKeysFromValue(componentKey));
 
   const { server, operation } = normalizedMcpToolParts(toolName);
   if (server && !["canvas", "sketch", "plugin-pipedream", "pipedream"].includes(server)) {
     queries.push(server);
   }
   if (server?.includes("pipedream")) {
-    queries.push(...appFromComponentKey(operation));
+    componentKeys.push(...componentKeysFromValue(operation));
   }
 
-  return uniqueQueries(queries);
+  return {
+    queries: uniqueQueries(queries),
+    componentKeys: uniqueQueries(componentKeys),
+  };
 }
 
-export function extractIntegrationLookupsFromProgressEvent(event: IntegrationProgressEventLike): {
-  queries: string[];
-  listConnected: boolean;
-} {
+export function extractIntegrationLookupsFromProgressEvent(
+  event: IntegrationProgressEventLike,
+): ExtractedIntegrationLookups {
   if (event.kind === "tool_result" && !toolResultIndicatesConnectionIssue(event.output)) {
-    return { queries: [], listConnected: false };
+    return { queries: [], componentKeys: [], listConnected: false };
   }
-  if (event.kind !== "tool_use" && event.kind !== "tool_result") return { queries: [], listConnected: false };
+  if (event.kind !== "tool_use" && event.kind !== "tool_result") {
+    return { queries: [], componentKeys: [], listConnected: false };
+  }
 
-  let lookup: { queries: string[]; listConnected: boolean };
+  let lookup: ExtractedIntegrationLookups;
   if (event.toolName === "Bash") {
     const command = typeof event.input?.command === "string" ? event.input.command : "";
     lookup = extractCanvasIntegrationLookups(command);
@@ -543,13 +494,75 @@ export function extractIntegrationLookupsFromProgressEvent(event: IntegrationPro
   }
 
   if (event.kind === "tool_result") {
+    const failureLookups = genericFailureLookups(event.toolName, event.input);
     return {
-      queries: uniqueQueries([...lookup.queries, ...genericFailureQueries(event.toolName, event.input)]),
+      queries: uniqueQueries([...lookup.queries, ...failureLookups.queries]),
+      componentKeys: uniqueQueries([...lookup.componentKeys, ...failureLookups.componentKeys]),
       listConnected: false,
     };
   }
 
   return lookup;
+}
+
+function componentKeyPrefixes(componentKey: string): string[] {
+  const parts = componentKey
+    .trim()
+    .toLowerCase()
+    .split("-")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const prefixes: string[] = [];
+  for (let length = parts.length - 1; length > 0; length -= 1) {
+    prefixes.push(parts.slice(0, length).join("-"));
+  }
+  return prefixes;
+}
+
+function connectionMatchesCandidateSlug(connection: IntegrationConnection, candidate: string): boolean {
+  const candidateKey = normalizeIntegrationLookup(candidate);
+  return [connection.appId, connection.app?.nameSlug]
+    .map(normalizeIntegrationLookup)
+    .some((connectionKey) => connectionKey === candidateKey);
+}
+
+function appFromConnection(connection: IntegrationConnection): IntegrationApp {
+  return {
+    id: connection.appId,
+    name: connection.appName || connection.app?.name || connection.appId,
+    description: "",
+    ...(connection.icon || connection.app?.imgSrc ? { icon: connection.icon ?? connection.app?.imgSrc } : {}),
+  };
+}
+
+async function resolveComponentKeyCard(
+  provider: IntegrationProvider,
+  connections: IntegrationConnection[],
+  componentKey: string,
+  appCache: Map<string, Promise<IntegrationApp | null>>,
+): Promise<WebChatIntegrationConnectionData | null> {
+  for (const candidate of componentKeyPrefixes(componentKey)) {
+    const exactConnections = connections.filter((connection) => connectionMatchesCandidateSlug(connection, candidate));
+    if (exactConnections.length > 0) {
+      const healthyConnection = exactConnections.find(isActiveIntegrationConnection);
+      return healthyConnection ? null : cardFromApp(appFromConnection(exactConnections[0]), null);
+    }
+
+    const candidateKey = normalizeIntegrationLookup(candidate);
+    let appRequest = appCache.get(candidateKey);
+    if (!appRequest) {
+      appRequest = provider
+        .listApps(candidate, 5, undefined)
+        .then((result) => result.apps.find((app) => normalizeIntegrationLookup(app.id) === candidateKey) ?? null);
+      appCache.set(candidateKey, appRequest);
+    }
+
+    const app = await appRequest;
+    if (!app) continue;
+    return connectionForApp(connections, app) ? null : cardFromApp(app, null);
+  }
+
+  return null;
 }
 
 export async function collectIntegrationCardsFromProgressEvents(params: {
@@ -562,14 +575,16 @@ export async function collectIntegrationCardsFromProgressEvents(params: {
   if (!params.loadIntegrationProvider || !params.collector || !params.userEmail) return;
 
   const queries = new Set<string>();
+  const componentKeys = new Set<string>();
   let listConnected = false;
   for (const event of params.events) {
     const lookup = extractIntegrationLookupsFromProgressEvent(event);
     for (const query of lookup.queries) queries.add(query);
+    for (const componentKey of lookup.componentKeys) componentKeys.add(componentKey);
     listConnected ||= lookup.listConnected;
   }
 
-  if (queries.size === 0 && !listConnected) return;
+  if (queries.size === 0 && componentKeys.size === 0 && !listConnected) return;
 
   const provider = await params.loadIntegrationProvider();
   if (!provider) return;
@@ -581,6 +596,11 @@ export async function collectIntegrationCardsFromProgressEvents(params: {
   for (const query of queries) {
     const result = await resolveIntegrationLookup(provider, connections, { query });
     cards.push(...result.cards.filter((card) => (card.state ?? "connect") === "connect"));
+  }
+  const appCache = new Map<string, Promise<IntegrationApp | null>>();
+  for (const componentKey of componentKeys) {
+    const card = await resolveComponentKeyCard(provider, connections, componentKey, appCache);
+    if (card) cards.push(card);
   }
   for (const card of dedupeIntegrationCards(cards)) {
     params.collector.collect(card);

--- a/packages/server/src/integrations/cards.ts
+++ b/packages/server/src/integrations/cards.ts
@@ -120,7 +120,8 @@ export function dedupeIntegrationCards(cards: WebChatIntegrationConnectionData[]
   const seen = new Set<string>();
   const deduped: WebChatIntegrationConnectionData[] = [];
   for (const card of cards) {
-    const key = `${card.state ?? "connect"}:${normalizeIntegrationLookup(card.appId)}`;
+    const appKey = normalizeExactIntegrationSlug(card.appId) ?? normalizeIntegrationLookup(card.appId);
+    const key = `${card.state ?? "connect"}:${appKey}`;
     if (seen.has(key)) continue;
     seen.add(key);
     deduped.push(card);

--- a/packages/server/src/integrations/cards.ts
+++ b/packages/server/src/integrations/cards.ts
@@ -559,7 +559,10 @@ async function resolveComponentKeyCard(
 
     const app = await appRequest;
     if (!app) continue;
-    return connectionForApp(connections, app) ? null : cardFromApp(app, null);
+    const healthyConnection = connections.find(
+      (connection) => connectionMatchesCandidateSlug(connection, app.id) && isActiveIntegrationConnection(connection),
+    );
+    return healthyConnection ? null : cardFromApp(app, null);
   }
 
   return null;

--- a/packages/web/src/components/sketch/automation-artifact-card.isolated.test.tsx
+++ b/packages/web/src/components/sketch/automation-artifact-card.isolated.test.tsx
@@ -36,9 +36,9 @@ describe("AutomationArtifactCard", () => {
 
     expect(screen.getByText("Daily account brief")).toBeInTheDocument();
     expect(screen.getByText("ClickUp")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open Builder" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open automation" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Open Builder" }));
+    await user.click(screen.getByRole("button", { name: "Open automation" }));
     expect(mocks.navigate).toHaveBeenCalledWith({
       to: "/scheduled-tasks/$taskId/edit",
       params: { taskId: "task-123" },

--- a/packages/web/src/components/sketch/automation-artifact-card.tsx
+++ b/packages/web/src/components/sketch/automation-artifact-card.tsx
@@ -65,7 +65,7 @@ export function AutomationArtifactCard({
           className="h-9 rounded-[8px] bg-brand-accent px-4 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-[#161300] shadow-none hover:bg-brand-accent/90 sm:px-5"
           onClick={openBuilder}
         >
-          Open Builder
+          Open automation
         </Button>
         <Button
           type="button"


### PR DESCRIPTION
## Summary

- replace verb-based Canvas component-key parsing with canonical longest-prefix app resolution
- prevent false integration cards when the exact app is already connected
- replace user-facing automation “builder” terminology with plain automation wording

## Implementation Details

- retain complete component keys separately from explicit fuzzy app queries
- resolve component candidates longest-first with separator-preserving exact slug matching
- reject malformed component keys and fuzzy candidate-only provider results
- suppress cards for healthy exact connections while preserving reconnect cards for inactive or unhealthy connections
- cache candidate searches and the Canvas custom-app catalog fallback within each collection run
- preserve exact slug boundaries during final card deduplication
- update Slack/WhatsApp link headings, artifact-only fallback copy, prompt guidance, and the web automation-card CTA
- keep internal `builderUrl` fields, routes, and navigation unchanged

## Verification

- `pnpm lint` — passed; 1,123 files checked
- `pnpm typecheck` — passed for shared, UI, server, and web
- `pnpm test` — passed; server 3,969 passed / 20 skipped, web 334 passed
- `pnpm build` — passed for shared, UI, server, and web
- independent code review and QA assurance — no remaining Critical or Important findings

## Risk / Rollout

- no migrations, API changes, new environment variables, or feature flags
- the Canvas custom-app fallback checks the first 20 unfiltered apps, relying on injected custom apps remaining on the first catalog page
- authenticated Google Sheets and Slack/WhatsApp delivery checks remain manual
