### PR TITLE
feat(web): add Claude-style application shell

### DIFF
--- a/packages/web/src/components/agents/agent-detail.tsx
+++ b/packages/web/src/components/agents/agent-detail.tsx
@@ -1,3 +1,4 @@
+import { QuietAddButton } from "@/components/quiet-add-button";
 /**
  * The agent detail lets users review generated output history and tune one
  * code-owned prebuilt agent through schedule, sources, focus, volume, delivery,
@@ -19,7 +20,6 @@ import {
   CheckCircleIcon,
   HashIcon,
   PencilSimpleIcon,
-  PlusIcon,
   SlackLogoIcon,
   UserIcon,
   UsersThreeIcon,
@@ -357,14 +357,7 @@ function SummariserIndex({
             <span className="font-mono text-[11px] uppercase tracking-[0.07em] text-muted-foreground">Summarisers</span>
             <span className="font-mono text-[10px] text-muted-foreground/60">{agent.routes.length}</span>
           </div>
-          <button
-            type="button"
-            onClick={() => setModalOpen(true)}
-            className="inline-flex items-center gap-1.5 rounded-md border-[0.5px] border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:bg-[#111110] dark:hover:bg-[#1C1C1A]"
-          >
-            <PlusIcon size={12} weight="bold" aria-hidden />
-            New summariser
-          </button>
+          <QuietAddButton onClick={() => setModalOpen(true)}>New summariser</QuietAddButton>
         </div>
 
         {agent.routes.length === 0 ? (

--- a/packages/web/src/components/agents/agent-roster.tsx
+++ b/packages/web/src/components/agents/agent-roster.tsx
@@ -1,3 +1,4 @@
+import { QuietAddButton } from "@/components/quiet-add-button";
 /**
  * The agents landing — the curated catalog of prebuilt agents. Most are a single
  * code-owned, opt-in job rendered as one row with an on/off switch. A
@@ -6,7 +7,7 @@
  * summariser" action that opens the first-time-setup modal.
  */
 import { type AgentRoute, type AgentSourceConfig, type AgentSummary, api } from "@/lib/api";
-import { CaretRightIcon, PlusIcon } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 import { Switch } from "@sketch/ui/components/switch";
 import { cn } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -140,14 +141,7 @@ function SummariserGroup({ agent }: { agent: AgentSummary }) {
           <span className="text-[14px] font-medium text-foreground">{agent.title}</span>
           <p className="mt-0.5 text-[12.5px] text-muted-foreground">{agent.tagline}</p>
         </Link>
-        <button
-          type="button"
-          onClick={() => setModalOpen(true)}
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-        >
-          <PlusIcon size={12} weight="bold" aria-hidden />
-          New
-        </button>
+        <QuietAddButton onClick={() => setModalOpen(true)}>New</QuietAddButton>
       </div>
 
       <div className="ml-4 flex flex-col">

--- a/packages/web/src/components/app-sidebar.isolated.test.tsx
+++ b/packages/web/src/components/app-sidebar.isolated.test.tsx
@@ -1,91 +1,164 @@
 import { server } from "@/test/msw";
 import { renderWithProviders } from "@/test/utils";
 import { SidebarProvider } from "@sketch/ui/components/sidebar";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppSidebar } from "./app-sidebar";
 
 const mockNavigate = vi.fn();
-let mockPathname = "/channels";
+let mockPathname = "/home";
 
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual("@tanstack/react-router");
+  const React = await import("react");
+  const Link = React.forwardRef<
+    HTMLAnchorElement,
+    {
+      to: string;
+      params?: Record<string, string>;
+      children?: React.ReactNode;
+      viewTransition?: unknown;
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement>
+  >(({ to, params, children, viewTransition: _viewTransition, ...props }, ref) => {
+    const href = params
+      ? Object.entries(params).reduce((path, [key, value]) => path.replace(`$${key}`, value), to)
+      : to;
+    return React.createElement("a", { ...props, ref, href }, children);
+  });
   return {
     ...actual,
+    Link,
     useLocation: () => ({ pathname: mockPathname }),
     useNavigate: () => mockNavigate,
   };
 });
 
-function renderSidebar(role?: "admin" | "member") {
+function renderSidebar(role?: "admin" | "member", defaultOpen = true) {
   return renderWithProviders(
-    <SidebarProvider>
+    <SidebarProvider defaultOpen={defaultOpen}>
       <AppSidebar displayName="User" displayIdentifier="user@test.com" role={role} />
     </SidebarProvider>,
+  );
+}
+
+function conversations(count: number) {
+  server.use(
+    http.get("/api/web-chat/conversations", () =>
+      HttpResponse.json({
+        conversations: Array.from({ length: count }, (_, index) => ({
+          id: `chat-${index + 1}`,
+          title: `Conversation ${index + 1}`,
+          channel: "web",
+          updatedAt: `2026-07-${String(17 - index).padStart(2, "0")}T08:00:00.000Z`,
+        })),
+      }),
+    ),
   );
 }
 
 describe("AppSidebar", () => {
   beforeEach(() => {
     mockNavigate.mockReset();
-    mockPathname = "/channels";
-  });
-
-  it("shows Home as the first primary tab and selects it on /home", () => {
     mockPathname = "/home";
-
-    renderSidebar("admin");
-
-    const primaryLabels = [
-      "Home",
-      "Chat",
-      "Channels",
-      "Files",
-      "Team",
-      "Automations",
-      "Skills",
-      "Integrations",
-      "Usage",
-      "Settings",
-    ];
-    const navButtons = screen
-      .getAllByRole("button")
-      .map((button) => button.textContent)
-      .filter((label): label is string => Boolean(label && primaryLabels.includes(label)));
-    expect(navButtons[0]).toBe("Home");
-    expect(navButtons[1]).toBe("Chat");
-    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute("data-active", "true");
   });
 
-  it("selects Chat while viewing the dedicated chat screen", () => {
-    mockPathname = "/chat";
-
+  it("renders top actions and the pinned surface hierarchy", () => {
     renderSidebar("admin");
 
-    expect(screen.getByRole("button", { name: "Chat" })).toHaveAttribute("data-active", "true");
-    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute("data-active", "false");
+    expect(screen.getByRole("button", { name: "New chat" })).toBeInTheDocument();
+    const links = screen.getAllByRole("link");
+    const labels = links.map((link) => link.textContent?.trim()).filter(Boolean);
+    expect(labels.slice(0, 5)).toEqual(["Add integration", "Home", "Agents", "Your org", "Automations"]);
+    expect(screen.queryByRole("link", { name: "Chat" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("data-active", "true");
   });
 
-  it("selects Chat while viewing a specific web chat conversation", () => {
-    mockPathname = "/chat/web-chat-2026-05-26-abcdef";
-
+  it("treats web chat as part of Home while marking the current recent row", async () => {
+    conversations(1);
+    mockPathname = "/chat/chat-1";
     renderSidebar("admin");
 
-    expect(screen.getByRole("button", { name: "Chat" })).toHaveAttribute("data-active", "true");
-    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute("data-active", "false");
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("data-active", "true");
+    expect(await screen.findByRole("link", { name: /Conversation 1/ })).toHaveAttribute("aria-current", "page");
   });
 
-  it("selects Automations while viewing the builder route", () => {
-    mockPathname = "/scheduled-tasks/task-123/edit";
-
+  it("opens a fresh conversation directly from New chat", async () => {
+    const user = userEvent.setup();
     renderSidebar("admin");
 
-    expect(screen.getByRole("button", { name: "Automations" })).toHaveAttribute("data-active", "true");
-    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute("data-active", "false");
+    await user.click(screen.getByRole("button", { name: "New chat" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/chat/$conversationId",
+        search: { new: true },
+      }),
+    );
   });
 
-  it("shows Account link for managed admins", async () => {
+  it("opens More inline and exposes the production destinations", async () => {
+    const user = userEvent.setup();
+    renderSidebar("admin");
+
+    const trigger = screen.getByRole("button", { name: "Show more destinations" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("link", { name: "Files" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Access" })).toHaveAttribute("href", "/team");
+    expect(screen.getByRole("link", { name: "Skills" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("defaults More open when one of its child routes is active", () => {
+    mockPathname = "/channels";
+    renderSidebar("admin");
+
+    expect(screen.getByRole("button", { name: "Hide more destinations" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("link", { name: "Channels" })).toHaveAttribute("data-active", "true");
+  });
+
+  it("uses a dropdown for More when the desktop rail is collapsed", async () => {
+    const user = userEvent.setup();
+    renderSidebar("admin", false);
+
+    await user.click(screen.getByRole("button", { name: "More destinations" }));
+    const menu = await screen.findByRole("menu");
+    expect(within(menu).getByRole("menuitem", { name: "Files" })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "Access" })).toBeInTheDocument();
+  });
+
+  it("renders real recents, caps them at five, and does not fabricate status rows", async () => {
+    conversations(7);
+    renderSidebar("admin");
+
+    expect(await screen.findByRole("link", { name: /Conversation 1/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Conversation 5/ })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Conversation 6/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("working")).not.toBeInTheDocument();
+  });
+
+  it("renders a quiet empty state when there are no conversations", async () => {
+    renderSidebar("admin");
+
+    expect(await screen.findByText("No recent conversations")).toBeInTheDocument();
+  });
+
+  it("shows the scoped Your Org count to admins and hides the row from members", async () => {
+    server.use(http.get("/api/entity-review", () => HttpResponse.json({ rows: [], total: 3 })));
+    const { unmount } = renderSidebar("admin");
+
+    expect(await screen.findByText("3")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Your org/ })).toBeInTheDocument();
+    unmount();
+
+    renderSidebar("member");
+    expect(screen.queryByRole("link", { name: /Your org/ })).not.toBeInTheDocument();
+  });
+
+  it("shows managed Account only to admins", async () => {
     server.use(
       http.get("/api/setup/status", () =>
         HttpResponse.json({
@@ -101,53 +174,36 @@ describe("AppSidebar", () => {
         }),
       ),
     );
+    mockPathname = "/channels";
+    const { unmount } = renderSidebar("admin");
 
-    renderSidebar("admin");
-
-    await waitFor(() => {
-      expect(screen.getByRole("link", { name: "Account" })).toHaveAttribute("href", "https://app.getsketch.ai");
-    });
-  });
-
-  it("hides Account link for managed members", async () => {
-    server.use(
-      http.get("/api/setup/status", () =>
-        HttpResponse.json({
-          completed: true,
-          currentStep: 5,
-          adminEmail: "admin@test.com",
-          orgName: "Acme",
-          botName: "Sketch",
-          slackConnected: true,
-          llmConnected: true,
-          llmProvider: "anthropic",
-          managedUrl: "https://app.getsketch.ai",
-        }),
-      ),
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Account" })).toHaveAttribute("href", "https://app.getsketch.ai"),
     );
+    unmount();
 
     renderSidebar("member");
-
-    await waitFor(() => {
-      expect(screen.queryByRole("link", { name: "Account" })).not.toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.queryByRole("link", { name: "Account" })).not.toBeInTheDocument());
   });
 
-  it("shows Settings link for admins", () => {
+  it("shows the signed-in role in the profile trigger", () => {
     renderSidebar("admin");
 
-    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Account menu, signed in as User" })).toHaveTextContent("Admin");
   });
 
-  it("shows Settings link for members", () => {
-    renderSidebar("member");
-
-    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
-  });
-
-  it("shows the signed-in user's auth role in the footer", () => {
+  it("keeps settings and usage in More instead of duplicating them in the profile menu", async () => {
+    const user = userEvent.setup();
     renderSidebar("admin");
 
-    expect(screen.getByText("Admin")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show more destinations" }));
+    expect(screen.getAllByRole("link", { name: /^(Settings|Usage)$/ })).toHaveLength(2);
+
+    await user.click(screen.getByRole("button", { name: "Account menu, signed in as User" }));
+    const menu = await screen.findByRole("menu");
+    expect(within(menu).queryByRole("menuitem", { name: "Settings" })).not.toBeInTheDocument();
+    expect(within(menu).queryByRole("menuitem", { name: "Usage" })).not.toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: /Theme/ })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "Log out" })).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app-sidebar.tsx
+++ b/packages/web/src/components/app-sidebar.tsx
@@ -1,23 +1,25 @@
-/**
- * App sidebar — navigation, branding, and user actions.
- * Follows the designer's sidebar structure with Phosphor icons.
- */
+import { ConversationRow } from "@/components/sketch/conversation-row";
 import { api } from "@/lib/api";
+import { createWebChatConversationId, shouldUseChatViewTransition } from "@/lib/chat-target";
+import { WEB_CHAT_CONVERSATIONS_QUERY_KEY, buildWebChatRecents } from "@/lib/web-chat-conversations";
 import {
   ArrowSquareOutIcon,
   BrainIcon,
   CalendarDotsIcon,
+  CaretDownIcon,
   CaretUpDownIcon,
   ChartBarIcon,
-  ChatCircleIcon,
   DesktopIcon,
   FolderSimpleIcon,
   FoldersIcon,
   GearIcon,
   HashIcon,
   HouseIcon,
+  type IconProps,
   LinkSimpleIcon,
   MoonIcon,
+  NotePencilIcon,
+  PlusIcon,
   RobotIcon,
   SignOutIcon,
   SunIcon,
@@ -42,48 +44,57 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
+  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarTrigger,
+  useSidebar,
 } from "@sketch/ui/components/sidebar";
 import { useTheme } from "@sketch/ui/hooks/use-theme";
-import { getInitials } from "@sketch/ui/lib/utils";
+import { cn, getInitials } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useLocation, useNavigate } from "@tanstack/react-router";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
+import { type ComponentType, useEffect, useMemo, useState } from "react";
+
+type InternalHref =
+  | "/home"
+  | "/agents"
+  | "/projects"
+  | "/scheduled-tasks"
+  | "/channels"
+  | "/integrations"
+  | "/files"
+  | "/team"
+  | "/skills"
+  | "/usage"
+  | "/settings";
 
 interface NavItem {
   label: string;
-  icon: React.ReactNode;
-  href: string;
-  disabled?: boolean;
+  href: InternalHref;
+  icon: ComponentType<IconProps>;
   adminOnly?: boolean;
-  /** Optional render-prop for a trailing element (e.g. a count badge). */
-  trailing?: React.ReactNode;
-  /**
-   * Relabel to "Your org" and show a pending-review count badge scoped to the
-   * org-taxonomy spine.
-   */
   yourOrgBadge?: boolean;
 }
 
-const allPrimaryNav: NavItem[] = [
-  { label: "Home", icon: <HouseIcon size={18} />, href: "/home" },
-  { label: "Agents", icon: <RobotIcon size={18} />, href: "/agents" },
-  { label: "Chat", icon: <ChatCircleIcon size={18} />, href: "/chat" },
-  { label: "Channels", icon: <HashIcon size={18} />, href: "/channels" },
-  { label: "Files", icon: <FolderSimpleIcon size={18} />, href: "/files" },
-  { label: "Projects", icon: <FoldersIcon size={18} />, href: "/projects", adminOnly: true, yourOrgBadge: true },
-  { label: "Team", icon: <UsersThreeIcon size={18} />, href: "/team" },
-  { label: "Automations", icon: <CalendarDotsIcon size={18} />, href: "/scheduled-tasks" },
-  { label: "Skills", icon: <BrainIcon size={18} />, href: "/skills" },
-  { label: "Integrations", icon: <LinkSimpleIcon size={18} />, href: "/integrations" },
-  { label: "Usage", icon: <ChartBarIcon size={18} />, href: "/usage" },
-  {
-    label: "Settings",
-    icon: <GearIcon size={18} />,
-    href: "/settings",
-  },
+const PINNED_NAV: NavItem[] = [
+  { label: "Home", href: "/home", icon: HouseIcon },
+  { label: "Agents", href: "/agents", icon: RobotIcon },
+  { label: "Your org", href: "/projects", icon: FoldersIcon, adminOnly: true, yourOrgBadge: true },
+  { label: "Automations", href: "/scheduled-tasks", icon: CalendarDotsIcon },
+];
+
+const MORE_NAV: NavItem[] = [
+  { label: "Channels", href: "/channels", icon: HashIcon },
+  { label: "Integrations", href: "/integrations", icon: LinkSimpleIcon },
+  { label: "Files", href: "/files", icon: FolderSimpleIcon },
+  { label: "Access", href: "/team", icon: UsersThreeIcon },
+  { label: "Skills", href: "/skills", icon: BrainIcon },
+  { label: "Usage", href: "/usage", icon: ChartBarIcon },
+  { label: "Settings", href: "/settings", icon: GearIcon },
 ];
 
 function formatRole(role?: "admin" | "member"): string | null {
@@ -92,11 +103,271 @@ function formatRole(role?: "admin" | "member"): string | null {
   return null;
 }
 
-function isNavItemActive(pathname: string, href: string): boolean {
-  if (href === "/home") return pathname === "/home";
-  if (href === "/chat") return pathname === "/chat" || pathname.startsWith("/chat/");
-  if (href === "/scheduled-tasks") return pathname === "/scheduled-tasks" || pathname.startsWith("/scheduled-tasks/");
-  return pathname === href;
+function isNavItemActive(pathname: string, href: InternalHref): boolean {
+  if (href === "/home") return pathname === "/home" || pathname === "/chat" || pathname.startsWith("/chat/");
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function InternalNavItem({
+  item,
+  active,
+  badge,
+  onSelect,
+}: {
+  item: NavItem;
+  active: boolean;
+  badge?: number;
+  onSelect: () => void;
+}) {
+  const Icon = item.icon;
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={active} tooltip={item.label}>
+        <Link to={item.href} onClick={onSelect}>
+          <Icon size={17} aria-hidden />
+          <span className="group-data-[collapsible=icon]:hidden">{item.label}</span>
+        </Link>
+      </SidebarMenuButton>
+      {badge && badge > 0 ? <SidebarMenuBadge>{badge}</SidebarMenuBadge> : null}
+    </SidebarMenuItem>
+  );
+}
+
+function MoreNavigation({
+  items,
+  pathname,
+  managedUrl,
+  onSelect,
+}: {
+  items: NavItem[];
+  pathname: string;
+  managedUrl?: string;
+  onSelect: () => void;
+}) {
+  const { state, isMobile } = useSidebar();
+  const hasActiveChild = items.some((item) => isNavItemActive(pathname, item.href));
+  const [open, setOpen] = useState(hasActiveChild);
+
+  useEffect(() => {
+    if (hasActiveChild) setOpen(true);
+  }, [hasActiveChild]);
+
+  if (state === "collapsed" && !isMobile) {
+    return (
+      <SidebarGroup className="pt-0">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton isActive={hasActiveChild} tooltip="More" aria-label="More destinations">
+                  <CaretDownIcon size={17} aria-hidden />
+                  <span className="group-data-[collapsible=icon]:hidden">More</span>
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="right" align="start" className="w-52">
+                {items.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <DropdownMenuItem key={item.href} asChild>
+                      <Link to={item.href} onClick={onSelect}>
+                        <Icon size={16} aria-hidden />
+                        {item.label}
+                      </Link>
+                    </DropdownMenuItem>
+                  );
+                })}
+                {managedUrl ? (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem asChild>
+                      <a href={managedUrl} target="_blank" rel="noopener noreferrer">
+                        <ArrowSquareOutIcon size={16} aria-hidden />
+                        Account
+                      </a>
+                    </DropdownMenuItem>
+                  </>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+    );
+  }
+
+  const isOpen = open || hasActiveChild;
+  return (
+    <SidebarGroup className="pt-0">
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-label={isOpen ? "Hide more destinations" : "Show more destinations"}
+        onClick={() => setOpen((current) => !current)}
+        className="group flex w-full items-center gap-2 py-1.5 outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+      >
+        <span className="h-px flex-1 bg-sidebar-border transition-colors group-hover:bg-sidebar-foreground/25" />
+        <span className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground group-hover:text-foreground">
+          More
+          <CaretDownIcon size={11} aria-hidden className={cn("transition-transform", !isOpen && "-rotate-90")} />
+        </span>
+        <span className="h-px flex-1 bg-sidebar-border transition-colors group-hover:bg-sidebar-foreground/25" />
+      </button>
+      {isOpen ? (
+        <SidebarGroupContent className="mt-1">
+          <SidebarMenu>
+            {items.map((item) => (
+              <InternalNavItem
+                key={item.href}
+                item={item}
+                active={isNavItemActive(pathname, item.href)}
+                onSelect={onSelect}
+              />
+            ))}
+            {managedUrl ? (
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild tooltip="Account">
+                  <a href={managedUrl} target="_blank" rel="noopener noreferrer">
+                    <ArrowSquareOutIcon size={17} aria-hidden />
+                    <span>Account</span>
+                  </a>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ) : null}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      ) : null}
+    </SidebarGroup>
+  );
+}
+
+function RecentsNavigation({ pathname, onSelect }: { pathname: string; onSelect: () => void }) {
+  const { state, isMobile } = useSidebar();
+  const conversations = useQuery({
+    queryKey: WEB_CHAT_CONVERSATIONS_QUERY_KEY,
+    queryFn: () => api.webChat.conversations(),
+    staleTime: 30_000,
+  });
+  const recents = useMemo(() => buildWebChatRecents(conversations.data?.conversations ?? []), [conversations.data]);
+
+  if (state === "collapsed" && !isMobile) return null;
+
+  return (
+    <SidebarGroup className="min-h-0 flex-1 py-1">
+      <SidebarGroupLabel className="h-7 font-mono text-[10px] uppercase tracking-[0.1em]">Recents</SidebarGroupLabel>
+      <SidebarGroupContent className="min-h-0 overflow-y-auto">
+        {conversations.isLoading ? (
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">Loading conversations…</p>
+        ) : recents.length === 0 ? (
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">No recent conversations</p>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {recents.map((conversation) => (
+              <ConversationRow
+                key={conversation.id}
+                {...conversation}
+                isActive={pathname === `/chat/${conversation.id}`}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+function ProfileMenu({
+  displayName,
+  displayIdentifier,
+  role,
+  onLogout,
+}: {
+  displayName: string;
+  displayIdentifier: string;
+  role?: "admin" | "member";
+  onLogout: () => void;
+}) {
+  const { state, isMobile } = useSidebar();
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const collapsed = state === "collapsed" && !isMobile;
+  const initials = getInitials(displayIdentifier);
+  const roleLabel = formatRole(role);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Account menu, signed in as ${displayName}`}
+          className={cn(
+            "flex w-full items-center rounded-lg text-left outline-none transition-colors hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+            collapsed ? "justify-center p-1" : "gap-2 px-2 py-2",
+          )}
+        >
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+            {initials}
+          </span>
+          {!collapsed ? (
+            <>
+              <span className="flex min-w-0 flex-1 flex-col text-xs leading-tight">
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <span className="truncate font-medium">{displayName}</span>
+                  {roleLabel ? (
+                    <Badge variant="secondary" className="h-4 shrink-0 px-1.5 py-0 text-[9px] font-medium">
+                      {roleLabel}
+                    </Badge>
+                  ) : null}
+                </span>
+                <span className="mt-0.5 truncate text-muted-foreground">{displayIdentifier}</span>
+              </span>
+              <CaretUpDownIcon size={15} className="shrink-0 text-muted-foreground" aria-hidden />
+            </>
+          ) : null}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align={collapsed ? "center" : "start"} className="w-64">
+        <div className="flex items-center gap-2 px-2 py-2">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+            {initials}
+          </span>
+          <span className="flex min-w-0 flex-1 flex-col text-xs">
+            <span className="truncate font-medium">{displayName}</span>
+            <span className="truncate text-muted-foreground">{displayIdentifier}</span>
+          </span>
+          {roleLabel ? (
+            <Badge variant="secondary" className="h-4 px-1.5 py-0 text-[9px] font-medium">
+              {roleLabel}
+            </Badge>
+          ) : null}
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {resolvedTheme === "dark" ? <MoonIcon size={16} /> : <SunIcon size={16} />}
+            Theme
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuRadioGroup value={theme} onValueChange={(value) => setTheme(value as typeof theme)}>
+              <DropdownMenuRadioItem value="light">
+                <SunIcon size={16} /> Light
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="dark">
+                <MoonIcon size={16} /> Dark
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="system">
+                <DesktopIcon size={16} /> System
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onSelect={onLogout}>
+          <SignOutIcon size={16} aria-hidden />
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }
 
 export function AppSidebar({
@@ -110,33 +381,19 @@ export function AppSidebar({
 }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const { theme, resolvedTheme, setTheme, logoSrc } = useTheme();
   const queryClient = useQueryClient();
+  const { logoSrc } = useTheme();
+  const { isMobile, setOpenMobile } = useSidebar();
 
-  const { data: identity } = useQuery({
-    queryKey: ["settings", "identity"],
-    queryFn: () => api.settings.identity(),
-  });
-
-  const { data: setupStatus } = useQuery({
-    queryKey: ["setup", "status"],
-    queryFn: () => api.setup.status(),
-  });
-
-  const { data: yourOrgReview } = useQuery({
+  const identity = useQuery({ queryKey: ["settings", "identity"], queryFn: () => api.settings.identity() });
+  const setupStatus = useQuery({ queryKey: ["setup", "status"], queryFn: () => api.setup.status() });
+  const yourOrgReview = useQuery({
     queryKey: ["entity-review", "band-count", "spine"],
     queryFn: () => api.entityReview.list({ limit: 0, types: ["product", "project", "team"] }),
     enabled: role === "admin",
-    refetchInterval: 30000,
+    refetchInterval: 30_000,
   });
-  const yourOrgCount = yourOrgReview?.total ?? 0;
-  const primaryNav = allPrimaryNav.filter((item) => {
-    if (item.adminOnly && role !== "admin") return false;
-    return true;
-  });
-  const roleLabel = formatRole(role);
-
-  const logoutMutation = useMutation({
+  const logout = useMutation({
     mutationFn: () => api.auth.logout(),
     onSuccess: () => {
       queryClient.clear();
@@ -144,120 +401,80 @@ export function AppSidebar({
     },
   });
 
-  const initials = getInitials(displayIdentifier);
+  const closeMobile = () => {
+    if (isMobile) setOpenMobile(false);
+  };
+  const pinned = PINNED_NAV.filter((item) => !item.adminOnly || role === "admin");
+  const managedUrl = role === "admin" ? setupStatus.data?.managedUrl : undefined;
+  const orgLabel = identity.data?.orgName ?? identity.data?.botName ?? "Sketch";
 
   return (
     <Sidebar collapsible="icon">
-      <SidebarHeader>
+      <SidebarHeader className="relative gap-2 px-2 pt-3 pb-1">
+        <SidebarTrigger className="absolute top-5 -right-3 z-30 hidden size-6 rounded-full border bg-background shadow-sm md:inline-flex" />
+        <div className="flex h-10 items-center gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+          <img src={logoSrc} alt="Sketch" className="size-7 shrink-0" />
+          <div className="min-w-0 group-data-[collapsible=icon]:hidden">
+            <p className="truncate text-sm font-semibold">Sketch</p>
+            <p className="truncate text-[11px] text-muted-foreground">{orgLabel}</p>
+          </div>
+        </div>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton size="lg" className="pointer-events-none hover:bg-transparent active:bg-transparent">
-              <div className="flex size-8 shrink-0 items-center justify-center">
-                <img src={logoSrc} alt="Sketch" className="size-7" />
-              </div>
-              <div className="flex min-w-0 flex-col text-left">
-                <span className="truncate text-base font-semibold tracking-tight">{identity?.botName ?? "Sketch"}</span>
-                {identity?.orgName ? (
-                  <span className="truncate text-xs text-muted-foreground">{identity.orgName}</span>
-                ) : null}
-              </div>
+            <SidebarMenuButton
+              tooltip="New chat"
+              className="border border-brand-accent/70 bg-brand-accent/[0.06] hover:bg-brand-accent/15"
+              onClick={() => {
+                closeMobile();
+                navigate({
+                  to: "/chat/$conversationId",
+                  params: { conversationId: createWebChatConversationId() },
+                  search: { new: true },
+                  viewTransition: shouldUseChatViewTransition(),
+                });
+              }}
+            >
+              <NotePencilIcon size={17} aria-hidden />
+              <span className="group-data-[collapsible=icon]:hidden">New chat</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Add integration">
+              <Link to="/integrations" onClick={closeMobile}>
+                <PlusIcon size={17} aria-hidden />
+                <span className="group-data-[collapsible=icon]:hidden">Add integration</span>
+              </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
 
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {primaryNav.map((item) => {
-                const yourOrg = item.yourOrgBadge === true;
-                const label = yourOrg ? "Your org" : item.label;
-                return (
-                  <SidebarMenuItem key={item.href}>
-                    <SidebarMenuButton
-                      isActive={isNavItemActive(location.pathname, item.href)}
-                      onClick={() => !item.disabled && navigate({ to: item.href })}
-                      disabled={item.disabled}
-                      tooltip={label}
-                    >
-                      {item.icon}
-                      <span className="flex-1">{label}</span>
-                      {yourOrg && yourOrgCount > 0 ? (
-                        <Badge variant="secondary" className="h-4 min-w-4 justify-center px-1 text-[10px] tabular-nums">
-                          {yourOrgCount}
-                        </Badge>
-                      ) : null}
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                );
-              })}
-              {setupStatus?.managedUrl && role === "admin" ? (
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild tooltip="Account">
-                    <a href={setupStatus.managedUrl} target="_blank" rel="noopener noreferrer">
-                      <ArrowSquareOutIcon size={18} />
-                      <span>Account</span>
-                    </a>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ) : null}
-            </SidebarMenu>
-          </SidebarGroupContent>
+      <SidebarContent className="gap-0 overflow-hidden">
+        <SidebarGroup className="pb-1">
+          <SidebarMenu>
+            {pinned.map((item) => (
+              <InternalNavItem
+                key={item.href}
+                item={item}
+                active={isNavItemActive(location.pathname, item.href)}
+                badge={item.yourOrgBadge ? (yourOrgReview.data?.total ?? 0) : undefined}
+                onSelect={closeMobile}
+              />
+            ))}
+          </SidebarMenu>
         </SidebarGroup>
+
+        <MoreNavigation items={MORE_NAV} pathname={location.pathname} managedUrl={managedUrl} onSelect={closeMobile} />
+        <RecentsNavigation pathname={location.pathname} onSelect={closeMobile} />
       </SidebarContent>
 
-      <SidebarFooter>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="flex h-12 w-full items-center gap-2 overflow-hidden rounded-md text-left text-sm outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground"
-            >
-              <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-medium text-primary">
-                {initials}
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col text-left text-xs leading-tight">
-                <span className="truncate font-medium">{displayName}</span>
-                <span className="flex min-w-0 items-center gap-1.5">
-                  <span className="truncate text-muted-foreground">{displayIdentifier}</span>
-                  {roleLabel ? (
-                    <Badge variant="secondary" className="h-4 shrink-0 px-1.5 py-0 text-[10px] font-medium">
-                      {roleLabel}
-                    </Badge>
-                  ) : null}
-                </span>
-              </div>
-              <CaretUpDownIcon size={16} className="shrink-0 text-muted-foreground" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent side="top" align="start" className="w-60">
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                {resolvedTheme === "dark" ? <MoonIcon size={16} /> : <SunIcon size={16} />}
-                Theme
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                <DropdownMenuRadioGroup value={theme} onValueChange={(v) => setTheme(v as "dark" | "light" | "system")}>
-                  <DropdownMenuRadioItem value="light">
-                    <SunIcon size={16} /> Light
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="dark">
-                    <MoonIcon size={16} /> Dark
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="system">
-                    <DesktopIcon size={16} /> System
-                  </DropdownMenuRadioItem>
-                </DropdownMenuRadioGroup>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => logoutMutation.mutate()}>
-              <SignOutIcon size={16} className="mr-2" />
-              Log out
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+      <SidebarFooter className="border-t border-sidebar-border p-2">
+        <ProfileMenu
+          displayName={displayName}
+          displayIdentifier={displayIdentifier}
+          role={role}
+          onLogout={() => logout.mutate()}
+        />
       </SidebarFooter>
     </Sidebar>
   );

--- a/packages/web/src/components/connections/environment-variables-section.tsx
+++ b/packages/web/src/components/connections/environment-variables-section.tsx
@@ -1,3 +1,4 @@
+import { QuietAddButton } from "@/components/quiet-add-button";
 import { api } from "@/lib/api";
 import type { SlackChannelInfo, User, WhatsAppGroupInfo } from "@/lib/api";
 import {
@@ -6,7 +7,6 @@ import {
   EyeSlashIcon,
   LockIcon,
   PencilSimpleIcon,
-  PlusIcon,
   ShareNetworkIcon,
   SpinnerGapIcon,
   TrashIcon,
@@ -63,10 +63,7 @@ export function EnvironmentVariablesSection({
     <div>
       <div className="mb-3 flex items-center justify-between">
         <p className="text-sm font-medium text-muted-foreground">Environment variables</p>
-        <Button variant="ghost" size="sm" className="gap-1.5 hover:bg-brand-accent/8" onClick={onAdd}>
-          <PlusIcon size={14} weight="bold" />
-          New variable
-        </Button>
+        <QuietAddButton onClick={onAdd}>New variable</QuietAddButton>
       </div>
 
       {variables.length === 0 ? (
@@ -78,10 +75,9 @@ export function EnvironmentVariablesSection({
           <p className="mt-1.5 max-w-sm text-sm text-muted-foreground">
             Add credentials and config for Bash commands run by Sketch.
           </p>
-          <Button variant="ghost" size="sm" className="mt-4 gap-1.5 hover:bg-brand-accent/8" onClick={onAdd}>
-            <PlusIcon size={14} weight="bold" />
+          <QuietAddButton className="mt-4" onClick={onAdd}>
             New variable
-          </Button>
+          </QuietAddButton>
         </div>
       ) : (
         <div className="overflow-hidden rounded-lg border border-border bg-card">

--- a/packages/web/src/components/connections/integrations-section.tsx
+++ b/packages/web/src/components/connections/integrations-section.tsx
@@ -1,5 +1,6 @@
+import { QuietAddButton } from "@/components/quiet-add-button";
 import { api } from "@/lib/api";
-import { GearSixIcon, PlugIcon, PlusIcon, SpinnerGapIcon, TrashIcon } from "@phosphor-icons/react";
+import { GearSixIcon, PlugIcon, SpinnerGapIcon, TrashIcon } from "@phosphor-icons/react";
 import type { IntegrationConnection } from "@sketch/shared";
 import { Badge } from "@sketch/ui/components/badge";
 import { Button } from "@sketch/ui/components/button";
@@ -70,10 +71,9 @@ export function IntegrationsSection({
           </div>
           <p className="mt-3 text-sm font-medium">No apps connected yet</p>
           <p className="mt-1.5 text-sm text-muted-foreground">Add an integration to connect your apps.</p>
-          <Button variant="ghost" size="sm" className="mt-4 gap-1.5 hover:bg-brand-accent/8" onClick={onAdd}>
-            <PlusIcon size={14} weight="bold" />
+          <QuietAddButton className="mt-4" onClick={onAdd}>
             Add integration
-          </Button>
+          </QuietAddButton>
         </div>
       ) : (
         <div className="overflow-hidden rounded-lg border border-border bg-card">

--- a/packages/web/src/components/connections/mcp-servers-section.tsx
+++ b/packages/web/src/components/connections/mcp-servers-section.tsx
@@ -1,4 +1,5 @@
-import { DotsThreeIcon, GearIcon, PencilSimpleIcon, PlugIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
+import { QuietAddButton } from "@/components/quiet-add-button";
+import { DotsThreeIcon, GearIcon, PencilSimpleIcon, PlugIcon, TrashIcon } from "@phosphor-icons/react";
 import type { McpServerRecord } from "@sketch/shared";
 /**
  * MCP Servers section: admin CRUD for workspace-level MCP servers.
@@ -30,10 +31,7 @@ export function McpServersSection({
     <div>
       <div className="mb-3 flex items-center justify-between">
         <p className="text-sm font-medium text-muted-foreground">MCP Servers</p>
-        <Button variant="ghost" size="sm" className="gap-1.5 hover:bg-brand-accent/8" onClick={onAdd}>
-          <PlusIcon size={14} weight="bold" />
-          New server
-        </Button>
+        <QuietAddButton onClick={onAdd}>New server</QuietAddButton>
       </div>
 
       {servers.length === 0 ? (
@@ -45,10 +43,9 @@ export function McpServersSection({
           <p className="mt-1.5 max-w-xs text-sm text-muted-foreground">
             Connect a custom MCP server to give the agent access to your internal tools.
           </p>
-          <Button variant="ghost" size="sm" className="mt-4 gap-1.5 hover:bg-brand-accent/8" onClick={onAdd}>
-            <PlusIcon size={14} weight="bold" />
+          <QuietAddButton className="mt-4" onClick={onAdd}>
             New server
-          </Button>
+          </QuietAddButton>
         </div>
       ) : (
         <div className="rounded-lg border border-border bg-card">

--- a/packages/web/src/components/quiet-add-button.tsx
+++ b/packages/web/src/components/quiet-add-button.tsx
@@ -1,0 +1,21 @@
+import { PlusIcon } from "@phosphor-icons/react";
+import { Button } from "@sketch/ui/components/button";
+import { cn } from "@sketch/ui/lib/utils";
+import type { ComponentProps } from "react";
+
+export function QuietAddButton({ className, children, ...props }: ComponentProps<typeof Button>) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "h-auto gap-1 px-2 py-1 text-[12px] text-muted-foreground hover:bg-muted/50 hover:text-foreground [&_svg]:size-3",
+        className,
+      )}
+      {...props}
+    >
+      <PlusIcon weight="bold" aria-hidden />
+      {children}
+    </Button>
+  );
+}

--- a/packages/web/src/components/sketch/conversation-row.tsx
+++ b/packages/web/src/components/sketch/conversation-row.tsx
@@ -26,6 +26,8 @@ export interface ConversationRowProps {
   occurredAt: string;
   now?: Date;
   onConversationIntent?: (conversationId: string) => void;
+  isActive?: boolean;
+  onSelect?: () => void;
 }
 
 const CHANNEL_ICON = {
@@ -74,6 +76,8 @@ export function ConversationRow({
   onDelete,
   isDeleting,
   onConversationIntent,
+  isActive = false,
+  onSelect,
 }: ConversationRowProps & ConversationRowActionProps) {
   const ChannelIcon = CHANNEL_ICON[channel];
   const content = (
@@ -97,9 +101,12 @@ export function ConversationRow({
         viewTransition={shouldUseChatViewTransition()}
         onMouseEnter={() => onConversationIntent?.(id)}
         onFocus={() => onConversationIntent?.(id)}
+        onClick={onSelect}
+        aria-current={isActive ? "page" : undefined}
         className={cn(
           "group flex w-full items-center gap-[12px] rounded-[6px] px-[8px] py-[8px]",
           "transition-colors duration-100 ease-out hover:bg-accent",
+          isActive && "bg-accent font-medium",
         )}
       >
         {content}
@@ -120,6 +127,8 @@ export function ConversationRow({
         viewTransition={shouldUseChatViewTransition()}
         onMouseEnter={() => onConversationIntent?.(id)}
         onFocus={() => onConversationIntent?.(id)}
+        onClick={onSelect}
+        aria-current={isActive ? "page" : undefined}
         className="flex min-w-0 flex-1 items-center gap-[12px]"
       >
         {content}

--- a/packages/web/src/components/skills/skills-empty-state.tsx
+++ b/packages/web/src/components/skills/skills-empty-state.tsx
@@ -1,4 +1,5 @@
-import { BrainIcon, FolderOpenIcon, MagnifyingGlassIcon, PlusIcon } from "@phosphor-icons/react";
+import { QuietAddButton } from "@/components/quiet-add-button";
+import { BrainIcon, FolderOpenIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { Button } from "@sketch/ui/components/button";
 
 interface SkillsEmptyStateProps {
@@ -27,10 +28,9 @@ export function SkillsEmptyState({
           <p className="mt-1 max-w-xs text-xs text-muted-foreground">
             Skills let you define custom behaviors, connect integrations, and automate workflows with Sketch.
           </p>
-          <Button onClick={onCreateClick} size="sm" className="mt-4 gap-1.5">
-            <PlusIcon size={14} weight="bold" />
+          <QuietAddButton onClick={onCreateClick} className="mt-4">
             Create Your First Skill
-          </Button>
+          </QuietAddButton>
         </>
       )}
 
@@ -49,10 +49,7 @@ export function SkillsEmptyState({
                 Clear Search
               </Button>
             )}
-            <Button onClick={onCreateClick} size="sm" className="gap-1.5">
-              <PlusIcon size={14} weight="bold" />
-              Create Skill
-            </Button>
+            <QuietAddButton onClick={onCreateClick}>Create Skill</QuietAddButton>
           </div>
         </>
       )}
@@ -66,10 +63,9 @@ export function SkillsEmptyState({
           <p className="mt-1 max-w-xs text-xs text-muted-foreground">
             {`Create your first ${category?.toLowerCase()} skill to get started.`}
           </p>
-          <Button onClick={onCreateClick} size="sm" className="mt-4 gap-1.5">
-            <PlusIcon size={14} weight="bold" />
+          <QuietAddButton onClick={onCreateClick} className="mt-4">
             Create Skill
-          </Button>
+          </QuietAddButton>
         </>
       )}
     </div>

--- a/packages/web/src/lib/web-chat-conversations.ts
+++ b/packages/web/src/lib/web-chat-conversations.ts
@@ -1,0 +1,13 @@
+import type { ConversationRowProps } from "@/components/sketch/conversation-row";
+import type { WebChatConversationSummary } from "@/lib/api";
+
+export const WEB_CHAT_CONVERSATIONS_QUERY_KEY = ["web-chat", "conversations"] as const;
+
+export function buildWebChatRecents(conversations: WebChatConversationSummary[]): ConversationRowProps[] {
+  return conversations.slice(0, 5).map((conversation) => ({
+    id: conversation.id,
+    title: conversation.title,
+    channel: conversation.channel,
+    occurredAt: conversation.updatedAt,
+  }));
+}

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -340,7 +340,7 @@ export function AutomationBuilderPage() {
 
   if (automationQuery.isLoading || !draft || !automationQuery.data) {
     return (
-      <div className="flex min-h-[calc(100vh-52px)] items-center justify-center text-sm text-muted-foreground">
+      <div className="flex min-h-[calc(100vh-3rem)] items-center justify-center text-sm text-muted-foreground md:min-h-screen">
         Loading builder...
       </div>
     );
@@ -358,7 +358,7 @@ export function AutomationBuilderPage() {
   const selectedOutput = selectedStep ? selectedRun?.stepOutputs[selectedStep.id] : undefined;
   const builderTitle = draft.title?.trim() || draft.prompt;
   return (
-    <div className="relative flex h-[calc(100vh-52px)] min-h-0 overflow-hidden bg-background">
+    <div className="relative flex h-[calc(100vh-3rem)] min-h-0 overflow-hidden bg-background md:h-screen">
       <BuilderChatSidecar
         conversationId={builderConversationId}
         taskId={taskId}

--- a/packages/web/src/routes/channels.tsx
+++ b/packages/web/src/routes/channels.tsx
@@ -75,8 +75,8 @@ export function ChannelsPage() {
 
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
-      <h1 className="text-xl font-semibold text-foreground">Channels</h1>
-      <p className="mt-2 text-sm text-muted-foreground">Manage your messaging platform connections.</p>
+      <h1 className="text-[22px] font-medium text-foreground">Channels</h1>
+      <p className="mt-1 text-[13px] text-muted-foreground">Manage your messaging platform connections.</p>
       {!canManageChannels && (
         <p className="mt-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
           Channel settings are managed by admins.

--- a/packages/web/src/routes/chat.isolated.test.tsx
+++ b/packages/web/src/routes/chat.isolated.test.tsx
@@ -1,4 +1,5 @@
 import { setPendingWebChatSubmission, takePendingWebChatSubmission } from "@/lib/chat-target";
+import { WEB_CHAT_CONVERSATIONS_QUERY_KEY } from "@/lib/web-chat-conversations";
 import { renderWithProviders } from "@/test/utils";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, renderHook, screen, waitFor, within } from "@testing-library/react";
@@ -196,83 +197,15 @@ describe("chat route", () => {
     mocks.search = { message: "Plan my day" };
   });
 
-  it("prefetches intended recent conversations with React Query cancellation", async () => {
-    const prefetchQuery = vi.spyOn(QueryClient.prototype, "prefetchQuery");
+  it("redirects the legacy chat index to a clean new conversation", async () => {
     mocks.search = {};
-    renderWithProviders(<ChatIndexPage />);
-
-    await waitFor(() => expect(mocks.homePaneProps).toHaveBeenCalled());
-    const onConversationIntent = mocks.homePaneProps.mock.lastCall?.[0].onConversationIntent as
-      | ((conversationId: string) => void)
-      | undefined;
-    expect(onConversationIntent).toBeTypeOf("function");
-
-    act(() => onConversationIntent?.("chat-alpha"));
-
-    await waitFor(() =>
-      expect(prefetchQuery).toHaveBeenCalledWith(
-        expect.objectContaining({
-          queryKey: webChatMessagesQueryKey("chat-alpha"),
-          staleTime: 15_000,
-        }),
-      ),
-    );
-    await waitFor(() =>
-      expect(mocks.loadMessages).toHaveBeenCalledWith(
-        "chat-alpha",
-        expect.objectContaining({ signal: expect.any(AbortSignal) }),
-      ),
-    );
-  });
-
-  it("uses a view transition when Home starts a chat", async () => {
-    mocks.search = {};
-    renderWithProviders(<ChatIndexPage />);
-
-    await waitFor(() => expect(mocks.homePaneProps).toHaveBeenCalled());
-    const onSubmit = mocks.homePaneProps.mock.lastCall?.[0].onSubmit as
-      | ((value: string, attachments: never[]) => void)
-      | undefined;
-    expect(onSubmit).toBeTypeOf("function");
-
-    act(() => onSubmit?.("Plan my day", []));
-
-    expect(mocks.navigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: "/chat/$conversationId",
-        viewTransition: true,
-      }),
-    );
-  });
-
-  it("disables the Home transition when reduced motion is preferred", async () => {
-    mockReducedMotionPreference();
-    mocks.search = {};
-    renderWithProviders(<ChatIndexPage />);
-
-    await waitFor(() => expect(mocks.homePaneProps).toHaveBeenCalled());
-    const onSubmit = mocks.homePaneProps.mock.lastCall?.[0].onSubmit as
-      | ((value: string, attachments: never[]) => void)
-      | undefined;
-    expect(onSubmit).toBeTypeOf("function");
-
-    act(() => onSubmit?.("Plan my day", []));
-
-    expect(mocks.navigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: "/chat/$conversationId",
-        viewTransition: false,
-      }),
-    );
-  });
-
-  it("uses a view transition when /chat?message redirects into a conversation", async () => {
     renderWithProviders(<ChatIndexPage />);
 
     await waitFor(() =>
       expect(mocks.navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           to: "/chat/$conversationId",
+          search: { new: true },
           replace: true,
           viewTransition: true,
         }),
@@ -280,50 +213,34 @@ describe("chat route", () => {
     );
   });
 
-  it("disables the /chat?message redirect transition when reduced motion is preferred", async () => {
+  it("respects reduced motion when opening a clean chat from the legacy index", async () => {
     mockReducedMotionPreference();
+    mocks.search = {};
     renderWithProviders(<ChatIndexPage />);
 
     await waitFor(() =>
       expect(mocks.navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           to: "/chat/$conversationId",
-          replace: true,
+          search: { new: true },
           viewTransition: false,
         }),
       ),
     );
   });
 
-  it("removes deleted conversation history from the shared cache", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        mutations: { retry: false },
-        queries: { retry: false },
-      },
-    });
-    queryClient.setQueryData(webChatMessagesQueryKey("chat-alpha"), {
-      messages: [{ id: "u-cached", role: "user", parts: [{ type: "text", text: "Cached question" }] }],
-      updatedAt: "2026-07-13T08:00:00.000Z",
-    });
-    mocks.search = {};
+  it("preserves an initial message when the legacy chat index redirects", async () => {
+    renderWithProviders(<ChatIndexPage />);
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <ChatIndexPage />
-      </QueryClientProvider>,
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "/chat/$conversationId",
+          search: { message: "Plan my day" },
+          replace: true,
+        }),
+      ),
     );
-
-    await waitFor(() => expect(mocks.homePaneProps).toHaveBeenCalled());
-    const onDeleteConversation = mocks.homePaneProps.mock.lastCall?.[0].onDeleteConversation as
-      | ((conversation: { id: string }) => void)
-      | undefined;
-    expect(onDeleteConversation).toBeTypeOf("function");
-
-    act(() => onDeleteConversation?.({ id: "chat-alpha" }));
-
-    await waitFor(() => expect(mocks.removeConversation).toHaveBeenCalledWith("chat-alpha"));
-    await waitFor(() => expect(queryClient.getQueryData(webChatMessagesQueryKey("chat-alpha"))).toBeUndefined());
   });
 
   it("validates optional initial message search state", () => {
@@ -337,6 +254,9 @@ describe("chat route", () => {
     expect(validateChatSearch({ prefill: "" })).toEqual({});
     expect(validateChatSearch({ message: ["No"] })).toEqual({});
     expect(validateChatSearch({ prefill: ["No"] })).toEqual({});
+    expect(validateChatSearch({ new: true })).toEqual({ new: true });
+    expect(validateChatSearch({ new: "true" })).toEqual({ new: true });
+    expect(validateChatSearch({ new: "false" })).toEqual({});
   });
 
   it("extracts visible user and assistant text from AI SDK UI messages", () => {
@@ -853,6 +773,26 @@ describe("chat route", () => {
 
     await waitFor(() => expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: "Plan my day" })));
     expect(queryClient.getQueryData(webChatMessagesQueryKey("chat-alpha"))).toBeUndefined();
+  });
+
+  it("refreshes sidebar recents after the first new-chat message persists", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    sendMessage.mockResolvedValueOnce(undefined);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChatPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: "Plan my day" })));
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: WEB_CHAT_CONVERSATIONS_QUERY_KEY }));
   });
 
   it("preserves the initial message during StrictMode effect replay", async () => {

--- a/packages/web/src/routes/chat.tsx
+++ b/packages/web/src/routes/chat.tsx
@@ -21,13 +21,10 @@ import {
   type ChatThreadProgressItem,
   type ChatThreadTimelineEntry,
 } from "@/components/sketch/chat-thread";
-import type { ConversationRowProps } from "@/components/sketch/conversation-row";
-import { HomePane } from "@/components/sketch/home-pane";
 import { DEFAULT_TILES, type TileDef } from "@/components/sketch/tile-grid";
 import { useWebChatReconciliation } from "@/hooks/use-web-chat-reconciliation";
 import {
   type AutomationArtifact,
-  type WebChatConversationSummary,
   type WebChatMessagesResponse,
   type WebChatToolProgress,
   type WebChatUploadedAttachment,
@@ -37,20 +34,22 @@ import {
 import {
   createWebChatConversationId,
   hasPendingWebChatSubmission,
-  setPendingWebChatSubmission,
   shouldUseChatViewTransition,
   takePendingWebChatSubmission,
 } from "@/lib/chat-target";
+import { WEB_CHAT_CONVERSATIONS_QUERY_KEY, buildWebChatRecents } from "@/lib/web-chat-conversations";
 import { useChat } from "@ai-sdk/react";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import type { IntegrationApp, IntegrationConnection } from "@sketch/shared";
 import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
-import { type QueryClient, isCancelledError, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, isCancelledError, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createRoute, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { DefaultChatTransport, type UIMessage } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { dashboardRoute, useDashboardAuth } from "./dashboard";
+import { dashboardRoute } from "./dashboard";
+
+export { buildWebChatRecents };
 
 type WebChatDataParts = {
   progress: {
@@ -95,10 +94,7 @@ type ActiveIntegrationConnection = {
 export interface ChatSearch {
   message?: string;
   prefill?: string;
-}
-
-function firstNameOf(name: string): string {
-  return name.trim().split(/\s+/)[0] || "there";
+  new?: boolean;
 }
 
 const NEXT_RUN_FORMATTER = new Intl.DateTimeFormat("en-US", {
@@ -150,16 +146,6 @@ export function buildSummaryTiles(summary: WorkspaceSummary): TileDef[] {
   ];
 }
 
-export function buildWebChatRecents(conversations: WebChatConversationSummary[]): ConversationRowProps[] {
-  return conversations.slice(0, 5).map((conversation) => ({
-    id: conversation.id,
-    title: conversation.title,
-    channel: conversation.channel,
-    occurredAt: conversation.updatedAt,
-  }));
-}
-
-const WEB_CHAT_CONVERSATIONS_QUERY_KEY = ["web-chat", "conversations"];
 const WEB_CHAT_MESSAGES_STALE_TIME_MS = 15_000;
 
 export const webChatMessagesQueryKey = (conversationId: string) => ["web-chat", "messages", conversationId] as const;
@@ -200,23 +186,14 @@ export function useKnownNewWebChatConversation(conversationId: string, hasNewCon
   return hasNewConversationIntent || knownNewConversationId === conversationId;
 }
 
-function removeWebChatConversationFromCache(
-  data: { conversations: WebChatConversationSummary[] } | undefined,
-  conversationId: string,
-) {
-  return { conversations: (data?.conversations ?? []).filter((conversation) => conversation.id !== conversationId) };
-}
-
-function getDeleteConversationError(error: unknown) {
-  return error instanceof Error && error.message ? error.message : "Failed to delete conversation";
-}
-
 export function validateChatSearch(search: Record<string, unknown>): ChatSearch {
   const message = typeof search.message === "string" ? search.message.trim() : "";
   const prefill = typeof search.prefill === "string" ? search.prefill.trim() : "";
+  const isNew = search.new === true || search.new === "true";
   return {
     ...(message ? { message } : {}),
     ...(prefill ? { prefill } : {}),
+    ...(isNew ? { new: true } : {}),
   };
 }
 
@@ -821,80 +798,20 @@ export const chatRoute = createRoute({
 });
 
 function ChatIndexPage() {
-  const auth = useDashboardAuth();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const search = useSearch({ from: chatIndexRoute.id }) as ChatSearch;
-  const summaryQuery = useQuery({
-    queryKey: ["workspace", "summary"],
-    queryFn: () => api.workspace.summary(),
-  });
-  const webChatQuery = useQuery({
-    queryKey: WEB_CHAT_CONVERSATIONS_QUERY_KEY,
-    queryFn: () => api.webChat.conversations(),
-  });
-  const deleteConversationMutation = useMutation({
-    mutationFn: (conversationId: string) => api.webChat.removeConversation(conversationId),
-    onSuccess: (_result, conversationId) => {
-      queryClient.setQueryData<{ conversations: WebChatConversationSummary[] }>(
-        WEB_CHAT_CONVERSATIONS_QUERY_KEY,
-        (data) => removeWebChatConversationFromCache(data, conversationId),
-      );
-      queryClient.removeQueries({ queryKey: webChatMessagesQueryKey(conversationId), exact: true });
-      toast.success("Conversation deleted");
-    },
-    onError: (error) => {
-      toast.error(getDeleteConversationError(error));
-    },
-  });
-  const handleConversationIntent = useCallback(
-    (conversationId: string) => {
-      void queryClient.prefetchQuery({
-        queryKey: webChatMessagesQueryKey(conversationId),
-        queryFn: ({ signal }) => api.webChat.messages(conversationId, { signal }),
-        staleTime: WEB_CHAT_MESSAGES_STALE_TIME_MS,
-      });
-    },
-    [queryClient],
-  );
 
   useEffect(() => {
-    if (!search.message) return;
     void navigate({
       to: "/chat/$conversationId",
       params: { conversationId: createWebChatConversationId() },
-      search,
+      search: search.message || search.prefill ? search : { new: true },
       replace: true,
       viewTransition: shouldUseChatViewTransition(),
     });
   }, [navigate, search]);
 
-  if (search.message) return null;
-
-  return (
-    <HomePane
-      firstName={firstNameOf(auth.displayName)}
-      tiles={summaryQuery.data ? buildSummaryTiles(summaryQuery.data) : undefined}
-      recents={webChatQuery.data ? buildWebChatRecents(webChatQuery.data.conversations) : []}
-      deletingConversationId={deleteConversationMutation.variables ?? null}
-      onConversationIntent={handleConversationIntent}
-      onDeleteConversation={(conversation) => {
-        deleteConversationMutation.mutate(conversation.id);
-      }}
-      onSubmit={(value, attachments) => {
-        const target = {
-          to: "/chat/$conversationId" as const,
-          params: { conversationId: createWebChatConversationId() },
-          search: { message: value.trim() },
-          viewTransition: shouldUseChatViewTransition(),
-        };
-        if (attachments.length > 0) {
-          setPendingWebChatSubmission(target.params.conversationId, { text: value.trim(), attachments });
-        }
-        void navigate(target);
-      }}
-    />
-  );
+  return null;
 }
 
 export function ChatPage() {
@@ -907,7 +824,7 @@ export function ChatPage() {
   const toolProgressMutationId = useRef(0);
   const queryClient = useQueryClient();
   const hasNewConversationIntent = Boolean(
-    search.message || search.prefill || hasPendingWebChatSubmission(conversationId),
+    search.new || search.message || search.prefill || hasPendingWebChatSubmission(conversationId),
   );
   const knownNewConversation = useKnownNewWebChatConversation(conversationId, hasNewConversationIntent);
   const freshCachedHistory = knownNewConversation ? null : freshCachedWebChatMessages(queryClient, conversationId);
@@ -1225,11 +1142,12 @@ export function ChatPage() {
     sentInitialMessage.current = initialMessageKey;
     queryClient.removeQueries({ queryKey: webChatMessagesQueryKey(conversationId), exact: true });
     const requestOptions = outgoingRequestOptions(initialAttachments);
-    if (requestOptions) {
-      void chat.sendMessage(outgoingTextMessage(initialText, initialAttachments), requestOptions);
-    } else {
-      void chat.sendMessage(outgoingTextMessage(initialText));
-    }
+    const send = requestOptions
+      ? chat.sendMessage(outgoingTextMessage(initialText, initialAttachments), requestOptions)
+      : chat.sendMessage(outgoingTextMessage(initialText));
+    void Promise.resolve(send).then(() =>
+      queryClient.invalidateQueries({ queryKey: WEB_CHAT_CONVERSATIONS_QUERY_KEY }),
+    );
     void navigate({
       to: "/chat/$conversationId",
       params: { conversationId },
@@ -1245,8 +1163,8 @@ export function ChatPage() {
   }, [conversationId, navigate, search.prefill]);
 
   return (
-    <TabContentContainer className="mx-auto box-content flex min-h-[calc(100vh-52px)] max-w-4xl flex-col w-[calc(100%-32px)] px-4 sm:w-[calc(100%-80px)] sm:px-10">
-      <ChatHeader title={chatTitle} onBack={() => navigate({ to: "/chat" })} />
+    <TabContentContainer className="mx-auto box-content flex min-h-[calc(100vh-3rem)] max-w-4xl flex-col w-[calc(100%-32px)] px-4 sm:w-[calc(100%-80px)] sm:px-10 md:min-h-screen">
+      <ChatHeader title={chatTitle} onBack={() => navigate({ to: "/home" })} />
 
       <div className="sketch-chat-route-enter relative min-h-0 flex-1">
         <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[28px] bg-gradient-to-b from-background to-transparent" />
@@ -1302,7 +1220,21 @@ export function ChatPage() {
             placeholder="Reply to Sketch..."
             onSubmit={(value, attachments) => {
               queryClient.removeQueries({ queryKey: webChatMessagesQueryKey(conversationId), exact: true });
-              void chat.sendMessage(outgoingTextMessage(value, attachments), outgoingRequestOptions(attachments));
+              const send = chat.sendMessage(
+                outgoingTextMessage(value, attachments),
+                outgoingRequestOptions(attachments),
+              );
+              void Promise.resolve(send).then(() =>
+                queryClient.invalidateQueries({ queryKey: WEB_CHAT_CONVERSATIONS_QUERY_KEY }),
+              );
+              if (search.new) {
+                void navigate({
+                  to: "/chat/$conversationId",
+                  params: { conversationId },
+                  search: {},
+                  replace: true,
+                });
+              }
             }}
           />
         </div>

--- a/packages/web/src/routes/connections.tsx
+++ b/packages/web/src/routes/connections.tsx
@@ -29,8 +29,9 @@ import { IntegrationsSection } from "@/components/connections/integrations-secti
 import { McpServersSection } from "@/components/connections/mcp-servers-section";
 import { RemoveMcpDialog } from "@/components/connections/remove-mcp-dialog";
 import { LoadingSkeleton } from "@/components/connections/shared";
+import { QuietAddButton } from "@/components/quiet-add-button";
 import { api } from "@/lib/api";
-import { CheckCircleIcon, MagnifyingGlassIcon, PlusIcon, SpinnerGapIcon, WarningIcon } from "@phosphor-icons/react";
+import { CheckCircleIcon, MagnifyingGlassIcon, SpinnerGapIcon, WarningIcon } from "@phosphor-icons/react";
 import type { AgentEnvironmentVariableRecord, IntegrationConnection, McpServerRecord } from "@sketch/shared";
 import { Button } from "@sketch/ui/components/button";
 import { TabButton } from "@sketch/ui/components/tab-button";
@@ -580,8 +581,8 @@ export function ConnectionsPage() {
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div>
-        <h1 className="text-xl font-semibold text-foreground">Integrations</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Connect apps and tools to extend your workspace.</p>
+        <h1 className="text-[22px] font-medium text-foreground">Integrations</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">Connect apps and tools to extend your workspace.</p>
       </div>
 
       <div className="mt-6 flex items-center gap-6 border-b border-border">
@@ -624,18 +625,15 @@ export function ConnectionsPage() {
                       <span className="inline-block size-1.5 rounded-full bg-[#FEED01]" />
                       via {provider.type === "canvas" ? "Canvas" : (provider.type ?? "Provider")}
                     </span>
-                    <button
-                      type="button"
+                    <QuietAddButton
                       onClick={() => {
                         setRequestedAppConnect(null);
                         setRequestedAppSearch(null);
                         setShowAddIntegrationDialog(true);
                       }}
-                      className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
                     >
-                      <PlusIcon size={12} weight="bold" />
                       Add app
-                    </button>
+                    </QuietAddButton>
                   </div>
                 )}
                 <IntegrationsSection

--- a/packages/web/src/routes/dashboard.test.ts
+++ b/packages/web/src/routes/dashboard.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { sidebarDefaultOpen } from "./dashboard";
+
+describe("sidebarDefaultOpen", () => {
+  it("restores a collapsed sidebar from its cookie", () => {
+    expect(sidebarDefaultOpen("theme=dark; sidebar_state=false; session=abc")).toBe(false);
+  });
+
+  it("keeps the sidebar open when its cookie is true or absent", () => {
+    expect(sidebarDefaultOpen("sidebar_state=true")).toBe(true);
+    expect(sidebarDefaultOpen("theme=dark")).toBe(true);
+  });
+});

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -2,6 +2,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { api } from "@/lib/api";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@sketch/ui/components/sidebar";
 import { Outlet, createRoute, redirect, useRouteContext } from "@tanstack/react-router";
+import type { CSSProperties } from "react";
 import { redirectToManagedLogin } from "./managed-redirect";
 import { rootRoute } from "./root";
 
@@ -76,14 +77,33 @@ function DashboardLayout() {
   const auth = useDashboardAuth();
 
   return (
-    <SidebarProvider>
+    <SidebarProvider
+      defaultOpen={sidebarDefaultOpen()}
+      style={
+        {
+          "--sidebar-width": "16rem",
+          "--sidebar-width-icon": "3rem",
+        } as CSSProperties
+      }
+    >
       <AppSidebar displayName={auth.displayName} displayIdentifier={auth.displayIdentifier} role={auth.role} />
       <SidebarInset>
-        <SidebarTrigger className="absolute left-3 top-3 z-20" />
-        <main className="flex-1 overflow-auto pt-[52px]">
+        <div className="flex h-12 shrink-0 items-center border-b px-3 md:hidden">
+          <SidebarTrigger />
+        </div>
+        <main className="flex-1 overflow-auto">
           <Outlet />
         </main>
       </SidebarInset>
     </SidebarProvider>
   );
+}
+
+export function sidebarDefaultOpen(cookie = typeof document === "undefined" ? "" : document.cookie): boolean {
+  const value = cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("sidebar_state="))
+    ?.slice("sidebar_state=".length);
+  return value !== "false";
 }

--- a/packages/web/src/routes/files/connector-picker.tsx
+++ b/packages/web/src/routes/files/connector-picker.tsx
@@ -10,6 +10,7 @@ import {
   isOwnedOrPersonalAppConnection,
 } from "@/components/connections/connection-status";
 import { ConnectorLogo } from "@/components/connector-logos";
+import { QuietAddButton } from "@/components/quiet-add-button";
 import type { ConnectorConfig } from "@/lib/api";
 import { api } from "@/lib/api";
 import { INTEGRATIONS, type IntegrationDefinition, type IntegrationType, getIntegration } from "@/lib/integrations";
@@ -778,10 +779,9 @@ function ConnectorRow({
               </Button>
             )}
             {onlyOtherPerUserConnectors && (
-              <Button variant="outline" size="sm" className="h-7 gap-1.5 whitespace-nowrap text-xs" onClick={onConnect}>
-                <PlusIcon size={12} />
+              <QuietAddButton className="whitespace-nowrap" onClick={onConnect}>
                 Connect mine
-              </Button>
+              </QuietAddButton>
             )}
             {needsScopeSetup && canManage && (
               <Button size="sm" className="h-7 whitespace-nowrap text-xs" onClick={() => onManage(connector)}>
@@ -809,10 +809,9 @@ function ConnectorRow({
           </div>
         ) : canConnect ? (
           <div className="flex items-center justify-end gap-2 self-end sm:self-auto sm:shrink-0">
-            <Button variant="outline" size="sm" className="h-7 whitespace-nowrap text-xs" onClick={onConnect}>
-              <PlusIcon size={12} />
+            <QuietAddButton className="whitespace-nowrap" onClick={onConnect}>
               Connect
-            </Button>
+            </QuietAddButton>
           </div>
         ) : (
           <span className="self-end whitespace-nowrap text-xs text-muted-foreground sm:self-auto sm:shrink-0">

--- a/packages/web/src/routes/files/entity-explorer.tsx
+++ b/packages/web/src/routes/files/entity-explorer.tsx
@@ -15,6 +15,7 @@ import { AddEntityDialog } from "@/components/entity-review/add-entity-dialog";
 import { humanSourceType } from "@/components/entity-review/entity-format";
 import { GhostReviewRow, ReviewDetailSheet } from "@/components/entity-review/review-band";
 import { GraphRebuildDialog, type GraphRebuildDialogPrefill } from "@/components/graph-rebuild-dialog";
+import { QuietAddButton } from "@/components/quiet-add-button";
 import { RebuildBanner } from "@/components/rebuild-banner";
 import { countKey, listKey } from "@/components/review-actions";
 import { useRebuildJob } from "@/hooks/use-rebuild-job";
@@ -30,7 +31,6 @@ import {
   CubeIcon,
   DotsThreeIcon,
   MagnifyingGlassIcon,
-  PlusIcon,
   UserIcon,
   XIcon,
 } from "@phosphor-icons/react";
@@ -237,10 +237,7 @@ export function EntityExplorer() {
           {showSystem ? "Hide system entities" : "Show system entities"}
         </Button>
 
-        <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" onClick={() => setShowAddDialog(true)}>
-          <PlusIcon size={12} />
-          Add Entity
-        </Button>
+        <QuietAddButton onClick={() => setShowAddDialog(true)}>Add Entity</QuietAddButton>
 
         {isAdmin && (
           <DropdownMenu>

--- a/packages/web/src/routes/files/index.tsx
+++ b/packages/web/src/routes/files/index.tsx
@@ -334,8 +334,8 @@ export function FilesPage() {
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-bold">Files</h1>
-          <p className="mt-1 text-sm text-muted-foreground">Your team's indexed knowledge base</p>
+          <h1 className="text-[22px] font-medium text-foreground">Files</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">Your team's indexed knowledge base</p>
         </div>
         <div className="flex items-center gap-3">
           {!isLoadingConnectors && totalFiles > 0 && (

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -39,7 +39,7 @@ export function HomePage() {
   const running = briefQuery.data?.running || generateMutation.isPending;
 
   return (
-    <TabContentContainer className="mx-auto box-border min-h-[calc(100vh-52px)] max-w-4xl px-5 py-10 sm:px-10">
+    <TabContentContainer className="mx-auto box-border min-h-[calc(100vh-3rem)] max-w-4xl px-5 py-10 sm:px-10 md:min-h-screen">
       {brief ? (
         <DailyBrief
           brief={brief}

--- a/packages/web/src/routes/projects/index.tsx
+++ b/packages/web/src/routes/projects/index.tsx
@@ -18,11 +18,11 @@
  */
 import { AddEntityDialog } from "@/components/entity-review/add-entity-dialog";
 import { ReviewBand } from "@/components/entity-review/review-band";
+import { QuietAddButton } from "@/components/quiet-add-button";
 import { type CuratedProduct, type EntityListItem, type ProjectSummary, api } from "@/lib/api";
 import { useEntityUi } from "@/lib/entity-ui";
-import { CaretRightIcon, CubeIcon, FolderSimpleIcon, PlusIcon, UsersThreeIcon } from "@phosphor-icons/react";
+import { CaretRightIcon, CubeIcon, FolderSimpleIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { Badge } from "@sketch/ui/components/badge";
-import { Button } from "@sketch/ui/components/button";
 import { Skeleton } from "@sketch/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
@@ -50,10 +50,9 @@ export function ProjectsPage() {
             it should already know.
           </p>
         </div>
-        <Button variant="outline" size="sm" className="h-7 shrink-0 gap-1.5 text-xs" onClick={() => setShowAdd(true)}>
-          <PlusIcon size={12} />
+        <QuietAddButton className="shrink-0" onClick={() => setShowAdd(true)}>
           Add
-        </Button>
+        </QuietAddButton>
       </div>
 
       <ReviewBand types={SPINE_TYPES} />

--- a/packages/web/src/routes/scheduled-tasks.tsx
+++ b/packages/web/src/routes/scheduled-tasks.tsx
@@ -513,8 +513,8 @@ export function ScheduledTasksPage() {
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div>
-        <h1 className="text-xl font-semibold text-foreground">Scheduled tasks</h1>
-        <p className="mt-2 text-sm text-muted-foreground">{getSubtitle(auth.role ?? "member")}</p>
+        <h1 className="text-[22px] font-medium text-foreground">Automations</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">{getSubtitle(auth.role ?? "member")}</p>
       </div>
 
       <div className="mt-6">

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -44,8 +44,8 @@ export function SettingsPage() {
   if (auth.role !== "admin") {
     return (
       <div className="mx-auto box-content max-w-4xl px-10 py-8">
-        <h1 className="text-xl font-semibold text-foreground">Settings</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Manage your personal Sketch settings.</p>
+        <h1 className="text-[22px] font-medium text-foreground">Settings</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">Manage your personal Sketch settings.</p>
         <div className="mt-6 space-y-8">
           <LocalDevicesSection />
           <ApiTokensSection />
@@ -56,8 +56,8 @@ export function SettingsPage() {
 
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
-      <h1 className="text-xl font-semibold text-foreground">Settings</h1>
-      <p className="mt-2 text-sm text-muted-foreground">Manage workspace-level configuration.</p>
+      <h1 className="text-[22px] font-medium text-foreground">Settings</h1>
+      <p className="mt-1 text-[13px] text-muted-foreground">Manage workspace-level configuration.</p>
 
       <div className="mt-6 space-y-8">
         <OrgContextSection />

--- a/packages/web/src/routes/skills.tsx
+++ b/packages/web/src/routes/skills.tsx
@@ -1,3 +1,4 @@
+import { QuietAddButton } from "@/components/quiet-add-button";
 import { DeleteSkillDialog } from "@/components/skills/delete-skill-dialog";
 import { DiscardChangesDialog } from "@/components/skills/discard-changes-dialog";
 import { SkillCard } from "@/components/skills/skill-card";
@@ -7,7 +8,6 @@ import { SkillsEmptyState } from "@/components/skills/skills-empty-state";
 import { SkillsFilterBar } from "@/components/skills/skills-filter-bar";
 import { api } from "@/lib/api";
 import { type Skill, categoryMeta, fromApiSkill, isSkillEnabled } from "@/lib/skills-data";
-import { PlusIcon } from "@phosphor-icons/react";
 import { Button } from "@sketch/ui/components/button";
 import { Skeleton } from "@sketch/ui/components/skeleton";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -257,8 +257,8 @@ export function SkillsPage() {
     return (
       <div className="mx-auto box-content max-w-4xl px-10 py-8">
         <div>
-          <h1 className="text-xl font-semibold text-foreground">Skills</h1>
-          <p className="mt-2 text-sm text-muted-foreground">Discover and manage your bot&apos;s capabilities.</p>
+          <h1 className="text-[22px] font-medium text-foreground">Skills</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">Discover and manage your bot&apos;s capabilities.</p>
         </div>
         <div className="mt-6 rounded-xl border border-destructive/20 bg-destructive/5 p-6">
           <h2 className="text-sm font-semibold text-destructive">Couldn&apos;t load skills</h2>
@@ -327,13 +327,10 @@ export function SkillsPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold text-foreground">Skills</h1>
-          <p className="mt-2 text-sm text-muted-foreground">Discover and manage your bot&apos;s capabilities.</p>
+          <h1 className="text-[22px] font-medium text-foreground">Skills</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">Discover and manage your bot&apos;s capabilities.</p>
         </div>
-        <Button variant="ghost" size="sm" className="gap-1.5 hover:bg-brand-accent/8" onClick={handleCreateClick}>
-          <PlusIcon size={14} weight="bold" />
-          Create Skill
-        </Button>
+        <QuietAddButton onClick={handleCreateClick}>Create Skill</QuietAddButton>
       </div>
 
       {/* Search */}

--- a/packages/web/src/routes/team.tsx
+++ b/packages/web/src/routes/team.tsx
@@ -1,3 +1,4 @@
+import { QuietAddButton } from "@/components/quiet-add-button";
 /**
  * Team page — manage workspace members.
  * Primary use case: add WhatsApp users so they can chat with the bot.
@@ -14,7 +15,7 @@ import { MemberList } from "@/components/team/member-list";
 import type { User } from "@/lib/api";
 import { api } from "@/lib/api";
 import { useDashboardAuth } from "@/routes/dashboard";
-import { PlusIcon, RobotIcon, UsersThreeIcon } from "@phosphor-icons/react";
+import { RobotIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { Avatar, AvatarFallback } from "@sketch/ui/components/avatar";
 import { Badge } from "@sketch/ui/components/badge";
 import { Button } from "@sketch/ui/components/button";
@@ -55,18 +56,10 @@ export function TeamPage() {
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold text-foreground">Team</h1>
-          <p className="mt-2 text-sm text-muted-foreground">Manage your workspace members and roles.</p>
+          <h1 className="text-[22px] font-medium text-foreground">Access</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">Manage your workspace members and roles.</p>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="gap-1.5 hover:bg-brand-accent/8"
-          onClick={() => setShowAddDialog(true)}
-        >
-          <PlusIcon size={14} weight="bold" />
-          Add member
-        </Button>
+        <QuietAddButton onClick={() => setShowAddDialog(true)}>Add member</QuietAddButton>
       </div>
 
       <div className="mt-6 w-full">
@@ -271,10 +264,9 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
       </div>
       <p className="mt-4 text-sm font-medium">Your team's empty!</p>
       <p className="mt-1 text-xs text-muted-foreground">Add your first team member to get started.</p>
-      <Button size="sm" onClick={onAdd} className="mt-4">
-        <PlusIcon size={14} weight="bold" />
+      <QuietAddButton onClick={onAdd} className="mt-4">
         Add member
-      </Button>
+      </QuietAddButton>
     </div>
   );
 }

--- a/packages/web/src/routes/workspace/workspace-page.tsx
+++ b/packages/web/src/routes/workspace/workspace-page.tsx
@@ -660,7 +660,7 @@ export function WorkspacePage() {
       <div
         className={cn(
           "flex overflow-hidden border-t border-border",
-          isMobile ? "flex-col h-[calc(100vh-52px)]" : "flex-row h-[calc(100vh-52px)]",
+          isMobile ? "flex-col h-[calc(100vh-3rem)]" : "flex-row h-screen",
         )}
       >
         {isMobile ? (

--- a/packages/web/src/test/msw.ts
+++ b/packages/web/src/test/msw.ts
@@ -391,6 +391,10 @@ export const handlers = [
     return HttpResponse.json({ rows: [], total: 0 });
   }),
 
+  http.get("/api/web-chat/conversations", () => {
+    return HttpResponse.json({ conversations: [] });
+  }),
+
   http.get("/api/auth/session", () => {
     return HttpResponse.json({ authenticated: false });
   }),


### PR DESCRIPTION
## Summary
- rebuild the application shell on the shared sidebar primitives with pinned destinations, More disclosure, mobile sheet, and collapsed navigation
- add live web-chat recents and make New chat open a clean conversation directly
- align destination headers and additive action styling across the frontend
- preserve admin-only Your Org review counts, managed Account access, theme controls, and existing routes

## Validation
- `pnpm biome check`
- `pnpm typecheck`
- `pnpm test` (4,104 server tests + 385 web tests passed; 20 live-provider tests skipped)
- `pnpm build`
- desktop expanded/collapsed, collapsed More, mobile sheet, and light/dark visual review