### PR TITLE
Fix Daily Brief reader-owned todo personalization

### DIFF
--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -394,6 +394,53 @@ describe("dailyBriefDefinition.augmentRuntimeContext", () => {
     ]);
     expect(context?.identityUnresolvedTaskCount).toBe(1);
   });
+
+  it("loads the complete reader-owned allowlist while reconciliation caps displayed todos", async () => {
+    const user = await seedUser(db, {
+      id: "reader-many-tasks",
+      email: "many-tasks@example.com",
+      emailVerified: true,
+    });
+    await seedEntity(db, { id: "project-many-tasks", name: "Many Tasks Project" });
+    const taskIds = Array.from({ length: 55 }, (_, index) => `task-many-${String(index).padStart(2, "0")}`);
+    for (const taskId of taskIds) {
+      await seedTask(db, {
+        id: taskId,
+        title: `Canonical ${taskId}`,
+        provenance: "summary",
+        createdByUserId: user.id,
+        parentEntityId: "project-many-tasks",
+      });
+    }
+
+    const context = await dailyBriefDefinition.augmentRuntimeContext?.({
+      db,
+      config: createTestConfig(),
+      users: createUserRepository(db),
+      userId: user.id,
+      maxItemsPerSection: 4,
+      baseContext: { outputDate: "2026-06-25", timezone: "UTC" },
+    });
+
+    const openDurableTasks = context?.openDurableTasks as Array<{ id: string }>;
+    expect(openDurableTasks.map((task) => task.id).sort()).toEqual(taskIds);
+
+    const reconciled =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items: [],
+        runtimeContext: {
+          ...context,
+          sections: ["todos"],
+          maxItemsPerSection: 4,
+        },
+        logger: { info: vi.fn() } as never,
+        outputId: "output-many-tasks",
+        userId: user.id,
+      })) ?? [];
+
+    expect(reconciled.filter((item) => item.sectionKey === "todos")).toHaveLength(4);
+  });
 });
 
 describe("buildDailyBriefCandidateContext", () => {

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -1,8 +1,10 @@
 import type { Kysely, Selectable } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentOutputItemInput } from "../../db/repositories/agent-outputs";
+import { createTaskRepository } from "../../db/repositories/tasks";
+import { createUserRepository } from "../../db/repositories/users";
 import type { DB, UsersTable } from "../../db/schema";
-import { createTestDb } from "../../test-utils";
+import { createTestConfig, createTestDb } from "../../test-utils";
 import {
   DAILY_BRIEF_ENTITY_WINDOW_DAYS,
   DAILY_BRIEF_EVIDENCE_WINDOW_DAYS,
@@ -17,15 +19,22 @@ const NOW = new Date("2026-06-25T08:00:00.000Z");
 
 async function seedUser(
   db: Kysely<DB>,
-  params: { id?: string; email?: string; authRole?: "member" | "admin" } = {},
+  params: {
+    id?: string;
+    name?: string;
+    email?: string;
+    emailVerified?: boolean;
+    authRole?: "member" | "admin";
+  } = {},
 ): Promise<Selectable<UsersTable>> {
   const id = params.id ?? "user-1";
   await db
     .insertInto("users")
     .values({
       id,
-      name: "Agent User",
+      name: params.name ?? "Agent User",
       email: params.email ?? "agent@example.com",
+      email_verified_at: params.emailVerified ? NOW.toISOString() : null,
       auth_role: params.authRole ?? "member",
     })
     .execute();
@@ -120,6 +129,96 @@ async function seedMention(
     .execute();
 }
 
+async function seedPersonEntity(
+  db: Kysely<DB>,
+  params: { id: string; name: string; emails?: string[] },
+): Promise<void> {
+  await db
+    .insertInto("entities")
+    .values({
+      id: params.id,
+      name: params.name,
+      source_type: "person",
+      subtype: null,
+      aliases: null,
+      metadata: null,
+      source_ref_id: null,
+      status: "confirmed",
+      hotness: 0,
+      created_at: NOW.toISOString(),
+      updated_at: NOW.toISOString(),
+      ai_brief: null,
+    })
+    .execute();
+  for (const [index, email] of (params.emails ?? []).entries()) {
+    await db
+      .insertInto("entity_contact_points")
+      .values({
+        id: `${params.id}-email-${index}`,
+        entity_id: params.id,
+        kind: "email",
+        value: email.toLowerCase(),
+        display_value: email,
+        label: null,
+        source: "test",
+        connector_config_id: null,
+        created_by_user_id: null,
+        verified_at: NOW.toISOString(),
+        last_contacted_at: null,
+      })
+      .execute();
+  }
+}
+
+async function seedTask(
+  db: Kysely<DB>,
+  params: {
+    id: string;
+    title: string;
+    status?: "open" | "in_progress" | "done" | "dropped";
+    statusRaw?: string;
+    priority?: string | null;
+    provenance?: "structural" | "brief" | "summary";
+    assigneeEntityId?: string | null;
+    parentEntityId?: string | null;
+    createdByUserId?: string | null;
+    updatedAt?: string;
+    fileIds?: string[];
+    entityIds?: string[];
+  },
+): Promise<void> {
+  const repo = createTaskRepository(db);
+  await repo.upsertTask({
+    parentEntityId: params.parentEntityId ?? null,
+    parentSourceRef: null,
+    parentName: null,
+    source: params.provenance === "structural" ? "linear" : (params.provenance ?? "summary"),
+    externalRef: `EXT-${params.id}`,
+    title: params.title,
+    status: params.status ?? "open",
+    statusRaw: params.statusRaw ?? params.status ?? "open",
+    statusAuthority: params.provenance === "structural" ? "external" : "local",
+    assigneeEntityId: params.assigneeEntityId ?? null,
+    priority: params.priority ?? null,
+    dueAt: null,
+    provenance: params.provenance ?? "summary",
+    sourceTaskId: params.id,
+    createdByUserId: params.createdByUserId ?? null,
+  });
+  const task = await db
+    .selectFrom("tasks")
+    .select("id")
+    .where("source_task_id", "=", params.id)
+    .executeTakeFirstOrThrow();
+  await db
+    .updateTable("tasks")
+    .set({ id: params.id, updated_at: params.updatedAt ?? NOW.toISOString() })
+    .where("id", "=", task.id)
+    .execute();
+  for (const fileId of params.fileIds ?? []) await repo.upsertEvidence(params.id, "file", fileId);
+  for (const entityId of params.entityIds ?? []) await repo.upsertEvidence(params.id, "entity", entityId);
+}
+
 describe("dailyBriefDefinition.buildInstructions", () => {
   it("is static and defers per-user values to the runtime context (prompt-cache safe)", () => {
     const instructions = dailyBriefDefinition.buildInstructions();
@@ -136,6 +235,164 @@ describe("dailyBriefDefinition.buildInstructions", () => {
     expect(instructions).toContain("active_projects:");
 
     expect(instructions).not.toMatch(/at most \d+ items/);
+  });
+
+  it("requires todos to project only allowlisted durable task ids", () => {
+    const instructions = dailyBriefDefinition.buildInstructions();
+
+    expect(instructions).toContain("structuredPayload.durableTaskId");
+    expect(instructions).toContain("openDurableTasks");
+    expect(instructions).toMatch(/only IDs present in `openDurableTasks`/);
+    expect(instructions).toMatch(/Do not derive new todos from recentSummaries or broad search/);
+  });
+});
+
+describe("dailyBriefDefinition.augmentRuntimeContext", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedConnectorConfig(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("resolves verified primary and provider emails into an unambiguous reader-owned task runtime", async () => {
+    const user = await seedUser(db, {
+      id: "reader-1",
+      email: "primary@example.com",
+      emailVerified: true,
+    });
+    await db
+      .insertInto("user_provider_identities")
+      .values({
+        id: "provider-reader-1",
+        user_id: user.id,
+        provider: "google",
+        provider_user_id: "google-reader-1",
+        provider_email: "provider@example.com",
+      })
+      .execute();
+    await seedPersonEntity(db, {
+      id: "person-reader",
+      name: "Reader Person",
+      emails: ["primary@example.com", "provider@example.com"],
+    });
+    await seedEntity(db, { id: "project-runtime", name: "Runtime Project" });
+    await seedIndexedFile(db, { id: "file-runtime", sourceUpdatedAt: NOW.toISOString() });
+    await seedTask(db, {
+      id: "task-runtime",
+      title: "Canonical task title",
+      status: "in_progress",
+      statusRaw: "Started",
+      priority: "Urgent",
+      provenance: "structural",
+      assigneeEntityId: "person-reader",
+      parentEntityId: "project-runtime",
+      updatedAt: "2026-06-25T07:00:00.000Z",
+      fileIds: ["file-runtime"],
+    });
+    await seedTask(db, {
+      id: "summary-assigned",
+      title: "Assigned summary task",
+      provenance: "summary",
+      assigneeEntityId: "person-reader",
+      updatedAt: "2026-06-25T06:00:00.000Z",
+      fileIds: ["file-runtime"],
+    });
+
+    const context = await dailyBriefDefinition.augmentRuntimeContext?.({
+      db,
+      config: createTestConfig(),
+      users: createUserRepository(db),
+      userId: user.id,
+      maxItemsPerSection: 4,
+      baseContext: { outputDate: "2026-06-25", timezone: "UTC" },
+    });
+
+    expect(context?.openDurableTasks).toEqual([
+      {
+        id: "task-runtime",
+        title: "Canonical task title",
+        status: "in_progress",
+        statusRaw: "Started",
+        priority: "Urgent",
+        provenance: "structural",
+        externalRef: "EXT-task-runtime",
+        updatedAt: "2026-06-25T07:00:00.000Z",
+        createdByReader: false,
+        assignedToReader: true,
+        parentEntity: { id: "project-runtime", name: "Runtime Project", sourceType: "project" },
+        assigneeEntity: { id: "person-reader", name: "Reader Person", sourceType: "person" },
+        knowledgeRefs: {
+          entityIds: ["person-reader", "project-runtime"],
+          fileIds: ["file-runtime"],
+        },
+      },
+      {
+        id: "summary-assigned",
+        title: "Assigned summary task",
+        status: "open",
+        statusRaw: "open",
+        priority: null,
+        provenance: "summary",
+        externalRef: "EXT-summary-assigned",
+        updatedAt: "2026-06-25T06:00:00.000Z",
+        createdByReader: false,
+        assignedToReader: true,
+        parentEntity: null,
+        assigneeEntity: { id: "person-reader", name: "Reader Person", sourceType: "person" },
+        knowledgeRefs: {
+          entityIds: ["person-reader"],
+          fileIds: ["file-runtime"],
+        },
+      },
+    ]);
+    expect(context?.summaryTasks).toEqual([
+      expect.objectContaining({ id: "summary-assigned", title: "Assigned summary task" }),
+    ]);
+    expect(context?.identityUnresolvedTaskCount).toBe(0);
+  });
+
+  it("does not fall back to matching the user name and fails structural tasks closed when identity is unresolved", async () => {
+    const user = await seedUser(db, {
+      id: "reader-unresolved",
+      name: "Matching Person Name",
+      email: "verified-but-unmapped@example.com",
+      emailVerified: true,
+    });
+    await seedPersonEntity(db, { id: "person-name-only", name: "Matching Person Name" });
+    await seedIndexedFile(db, { id: "file-unresolved", sourceUpdatedAt: NOW.toISOString() });
+    await seedTask(db, {
+      id: "structural-withheld",
+      title: "Withheld structural task",
+      provenance: "structural",
+      assigneeEntityId: "person-name-only",
+      fileIds: ["file-unresolved"],
+    });
+    await seedTask(db, {
+      id: "reader-created-local",
+      title: "Reader-created local task",
+      provenance: "summary",
+      createdByUserId: user.id,
+      fileIds: ["file-unresolved"],
+    });
+
+    const context = await dailyBriefDefinition.augmentRuntimeContext?.({
+      db,
+      config: createTestConfig(),
+      users: createUserRepository(db),
+      userId: user.id,
+      maxItemsPerSection: 4,
+      baseContext: { outputDate: "2026-06-25", timezone: "UTC" },
+    });
+
+    expect(context?.openDurableTasks).toEqual([
+      expect.objectContaining({ id: "reader-created-local", createdByReader: true, assignedToReader: false }),
+    ]);
+    expect(context?.identityUnresolvedTaskCount).toBe(1);
   });
 });
 
@@ -642,6 +899,45 @@ describe("dailyBriefDefinition.reconcileItems", () => {
     };
   }
 
+  function todoItem(durableTaskId: unknown, overrides: Partial<AgentOutputItemInput> = {}): AgentOutputItemInput {
+    return {
+      sectionKey: "todos",
+      title: "Model todo title",
+      summary: "Model todo summary",
+      priority: "low",
+      label: "blocked",
+      actionLabel: "Unblock with Sketch",
+      actionPrompt: "Model prompt",
+      structuredPayload: { durableTaskId, unrelated: "model data" },
+      knowledgeRefs: { entityIds: ["model-entity"], fileIds: ["model-file"] },
+      sortOrder: 99,
+      ...overrides,
+    };
+  }
+
+  function durableTask(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      id,
+      title: `Canonical ${id}`,
+      status: "open",
+      statusRaw: "Open",
+      priority: "medium",
+      provenance: "structural",
+      externalRef: `EXT-${id}`,
+      updatedAt: "2026-06-25T06:00:00.000Z",
+      createdByReader: false,
+      assignedToReader: true,
+      parentEntity: null,
+      assigneeEntity: { id: "person-reader", name: "Reader", sourceType: "person" },
+      knowledgeRefs: { entityIds: ["person-reader"], fileIds: [`file-${id}`] },
+      ...overrides,
+    };
+  }
+
+  function reconcileLogger() {
+    return { info: vi.fn() };
+  }
+
   it("uses the skeleton as truth: enriches matches, backfills skipped, drops invented meetings", async () => {
     const items: AgentOutputItemInput[] = [
       meetingItem("evt-1", {
@@ -651,11 +947,12 @@ describe("dailyBriefDefinition.reconcileItems", () => {
       meetingItem("ghost", { context: "Invented meeting." }),
       {
         sectionKey: "todos",
-        title: "Ship the thing",
+        title: "Model todo title",
         summary: "do it",
         priority: "high",
         label: "todo",
-        knowledgeRefs: { entityIds: [], fileIds: [] },
+        structuredPayload: { durableTaskId: "task-1" },
+        knowledgeRefs: { entityIds: ["model-entity"], fileIds: ["model-file"] },
         sortOrder: 0,
       },
     ];
@@ -664,7 +961,16 @@ describe("dailyBriefDefinition.reconcileItems", () => {
       (await dailyBriefDefinition.reconcileItems?.({
         db,
         items,
-        runtimeContext: { sections: ["meetings", "todos"], todaysMeetings: skeleton },
+        runtimeContext: {
+          sections: ["meetings", "todos"],
+          maxItemsPerSection: 4,
+          todaysMeetings: skeleton,
+          openDurableTasks: [durableTask("task-1")],
+          identityUnresolvedTaskCount: 0,
+        },
+        logger: reconcileLogger() as never,
+        outputId: "output-meetings",
+        userId: "user-meetings",
       })) ?? [];
 
     const meetings = result.filter((item) => item.sectionKey === DAILY_BRIEF_MEETINGS_SECTION_KEY);
@@ -693,6 +999,9 @@ describe("dailyBriefDefinition.reconcileItems", () => {
         db,
         items: [meetingItem("evt-1", null)],
         runtimeContext: { sections: ["meetings"], todaysMeetings: [] },
+        logger: reconcileLogger() as never,
+        outputId: "output-empty-meetings",
+        userId: "user-meetings",
       })) ?? [];
 
     expect(result).toEqual([]);
@@ -704,8 +1013,197 @@ describe("dailyBriefDefinition.reconcileItems", () => {
       db,
       items,
       runtimeContext: { sections: ["todos"], todaysMeetings: skeleton },
+      logger: reconcileLogger() as never,
+      outputId: "output-meetings-disabled",
+      userId: "user-meetings",
     });
 
     expect(result).toBe(items);
+  });
+
+  it("accepts only unique allowlisted durable task ids and canonicalizes task-owned fields", async () => {
+    const logger = reconcileLogger();
+    const customer = {
+      sectionKey: "customer_updates",
+      title: "Customer unchanged",
+      summary: "Keep this model content",
+      priority: "high",
+      label: "warm",
+      knowledgeRefs: { entityIds: ["customer-1"], fileIds: ["customer-file"] },
+      sortOrder: 0,
+    } satisfies AgentOutputItemInput;
+    const items = [
+      todoItem("task-valid"),
+      todoItem(undefined, { structuredPayload: {} }),
+      todoItem(42),
+      todoItem("task-invented"),
+      todoItem("task-valid"),
+      customer,
+    ];
+
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items,
+        runtimeContext: {
+          sections: ["todos", "customer_updates"],
+          maxItemsPerSection: 4,
+          openDurableTasks: [
+            durableTask("task-valid", {
+              title: "Canonical urgent task",
+              status: "in_progress",
+              statusRaw: "Started",
+              priority: "urgent",
+              knowledgeRefs: { entityIds: ["project-1"], fileIds: ["canonical-file"] },
+            }),
+            durableTask("task-no-refs", {
+              knowledgeRefs: { entityIds: [], fileIds: [] },
+            }),
+          ],
+          identityUnresolvedTaskCount: 3,
+        },
+        logger: logger as never,
+        outputId: "output-reconcile",
+        userId: "user-reconcile",
+      })) ?? [];
+
+    expect(result.filter((item) => item.sectionKey === "todos")).toEqual([
+      expect.objectContaining({
+        title: "Canonical urgent task",
+        label: "in_progress",
+        priority: "high",
+        structuredPayload: { durableTaskId: "task-valid" },
+        knowledgeRefs: { entityIds: ["project-1"], fileIds: ["canonical-file"] },
+        sortOrder: 0,
+      }),
+    ]);
+    expect(result.find((item) => item.sectionKey === "customer_updates")).toBe(customer);
+    expect(JSON.stringify(result)).not.toContain("model-entity");
+    expect(JSON.stringify(result)).not.toContain("model-file");
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info.mock.calls[0]?.[0]).toEqual({
+      outputId: "output-reconcile",
+      userId: "user-reconcile",
+      allowedTaskCount: 1,
+      rejectedTaskCount: 4,
+      backfilledTaskCount: 0,
+      identityUnresolvedTaskCount: 3,
+    });
+    expect(Object.keys(logger.info.mock.calls[0]?.[0] ?? {}).sort()).toEqual(
+      [
+        "allowedTaskCount",
+        "backfilledTaskCount",
+        "identityUnresolvedTaskCount",
+        "outputId",
+        "rejectedTaskCount",
+        "userId",
+      ].sort(),
+    );
+  });
+
+  it("backfills unused tasks in updatedAt DESC then id ASC order and enforces the todo cap", async () => {
+    const logger = reconcileLogger();
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items: [todoItem("task-b")],
+        runtimeContext: {
+          sections: ["todos"],
+          maxItemsPerSection: 3,
+          openDurableTasks: [
+            durableTask("task-a", {
+              priority: null,
+              updatedAt: "2026-06-25T06:00:00.000Z",
+            }),
+            durableTask("task-b", {
+              priority: "low",
+              updatedAt: "2026-06-25T06:00:00.000Z",
+            }),
+            durableTask("task-latest", {
+              status: "in_progress",
+              priority: "1",
+              updatedAt: "2026-06-25T07:00:00.000Z",
+            }),
+            durableTask("task-over-cap", {
+              updatedAt: "2026-06-25T05:00:00.000Z",
+            }),
+          ],
+          identityUnresolvedTaskCount: 0,
+        },
+        logger: logger as never,
+        outputId: "output-backfill",
+        userId: "user-backfill",
+      })) ?? [];
+
+    const todos = result.filter((item) => item.sectionKey === "todos");
+    expect(todos.map((item) => item.structuredPayload?.durableTaskId)).toEqual(["task-b", "task-latest", "task-a"]);
+    expect(todos.map((item) => item.priority)).toEqual(["low", "high", "medium"]);
+    expect(todos.map((item) => item.label)).toEqual(["todo", "in_progress", "todo"]);
+    expect(todos.slice(1)).toEqual([
+      expect.objectContaining({
+        summary: expect.any(String),
+        actionLabel: "Plan with Sketch",
+        actionPrompt: expect.any(String),
+        sortOrder: 1,
+      }),
+      expect.objectContaining({
+        summary: expect.any(String),
+        actionLabel: "Plan with Sketch",
+        actionPrompt: expect.any(String),
+        sortOrder: 2,
+      }),
+    ]);
+    expect(logger.info.mock.calls[0]?.[0]).toMatchObject({
+      allowedTaskCount: 4,
+      rejectedTaskCount: 0,
+      backfilledTaskCount: 2,
+    });
+  });
+
+  it("composes todo projection with meeting reconciliation while leaving customer and project items unchanged", async () => {
+    const logger = reconcileLogger();
+    const customer = {
+      sectionKey: "customer_updates",
+      title: "Customer update",
+      summary: "Customer model summary",
+      priority: "high",
+      label: "at_risk",
+      knowledgeRefs: { entityIds: ["customer-1"], fileIds: ["customer-file"] },
+      sortOrder: 0,
+    } satisfies AgentOutputItemInput;
+    const project = {
+      sectionKey: "active_projects",
+      title: "Project update",
+      summary: "Project model summary",
+      priority: "medium",
+      label: "active",
+      knowledgeRefs: { entityIds: ["project-1"], fileIds: ["project-file"] },
+      sortOrder: 0,
+    } satisfies AgentOutputItemInput;
+
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items: [meetingItem("evt-1", { context: "Meeting context" }), todoItem("task-compose"), customer, project],
+        runtimeContext: {
+          sections: ["meetings", "todos", "customer_updates", "active_projects"],
+          maxItemsPerSection: 2,
+          todaysMeetings: [skeleton[0]],
+          openDurableTasks: [durableTask("task-compose")],
+          identityUnresolvedTaskCount: 0,
+        },
+        logger: logger as never,
+        outputId: "output-compose",
+        userId: "user-compose",
+      })) ?? [];
+
+    expect(result.map((item) => item.sectionKey)).toEqual(["meetings", "todos", "customer_updates", "active_projects"]);
+    expect(result[0]).toMatchObject({ title: "Standup", summary: "Meeting context" });
+    expect(result[1]).toMatchObject({
+      title: "Canonical task-compose",
+      structuredPayload: { durableTaskId: "task-compose" },
+    });
+    expect(result[2]).toBe(customer);
+    expect(result[3]).toBe(project);
   });
 });

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -395,6 +395,80 @@ describe("dailyBriefDefinition.augmentRuntimeContext", () => {
     expect(context?.identityUnresolvedTaskCount).toBe(1);
   });
 
+  it("fails assignment-based tasks closed when verified emails resolve to different people", async () => {
+    const user = await seedUser(db, {
+      id: "reader-conflicting",
+      email: "primary-conflicting@example.com",
+      emailVerified: true,
+    });
+    await db
+      .insertInto("user_provider_identities")
+      .values({
+        id: "provider-reader-conflicting",
+        user_id: user.id,
+        provider: "google",
+        provider_user_id: "google-reader-conflicting",
+        provider_email: "provider-conflicting@example.com",
+      })
+      .execute();
+    await seedPersonEntity(db, {
+      id: "person-primary-conflicting",
+      name: "Primary Identity",
+      emails: ["primary-conflicting@example.com"],
+    });
+    await seedPersonEntity(db, {
+      id: "person-provider-conflicting",
+      name: "Provider Identity",
+      emails: ["provider-conflicting@example.com"],
+    });
+    await seedIndexedFile(db, { id: "file-conflicting", sourceUpdatedAt: NOW.toISOString() });
+    await seedTask(db, {
+      id: "structural-primary-conflicting",
+      title: "Primary structural task",
+      provenance: "structural",
+      assigneeEntityId: "person-primary-conflicting",
+      fileIds: ["file-conflicting"],
+    });
+    await seedTask(db, {
+      id: "structural-provider-conflicting",
+      title: "Provider structural task",
+      provenance: "structural",
+      assigneeEntityId: "person-provider-conflicting",
+      fileIds: ["file-conflicting"],
+    });
+    await seedTask(db, {
+      id: "local-assigned-conflicting",
+      title: "Assigned local task",
+      provenance: "summary",
+      assigneeEntityId: "person-primary-conflicting",
+      fileIds: ["file-conflicting"],
+    });
+    await seedTask(db, {
+      id: "local-created-conflicting",
+      title: "Reader-created local task",
+      provenance: "summary",
+      createdByUserId: user.id,
+      fileIds: ["file-conflicting"],
+    });
+
+    const context = await dailyBriefDefinition.augmentRuntimeContext?.({
+      db,
+      config: createTestConfig(),
+      users: createUserRepository(db),
+      userId: user.id,
+      maxItemsPerSection: 4,
+      baseContext: { outputDate: "2026-06-25", timezone: "UTC" },
+    });
+
+    expect((context?.openDurableTasks as Array<{ id: string }>).map((task) => task.id)).toEqual([
+      "local-created-conflicting",
+    ]);
+    expect(context?.summaryTasks).toEqual([
+      expect.objectContaining({ id: "local-created-conflicting", title: "Reader-created local task" }),
+    ]);
+    expect(context?.identityUnresolvedTaskCount).toBe(2);
+  });
+
   it("loads the complete reader-owned allowlist while reconciliation caps displayed todos", async () => {
     const user = await seedUser(db, {
       id: "reader-many-tasks",
@@ -1207,6 +1281,31 @@ describe("dailyBriefDefinition.reconcileItems", () => {
     });
   });
 
+  it("rejects valid model-selected todos beyond the section cap", async () => {
+    const logger = reconcileLogger();
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items: [todoItem("task-a"), todoItem("task-b"), todoItem("task-c")],
+        runtimeContext: {
+          sections: ["todos"],
+          maxItemsPerSection: 2,
+          openDurableTasks: [durableTask("task-a"), durableTask("task-b"), durableTask("task-c")],
+          identityUnresolvedTaskCount: 0,
+        },
+        logger: logger as never,
+        outputId: "output-model-cap",
+        userId: "user-model-cap",
+      })) ?? [];
+
+    expect(result.map((item) => item.structuredPayload?.durableTaskId)).toEqual(["task-a", "task-b"]);
+    expect(logger.info.mock.calls[0]?.[0]).toMatchObject({
+      allowedTaskCount: 3,
+      rejectedTaskCount: 1,
+      backfilledTaskCount: 0,
+    });
+  });
+
   it("composes todo projection with meeting reconciliation while leaving customer and project items unchanged", async () => {
     const logger = reconcileLogger();
     const customer = {
@@ -1252,6 +1351,59 @@ describe("dailyBriefDefinition.reconcileItems", () => {
     });
     expect(result[2]).toBe(customer);
     expect(result[3]).toBe(project);
+  });
+
+  it("revalidates the runtime task snapshot before persistence", async () => {
+    await seedConnectorConfig(db);
+    const user = await seedUser(db, {
+      id: "user-revalidate",
+      email: "revalidate@example.com",
+      emailVerified: true,
+    });
+    await seedPersonEntity(db, {
+      id: "person-revalidate",
+      name: "Revalidate Person",
+      emails: ["revalidate@example.com"],
+    });
+    await seedIndexedFile(db, { id: "file-revalidate", sourceUpdatedAt: NOW.toISOString() });
+    await seedTask(db, {
+      id: "task-revalidate",
+      title: "Task that closes during generation",
+      provenance: "structural",
+      assigneeEntityId: "person-revalidate",
+      fileIds: ["file-revalidate"],
+    });
+    const snapshot = await dailyBriefDefinition.augmentRuntimeContext?.({
+      db,
+      config: createTestConfig(),
+      users: createUserRepository(db),
+      userId: user.id,
+      maxItemsPerSection: 4,
+      baseContext: { outputDate: "2026-06-25", timezone: "UTC" },
+    });
+    await db.updateTable("tasks").set({ status: "done" }).where("id", "=", "task-revalidate").execute();
+
+    const logger = reconcileLogger();
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items: [todoItem("task-revalidate")],
+        runtimeContext: {
+          ...snapshot,
+          sections: ["todos"],
+          maxItemsPerSection: 4,
+        },
+        logger: logger as never,
+        outputId: "output-revalidate",
+        userId: user.id,
+      })) ?? [];
+
+    expect(result).toEqual([]);
+    expect(logger.info.mock.calls[0]?.[0]).toMatchObject({
+      allowedTaskCount: 0,
+      rejectedTaskCount: 1,
+      backfilledTaskCount: 0,
+    });
   });
 });
 

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -1405,6 +1405,67 @@ describe("dailyBriefDefinition.reconcileItems", () => {
       backfilledTaskCount: 0,
     });
   });
+
+  it("drops model enrichment when canonical task references change during generation", async () => {
+    await seedConnectorConfig(db);
+    const user = await seedUser(db, {
+      id: "user-reference-change",
+      email: "reference-change@example.com",
+      emailVerified: true,
+    });
+    await seedPersonEntity(db, {
+      id: "person-reference-change",
+      name: "Reference Change Person",
+      emails: ["reference-change@example.com"],
+    });
+    await seedIndexedFile(db, { id: "file-reference-revoked", sourceUpdatedAt: NOW.toISOString() });
+    await seedIndexedFile(db, { id: "file-reference-retained", sourceUpdatedAt: NOW.toISOString() });
+    await seedTask(db, {
+      id: "task-reference-change",
+      title: "Task whose evidence access changes",
+      provenance: "structural",
+      assigneeEntityId: "person-reference-change",
+      fileIds: ["file-reference-revoked", "file-reference-retained"],
+    });
+    const snapshot = await dailyBriefDefinition.augmentRuntimeContext?.({
+      db,
+      config: createTestConfig(),
+      users: createUserRepository(db),
+      userId: user.id,
+      maxItemsPerSection: 4,
+      baseContext: { outputDate: "2026-06-25", timezone: "UTC" },
+    });
+    await db
+      .insertInto("file_access")
+      .values({ indexed_file_id: "file-reference-revoked", email: "someone-else@example.com" })
+      .execute();
+
+    const result =
+      (await dailyBriefDefinition.reconcileItems?.({
+        db,
+        items: [todoItem("task-reference-change")],
+        runtimeContext: {
+          ...snapshot,
+          sections: ["todos"],
+          maxItemsPerSection: 4,
+        },
+        logger: reconcileLogger() as never,
+        outputId: "output-reference-change",
+        userId: user.id,
+      })) ?? [];
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        title: "Task whose evidence access changes",
+        summary: "Open and ready for your attention.",
+        actionPrompt: expect.not.stringContaining("Model prompt"),
+        knowledgeRefs: {
+          entityIds: ["person-reference-change"],
+          fileIds: ["file-reference-retained"],
+        },
+      }),
+    ]);
+  });
 });
 
 describe("dailyBriefDefinition.onOutputSaved", () => {

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -4,7 +4,7 @@ import type { AgentOutputItemInput } from "../../db/repositories/agent-outputs";
 import { createTaskRepository } from "../../db/repositories/tasks";
 import { createUserRepository } from "../../db/repositories/users";
 import type { DB, UsersTable } from "../../db/schema";
-import { createTestConfig, createTestDb } from "../../test-utils";
+import { createTestConfig, createTestDb, createTestLogger } from "../../test-utils";
 import {
   DAILY_BRIEF_ENTITY_WINDOW_DAYS,
   DAILY_BRIEF_EVIDENCE_WINDOW_DAYS,
@@ -1252,5 +1252,57 @@ describe("dailyBriefDefinition.reconcileItems", () => {
     });
     expect(result[2]).toBe(customer);
     expect(result[3]).toBe(project);
+  });
+});
+
+describe("dailyBriefDefinition.onOutputSaved", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUser(db, { id: "user-1", name: "Agent User", email: "agent@example.com", emailVerified: true });
+    await seedConnectorConfig(db);
+    await seedPersonEntity(db, {
+      id: "person-agent",
+      name: "Agent User",
+      emails: ["agent@example.com"],
+    });
+    await seedIndexedFile(db, { id: "task-source", sourceUpdatedAt: NOW.toISOString() });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("skips promotion for every todo carrying a valid durable task id even when task creation is enabled", async () => {
+    await dailyBriefDefinition.onOutputSaved?.({
+      db,
+      config: createTestConfig(),
+      logger: createTestLogger(),
+      userId: "user-1",
+      outputId: "output-task-backed",
+      createTasks: true,
+      items: [
+        {
+          sectionKey: "todos",
+          title: "Task-backed todo",
+          summary: "Already represents a durable task.",
+          priority: "high",
+          label: "todo",
+          structuredPayload: {
+            durableTaskId: "durable-task-1",
+            assigneeName: "Agent User",
+          },
+          knowledgeRefs: { entityIds: [], fileIds: ["task-source"] },
+          sortOrder: 0,
+        },
+      ],
+    });
+
+    const row = await db
+      .selectFrom("tasks")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .executeTakeFirstOrThrow();
+    expect(Number(row.count)).toBe(0);
   });
 });

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -159,6 +159,9 @@ type RuntimeDurableTask = {
   priority: string | null;
   externalRef: string | null;
   updatedAt: string;
+  createdByReader: boolean;
+  assignedToReader: boolean;
+  suppressModelEnrichment: boolean;
   knowledgeRefs: AgentKnowledgeRefs;
 };
 
@@ -870,6 +873,9 @@ function parseRuntimeDurableTasks(value: unknown): RuntimeDurableTask[] {
       priority: readString(task?.priority),
       externalRef: readString(task?.externalRef),
       updatedAt: readString(task?.updatedAt) ?? "",
+      createdByReader: task?.createdByReader === true,
+      assignedToReader: task?.assignedToReader === true,
+      suppressModelEnrichment: task?.suppressModelEnrichment === true,
       knowledgeRefs: {
         entityIds: uniqueStrings(refs?.entityIds),
         fileIds: uniqueStrings(refs?.fileIds),
@@ -972,7 +978,7 @@ function reconcileTodoItems(
       continue;
     }
     usedIds.add(task.id);
-    accepted.push(canonicalTodoItem(task, item, accepted.length));
+    accepted.push(canonicalTodoItem(task, task.suppressModelEnrichment ? undefined : item, accepted.length));
   }
 
   const remaining = [...allowedById.values()]
@@ -1248,14 +1254,41 @@ async function revalidateRuntimeDurableTasks(
   runtimeContext: Record<string, unknown>,
 ): Promise<unknown> {
   if (readString(runtimeContext.readerTaskSnapshotUserId) !== userId) return runtimeContext.openDurableTasks;
-  const snapshotIds = new Set(parseRuntimeDurableTasks(runtimeContext.openDurableTasks).map((task) => task.id));
-  if (snapshotIds.size === 0) return [];
+  const snapshotById = new Map(
+    parseRuntimeDurableTasks(runtimeContext.openDurableTasks).map((task) => [task.id, task]),
+  );
+  if (snapshotById.size === 0) return [];
   const { tasks } = await loadOpenDurableTasksForReader({
     db,
     userId,
     users: createUserRepository(db),
   });
-  return tasks.filter((task) => snapshotIds.has(task.id)).map(runtimeDurableTask);
+  return tasks.flatMap((task) => {
+    const snapshot = snapshotById.get(task.id);
+    if (!snapshot) return [];
+    const current = parseRuntimeDurableTasks([runtimeDurableTask(task)])[0];
+    if (!current) return [];
+    return [
+      {
+        ...runtimeDurableTask(task),
+        suppressModelEnrichment: !sameRuntimeDurableTask(snapshot, current),
+      },
+    ];
+  });
+}
+
+function sameRuntimeDurableTask(left: RuntimeDurableTask, right: RuntimeDurableTask): boolean {
+  return (
+    left.title === right.title &&
+    left.status === right.status &&
+    left.priority === right.priority &&
+    left.externalRef === right.externalRef &&
+    left.updatedAt === right.updatedAt &&
+    left.createdByReader === right.createdByReader &&
+    left.assignedToReader === right.assignedToReader &&
+    [...left.knowledgeRefs.entityIds].sort().join("\0") === [...right.knowledgeRefs.entityIds].sort().join("\0") &&
+    [...left.knowledgeRefs.fileIds].sort().join("\0") === [...right.knowledgeRefs.fileIds].sort().join("\0")
+  );
 }
 
 async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Record<string, unknown>> {

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -1266,6 +1266,7 @@ async function onOutputSaved(args: AgentOutputSavedArgs): Promise<void> {
   const taskRepo = createTaskRepository(args.db);
   for (const item of args.items) {
     if (item.sectionKey !== "todos") continue;
+    if (readString(item.structuredPayload?.durableTaskId)) continue;
     try {
       await taskRepo.promoteBriefTask({
         userId: args.userId,

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -1199,17 +1199,12 @@ async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Rec
   const taskRepo = createTaskRepository(args.db);
   const outputRepo = createAgentOutputRepository(args.db);
   const summarySince = dailyBriefSummarySince(args.baseContext);
-  const runtimeMaxItemsPerSection =
-    typeof args.baseContext.maxItemsPerSection === "number" && Number.isFinite(args.baseContext.maxItemsPerSection)
-      ? Math.max(0, Math.floor(args.baseContext.maxItemsPerSection))
-      : args.maxItemsPerSection;
   const { verifiedEmails, assigneeEntityIds } = await resolveReaderTaskIdentity(args);
   const [openDurableTasks, recentSummaries, summaryTasks, identityUnresolvedTaskCount] = await Promise.all([
     taskRepo.loadOpenDurableTasksForBrief({
       userId: args.userId,
       userEmails: verifiedEmails,
       assigneeEntityIds,
-      limit: runtimeMaxItemsPerSection * 4,
     }),
     outputRepo.listCompletedForUserSince(CONVERSATION_SUMMARY_AGENT_KEY, args.userId, summarySince, {
       limit: DAILY_BRIEF_SUMMARY_OUTPUT_LIMIT,

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -8,7 +8,7 @@ import {
   type AgentStructuredPayload,
   createAgentOutputRepository,
 } from "../../db/repositories/agent-outputs";
-import { whereLiveEntity } from "../../db/repositories/entities";
+import { createEntityRepository, whereLiveEntity } from "../../db/repositories/entities";
 import { createTaskRepository } from "../../db/repositories/tasks";
 import { createUserRepository } from "../../db/repositories/users";
 import type { DB } from "../../db/schema";
@@ -33,6 +33,7 @@ export const DAILY_BRIEF_HOT_FALLBACK_LIMIT = 10;
 const FILE_ACCESS_FILTER_CHUNK_SIZE = 500;
 const DAILY_BRIEF_SUMMARY_OUTPUT_LIMIT = 10;
 const DAILY_BRIEF_SUMMARY_TASK_LIMIT = 50;
+const DAILY_BRIEF_DEFAULT_MAX_ITEMS_PER_SECTION = 4;
 
 export const DAILY_BRIEF_SECTION_LABELS = {
   meetings: ["meeting"],
@@ -149,6 +150,16 @@ type MeetingAttendeeEnrichment = {
   role?: string;
   note?: string;
   emphasis?: boolean;
+};
+
+type RuntimeDurableTask = {
+  id: string;
+  title: string;
+  status: "open" | "in_progress" | "done";
+  priority: string | null;
+  externalRef: string | null;
+  updatedAt: string;
+  knowledgeRefs: AgentKnowledgeRefs;
 };
 
 /** Per-attendee shape persisted in the meeting item's structured payload. */
@@ -686,10 +697,11 @@ const DAILY_BRIEF_INSTRUCTIONS = [
 ].join("\n");
 
 const DURABLE_TASKS_INSTRUCTION = [
-  "- The runtime context may include openDurableTasks and summaryTasks: tasks that already exist with the shown status. Render those as-is and only create todos for genuinely new work; do not duplicate an existing task.",
-  "- Some summary tasks may also appear in openDurableTasks. Treat matching ids, titles, or parents as one existing task, not as separate pieces of work.",
-  "- Use recentSummaries to understand what Summarizer already extracted from chat. Treat those action items as already-derived context, not as raw source material to derive again.",
-  "- Do not create a new todo if it matches an existing durable task or summary task. Create todos only for genuinely new work from non-Summarizer-covered sources or newly discovered evidence.",
+  "- The runtime context includes `openDurableTasks`, the complete allowlist for the todos section.",
+  "- Every emitted todo must set `structuredPayload.durableTaskId` to one of the task IDs in `openDurableTasks`.",
+  "- Todos may reference only IDs present in `openDurableTasks`. Do not emit a todo for any other task or inferred action.",
+  "- Preserve recentSummaries and summaryTasks only as context for describing allowlisted tasks. Do not derive new todos from recentSummaries or broad search.",
+  "- Search results, recent summaries, and other evidence must never create a newly inferred todo, even when they look actionable.",
 ].join("\n");
 
 function buildInstructions(): string {
@@ -827,6 +839,166 @@ function reconcileMeetingItems(items: AgentOutputItemInput[], meetings: TodaysMe
   });
 
   return [...reconciled, ...others];
+}
+
+function uniqueStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.flatMap((entry) => {
+        const text = readString(entry);
+        return text ? [text] : [];
+      }),
+    ),
+  ];
+}
+
+function parseRuntimeDurableTasks(value: unknown): RuntimeDurableTask[] {
+  if (!Array.isArray(value)) return [];
+  const tasks: RuntimeDurableTask[] = [];
+  for (const entry of value) {
+    const task = asRecord(entry);
+    const id = readString(task?.id);
+    const title = readString(task?.title);
+    const status = readString(task?.status);
+    if (!id || !title || (status !== "open" && status !== "in_progress" && status !== "done")) continue;
+    const refs = asRecord(task?.knowledgeRefs);
+    tasks.push({
+      id,
+      title,
+      status,
+      priority: readString(task?.priority),
+      externalRef: readString(task?.externalRef),
+      updatedAt: readString(task?.updatedAt) ?? "",
+      knowledgeRefs: {
+        entityIds: uniqueStrings(refs?.entityIds),
+        fileIds: uniqueStrings(refs?.fileIds),
+      },
+    });
+  }
+  return tasks;
+}
+
+function normalizeDurableTaskPriority(value: string | null): "high" | "medium" | "low" {
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replaceAll(/[\s_-]+/g, "");
+  if (!normalized) return "medium";
+  if (["1", "2", "p0", "p1", "urgent", "critical", "blocker", "highest", "high"].includes(normalized)) {
+    return "high";
+  }
+  if (["4", "p3", "p4", "lowest", "low", "minor", "trivial"].includes(normalized)) return "low";
+  if (["3", "p2", "medium", "normal", "default", "nopriority", "none"].includes(normalized)) return "medium";
+  return "medium";
+}
+
+function durableTaskLabel(status: RuntimeDurableTask["status"]): "todo" | "in_progress" | "done" {
+  if (status === "in_progress") return "in_progress";
+  if (status === "done") return "done";
+  return "todo";
+}
+
+function durableTaskFallbackSummary(status: RuntimeDurableTask["status"]): string {
+  if (status === "in_progress") return "In progress and ready for the next step.";
+  if (status === "done") return "Completed and ready to review.";
+  return "Open and ready for your attention.";
+}
+
+function durableTaskActionPrompt(task: RuntimeDurableTask): string {
+  if (task.status === "done") {
+    return `Review the completed task "${task.title}" with me using the linked organizational context. Summarize the outcome and any follow-up worth tracking.`;
+  }
+  return `Help me plan the next step for "${task.title}" using the linked organizational context. Summarize what matters, identify blockers, and propose a concrete next action.`;
+}
+
+function canonicalTodoItem(
+  task: RuntimeDurableTask,
+  source: AgentOutputItemInput | undefined,
+  sortOrder: number,
+): AgentOutputItemInput {
+  const label = durableTaskLabel(task.status);
+  return {
+    sectionKey: "todos",
+    title: task.title,
+    summary: readString(source?.summary) ?? durableTaskFallbackSummary(task.status),
+    priority: normalizeDurableTaskPriority(task.priority),
+    label,
+    displayRef: task.externalRef,
+    actionType: "task",
+    actionLabel: defaultActionLabel("todos", label),
+    actionPrompt: readString(source?.actionPrompt) ?? durableTaskActionPrompt(task),
+    sourceUrl: null,
+    structuredPayload: { durableTaskId: task.id },
+    knowledgeRefs: task.knowledgeRefs,
+    sortOrder,
+  };
+}
+
+function reconcileTodoItems(
+  items: AgentOutputItemInput[],
+  runtimeContext: Record<string, unknown>,
+): {
+  items: AgentOutputItemInput[];
+  allowedTaskCount: number;
+  rejectedTaskCount: number;
+  backfilledTaskCount: number;
+} {
+  const allowedById = new Map<string, RuntimeDurableTask>();
+  for (const task of parseRuntimeDurableTasks(runtimeContext.openDurableTasks)) {
+    if (task.knowledgeRefs.entityIds.length + task.knowledgeRefs.fileIds.length === 0) continue;
+    if (!allowedById.has(task.id)) allowedById.set(task.id, task);
+  }
+  if (!readStringArray(runtimeContext.sections).includes("todos")) {
+    return { items, allowedTaskCount: allowedById.size, rejectedTaskCount: 0, backfilledTaskCount: 0 };
+  }
+
+  const rawMaxItems = runtimeContext.maxItemsPerSection;
+  const maxItemsPerSection =
+    typeof rawMaxItems === "number" && Number.isFinite(rawMaxItems)
+      ? Math.max(0, Math.floor(rawMaxItems))
+      : DAILY_BRIEF_DEFAULT_MAX_ITEMS_PER_SECTION;
+  const modelTodos = items.filter((item) => item.sectionKey === "todos");
+  const otherItems = items.filter((item) => item.sectionKey !== "todos");
+  const usedIds = new Set<string>();
+  const accepted: AgentOutputItemInput[] = [];
+  let rejectedTaskCount = 0;
+
+  for (const item of modelTodos) {
+    const taskId = readString(item.structuredPayload?.durableTaskId);
+    const task = taskId ? allowedById.get(taskId) : undefined;
+    if (!task || usedIds.has(task.id) || accepted.length >= maxItemsPerSection) {
+      rejectedTaskCount += 1;
+      continue;
+    }
+    usedIds.add(task.id);
+    accepted.push(canonicalTodoItem(task, item, accepted.length));
+  }
+
+  const remaining = [...allowedById.values()]
+    .filter((task) => !usedIds.has(task.id))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.id.localeCompare(b.id));
+  let backfilledTaskCount = 0;
+  for (const task of remaining) {
+    if (accepted.length >= maxItemsPerSection) break;
+    accepted.push(canonicalTodoItem(task, undefined, accepted.length));
+    backfilledTaskCount += 1;
+  }
+
+  if (modelTodos.length === 0 && accepted.length === 0) {
+    return {
+      items,
+      allowedTaskCount: allowedById.size,
+      rejectedTaskCount,
+      backfilledTaskCount,
+    };
+  }
+  return {
+    items: [...accepted, ...otherItems],
+    allowedTaskCount: allowedById.size,
+    rejectedTaskCount,
+    backfilledTaskCount,
+  };
 }
 
 async function enrichItems(db: Kysely<DB>, items: AgentOutputItemInput[]): Promise<AgentOutputItemInput[]> {
@@ -974,25 +1146,81 @@ function compactRecentSummary(summary: AgentOutputWithItems) {
   };
 }
 
+async function resolveReaderTaskIdentity(args: AgentRuntimeContextArgs): Promise<{
+  verifiedEmails: string[];
+  assigneeEntityIds: string[];
+}> {
+  const verifiedEmails = [
+    ...new Set(
+      (await args.users.getVerifiedEmailsForUser(args.userId)).flatMap((email) => {
+        const normalized = normalizeEmail(email);
+        return normalized ? [normalized] : [];
+      }),
+    ),
+  ];
+  const entitiesByEmail = await createEntityRepository(args.db).getPersonEntitiesByEmails(verifiedEmails);
+  const assigneeEntityIds = new Set<string>();
+  for (const email of verifiedEmails) {
+    const matches = entitiesByEmail.get(email) ?? [];
+    if (matches.length === 1) assigneeEntityIds.add(matches[0].id);
+  }
+  return {
+    verifiedEmails,
+    assigneeEntityIds: [...assigneeEntityIds].sort(),
+  };
+}
+
+async function countIdentityUnresolvedStructuralTasks(
+  db: Kysely<DB>,
+  verifiedEmails: string[],
+  assigneeEntityIds: string[],
+): Promise<number> {
+  if (verifiedEmails.length === 0 || assigneeEntityIds.length > 0) return 0;
+  const evidence = await db
+    .selectFrom("tasks")
+    .innerJoin("task_evidence", "task_evidence.task_id", "tasks.id")
+    .innerJoin("indexed_files", "indexed_files.id", "task_evidence.ref_id")
+    .select(["tasks.id as taskId", "indexed_files.id as fileId"])
+    .where("tasks.valid_to", "is", null)
+    .where("tasks.status", "in", ["open", "in_progress"])
+    .where("tasks.provenance", "=", "structural")
+    .where("task_evidence.kind", "=", "file")
+    .where("indexed_files.is_archived", "=", 0)
+    .execute();
+  const visibleFileIds = await filterVisibleCandidateFileIds(
+    db,
+    evidence.map((row) => row.fileId),
+    verifiedEmails,
+  );
+  return new Set(evidence.filter((row) => visibleFileIds.has(row.fileId)).map((row) => row.taskId)).size;
+}
+
 async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Record<string, unknown>> {
   const taskRepo = createTaskRepository(args.db);
   const outputRepo = createAgentOutputRepository(args.db);
   const summarySince = dailyBriefSummarySince(args.baseContext);
-  const userEmails = await args.users.getAllEmailsForUser(args.userId);
-  const [openDurableTasks, recentSummaries, summaryTasks] = await Promise.all([
+  const runtimeMaxItemsPerSection =
+    typeof args.baseContext.maxItemsPerSection === "number" && Number.isFinite(args.baseContext.maxItemsPerSection)
+      ? Math.max(0, Math.floor(args.baseContext.maxItemsPerSection))
+      : args.maxItemsPerSection;
+  const { verifiedEmails, assigneeEntityIds } = await resolveReaderTaskIdentity(args);
+  const [openDurableTasks, recentSummaries, summaryTasks, identityUnresolvedTaskCount] = await Promise.all([
     taskRepo.loadOpenDurableTasksForBrief({
       userId: args.userId,
-      userEmails,
-      limit: args.maxItemsPerSection * 4,
+      userEmails: verifiedEmails,
+      assigneeEntityIds,
+      limit: runtimeMaxItemsPerSection * 4,
     }),
     outputRepo.listCompletedForUserSince(CONVERSATION_SUMMARY_AGENT_KEY, args.userId, summarySince, {
       limit: DAILY_BRIEF_SUMMARY_OUTPUT_LIMIT,
     }),
     taskRepo.loadSummaryTasksForBrief({
       userId: args.userId,
+      assigneeEntityIds,
       since: summarySince,
       limit: DAILY_BRIEF_SUMMARY_TASK_LIMIT,
     }),
+    countIdentityUnresolvedStructuralTasks(args.db, verifiedEmails, assigneeEntityIds),
   ]);
   return {
     openDurableTasks: openDurableTasks.map((task) => ({
@@ -1000,10 +1228,27 @@ async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Rec
       title: task.title,
       status: task.status,
       statusRaw: task.status_raw,
+      priority: task.priority,
       provenance: task.provenance,
       externalRef: task.external_ref,
-      parentEntityId: task.parent_entity_id,
       updatedAt: task.updated_at,
+      createdByReader: task.createdByReader,
+      assignedToReader: task.assignedToReader,
+      parentEntity: task.parentEntity
+        ? {
+            id: task.parentEntity.id,
+            name: task.parentEntity.name,
+            sourceType: task.parentEntity.source_type,
+          }
+        : null,
+      assigneeEntity: task.assigneeEntity
+        ? {
+            id: task.assigneeEntity.id,
+            name: task.assigneeEntity.name,
+            sourceType: task.assigneeEntity.source_type,
+          }
+        : null,
+      knowledgeRefs: task.knowledgeRefs,
     })),
     recentSummaries: recentSummaries.map(compactRecentSummary),
     summaryTasks: summaryTasks.map((task) => ({
@@ -1015,6 +1260,7 @@ async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Rec
       parentEntityId: task.parent_entity_id,
       updatedAt: task.updated_at,
     })),
+    identityUnresolvedTaskCount,
     sameDayPreviousOutput: dropCompletedTodos(args.baseContext.sameDayPreviousOutput as FormattedPriorOutput | null),
     previousDayOutput: dropCompletedTodos(args.baseContext.previousDayOutput as FormattedPriorOutput | null),
   };
@@ -1083,10 +1329,27 @@ export const dailyBriefDefinition: AgentDefinition = {
     ]);
     return { dailyBriefCandidateContext, todaysMeetings };
   },
-  reconcileItems: async ({ items, runtimeContext }) => {
+  reconcileItems: async ({ items, runtimeContext, logger, outputId, userId }) => {
     const sections = Array.isArray(runtimeContext.sections) ? (runtimeContext.sections as string[]) : [];
-    if (!sections.includes(DAILY_BRIEF_MEETINGS_SECTION_KEY)) return items;
-    return reconcileMeetingItems(items, parseTodaysMeetings(runtimeContext.todaysMeetings));
+    const todoResult = reconcileTodoItems(items, runtimeContext);
+    const reconciled = sections.includes(DAILY_BRIEF_MEETINGS_SECTION_KEY)
+      ? reconcileMeetingItems(todoResult.items, parseTodaysMeetings(runtimeContext.todaysMeetings))
+      : todoResult.items;
+    logger.info(
+      {
+        outputId,
+        userId,
+        allowedTaskCount: todoResult.allowedTaskCount,
+        rejectedTaskCount: todoResult.rejectedTaskCount,
+        backfilledTaskCount: todoResult.backfilledTaskCount,
+        identityUnresolvedTaskCount:
+          typeof runtimeContext.identityUnresolvedTaskCount === "number"
+            ? runtimeContext.identityUnresolvedTaskCount
+            : 0,
+      },
+      "Daily Brief: todo reconciliation",
+    );
+    return reconciled;
   },
   enrichItems,
   toApiItem,

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -9,7 +9,7 @@ import {
   createAgentOutputRepository,
 } from "../../db/repositories/agent-outputs";
 import { createEntityRepository, whereLiveEntity } from "../../db/repositories/entities";
-import { createTaskRepository } from "../../db/repositories/tasks";
+import { type DurableTaskForBrief, createTaskRepository } from "../../db/repositories/tasks";
 import { createUserRepository } from "../../db/repositories/users";
 import type { DB } from "../../db/schema";
 import { parseOnceSchedule } from "../../scheduler/parse-once";
@@ -1146,7 +1146,7 @@ function compactRecentSummary(summary: AgentOutputWithItems) {
   };
 }
 
-async function resolveReaderTaskIdentity(args: AgentRuntimeContextArgs): Promise<{
+async function resolveReaderTaskIdentity(args: Pick<AgentRuntimeContextArgs, "db" | "userId" | "users">): Promise<{
   verifiedEmails: string[];
   assigneeEntityIds: string[];
 }> {
@@ -1159,14 +1159,17 @@ async function resolveReaderTaskIdentity(args: AgentRuntimeContextArgs): Promise
     ),
   ];
   const entitiesByEmail = await createEntityRepository(args.db).getPersonEntitiesByEmails(verifiedEmails);
-  const assigneeEntityIds = new Set<string>();
+  const matchedEntityIds = new Set<string>();
+  let ambiguous = false;
   for (const email of verifiedEmails) {
     const matches = entitiesByEmail.get(email) ?? [];
-    if (matches.length === 1) assigneeEntityIds.add(matches[0].id);
+    if (matches.length > 1) ambiguous = true;
+    if (matches.length === 1) matchedEntityIds.add(matches[0].id);
   }
+  if (matchedEntityIds.size > 1) ambiguous = true;
   return {
     verifiedEmails,
-    assigneeEntityIds: [...assigneeEntityIds].sort(),
+    assigneeEntityIds: ambiguous ? [] : [...matchedEntityIds].sort(),
   };
 }
 
@@ -1195,17 +1198,72 @@ async function countIdentityUnresolvedStructuralTasks(
   return new Set(evidence.filter((row) => visibleFileIds.has(row.fileId)).map((row) => row.taskId)).size;
 }
 
+function runtimeDurableTask(task: DurableTaskForBrief) {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    statusRaw: task.status_raw,
+    priority: task.priority,
+    provenance: task.provenance,
+    externalRef: task.external_ref,
+    updatedAt: task.updated_at,
+    createdByReader: task.createdByReader,
+    assignedToReader: task.assignedToReader,
+    parentEntity: task.parentEntity
+      ? {
+          id: task.parentEntity.id,
+          name: task.parentEntity.name,
+          sourceType: task.parentEntity.source_type,
+        }
+      : null,
+    assigneeEntity: task.assigneeEntity
+      ? {
+          id: task.assigneeEntity.id,
+          name: task.assigneeEntity.name,
+          sourceType: task.assigneeEntity.source_type,
+        }
+      : null,
+    knowledgeRefs: task.knowledgeRefs,
+  };
+}
+
+async function loadOpenDurableTasksForReader(args: Pick<AgentRuntimeContextArgs, "db" | "userId" | "users">): Promise<{
+  verifiedEmails: string[];
+  assigneeEntityIds: string[];
+  tasks: DurableTaskForBrief[];
+}> {
+  const { verifiedEmails, assigneeEntityIds } = await resolveReaderTaskIdentity(args);
+  const tasks = await createTaskRepository(args.db).loadOpenDurableTasksForBrief({
+    userId: args.userId,
+    userEmails: verifiedEmails,
+    assigneeEntityIds,
+  });
+  return { verifiedEmails, assigneeEntityIds, tasks };
+}
+
+async function revalidateRuntimeDurableTasks(
+  db: Kysely<DB>,
+  userId: string,
+  runtimeContext: Record<string, unknown>,
+): Promise<unknown> {
+  if (readString(runtimeContext.readerTaskSnapshotUserId) !== userId) return runtimeContext.openDurableTasks;
+  const snapshotIds = new Set(parseRuntimeDurableTasks(runtimeContext.openDurableTasks).map((task) => task.id));
+  if (snapshotIds.size === 0) return [];
+  const { tasks } = await loadOpenDurableTasksForReader({
+    db,
+    userId,
+    users: createUserRepository(db),
+  });
+  return tasks.filter((task) => snapshotIds.has(task.id)).map(runtimeDurableTask);
+}
+
 async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Record<string, unknown>> {
   const taskRepo = createTaskRepository(args.db);
   const outputRepo = createAgentOutputRepository(args.db);
   const summarySince = dailyBriefSummarySince(args.baseContext);
-  const { verifiedEmails, assigneeEntityIds } = await resolveReaderTaskIdentity(args);
-  const [openDurableTasks, recentSummaries, summaryTasks, identityUnresolvedTaskCount] = await Promise.all([
-    taskRepo.loadOpenDurableTasksForBrief({
-      userId: args.userId,
-      userEmails: verifiedEmails,
-      assigneeEntityIds,
-    }),
+  const { verifiedEmails, assigneeEntityIds, tasks: openDurableTasks } = await loadOpenDurableTasksForReader(args);
+  const [recentSummaries, summaryTasks, identityUnresolvedTaskCount] = await Promise.all([
     outputRepo.listCompletedForUserSince(CONVERSATION_SUMMARY_AGENT_KEY, args.userId, summarySince, {
       limit: DAILY_BRIEF_SUMMARY_OUTPUT_LIMIT,
     }),
@@ -1218,33 +1276,8 @@ async function augmentRuntimeContext(args: AgentRuntimeContextArgs): Promise<Rec
     countIdentityUnresolvedStructuralTasks(args.db, verifiedEmails, assigneeEntityIds),
   ]);
   return {
-    openDurableTasks: openDurableTasks.map((task) => ({
-      id: task.id,
-      title: task.title,
-      status: task.status,
-      statusRaw: task.status_raw,
-      priority: task.priority,
-      provenance: task.provenance,
-      externalRef: task.external_ref,
-      updatedAt: task.updated_at,
-      createdByReader: task.createdByReader,
-      assignedToReader: task.assignedToReader,
-      parentEntity: task.parentEntity
-        ? {
-            id: task.parentEntity.id,
-            name: task.parentEntity.name,
-            sourceType: task.parentEntity.source_type,
-          }
-        : null,
-      assigneeEntity: task.assigneeEntity
-        ? {
-            id: task.assigneeEntity.id,
-            name: task.assigneeEntity.name,
-            sourceType: task.assigneeEntity.source_type,
-          }
-        : null,
-      knowledgeRefs: task.knowledgeRefs,
-    })),
+    openDurableTasks: openDurableTasks.map(runtimeDurableTask),
+    readerTaskSnapshotUserId: args.userId,
     recentSummaries: recentSummaries.map(compactRecentSummary),
     summaryTasks: summaryTasks.map((task) => ({
       id: task.id,
@@ -1325,9 +1358,13 @@ export const dailyBriefDefinition: AgentDefinition = {
     ]);
     return { dailyBriefCandidateContext, todaysMeetings };
   },
-  reconcileItems: async ({ items, runtimeContext, logger, outputId, userId }) => {
+  reconcileItems: async ({ db, items, runtimeContext, logger, outputId, userId }) => {
     const sections = Array.isArray(runtimeContext.sections) ? (runtimeContext.sections as string[]) : [];
-    const todoResult = reconcileTodoItems(items, runtimeContext);
+    const currentOpenDurableTasks = await revalidateRuntimeDurableTasks(db, userId, runtimeContext);
+    const todoResult = reconcileTodoItems(items, {
+      ...runtimeContext,
+      openDurableTasks: currentOpenDurableTasks,
+    });
     const reconciled = sections.includes(DAILY_BRIEF_MEETINGS_SECTION_KEY)
       ? reconcileMeetingItems(todoResult.items, parseTodaysMeetings(runtimeContext.todaysMeetings))
       : todoResult.items;

--- a/packages/server/src/agents/service.isolated.test.ts
+++ b/packages/server/src/agents/service.isolated.test.ts
@@ -561,6 +561,8 @@ describe("AgentRunService", () => {
       db,
       tasks,
       briefItem({
+        sectionKey: "customer_updates",
+        label: "warm",
         sourceUrl: "javascript:alert(1)",
         knowledgeRefs: { entityIds: [], fileIds: ["safe-source-file"] },
       }),
@@ -576,7 +578,7 @@ describe("AgentRunService", () => {
     await tasks[0]();
     const output = await service.getByIdForUser(DAILY_BRIEF_AGENT_KEY, row.id, user.id);
 
-    expect(output?.sections.todos[0].sourceUrl).toBe("https://docs.example.com/source");
+    expect(output?.sections.customer_updates[0].sourceUrl).toBe("https://docs.example.com/source");
   });
 
   it("drops agent-provided source URLs when referenced files have no provider URL", async () => {
@@ -588,6 +590,8 @@ describe("AgentRunService", () => {
       db,
       tasks,
       briefItem({
+        sectionKey: "customer_updates",
+        label: "warm",
         sourceUrl: "https://phishing.example.com/source",
         knowledgeRefs: { entityIds: [], fileIds: ["source-file-without-url"] },
       }),
@@ -603,7 +607,7 @@ describe("AgentRunService", () => {
     await tasks[0]();
     const output = await service.getByIdForUser(DAILY_BRIEF_AGENT_KEY, row.id, user.id);
 
-    expect(output?.sections.todos[0].sourceUrl).toBeNull();
+    expect(output?.sections.customer_updates[0].sourceUrl).toBeNull();
   });
 
   it("passes Daily Brief candidate context into the agent runtime message", async () => {
@@ -830,7 +834,7 @@ describe("AgentRunService", () => {
     expect(latest.enabledSections).not.toContain("customer_updates");
   });
 
-  it("defaults agent task creation off and passes the toggle through runtime context", async () => {
+  it("keeps the create-tasks toggle harmless for inferred Daily Brief todos", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);
     const user = await users.create({ name: "Agent User", email: "user@example.com", emailVerified: true });
@@ -930,7 +934,7 @@ describe("AgentRunService", () => {
 
     expect(defaultConfig?.createTasks).toBe(false);
     expect(disabledCount.count).toBe(0);
-    expect(enabledCount.count).toBe(1);
+    expect(enabledCount.count).toBe(0);
     expect(contexts.map((context) => context.createTasks)).toEqual([false, true]);
   });
 

--- a/packages/server/src/agents/service.test.ts
+++ b/packages/server/src/agents/service.test.ts
@@ -1,11 +1,16 @@
 import type { Kysely } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RunAgentParams, RunAgentResult } from "../agent/runner";
-import { type AgentOutputItemInput, createAgentOutputRepository } from "../db/repositories/agent-outputs";
+import {
+  type AgentOutputItemInput,
+  type AgentOutputWithItems,
+  createAgentOutputRepository,
+} from "../db/repositories/agent-outputs";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createTaskRepository } from "../db/repositories/tasks";
 import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
+import type { Logger } from "../logger";
 import type { QueueManager } from "../queue";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 import { CONVERSATION_SUMMARY_AGENT_KEY, CONVERSATION_SUMMARY_AGENT_VERSION } from "./definitions/conversation-summary";
@@ -13,7 +18,6 @@ import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION } from "./definitions/
 import { AgentRunService } from "./service";
 
 const OUTPUT_DATE = "2026-06-15";
-const PREVIOUS_DATE = "2026-06-14";
 
 describe("Daily Brief durable-task hooks", () => {
   let db: Kysely<DB>;
@@ -26,7 +30,7 @@ describe("Daily Brief durable-task hooks", () => {
     await db.destroy();
   });
 
-  it("surfaces open durable tasks, scrubs completed prior todos, and promotes emitted todos", async () => {
+  it("passes only reader-owned structural and local tasks into the runtime context", async () => {
     const users = createUserRepository(db);
     const user = await users.create({
       name: "Daily Brief User",
@@ -34,55 +38,98 @@ describe("Daily Brief durable-task hooks", () => {
       emailVerified: true,
     });
     await seedAssignablePerson(db, "person-brief-owner", "Daily Brief User", "brief-owner@example.com");
-    await seedIndexedFile(db, "brief-file-1", user.id);
-    await seedCompletedOutput(db, user.id, OUTPUT_DATE);
-    await seedCompletedOutput(db, user.id, PREVIOUS_DATE);
-    const tasksWithToggle = await runAndCapture(db, user.id, "2026-06-16", [], { createTasks: true });
+    await seedAssignablePerson(db, "person-other", "Other Person", "other@example.com");
+    await seedIndexedFile(db, "visible-file", user.id);
+    await seedIndexedFile(db, "invisible-file", user.id, "other@example.com");
 
-    const taskRepo = createTaskRepository(db);
-    await taskRepo.promoteBriefTask({
-      userId: user.id,
-      todo: briefItem({
-        title: "Open durable task",
-        label: "todo",
-        structuredPayload: { assigneeName: "Daily Brief User" },
-      }),
-      knowledgeRefs: { entityIds: [], fileIds: ["brief-file-1"] },
+    await seedDurableTask(db, {
+      sourceTaskId: "reader-structural",
+      title: "Reader structural",
+      provenance: "structural",
+      assigneeEntityId: "person-brief-owner",
+      fileIds: ["visible-file"],
     });
-    await taskRepo.promoteBriefTask({
-      userId: user.id,
-      todo: briefItem({
-        title: "Done durable task",
-        label: "done",
-        structuredPayload: { assigneeName: "Daily Brief User" },
-      }),
-      knowledgeRefs: { entityIds: [], fileIds: ["brief-file-1"] },
+    await seedDurableTask(db, {
+      sourceTaskId: "other-structural",
+      title: "Other structural",
+      provenance: "structural",
+      assigneeEntityId: "person-other",
+      fileIds: ["visible-file"],
+    });
+    await seedDurableTask(db, {
+      sourceTaskId: "unassigned-structural",
+      title: "Unassigned structural",
+      provenance: "structural",
+      fileIds: ["visible-file"],
+    });
+    await seedDurableTask(db, {
+      sourceTaskId: "invisible-structural",
+      title: "Invisible structural",
+      provenance: "structural",
+      assigneeEntityId: "person-brief-owner",
+      fileIds: ["invisible-file"],
+    });
+    await seedDurableTask(db, {
+      sourceTaskId: "reader-created-local",
+      title: "Reader-created local",
+      provenance: "summary",
+      createdByUserId: user.id,
+      fileIds: ["visible-file"],
+    });
+    await seedDurableTask(db, {
+      sourceTaskId: "reader-assigned-local",
+      title: "Reader-assigned local",
+      provenance: "summary",
+      assigneeEntityId: "person-brief-owner",
+      fileIds: ["visible-file"],
+    });
+    await seedDurableTask(db, {
+      sourceTaskId: "unrelated-local",
+      title: "Unrelated local",
+      provenance: "summary",
+      fileIds: ["visible-file"],
     });
 
-    const before = await countTasks(db);
-    const run = await runAndCapture(
-      db,
-      user.id,
-      OUTPUT_DATE,
-      [
-        briefItem({
-          title: "Brand new follow-up",
-          structuredPayload: { assigneeName: "Daily Brief User" },
-          knowledgeRefs: { entityIds: [], fileIds: ["brief-file-1"] },
-        }),
-      ],
-      { createTasks: true },
+    const run = await runAndCapture(db, user.id, OUTPUT_DATE, []);
+    const tasks = run.context.openDurableTasks as Array<{ title: string }>;
+
+    expect(tasks.map((task) => task.title)).toEqual(
+      expect.arrayContaining(["Reader structural", "Reader-created local", "Reader-assigned local"]),
     );
-    const after = await countTasks(db);
+    expect(tasks).toHaveLength(3);
+    expect(run.instructions).toContain("openDurableTasks");
+  });
+
+  it("does not admit structural tasks by matching the reader name without verified email linkage", async () => {
+    const users = createUserRepository(db);
+    const user = await users.create({
+      name: "Name Match",
+      email: "reader@example.com",
+      emailVerified: true,
+    });
+    await seedAssignablePerson(db, "person-name-match", "Name Match");
+    await seedIndexedFile(db, "visible-file", user.id);
+    await seedDurableTask(db, {
+      sourceTaskId: "name-only-structural",
+      title: "Name-only structural",
+      provenance: "structural",
+      assigneeEntityId: "person-name-match",
+      fileIds: ["visible-file"],
+    });
+    await seedDurableTask(db, {
+      sourceTaskId: "reader-local",
+      title: "Reader local",
+      provenance: "summary",
+      createdByUserId: user.id,
+      fileIds: ["visible-file"],
+    });
+
+    const run = await runAndCapture(db, user.id, OUTPUT_DATE, []);
 
     expect((run.context.openDurableTasks as Array<{ title: string }>).map((task) => task.title)).toEqual([
-      "Open durable task",
+      "Reader local",
     ]);
-    expect(priorTitles(run.context.sameDayPreviousOutput)).toEqual(["Open prior todo"]);
-    expect(priorTitles(run.context.previousDayOutput)).toEqual(["Open prior todo"]);
-    expect(run.instructions).toContain("openDurableTasks");
-    expect(tasksWithToggle.context.createTasks).toBe(true);
-    expect(after).toBeGreaterThan(before);
+    expect(run.context.identityUnresolvedTaskCount).toBe(1);
   });
 
   it("adds recent Summarizer outputs and user-owned summary tasks to Daily Brief context without replaying old summaries", async () => {
@@ -157,7 +204,33 @@ describe("Daily Brief durable-task hooks", () => {
     expect(run.instructions).toContain("recentSummaries");
   });
 
-  it("keeps create-tasks disabled for Brief writes while allowing genuinely new Brief tasks when enabled", async () => {
+  it("drops broad-search todos without an allowlisted durable id from persisted output", async () => {
+    const users = createUserRepository(db);
+    const user = await users.create({
+      name: "Daily Brief User",
+      email: "brief-owner@example.com",
+      emailVerified: true,
+    });
+    await seedIndexedFile(db, "brief-file-1", user.id);
+
+    const run = await runAndCapture(db, user.id, OUTPUT_DATE, [
+      briefItem({
+        title: "Inferred from broad search",
+        structuredPayload: {},
+        knowledgeRefs: { entityIds: [], fileIds: ["brief-file-1"] },
+      }),
+      briefItem({
+        title: "Unknown durable task",
+        structuredPayload: { durableTaskId: "unknown-task-id" },
+        knowledgeRefs: { entityIds: [], fileIds: ["brief-file-1"] },
+        sortOrder: 1,
+      }),
+    ]);
+
+    expect(run.output.items).toEqual([]);
+  });
+
+  it("persists canonical data for an allowlisted durable id without increasing task count when creation is enabled", async () => {
     const users = createUserRepository(db);
     const user = await users.create({
       name: "Daily Brief User",
@@ -167,19 +240,125 @@ describe("Daily Brief durable-task hooks", () => {
     await seedAssignablePerson(db, "person-brief-owner", "Daily Brief User", "brief-owner@example.com");
     await seedProject(db, "project-x", "Project X");
     await seedIndexedFile(db, "brief-file-1", user.id);
-    const todo = briefItem({
-      title: "New Brief-only follow-up",
-      structuredPayload: { assigneeName: "Daily Brief User" },
-      knowledgeRefs: { entityIds: ["project-x"], fileIds: ["brief-file-1"] },
+    const taskId = await seedDurableTask(db, {
+      sourceTaskId: "canonical-structural",
+      title: "Canonical durable title",
+      provenance: "structural",
+      status: "in_progress",
+      priority: "urgent",
+      externalRef: "SKE-321",
+      assigneeEntityId: "person-brief-owner",
+      parentEntityId: "project-x",
+      fileIds: ["brief-file-1"],
+    });
+    const before = await countTasks(db);
+
+    const run = await runAndCapture(
+      db,
+      user.id,
+      OUTPUT_DATE,
+      [
+        briefItem({
+          title: "Invented model title",
+          summary: "Model-authored context survives.",
+          priority: "low",
+          label: "blocked",
+          structuredPayload: { durableTaskId: taskId, unrelated: "discard me" },
+          knowledgeRefs: { entityIds: ["unknown-model-entity"], fileIds: ["unknown-model-file"] },
+        }),
+      ],
+      { createTasks: true },
+    );
+    const after = await countTasks(db);
+
+    expect(run.output.items).toEqual([
+      expect.objectContaining({
+        section_key: "todos",
+        title: "Canonical durable title",
+        summary: "Model-authored context survives.",
+        priority: "high",
+        label: "in_progress",
+        display_ref: "SKE-321",
+        structuredPayload: { durableTaskId: taskId },
+        knowledgeRefs: {
+          entityIds: ["person-brief-owner", "project-x"],
+          fileIds: ["brief-file-1"],
+        },
+      }),
+    ]);
+    expect(after).toBe(before);
+    expect(run.context.createTasks).toBe(true);
+  });
+
+  it("preserves admin-visible non-todo sections and emits aggregate-only reconciliation metrics", async () => {
+    const users = createUserRepository(db);
+    const user = await users.create({
+      name: "Admin User",
+      email: "admin@example.com",
+      emailVerified: true,
+      authRole: "admin",
+    });
+    await seedProject(db, "admin-project", "Admin-visible project");
+    await seedIndexedFile(db, "restricted-file", user.id, "someone-else@example.com");
+    await db
+      .updateTable("indexed_files")
+      .set({ source_updated_at: "2026-06-15T08:00:00.000Z" })
+      .where("id", "=", "restricted-file")
+      .execute();
+    await seedMention(db, "admin-project-mention", "admin-project", "restricted-file");
+    const settings = createSettingsRepository(db);
+    await settings.ensure();
+    await settings.update({ adminCanReadAllFiles: true });
+    const info = vi.fn();
+    const logger = { info, warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+    const customer = briefItem({
+      sectionKey: "customer_updates",
+      title: "Customer remains visible",
+      summary: "Customer model summary",
+      label: "warm",
+      knowledgeRefs: { entityIds: ["admin-project"], fileIds: ["restricted-file"] },
+    });
+    const project = briefItem({
+      sectionKey: "active_projects",
+      title: "Project remains visible",
+      summary: "Project model summary",
+      label: "active",
+      knowledgeRefs: { entityIds: ["admin-project"], fileIds: ["restricted-file"] },
+      sortOrder: 1,
     });
 
-    await runAndCapture(db, user.id, OUTPUT_DATE, [todo], { createTasks: false });
-    const afterDisabled = await countTasks(db);
-    await runAndCapture(db, user.id, "2026-06-16", [todo], { createTasks: true });
-    const afterEnabled = await countTasks(db);
+    const run = await runAndCapture(
+      db,
+      user.id,
+      OUTPUT_DATE,
+      [
+        briefItem({
+          title: "Sensitive inferred todo title",
+          summary: "Sensitive inferred todo content",
+          structuredPayload: {},
+          knowledgeRefs: { entityIds: ["admin-project"], fileIds: ["restricted-file"] },
+        }),
+        customer,
+        project,
+      ],
+      {},
+      logger,
+    );
 
-    expect(afterDisabled).toBe(0);
-    expect(afterEnabled).toBe(1);
+    expect(JSON.stringify(run.context.dailyBriefCandidateContext)).toContain("Admin-visible project");
+    expect(run.output.items.map((item) => item.title)).toEqual(["Project remains visible", "Customer remains visible"]);
+    const reconciliationCall = info.mock.calls.find((call) => call[1] === "Daily Brief: todo reconciliation");
+    expect(reconciliationCall?.[0]).toEqual({
+      outputId: run.output.output.id,
+      userId: user.id,
+      allowedTaskCount: 0,
+      rejectedTaskCount: 1,
+      backfilledTaskCount: 0,
+      identityUnresolvedTaskCount: 0,
+    });
+    expect(JSON.stringify(reconciliationCall)).not.toMatch(
+      /Sensitive inferred todo title|Sensitive inferred todo content|Customer model summary|Project model summary/,
+    );
   });
 });
 
@@ -189,13 +368,14 @@ async function runAndCapture(
   outputDate: string,
   items: AgentOutputItemInput[],
   configPatch: { createTasks?: boolean } = {},
-): Promise<{ context: Record<string, unknown>; instructions: string }> {
+  logger: Logger = createTestLogger(),
+): Promise<{ context: Record<string, unknown>; instructions: string; output: AgentOutputWithItems }> {
   const queued: Array<() => Promise<void>> = [];
   const capturedParams: RunAgentParams[] = [];
   const service = new AgentRunService({
     db,
     config: createTestConfig(),
-    logger: createTestLogger(),
+    logger,
     users: createUserRepository(db),
     settings: createSettingsRepository(db),
     runAgent: async (params) => {
@@ -213,7 +393,7 @@ async function runAndCapture(
     queueManager: createPausedQueueManager(queued),
   });
 
-  const row = await service.requestGenerationForUser({
+  const [row] = await service.requestGenerationForUser({
     agentKey: DAILY_BRIEF_AGENT_KEY,
     userId,
     outputDate,
@@ -226,15 +406,13 @@ async function runAndCapture(
   await queued.at(-1)?.();
   const params = capturedParams[0];
   if (!params) throw new Error("runAgent was not called");
+  const output = await createAgentOutputRepository(db).getByIdForUser(DAILY_BRIEF_AGENT_KEY, row.id, userId);
+  if (!output) throw new Error("Expected a persisted output");
   return {
     context: parseRuntimeContext(params.userMessage),
     instructions: params.agentInstructions ?? "",
+    output,
   };
-}
-
-function priorTitles(output: unknown): string[] {
-  const items = (output as { items?: Array<{ title: string }> } | null)?.items ?? [];
-  return items.map((item) => item.title);
 }
 
 async function countTasks(db: Kysely<DB>): Promise<number> {
@@ -339,7 +517,7 @@ async function seedSummaryOutput(
   return running.row.id;
 }
 
-async function seedIndexedFile(db: Kysely<DB>, id: string, userId: string): Promise<void> {
+async function seedIndexedFile(db: Kysely<DB>, id: string, userId: string, restrictedTo?: string): Promise<void> {
   await db
     .insertInto("connector_configs")
     .values({
@@ -373,9 +551,12 @@ async function seedIndexedFile(db: Kysely<DB>, id: string, userId: string): Prom
       embedding_status: "pending",
     })
     .execute();
+  if (restrictedTo) {
+    await db.insertInto("file_access").values({ indexed_file_id: id, email: restrictedTo }).execute();
+  }
 }
 
-async function seedAssignablePerson(db: Kysely<DB>, id: string, name: string, email: string): Promise<void> {
+async function seedAssignablePerson(db: Kysely<DB>, id: string, name: string, email?: string): Promise<void> {
   await db
     .insertInto("entities")
     .values({
@@ -383,7 +564,7 @@ async function seedAssignablePerson(db: Kysely<DB>, id: string, name: string, em
       name,
       source_type: "person",
       subtype: null,
-      aliases: JSON.stringify([email]),
+      aliases: email ? JSON.stringify([email]) : null,
       metadata: null,
       source_ref_id: null,
       status: "active",
@@ -393,6 +574,24 @@ async function seedAssignablePerson(db: Kysely<DB>, id: string, name: string, em
       ai_brief: null,
     })
     .execute();
+  if (email) {
+    await db
+      .insertInto("entity_contact_points")
+      .values({
+        id: `${id}-email`,
+        entity_id: id,
+        kind: "email",
+        value: email.toLowerCase(),
+        display_value: email,
+        label: null,
+        source: "test",
+        connector_config_id: null,
+        created_by_user_id: null,
+        verified_at: new Date().toISOString(),
+        last_contacted_at: null,
+      })
+      .execute();
+  }
 }
 
 async function seedProject(db: Kysely<DB>, id: string, name: string): Promise<void> {
@@ -413,6 +612,60 @@ async function seedProject(db: Kysely<DB>, id: string, name: string): Promise<vo
       ai_brief: null,
     })
     .execute();
+}
+
+async function seedMention(db: Kysely<DB>, id: string, entityId: string, fileId: string): Promise<void> {
+  await db
+    .insertInto("entity_mentions")
+    .values({
+      id,
+      entity_id: entityId,
+      indexed_file_id: fileId,
+      chunk_index: null,
+      context_snippet: null,
+      confidence: "EXTRACTED",
+      source: "test",
+      relation: "mentioned",
+      mentioned_at: "2026-06-15T08:00:00.000Z",
+    })
+    .execute();
+}
+
+async function seedDurableTask(
+  db: Kysely<DB>,
+  params: {
+    sourceTaskId: string;
+    title: string;
+    provenance: "structural" | "brief" | "summary";
+    status?: "open" | "in_progress";
+    priority?: string | null;
+    externalRef?: string | null;
+    assigneeEntityId?: string | null;
+    parentEntityId?: string | null;
+    createdByUserId?: string | null;
+    fileIds?: string[];
+  },
+): Promise<string> {
+  const repo = createTaskRepository(db);
+  const result = await repo.upsertTask({
+    parentEntityId: params.parentEntityId ?? null,
+    parentSourceRef: null,
+    parentName: null,
+    source: params.provenance === "structural" ? "linear" : params.provenance,
+    externalRef: params.externalRef ?? null,
+    title: params.title,
+    status: params.status ?? "open",
+    statusRaw: params.status ?? "open",
+    statusAuthority: params.provenance === "structural" ? "external" : "local",
+    assigneeEntityId: params.assigneeEntityId ?? null,
+    priority: params.priority ?? null,
+    dueAt: null,
+    provenance: params.provenance,
+    sourceTaskId: params.sourceTaskId,
+    createdByUserId: params.createdByUserId ?? null,
+  });
+  for (const fileId of params.fileIds ?? []) await repo.upsertEvidence(result.taskId, "file", fileId);
+  return result.taskId;
 }
 
 function briefItem(overrides: Partial<AgentOutputItemInput> = {}): AgentOutputItemInput {

--- a/packages/server/src/agents/service.test.ts
+++ b/packages/server/src/agents/service.test.ts
@@ -18,6 +18,7 @@ import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION } from "./definitions/
 import { AgentRunService } from "./service";
 
 const OUTPUT_DATE = "2026-06-15";
+const PREVIOUS_DATE = "2026-06-14";
 
 describe("Daily Brief durable-task hooks", () => {
   let db: Kysely<DB>;
@@ -130,6 +131,38 @@ describe("Daily Brief durable-task hooks", () => {
       "Reader local",
     ]);
     expect(run.context.identityUnresolvedTaskCount).toBe(1);
+  });
+
+  it("scrubs completed prior todos and excludes done durable tasks from runtime context", async () => {
+    const users = createUserRepository(db);
+    const user = await users.create({
+      name: "Daily Brief User",
+      email: "brief-owner@example.com",
+      emailVerified: true,
+    });
+    await seedCompletedOutput(db, user.id, OUTPUT_DATE);
+    await seedCompletedOutput(db, user.id, PREVIOUS_DATE);
+    await seedDurableTask(db, {
+      sourceTaskId: "reader-open-local",
+      title: "Open reader-owned durable task",
+      provenance: "summary",
+      createdByUserId: user.id,
+    });
+    await seedDurableTask(db, {
+      sourceTaskId: "reader-done-local",
+      title: "Done reader-owned durable task",
+      provenance: "summary",
+      status: "done",
+      createdByUserId: user.id,
+    });
+
+    const run = await runAndCapture(db, user.id, OUTPUT_DATE, []);
+
+    expect(priorTitles(run.context.sameDayPreviousOutput)).toEqual(["Open prior todo"]);
+    expect(priorTitles(run.context.previousDayOutput)).toEqual(["Open prior todo"]);
+    expect((run.context.openDurableTasks as Array<{ title: string }>).map((task) => task.title)).toEqual([
+      "Open reader-owned durable task",
+    ]);
   });
 
   it("adds recent Summarizer outputs and user-owned summary tasks to Daily Brief context without replaying old summaries", async () => {
@@ -415,6 +448,11 @@ async function runAndCapture(
   };
 }
 
+function priorTitles(output: unknown): string[] {
+  const items = (output as { items?: Array<{ title: string }> } | null)?.items ?? [];
+  return items.map((item) => item.title);
+}
+
 async function countTasks(db: Kysely<DB>): Promise<number> {
   const row = await db
     .selectFrom("tasks")
@@ -637,7 +675,7 @@ async function seedDurableTask(
     sourceTaskId: string;
     title: string;
     provenance: "structural" | "brief" | "summary";
-    status?: "open" | "in_progress";
+    status?: "open" | "in_progress" | "done";
     priority?: string | null;
     externalRef?: string | null;
     assigneeEntityId?: string | null;

--- a/packages/server/src/agents/service.ts
+++ b/packages/server/src/agents/service.ts
@@ -2337,7 +2337,14 @@ export class AgentRunService {
             internalSectionKeys.has(item.sectionKey),
         );
         const reconciled = def.reconcileItems
-          ? await def.reconcileItems({ db: this.deps.db, items: filtered, runtimeContext: params.runtimeContext })
+          ? await def.reconcileItems({
+              db: this.deps.db,
+              items: filtered,
+              runtimeContext: params.runtimeContext,
+              logger: this.deps.logger,
+              outputId: params.outputId,
+              userId: params.userId,
+            })
           : filtered;
         const itemsForHooks = await def.enrichItems(this.deps.db, reconciled);
         const visibleItems = itemsForHooks.filter(

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -149,6 +149,9 @@ export interface AgentDefinition {
     db: Kysely<DB>;
     items: AgentOutputItemInput[];
     runtimeContext: Record<string, unknown>;
+    logger: Logger;
+    outputId: string;
+    userId: string;
   }): Promise<AgentOutputItemInput[]>;
   /** Normalize a stored item into its API representation (label/action/displayRef fallbacks). */
   toApiItem(item: AgentStoredItem): AgentApiItem;

--- a/packages/server/src/db/repositories/tasks.test.ts
+++ b/packages/server/src/db/repositories/tasks.test.ts
@@ -1297,6 +1297,68 @@ describe("createTaskRepository sqlite", () => {
     expect(rows[0]?.knowledgeRefs.fileIds).toEqual(["file-active"]);
   });
 
+  it("includes structural evidence visible only through an entity shared to a reader email", async () => {
+    await seedUser(db, "entity-share-reader-u1", "entity-share-reader@example.com");
+    await seedPerson(db, "person-entity-share-reader", "Entity Share Reader", ["entity-share-reader@example.com"]);
+    await seedProject(db, "entity-shared-project", "Entity Shared Project");
+    await seedIndexedFile(db, "file-visible-via-entity-share");
+    await db
+      .insertInto("file_access")
+      .values({ indexed_file_id: "file-visible-via-entity-share", email: "other@example.com" })
+      .execute();
+    await db
+      .insertInto("entity_share_emails")
+      .values({
+        entity_id: "entity-shared-project",
+        email: "entity-share-alias@example.com",
+        granted_by_user_id: "entity-share-reader-u1",
+      })
+      .execute();
+    await db
+      .insertInto("entity_mentions")
+      .values({
+        id: "mention-file-visible-via-entity-share",
+        entity_id: "entity-shared-project",
+        indexed_file_id: "file-visible-via-entity-share",
+        chunk_index: null,
+        context_snippet: null,
+        confidence: "EXTRACTED",
+        source: "test",
+        relation: "mentioned",
+        mentioned_at: new Date().toISOString(),
+      })
+      .execute();
+
+    const repo = createTaskRepository(db);
+    const task = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-408",
+      title: "Entity-share-visible structural",
+      status: "open",
+      statusRaw: "Todo",
+      statusAuthority: "external",
+      assigneeEntityId: "person-entity-share-reader",
+      assigneeName: "Entity Share Reader",
+      priority: "medium",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "entity-share-visible-structural",
+    });
+    await repo.upsertEvidence(task.taskId, "file", "file-visible-via-entity-share");
+
+    const rows = await repo.loadOpenDurableTasksForBrief({
+      userId: "entity-share-reader-u1",
+      userEmails: ["entity-share-reader@example.com", "entity-share-alias@example.com"],
+      assigneeEntityIds: ["person-entity-share-reader"],
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([task.taskId]);
+    expect(rows[0]?.knowledgeRefs.fileIds).toEqual(["file-visible-via-entity-share"]);
+  });
+
   it("loads recent user-owned summary tasks for Daily Brief including completed protection rows", async () => {
     await seedUser(db, "summary-u1", "summary@example.com");
     await seedUser(db, "summary-u2", "other@example.com");

--- a/packages/server/src/db/repositories/tasks.test.ts
+++ b/packages/server/src/db/repositories/tasks.test.ts
@@ -1241,6 +1241,62 @@ describe("createTaskRepository sqlite", () => {
     });
   });
 
+  it("excludes archived-only structural evidence and omits archived file references", async () => {
+    await seedUser(db, "archived-reader-u1", "archived-reader@example.com");
+    await seedPerson(db, "person-archived-reader", "Archived Reader", ["archived-reader@example.com"]);
+    await seedIndexedFile(db, "file-active");
+    await seedIndexedFile(db, "file-archived");
+    await db.updateTable("indexed_files").set({ is_archived: 1 }).where("id", "=", "file-archived").execute();
+
+    const repo = createTaskRepository(db);
+    const archivedOnly = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-406",
+      title: "Archived-only structural",
+      status: "open",
+      statusRaw: "Todo",
+      statusAuthority: "external",
+      assigneeEntityId: "person-archived-reader",
+      assigneeName: "Archived Reader",
+      priority: "medium",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "archived-only-structural",
+    });
+    const mixedEvidence = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-407",
+      title: "Mixed structural evidence",
+      status: "open",
+      statusRaw: "Todo",
+      statusAuthority: "external",
+      assigneeEntityId: "person-archived-reader",
+      assigneeName: "Archived Reader",
+      priority: "medium",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "mixed-structural-evidence",
+    });
+    await repo.upsertEvidence(archivedOnly.taskId, "file", "file-archived");
+    await repo.upsertEvidence(mixedEvidence.taskId, "file", "file-active");
+    await repo.upsertEvidence(mixedEvidence.taskId, "file", "file-archived");
+
+    const rows = await repo.loadOpenDurableTasksForBrief({
+      userId: "archived-reader-u1",
+      userEmails: ["archived-reader@example.com"],
+      assigneeEntityIds: ["person-archived-reader"],
+    });
+
+    expect(rows.map((task) => task.id)).toEqual([mixedEvidence.taskId]);
+    expect(rows[0]?.knowledgeRefs.fileIds).toEqual(["file-active"]);
+  });
+
   it("loads recent user-owned summary tasks for Daily Brief including completed protection rows", async () => {
     await seedUser(db, "summary-u1", "summary@example.com");
     await seedUser(db, "summary-u2", "other@example.com");
@@ -1380,6 +1436,42 @@ describe("createTaskRepository sqlite", () => {
 
     expect(rows.map((task) => task.id)).toEqual([open.taskId, done.taskId, assigned.taskId]);
     expect(rows.map((task) => task.status)).toEqual(["open", "done", "done"]);
+  });
+
+  it("keeps summary tasks assigned to a merged-away reader person eligible", async () => {
+    await seedUser(db, "merged-summary-reader-u1", "merged-summary-reader@example.com");
+    await seedUser(db, "merged-summary-owner-u1", "merged-summary-owner@example.com");
+    await seedPerson(db, "person-summary-survivor", "Summary Survivor", ["merged-summary-reader@example.com"]);
+    await seedPerson(db, "person-summary-merged", "Summary Merged");
+    await mergeEntity(db, "person-summary-merged", "person-summary-survivor");
+
+    const repo = createTaskRepository(db);
+    const task = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Merged reader summary",
+      status: "done",
+      statusRaw: "done",
+      statusAuthority: "local",
+      assigneeEntityId: "person-summary-merged",
+      assigneeName: "Summary Merged",
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "merged-reader-summary",
+      createdByUserId: "merged-summary-owner-u1",
+    });
+
+    const rows = await repo.loadSummaryTasksForBrief({
+      userId: "merged-summary-reader-u1",
+      since: "2026-07-09T00:00:00.000Z",
+      assigneeEntityIds: ["person-summary-survivor"],
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([task.taskId]);
   });
 
   it("collates Brief todos with matching Summary tasks even when Brief evidence has no file", async () => {

--- a/packages/server/src/db/repositories/tasks.test.ts
+++ b/packages/server/src/db/repositories/tasks.test.ts
@@ -929,9 +929,216 @@ describe("createTaskRepository sqlite", () => {
     expect(externalUpdate).toBeNull();
   });
 
+  it("loads only reader-owned durable tasks with canonical visible knowledge references", async () => {
+    await seedUser(db, "reader-u1", "reader@example.com");
+    await seedUser(db, "other-u1", "other@example.com");
+    await seedPerson(db, "person-reader", "Reader Person", ["reader@example.com"]);
+    await seedPerson(db, "person-other", "Other Person", ["other@example.com"]);
+    await seedProject(db, "project-parent", "Parent Project");
+    await seedProject(db, "entity-evidence", "Evidence Entity");
+    await seedProject(db, "entity-deleted", "Deleted Evidence Entity");
+    await db
+      .updateTable("entities")
+      .set({ deleted_at: "2026-07-09T00:00:00.000Z" })
+      .where("id", "=", "entity-deleted")
+      .execute();
+    await seedIndexedFile(db, "file-visible");
+    await seedIndexedFile(db, "file-invisible");
+    await db
+      .insertInto("file_access")
+      .values({ indexed_file_id: "file-invisible", email: "other@example.com" })
+      .execute();
+
+    const repo = createTaskRepository(db);
+    const readerStructural = await repo.upsertTask({
+      parentEntityId: "project-parent",
+      parentSourceRef: null,
+      parentName: "Parent Project",
+      source: "linear",
+      externalRef: "SKE-401",
+      title: "Reader structural",
+      status: "open",
+      statusRaw: "Todo",
+      statusAuthority: "external",
+      assigneeEntityId: "person-reader",
+      assigneeName: "Reader Person",
+      priority: "high",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "reader-structural",
+      createdByUserId: "other-u1",
+    });
+    const otherStructural = await repo.upsertTask({
+      parentEntityId: "project-parent",
+      parentSourceRef: null,
+      parentName: "Parent Project",
+      source: "linear",
+      externalRef: "SKE-402",
+      title: "Other structural",
+      status: "open",
+      statusRaw: "Todo",
+      statusAuthority: "external",
+      assigneeEntityId: "person-other",
+      assigneeName: "Other Person",
+      priority: "medium",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "other-structural",
+    });
+    const unassignedStructural = await repo.upsertTask({
+      parentEntityId: "project-parent",
+      parentSourceRef: null,
+      parentName: "Parent Project",
+      source: "linear",
+      externalRef: "SKE-403",
+      title: "Unassigned structural",
+      status: "open",
+      statusRaw: "Todo",
+      statusAuthority: "external",
+      assigneeEntityId: null,
+      priority: "low",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "unassigned-structural",
+    });
+    const invisibleStructural = await repo.upsertTask({
+      parentEntityId: "project-parent",
+      parentSourceRef: null,
+      parentName: "Parent Project",
+      source: "linear",
+      externalRef: "SKE-404",
+      title: "Invisible structural",
+      status: "in_progress",
+      statusRaw: "In Progress",
+      statusAuthority: "external",
+      assigneeEntityId: "person-reader",
+      assigneeName: "Reader Person",
+      priority: "high",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "invisible-structural",
+    });
+    const readerCreatedLocal = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "brief",
+      externalRef: null,
+      title: "Reader-created local",
+      status: "open",
+      statusRaw: "todo",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "brief",
+      sourceTaskId: "reader-created-local",
+      createdByUserId: "reader-u1",
+    });
+    const readerAssignedLocal = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Reader-assigned local",
+      status: "in_progress",
+      statusRaw: "in_progress",
+      statusAuthority: "local",
+      assigneeEntityId: "person-reader",
+      assigneeName: "Reader Person",
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "reader-assigned-local",
+      createdByUserId: "other-u1",
+    });
+    const unrelatedLocal = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Unrelated local",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "unrelated-local",
+      createdByUserId: "other-u1",
+    });
+
+    for (const taskId of [
+      readerStructural.taskId,
+      otherStructural.taskId,
+      unassignedStructural.taskId,
+      readerCreatedLocal.taskId,
+    ]) {
+      await repo.upsertEvidence(taskId, "file", "file-visible");
+    }
+    await repo.upsertEvidence(readerStructural.taskId, "file", "file-invisible");
+    await repo.upsertEvidence(readerStructural.taskId, "entity", "entity-evidence");
+    await repo.upsertEvidence(readerStructural.taskId, "entity", "entity-evidence");
+    await repo.upsertEvidence(readerStructural.taskId, "entity", "entity-deleted");
+    await repo.upsertEvidence(invisibleStructural.taskId, "file", "file-invisible");
+    await db
+      .updateTable("tasks")
+      .set({ updated_at: "2026-07-10T12:00:00.000Z" })
+      .where("id", "in", [readerStructural.taskId, readerCreatedLocal.taskId, readerAssignedLocal.taskId])
+      .execute();
+
+    const rows = await repo.loadOpenDurableTasksForBrief({
+      userId: "reader-u1",
+      userEmails: ["reader@example.com"],
+      assigneeEntityIds: ["person-reader", "person-reader"],
+    });
+    const withoutReaderEntity = await repo.loadOpenDurableTasksForBrief({
+      userId: "reader-u1",
+      userEmails: ["reader@example.com"],
+      assigneeEntityIds: [],
+    });
+
+    expect(rows.map((task) => task.id)).toEqual(
+      [readerStructural.taskId, readerCreatedLocal.taskId, readerAssignedLocal.taskId].sort(),
+    );
+    expect(rows.map((task) => task.id)).not.toEqual(
+      expect.arrayContaining([
+        otherStructural.taskId,
+        unassignedStructural.taskId,
+        invisibleStructural.taskId,
+        unrelatedLocal.taskId,
+      ]),
+    );
+    expect(withoutReaderEntity.map((task) => task.id)).toEqual([readerCreatedLocal.taskId]);
+
+    const structural = rows.find((task) => task.id === readerStructural.taskId);
+    expect(structural).toMatchObject({
+      createdByReader: false,
+      assignedToReader: true,
+      parentEntity: { id: "project-parent", name: "Parent Project", source_type: "project" },
+      assigneeEntity: { id: "person-reader", name: "Reader Person", source_type: "person" },
+      knowledgeRefs: {
+        entityIds: ["entity-evidence", "person-reader", "project-parent"],
+        fileIds: ["file-visible"],
+      },
+    });
+    expect(rows.find((task) => task.id === readerCreatedLocal.taskId)).toMatchObject({
+      createdByReader: true,
+      assignedToReader: false,
+    });
+    expect(rows.find((task) => task.id === readerAssignedLocal.taskId)).toMatchObject({
+      createdByReader: false,
+      assignedToReader: true,
+    });
+  });
+
   it("loads recent user-owned summary tasks for Daily Brief including completed protection rows", async () => {
     await seedUser(db, "summary-u1", "summary@example.com");
     await seedUser(db, "summary-u2", "other@example.com");
+    await seedPerson(db, "person-summary-reader", "Summary Reader", ["summary@example.com"]);
     await seedProject(db, "project-x", "Project X");
     const repo = createTaskRepository(db);
     const open = await repo.upsertTask({
@@ -985,6 +1192,24 @@ describe("createTaskRepository sqlite", () => {
       sourceTaskId: "summary-old",
       createdByUserId: "summary-u1",
     });
+    const assigned = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Assigned summary task",
+      status: "done",
+      statusRaw: "done",
+      statusAuthority: "local",
+      assigneeEntityId: "person-summary-reader",
+      assigneeName: "Summary Reader",
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "summary-assigned-reader",
+      createdByUserId: "summary-u2",
+    });
     await repo.upsertTask({
       parentEntityId: null,
       parentSourceRef: null,
@@ -1021,8 +1246,18 @@ describe("createTaskRepository sqlite", () => {
     });
     await db
       .updateTable("tasks")
+      .set({ updated_at: "2026-07-09T13:00:00.000Z" })
+      .where("id", "=", open.taskId)
+      .execute();
+    await db
+      .updateTable("tasks")
       .set({ updated_at: "2026-07-09T12:00:00.000Z" })
-      .where("id", "in", [open.taskId, done.taskId])
+      .where("id", "=", done.taskId)
+      .execute();
+    await db
+      .updateTable("tasks")
+      .set({ updated_at: "2026-07-09T11:00:00.000Z" })
+      .where("id", "=", assigned.taskId)
       .execute();
     await db
       .updateTable("tasks")
@@ -1033,11 +1268,12 @@ describe("createTaskRepository sqlite", () => {
     const rows = await repo.loadSummaryTasksForBrief({
       userId: "summary-u1",
       since: "2026-07-09T00:00:00.000Z",
+      assigneeEntityIds: ["person-summary-reader"],
       limit: 10,
     });
 
-    expect(rows.map((task) => task.id)).toEqual([open.taskId, done.taskId]);
-    expect(rows.map((task) => task.status)).toEqual(["open", "done"]);
+    expect(rows.map((task) => task.id)).toEqual([open.taskId, done.taskId, assigned.taskId]);
+    expect(rows.map((task) => task.status)).toEqual(["open", "done", "done"]);
   });
 
   it("collates Brief todos with matching Summary tasks even when Brief evidence has no file", async () => {

--- a/packages/server/src/db/repositories/tasks.test.ts
+++ b/packages/server/src/db/repositories/tasks.test.ts
@@ -1135,6 +1135,112 @@ describe("createTaskRepository sqlite", () => {
     });
   });
 
+  it("keeps structural tasks assigned to a merged-away reader person eligible", async () => {
+    await seedUser(db, "merged-reader-u1", "merged-reader@example.com");
+    await seedPerson(db, "person-reader-survivor", "Reader Survivor", ["merged-reader@example.com"]);
+    await seedPerson(db, "person-reader-merged", "Reader Merged");
+    await mergeEntity(db, "person-reader-merged", "person-reader-survivor");
+    await seedIndexedFile(db, "merged-reader-file");
+
+    const repo = createTaskRepository(db);
+    const task = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "SKE-405",
+      title: "Merged reader structural",
+      status: "open",
+      statusRaw: "Todo",
+      statusAuthority: "external",
+      assigneeEntityId: "person-reader-merged",
+      assigneeName: "Reader Merged",
+      priority: "high",
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "merged-reader-structural",
+    });
+    await repo.upsertEvidence(task.taskId, "file", "merged-reader-file");
+
+    const rows = await repo.loadOpenDurableTasksForBrief({
+      userId: "merged-reader-u1",
+      userEmails: ["merged-reader@example.com"],
+      assigneeEntityIds: ["person-reader-survivor"],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: task.taskId,
+      assignedToReader: true,
+      assigneeEntity: {
+        id: "person-reader-survivor",
+        name: "Reader Survivor",
+        source_type: "person",
+      },
+    });
+  });
+
+  it("returns canonical survivor IDs for merged task entity refs without duplicates", async () => {
+    await seedUser(db, "canonical-reader-u1", "canonical-reader@example.com");
+    await seedProject(db, "project-parent-survivor", "Parent Survivor");
+    await seedProject(db, "project-parent-merged", "Parent Merged");
+    await seedPerson(db, "person-assignee-survivor", "Assignee Survivor");
+    await seedPerson(db, "person-assignee-merged", "Assignee Merged");
+    await seedProject(db, "entity-evidence-survivor", "Evidence Survivor");
+    await seedProject(db, "entity-evidence-merged", "Evidence Merged");
+    await mergeEntity(db, "project-parent-merged", "project-parent-survivor");
+    await mergeEntity(db, "person-assignee-merged", "person-assignee-survivor");
+    await mergeEntity(db, "entity-evidence-merged", "entity-evidence-survivor");
+
+    const repo = createTaskRepository(db);
+    const task = await repo.upsertTask({
+      parentEntityId: "project-parent-merged",
+      parentSourceRef: null,
+      parentName: "Parent Merged",
+      source: "brief",
+      externalRef: null,
+      title: "Canonical merged refs",
+      status: "open",
+      statusRaw: "todo",
+      statusAuthority: "local",
+      assigneeEntityId: "person-assignee-merged",
+      assigneeName: "Assignee Merged",
+      priority: "medium",
+      dueAt: null,
+      provenance: "brief",
+      sourceTaskId: "canonical-merged-refs",
+      createdByUserId: "canonical-reader-u1",
+    });
+    await repo.upsertEvidence(task.taskId, "entity", "entity-evidence-merged");
+    await repo.upsertEvidence(task.taskId, "entity", "entity-evidence-survivor");
+
+    const rows = await repo.loadOpenDurableTasksForBrief({
+      userId: "canonical-reader-u1",
+      userEmails: ["canonical-reader@example.com"],
+      assigneeEntityIds: ["person-assignee-survivor"],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: task.taskId,
+      assignedToReader: true,
+      parentEntity: {
+        id: "project-parent-survivor",
+        name: "Parent Survivor",
+        source_type: "project",
+      },
+      assigneeEntity: {
+        id: "person-assignee-survivor",
+        name: "Assignee Survivor",
+        source_type: "person",
+      },
+      knowledgeRefs: {
+        entityIds: ["entity-evidence-survivor", "person-assignee-survivor", "project-parent-survivor"],
+        fileIds: [],
+      },
+    });
+  });
+
   it("loads recent user-owned summary tasks for Daily Brief including completed protection rows", async () => {
     await seedUser(db, "summary-u1", "summary@example.com");
     await seedUser(db, "summary-u2", "other@example.com");
@@ -1536,6 +1642,18 @@ async function seedPerson(db: Kysely<DB>, id: string, name: string, aliases: str
       deleted_at: null,
       merged_into_entity_id: null,
     })
+    .execute();
+}
+
+async function mergeEntity(db: Kysely<DB>, mergedId: string, survivorId: string): Promise<void> {
+  await db
+    .updateTable("entities")
+    .set({
+      deleted_at: new Date().toISOString(),
+      merged_into_entity_id: survivorId,
+      updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", mergedId)
     .execute();
 }
 

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { type Kysely, type Selectable, sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
 import { fileAccessFilterSql } from "../../connectors/search";
+import { EntityRedirectError } from "../../entities/redirect";
 import type { DB, EntitiesTable, TasksTable } from "../schema";
 import type { AgentKnowledgeRefs, AgentOutputItemInput } from "./agent-outputs";
 import type { FileViewer } from "./connectors";
@@ -381,6 +382,10 @@ export function createTaskRepository(db: Kysely<DB>) {
 
     async loadOpenDurableTasksForBrief(opts: LoadOpenDurableTasksForBriefOptions): Promise<DurableTaskForBrief[]> {
       const assigneeEntityIds = [...new Set(opts.assigneeEntityIds ?? [])].filter(Boolean);
+      const canonicalAssigneeEntityIds = [
+        ...new Set((await resolveCanonicalEntityIds(db, assigneeEntityIds)).values()),
+      ];
+      const eligibleAssigneeEntityIds = await loadMergedEntityPredecessorIds(db, canonicalAssigneeEntityIds);
       const visibleFileEvidence =
         opts.userEmails.length === 0
           ? sql<boolean>`false`
@@ -398,9 +403,9 @@ export function createTaskRepository(db: Kysely<DB>) {
         .where("tasks.status", "in", ["open", "in_progress"])
         .where((eb) => {
           const assignedToReader =
-            assigneeEntityIds.length === 0
+            eligibleAssigneeEntityIds.length === 0
               ? sql<boolean>`false`
-              : eb("tasks.assignee_entity_id", "in", assigneeEntityIds);
+              : eb("tasks.assignee_entity_id", "in", eligibleAssigneeEntityIds);
           return eb.or([
             eb.and([eb("tasks.provenance", "=", "structural"), assignedToReader, visibleFileEvidence]),
             eb.and([
@@ -417,7 +422,7 @@ export function createTaskRepository(db: Kysely<DB>) {
       return loadDurableTaskMetadata(db, tasks, {
         userId: opts.userId,
         userEmails: opts.userEmails,
-        assigneeEntityIds,
+        assigneeEntityIds: canonicalAssigneeEntityIds,
       });
     },
 
@@ -503,13 +508,15 @@ async function loadDurableTaskMetadata(
       ...evidenceRows.filter((row) => row.kind === "entity").map((row) => row.ref_id),
     ]),
   ].filter((id): id is string => Boolean(id));
+  const canonicalEntityIdsById = await resolveCanonicalEntityIds(db, entityIds);
+  const canonicalEntityIds = [...new Set(canonicalEntityIdsById.values())];
   const entities =
-    entityIds.length === 0
+    canonicalEntityIds.length === 0
       ? []
       : await db
           .selectFrom("entities")
           .select(["id", "name", "source_type"])
-          .where("id", "in", entityIds)
+          .where("id", "in", canonicalEntityIds)
           .where(whereLiveEntity())
           .execute();
   const entitiesById = new Map(entities.map((entity) => [entity.id, entity]));
@@ -534,14 +541,19 @@ async function loadDurableTaskMetadata(
   const assigneeEntityIds = new Set(opts.assigneeEntityIds);
 
   return tasks.map((task) => {
-    const parentEntity = task.parent_entity_id ? (entitiesById.get(task.parent_entity_id) ?? null) : null;
-    const assigneeEntity = task.assignee_entity_id ? (entitiesById.get(task.assignee_entity_id) ?? null) : null;
+    const parentEntityId = task.parent_entity_id ? canonicalEntityIdsById.get(task.parent_entity_id) : null;
+    const assigneeEntityId = task.assignee_entity_id ? canonicalEntityIdsById.get(task.assignee_entity_id) : null;
+    const parentEntity = parentEntityId ? (entitiesById.get(parentEntityId) ?? null) : null;
+    const assigneeEntity = assigneeEntityId ? (entitiesById.get(assigneeEntityId) ?? null) : null;
     const taskEvidence = evidenceByTaskId.get(task.id) ?? [];
     const entityRefs = new Set<string>();
     if (parentEntity) entityRefs.add(parentEntity.id);
     if (assigneeEntity) entityRefs.add(assigneeEntity.id);
     for (const evidence of taskEvidence) {
-      if (evidence.kind === "entity" && entitiesById.has(evidence.ref_id)) entityRefs.add(evidence.ref_id);
+      const canonicalEntityId = canonicalEntityIdsById.get(evidence.ref_id);
+      if (evidence.kind === "entity" && canonicalEntityId && entitiesById.has(canonicalEntityId)) {
+        entityRefs.add(canonicalEntityId);
+      }
     }
     const fileRefs = new Set(
       taskEvidence
@@ -551,7 +563,7 @@ async function loadDurableTaskMetadata(
     return {
       ...task,
       createdByReader: task.created_by_user_id === opts.userId,
-      assignedToReader: Boolean(task.assignee_entity_id && assigneeEntityIds.has(task.assignee_entity_id)),
+      assignedToReader: Boolean(assigneeEntityId && assigneeEntityIds.has(assigneeEntityId)),
       parentEntity,
       assigneeEntity,
       knowledgeRefs: {
@@ -560,6 +572,76 @@ async function loadDurableTaskMetadata(
       },
     };
   });
+}
+
+async function resolveCanonicalEntityIds(db: Kysely<DB>, entityIds: string[]): Promise<Map<string, string>> {
+  const sourceIds = [...new Set(entityIds)].filter(Boolean);
+  if (sourceIds.length === 0) return new Map();
+
+  const redirects = new Map<string, string | null>();
+  let frontier = sourceIds;
+  for (let depth = 0; depth < 32 && frontier.length > 0; depth++) {
+    const rows = await db
+      .selectFrom("entities")
+      .select(["id", "merged_into_entity_id"])
+      .where("id", "in", frontier)
+      .execute();
+    const rowsById = new Map(rows.map((row) => [row.id, row]));
+    const next = new Set<string>();
+    for (const entityId of frontier) {
+      const mergedIntoEntityId = rowsById.get(entityId)?.merged_into_entity_id ?? null;
+      redirects.set(entityId, mergedIntoEntityId);
+      if (mergedIntoEntityId && !redirects.has(mergedIntoEntityId)) next.add(mergedIntoEntityId);
+    }
+    frontier = [...next];
+  }
+  if (frontier.length > 0) {
+    throw new EntityRedirectError("ENTITY_REDIRECT_TOO_DEEP", "entity merge redirect chain exceeded limit", {
+      entityIds: sourceIds,
+    });
+  }
+
+  const canonicalIds = new Map<string, string>();
+  for (const sourceId of sourceIds) {
+    let current = sourceId;
+    const seen = new Set<string>();
+    for (let depth = 0; depth < 32; depth++) {
+      if (seen.has(current)) {
+        throw new EntityRedirectError("ENTITY_REDIRECT_CYCLE", "entity merge redirect cycle detected", {
+          entityId: sourceId,
+        });
+      }
+      seen.add(current);
+      const target = redirects.get(current);
+      if (!target) {
+        canonicalIds.set(sourceId, current);
+        break;
+      }
+      current = target;
+    }
+    if (!canonicalIds.has(sourceId)) {
+      throw new EntityRedirectError("ENTITY_REDIRECT_TOO_DEEP", "entity merge redirect chain exceeded limit", {
+        entityId: sourceId,
+      });
+    }
+  }
+  return canonicalIds;
+}
+
+async function loadMergedEntityPredecessorIds(db: Kysely<DB>, entityIds: string[]): Promise<string[]> {
+  const resolvedIds = new Set(entityIds);
+  let frontier = [...resolvedIds];
+  for (let depth = 0; depth < 32 && frontier.length > 0; depth++) {
+    const rows = await db.selectFrom("entities").select("id").where("merged_into_entity_id", "in", frontier).execute();
+    frontier = rows.map((row) => row.id).filter((id) => !resolvedIds.has(id));
+    for (const id of frontier) resolvedIds.add(id);
+  }
+  if (frontier.length > 0) {
+    throw new EntityRedirectError("ENTITY_REDIRECT_TOO_DEEP", "entity merge redirect chain exceeded limit", {
+      entityIds,
+    });
+  }
+  return [...resolvedIds];
 }
 
 export async function upsertLlmTask(

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -84,14 +84,29 @@ export interface ReanchorNullParentTasksResult {
 export interface LoadOpenDurableTasksForBriefOptions {
   userId: string;
   userEmails: string[];
+  assigneeEntityIds?: string[];
   limit?: number;
 }
 
 export interface LoadSummaryTasksForBriefOptions {
   userId: string;
+  assigneeEntityIds?: string[];
   since: string;
   limit?: number;
 }
+
+export type BriefTaskEntityIdentity = Pick<Selectable<EntitiesTable>, "id" | "name" | "source_type">;
+
+export type DurableTaskForBrief = Selectable<TasksTable> & {
+  createdByReader: boolean;
+  assignedToReader: boolean;
+  parentEntity: BriefTaskEntityIdentity | null;
+  assigneeEntity: BriefTaskEntityIdentity | null;
+  knowledgeRefs: {
+    entityIds: string[];
+    fileIds: string[];
+  };
+};
 
 export interface UpsertLlmTaskInput {
   candidate: { title: string; dueAt?: string | null; assigneeEntityId?: string | null; assigneeName?: string | null };
@@ -364,7 +379,8 @@ export function createTaskRepository(db: Kysely<DB>) {
       return query.execute();
     },
 
-    async loadOpenDurableTasksForBrief(opts: LoadOpenDurableTasksForBriefOptions): Promise<Selectable<TasksTable>[]> {
+    async loadOpenDurableTasksForBrief(opts: LoadOpenDurableTasksForBriefOptions): Promise<DurableTaskForBrief[]> {
+      const assigneeEntityIds = [...new Set(opts.assigneeEntityIds ?? [])].filter(Boolean);
       const visibleFileEvidence =
         opts.userEmails.length === 0
           ? sql<boolean>`false`
@@ -375,41 +391,51 @@ export function createTaskRepository(db: Kysely<DB>) {
               AND task_evidence.kind = 'file'
               AND ${fileAccessFilterSql(opts.userEmails)}
           )`;
-      return db
+      const tasks = await db
         .selectFrom("tasks")
         .selectAll("tasks")
         .where("tasks.valid_to", "is", null)
         .where("tasks.status", "in", ["open", "in_progress"])
-        .where((eb) =>
-          eb.or([
-            eb.and([eb("tasks.provenance", "=", "structural"), visibleFileEvidence]),
+        .where((eb) => {
+          const assignedToReader =
+            assigneeEntityIds.length === 0
+              ? sql<boolean>`false`
+              : eb("tasks.assignee_entity_id", "in", assigneeEntityIds);
+          return eb.or([
+            eb.and([eb("tasks.provenance", "=", "structural"), assignedToReader, visibleFileEvidence]),
             eb.and([
-              eb("tasks.created_by_user_id", "=", opts.userId),
               eb("tasks.provenance", "in", ["brief", "summary"]),
+              eb("tasks.status_authority", "=", "local"),
+              eb.or([eb("tasks.created_by_user_id", "=", opts.userId), assignedToReader]),
             ]),
-          ]),
-        )
+          ]);
+        })
         .orderBy("tasks.updated_at", "desc")
+        .orderBy("tasks.id", "asc")
         .limit(opts.limit ?? 50)
         .execute();
+      return loadDurableTaskMetadata(db, tasks, {
+        userId: opts.userId,
+        userEmails: opts.userEmails,
+        assigneeEntityIds,
+      });
     },
 
     async loadSummaryTasksForBrief(opts: LoadSummaryTasksForBriefOptions): Promise<Selectable<TasksTable>[]> {
+      const assigneeEntityIds = [...new Set(opts.assigneeEntityIds ?? [])].filter(Boolean);
       return db
         .selectFrom("tasks")
         .selectAll()
         .where("valid_to", "is", null)
-        .where("created_by_user_id", "=", opts.userId)
+        .where((eb) =>
+          eb.or([
+            eb("created_by_user_id", "=", opts.userId),
+            ...(assigneeEntityIds.length > 0 ? [eb("assignee_entity_id", "in", assigneeEntityIds)] : []),
+          ]),
+        )
         .where("provenance", "=", "summary")
         .where("updated_at", ">=", opts.since)
         .where("status", "in", ["open", "in_progress", "done", "dropped"])
-        .orderBy(sql<number>`CASE
-          WHEN status = 'open' THEN 0
-          WHEN status = 'in_progress' THEN 1
-          WHEN status = 'done' THEN 2
-          WHEN status = 'dropped' THEN 3
-          ELSE 4
-        END`)
         .orderBy("updated_at", "desc")
         .orderBy("id", "asc")
         .limit(opts.limit ?? 50)
@@ -455,6 +481,85 @@ export function createTaskRepository(db: Kysely<DB>) {
       return db.selectFrom("tasks").selectAll().where("id", "=", input.taskId).executeTakeFirstOrThrow();
     },
   };
+}
+
+async function loadDurableTaskMetadata(
+  db: Kysely<DB>,
+  tasks: Selectable<TasksTable>[],
+  opts: { userId: string; userEmails: string[]; assigneeEntityIds: string[] },
+): Promise<DurableTaskForBrief[]> {
+  if (tasks.length === 0) return [];
+
+  const taskIds = tasks.map((task) => task.id);
+  const evidenceRows = await db
+    .selectFrom("task_evidence")
+    .select(["task_id", "kind", "ref_id"])
+    .where("task_id", "in", taskIds)
+    .where("kind", "in", ["entity", "file"])
+    .execute();
+  const entityIds = [
+    ...new Set([
+      ...tasks.flatMap((task) => [task.parent_entity_id, task.assignee_entity_id]),
+      ...evidenceRows.filter((row) => row.kind === "entity").map((row) => row.ref_id),
+    ]),
+  ].filter((id): id is string => Boolean(id));
+  const entities =
+    entityIds.length === 0
+      ? []
+      : await db
+          .selectFrom("entities")
+          .select(["id", "name", "source_type"])
+          .where("id", "in", entityIds)
+          .where(whereLiveEntity())
+          .execute();
+  const entitiesById = new Map(entities.map((entity) => [entity.id, entity]));
+
+  const evidenceFileIds = [...new Set(evidenceRows.filter((row) => row.kind === "file").map((row) => row.ref_id))];
+  const visibleFiles =
+    evidenceFileIds.length === 0 || opts.userEmails.length === 0
+      ? []
+      : await db
+          .selectFrom("indexed_files")
+          .select("id")
+          .where("id", "in", evidenceFileIds)
+          .where(fileAccessFilterSql(opts.userEmails))
+          .execute();
+  const visibleFileIds = new Set(visibleFiles.map((file) => file.id));
+  const evidenceByTaskId = new Map<string, Array<{ kind: string; ref_id: string }>>();
+  for (const evidence of evidenceRows) {
+    const taskEvidence = evidenceByTaskId.get(evidence.task_id) ?? [];
+    taskEvidence.push(evidence);
+    evidenceByTaskId.set(evidence.task_id, taskEvidence);
+  }
+  const assigneeEntityIds = new Set(opts.assigneeEntityIds);
+
+  return tasks.map((task) => {
+    const parentEntity = task.parent_entity_id ? (entitiesById.get(task.parent_entity_id) ?? null) : null;
+    const assigneeEntity = task.assignee_entity_id ? (entitiesById.get(task.assignee_entity_id) ?? null) : null;
+    const taskEvidence = evidenceByTaskId.get(task.id) ?? [];
+    const entityRefs = new Set<string>();
+    if (parentEntity) entityRefs.add(parentEntity.id);
+    if (assigneeEntity) entityRefs.add(assigneeEntity.id);
+    for (const evidence of taskEvidence) {
+      if (evidence.kind === "entity" && entitiesById.has(evidence.ref_id)) entityRefs.add(evidence.ref_id);
+    }
+    const fileRefs = new Set(
+      taskEvidence
+        .filter((evidence) => evidence.kind === "file" && visibleFileIds.has(evidence.ref_id))
+        .map((evidence) => evidence.ref_id),
+    );
+    return {
+      ...task,
+      createdByReader: task.created_by_user_id === opts.userId,
+      assignedToReader: Boolean(task.assignee_entity_id && assigneeEntityIds.has(task.assignee_entity_id)),
+      parentEntity,
+      assigneeEntity,
+      knowledgeRefs: {
+        entityIds: [...entityRefs].sort(),
+        fileIds: [...fileRefs].sort(),
+      },
+    };
+  });
 }
 
 export async function upsertLlmTask(

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -394,6 +394,7 @@ export function createTaskRepository(db: Kysely<DB>) {
             INNER JOIN indexed_files ON indexed_files.id = task_evidence.ref_id
             WHERE task_evidence.task_id = tasks.id
               AND task_evidence.kind = 'file'
+              AND indexed_files.is_archived = 0
               AND ${fileAccessFilterSql(opts.userEmails)}
           )`;
       const tasks = await db
@@ -428,6 +429,10 @@ export function createTaskRepository(db: Kysely<DB>) {
 
     async loadSummaryTasksForBrief(opts: LoadSummaryTasksForBriefOptions): Promise<Selectable<TasksTable>[]> {
       const assigneeEntityIds = [...new Set(opts.assigneeEntityIds ?? [])].filter(Boolean);
+      const canonicalAssigneeEntityIds = [
+        ...new Set((await resolveCanonicalEntityIds(db, assigneeEntityIds)).values()),
+      ];
+      const eligibleAssigneeEntityIds = await loadMergedEntityPredecessorIds(db, canonicalAssigneeEntityIds);
       return db
         .selectFrom("tasks")
         .selectAll()
@@ -435,7 +440,9 @@ export function createTaskRepository(db: Kysely<DB>) {
         .where((eb) =>
           eb.or([
             eb("created_by_user_id", "=", opts.userId),
-            ...(assigneeEntityIds.length > 0 ? [eb("assignee_entity_id", "in", assigneeEntityIds)] : []),
+            ...(eligibleAssigneeEntityIds.length > 0
+              ? [eb("assignee_entity_id", "in", eligibleAssigneeEntityIds)]
+              : []),
           ]),
         )
         .where("provenance", "=", "summary")
@@ -529,6 +536,7 @@ async function loadDurableTaskMetadata(
           .selectFrom("indexed_files")
           .select("id")
           .where("id", "in", evidenceFileIds)
+          .where("is_archived", "=", 0)
           .where(fileAccessFilterSql(opts.userEmails))
           .execute();
   const visibleFileIds = new Set(visibleFiles.map((file) => file.id));

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -1,7 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { type Kysely, type Selectable, sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
-import { fileAccessFilterSql } from "../../connectors/search";
 import { EntityRedirectError } from "../../entities/redirect";
 import type { DB, EntitiesTable, TasksTable } from "../schema";
 import type { AgentKnowledgeRefs, AgentOutputItemInput } from "./agent-outputs";
@@ -395,7 +394,7 @@ export function createTaskRepository(db: Kysely<DB>) {
             WHERE task_evidence.task_id = tasks.id
               AND task_evidence.kind = 'file'
               AND indexed_files.is_archived = 0
-              AND ${fileAccessFilterSql(opts.userEmails)}
+              AND ${fileVisibilityForEmails(opts.userEmails)}
           )`;
       const tasks = await db
         .selectFrom("tasks")
@@ -537,7 +536,7 @@ async function loadDurableTaskMetadata(
           .select("id")
           .where("id", "in", evidenceFileIds)
           .where("is_archived", "=", 0)
-          .where(fileAccessFilterSql(opts.userEmails))
+          .where(fileVisibilityForEmails(opts.userEmails))
           .execute();
   const visibleFileIds = new Set(visibleFiles.map((file) => file.id));
   const evidenceByTaskId = new Map<string, Array<{ kind: string; ref_id: string }>>();
@@ -580,6 +579,15 @@ async function loadDurableTaskMetadata(
       },
     };
   });
+}
+
+function fileVisibilityForEmails(userEmails: string[], alias = "indexed_files") {
+  const emails = [...new Set(userEmails)].filter(Boolean);
+  if (emails.length === 0) return sql<boolean>`false`;
+  return sql<boolean>`(${sql.join(
+    emails.map((email) => fileVisibilityPredicate({ email, isAdmin: false }, alias)),
+    sql` OR `,
+  )})`;
 }
 
 async function resolveCanonicalEntityIds(db: Kysely<DB>, entityIds: string[]): Promise<Map<string, string>> {

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -396,7 +396,7 @@ export function createTaskRepository(db: Kysely<DB>) {
               AND indexed_files.is_archived = 0
               AND ${fileVisibilityForEmails(opts.userEmails)}
           )`;
-      const tasks = await db
+      let query = db
         .selectFrom("tasks")
         .selectAll("tasks")
         .where("tasks.valid_to", "is", null)
@@ -416,9 +416,9 @@ export function createTaskRepository(db: Kysely<DB>) {
           ]);
         })
         .orderBy("tasks.updated_at", "desc")
-        .orderBy("tasks.id", "asc")
-        .limit(opts.limit ?? 50)
-        .execute();
+        .orderBy("tasks.id", "asc");
+      if (opts.limit !== undefined) query = query.limit(opts.limit);
+      const tasks = await query.execute();
       return loadDurableTaskMetadata(db, tasks, {
         userId: opts.userId,
         userEmails: opts.userEmails,


### PR DESCRIPTION
## Summary

- Make Daily Brief To-dos a deterministic projection of durable tasks owned by the reader.
- Exclude unassigned, other-user, invisible, unknown, duplicate, and newly inferred todos.
- Preserve meetings, customer updates, active projects, and admin-wide non-todo visibility.

## Implementation Details

- Resolve reader person identity only through verified primary/provider emails, with conflicting identities failing closed.
- Load structural tasks only when assigned to the reader and backed by reader-visible evidence.
- Load local Brief/Summarizer tasks only when created by or assigned to the reader.
- Add ownership metadata and canonical entity/file references to the runtime durable-task allowlist.
- Require `structuredPayload.durableTaskId`, canonicalize task-owned fields, reject invalid IDs, and deterministically backfill remaining section slots.
- Revalidate ownership, status, and access immediately before persistence.
- Discard model-authored enrichment if canonical task fields, ownership, or references changed during generation.
- Prevent task-backed todos from being promoted into duplicate durable tasks.
- Emit content-free allowed/rejected/backfilled/identity-unresolved metrics.

No database migration, HTTP API change, or frontend change is included.

## Verification

- `pnpm build` — passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm test` — passed: 3,991 server tests and 382 web tests; 20 expected skips
- Targeted Daily Brief/task tests — passed: 119 tests
- Deterministic QA-only complete Home brief — passed:
  - 3/3 persisted todos were canonical reader-owned durable tasks
  - zero inferred todos
  - zero duplicate task promotions
  - meetings, customer updates, and active projects remained present
- Independent `gpt-5.6-sol` code, QA, and QA-data audits approved with no Critical or Important findings.

## Risk / Rollout

- The complete reader-owned allowlist is intentionally included for deterministic backfill; very large task sets remain a prompt-size scalability consideration.
- Production rollout should occur only after merge, with the documented SQLite backup and verified identity-linkage procedure.
