### PR TITLE
Suppress stale connector authentication claims

### DIFF
--- a/packages/server/src/agents/context-authority.test.ts
+++ b/packages/server/src/agents/context-authority.test.ts
@@ -191,6 +191,11 @@ describe("context authority snapshot", () => {
 
   it("marks provider construction and connection-list failures unavailable without throwing", async () => {
     await seedConnector("calendar-active", "google_calendar", "active");
+    const rejectingProvider = {
+      listConnections: async () => {
+        throw new Error("connection list unavailable");
+      },
+    } as Pick<IntegrationProvider, "listConnections"> as IntegrationProvider;
 
     const loadFailure = await buildContextAuthoritySnapshot({
       db,
@@ -210,9 +215,18 @@ describe("context authority snapshot", () => {
         throw new Error("provider unavailable");
       },
     });
+    const connectionListFailure = await buildContextAuthoritySnapshot({
+      db,
+      userId: "user-1",
+      userEmail: "agent@example.com",
+      userName: "Agent User",
+      now: NOW,
+      getIntegrationStatus: async () => ({ kind: "ok", provider: rejectingProvider }),
+    });
 
     expect(loadFailure.integrations.status).toBe("unavailable");
     expect(listFailure.integrations.status).toBe("unavailable");
+    expect(connectionListFailure.integrations.status).toBe("unavailable");
   });
 });
 
@@ -243,6 +257,8 @@ describe("context authority reconciliation", () => {
   it.each([
     ["Gmail is disconnected", "Reconnect Gmail before continuing."],
     ["Gmail authentication required", "Authenticate Gmail before continuing."],
+    ["Gmail isn't connected", "Reconnect Gmail before continuing."],
+    ["Gmail connection issue", "Reconnect to Gmail because authentication is required."],
   ])("suppresses explicit disconnected or authentication-required wording: %s", (title, summary) => {
     const result = reconcileItemsWithContextAuthority([outputItem({ title, summary })], connected);
 
@@ -263,6 +279,11 @@ describe("context authority reconciliation", () => {
     {
       name: "generic target",
       title: "Reconnect both integrations",
+      summary: "Both integrations require authentication.",
+    },
+    {
+      name: "mixed concrete and generic targets",
+      title: "Reconnect Gmail",
       summary: "Both integrations require authentication.",
     },
     {

--- a/packages/server/src/agents/context-authority.test.ts
+++ b/packages/server/src/agents/context-authority.test.ts
@@ -164,6 +164,37 @@ describe("context authority snapshot", () => {
     );
   });
 
+  it("does not treat a provider auth mechanism as an application alias", async () => {
+    const provider = {
+      listConnections: async () => [
+        providerConnection({
+          appId: "google-calendar-oauth",
+          appName: "Google Calendar",
+          app: { name: "Google Calendar", nameSlug: "google-calendar-oauth" },
+        }),
+      ],
+    } as Pick<IntegrationProvider, "listConnections"> as IntegrationProvider;
+
+    const authority = await buildContextAuthoritySnapshot({
+      db,
+      userId: "user-1",
+      userEmail: "agent@example.com",
+      userName: "Agent User",
+      now: NOW,
+      getIntegrationStatus: async () => ({ kind: "ok", provider }),
+    });
+    const item = outputItem({
+      title: "OAuth is not connected",
+      summary: "Reconnect OAuth before continuing.",
+    });
+
+    expect(authority.connectedApps[0]?.aliases).not.toContain("oauth");
+    expect(reconcileItemsWithContextAuthority([item], authority)).toEqual({
+      items: [item],
+      suppressedCount: 0,
+    });
+  });
+
   it("preserves independent unavailable state and fails open when either read fails", async () => {
     await db.destroy();
     const provider = {
@@ -260,6 +291,8 @@ describe("context authority reconciliation", () => {
     ["Gmail isn't connected", "Reconnect Gmail before continuing."],
     ["Gmail connection issue", "Reconnect to Gmail because authentication is required."],
     ["Gmail has a connection issue", "Gmail is not connected."],
+    ["Authentication required: Google Calendar", "Reconnect Google Calendar before continuing."],
+    ["Reconnect both Google Calendar and Gmail", "Google Calendar and Gmail are not connected."],
   ])("suppresses explicit disconnected or authentication-required wording: %s", (title, summary) => {
     const result = reconcileItemsWithContextAuthority([outputItem({ title, summary })], connected);
 

--- a/packages/server/src/agents/context-authority.test.ts
+++ b/packages/server/src/agents/context-authority.test.ts
@@ -1,0 +1,296 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentOutputItemInput } from "../db/repositories/agent-outputs";
+import type { DB } from "../db/schema";
+import type { IntegrationConnection, IntegrationProvider } from "../integrations/types";
+import { createTestDb } from "../test-utils";
+import {
+  type ContextAuthorityApp,
+  type ContextAuthoritySnapshot,
+  buildContextAuthoritySnapshot,
+  readContextAuthoritySnapshot,
+  reconcileItemsWithContextAuthority,
+} from "./context-authority";
+
+const NOW = new Date("2026-07-17T09:30:00.000Z");
+
+function outputItem(overrides: Partial<AgentOutputItemInput> = {}): AgentOutputItemInput {
+  return {
+    sectionKey: "todos",
+    title: "Connect application",
+    summary: "The application is not connected.",
+    priority: "medium",
+    label: "todo",
+    actionPrompt: null,
+    knowledgeRefs: { entityIds: [], fileIds: [] },
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function connectedApp(
+  key: string,
+  source: ContextAuthorityApp["source"],
+  names: string[],
+  aliases: string[],
+): ContextAuthorityApp {
+  return {
+    key,
+    source,
+    names,
+    aliases,
+    updatedAt: NOW.toISOString(),
+  };
+}
+
+function snapshot(
+  apps: ContextAuthorityApp[],
+  overrides: Partial<Pick<ContextAuthoritySnapshot, "connectors" | "integrations">> = {},
+): ContextAuthoritySnapshot {
+  return {
+    capturedAt: NOW.toISOString(),
+    connectors: {
+      status: "available",
+      apps: apps.filter((app) => app.source === "connector"),
+    },
+    integrations: {
+      status: "available",
+      apps: apps.filter((app) => app.source === "integration"),
+    },
+    connectedApps: apps,
+    ...overrides,
+  };
+}
+
+function providerConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  return {
+    id: "connection-1",
+    providerId: "provider-1",
+    appId: "microsoft-outlook",
+    appName: "Microsoft Outlook",
+    app: { name: "Microsoft Outlook", nameSlug: "microsoft-outlook" },
+    status: "active",
+    healthy: true,
+    canUse: true,
+    createdAt: "2026-07-16T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("context authority snapshot", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await db
+      .insertInto("users")
+      .values([
+        { id: "user-1", name: "Agent User", email: "agent@example.com" },
+        { id: "user-2", name: "Other User", email: "other@example.com" },
+      ])
+      .execute();
+  });
+
+  afterEach(async () => {
+    await db.destroy().catch(() => undefined);
+  });
+
+  async function seedConnector(id: string, connectorType: string, syncStatus: string, createdBy = "user-1") {
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id,
+        connector_type: connectorType,
+        auth_type: "oauth",
+        credentials: `credential-${id}`,
+        sync_status: syncStatus,
+        created_by: createdBy,
+        last_synced_at: "2026-07-17T08:00:00.000Z",
+        updated_at: "2026-07-17T08:30:00.000Z",
+      })
+      .execute();
+  }
+
+  it("reads only active or syncing connectors owned by the run user without credentials", async () => {
+    await seedConnector("calendar-active", "google_calendar", "active");
+    await seedConnector("drive-syncing", "google_drive", "syncing");
+    await seedConnector("linear-error", "linear", "error");
+    await seedConnector("other-gmail", "gmail", "active", "user-2");
+
+    const authority = await buildContextAuthoritySnapshot({
+      db,
+      userId: "user-1",
+      userEmail: "agent@example.com",
+      userName: "Agent User",
+      now: NOW,
+      getIntegrationStatus: async () => ({ kind: "absent" }),
+    });
+
+    expect(authority.connectors.status).toBe("available");
+    expect(authority.integrations.status).toBe("absent");
+    expect(authority.connectedApps.map((app) => app.key)).toEqual([
+      "connector:google_calendar",
+      "connector:google_drive",
+    ]);
+    expect(authority.connectedApps[0]?.aliases).toEqual(
+      expect.arrayContaining(["google calendar", "googlecalendar", "calendar"]),
+    );
+    expect(JSON.stringify(authority)).not.toContain("credential-");
+  });
+
+  it("includes only active, healthy and permitted provider connections", async () => {
+    const provider = {
+      listConnections: async () => [
+        providerConnection(),
+        providerConnection({ id: "expired", appId: "github", appName: "GitHub", status: "expired" }),
+        providerConnection({ id: "unhealthy", appId: "notion", appName: "Notion", healthy: false }),
+        providerConnection({ id: "forbidden", appId: "salesforce", appName: "Salesforce", canUse: false }),
+      ],
+    } as Pick<IntegrationProvider, "listConnections"> as IntegrationProvider;
+
+    const authority = await buildContextAuthoritySnapshot({
+      db,
+      userId: "user-1",
+      userEmail: "agent@example.com",
+      userName: "Agent User",
+      now: NOW,
+      getIntegrationStatus: async () => ({ kind: "ok", provider }),
+    });
+
+    expect(authority.integrations.status).toBe("available");
+    expect(authority.connectedApps.map((app) => app.key)).toEqual(["integration:microsoft-outlook"]);
+    expect(authority.connectedApps[0]?.aliases).toEqual(
+      expect.arrayContaining(["microsoft outlook", "microsoftoutlook", "outlook"]),
+    );
+  });
+
+  it("preserves independent unavailable state and fails open when either read fails", async () => {
+    await db.destroy();
+    const provider = {
+      listConnections: async () => [providerConnection()],
+    } as Pick<IntegrationProvider, "listConnections"> as IntegrationProvider;
+
+    const authority = await buildContextAuthoritySnapshot({
+      db,
+      userId: "user-1",
+      userEmail: "agent@example.com",
+      userName: "Agent User",
+      now: NOW,
+      getIntegrationStatus: async () => ({ kind: "ok", provider }),
+    });
+    const result = reconcileItemsWithContextAuthority(
+      [outputItem({ title: "Reconnect Microsoft Outlook", summary: "Microsoft Outlook is not connected." })],
+      authority,
+    );
+
+    expect(authority.connectors.status).toBe("unavailable");
+    expect(authority.integrations.status).toBe("available");
+    expect(result.suppressedCount).toBe(0);
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("marks provider construction and connection-list failures unavailable without throwing", async () => {
+    await seedConnector("calendar-active", "google_calendar", "active");
+
+    const loadFailure = await buildContextAuthoritySnapshot({
+      db,
+      userId: "user-1",
+      userEmail: "agent@example.com",
+      userName: "Agent User",
+      now: NOW,
+      getIntegrationStatus: async () => ({ kind: "load_failed", type: "canvas", reason: "bad credentials" }),
+    });
+    const listFailure = await buildContextAuthoritySnapshot({
+      db,
+      userId: "user-1",
+      userEmail: "agent@example.com",
+      userName: "Agent User",
+      now: NOW,
+      getIntegrationStatus: async () => {
+        throw new Error("provider unavailable");
+      },
+    });
+
+    expect(loadFailure.integrations.status).toBe("unavailable");
+    expect(listFailure.integrations.status).toBe("unavailable");
+  });
+});
+
+describe("context authority reconciliation", () => {
+  const googleCalendar = connectedApp(
+    "connector:google_calendar",
+    "connector",
+    ["google_calendar"],
+    ["google calendar", "googlecalendar", "calendar"],
+  );
+  const gmail = connectedApp("integration:gmail", "integration", ["gmail"], ["gmail"]);
+  const connected = snapshot([googleCalendar, gmail]);
+
+  it("suppresses a connection-only item when every concrete target is connected", () => {
+    const result = reconcileItemsWithContextAuthority(
+      [
+        outputItem({
+          title: "Reconnect Google Calendar and Gmail",
+          summary: "Google Calendar and Gmail are not connected. Authenticate both before preparing the brief.",
+        }),
+      ],
+      connected,
+    );
+
+    expect(result).toEqual({ items: [], suppressedCount: 1 });
+  });
+
+  it.each([
+    {
+      name: "unknown target",
+      title: "Reconnect Jira",
+      summary: "Jira is not connected.",
+    },
+    {
+      name: "mixed targets",
+      title: "Reconnect Gmail and Jira",
+      summary: "Gmail and Jira are not connected.",
+    },
+    {
+      name: "generic target",
+      title: "Reconnect both integrations",
+      summary: "Both integrations require authentication.",
+    },
+    {
+      name: "token prefix collision",
+      title: "Reconnect Mail",
+      summary: "Mail is not connected.",
+    },
+    {
+      name: "mixed substantive content",
+      title: "Gmail is not connected and Acme renewal is at risk",
+      summary: "Reconnect Gmail, and ask the account owner to review the renewal.",
+    },
+    {
+      name: "corrective statement",
+      title: "Connection status corrected",
+      summary: "The previous summary was stale; Gmail is already connected and no longer needs authentication.",
+    },
+  ])("retains $name items", ({ title, summary }) => {
+    const item = outputItem({ title, summary });
+    const result = reconcileItemsWithContextAuthority([item], connected);
+
+    expect(result).toEqual({ items: [item], suppressedCount: 0 });
+  });
+
+  it("suppresses from an available local authority when the provider is authoritatively absent", () => {
+    const authority = snapshot([googleCalendar], {
+      integrations: { status: "absent", apps: [] },
+    });
+    const result = reconcileItemsWithContextAuthority(
+      [outputItem({ title: "Connect Google Calendar", summary: "Google Calendar is not connected." })],
+      authority,
+    );
+
+    expect(result.suppressedCount).toBe(1);
+  });
+
+  it("rejects malformed runtime snapshots", () => {
+    expect(readContextAuthoritySnapshot({ connectedApps: "gmail" })).toBeNull();
+  });
+});

--- a/packages/server/src/agents/context-authority.test.ts
+++ b/packages/server/src/agents/context-authority.test.ts
@@ -241,6 +241,15 @@ describe("context authority reconciliation", () => {
   });
 
   it.each([
+    ["Gmail is disconnected", "Reconnect Gmail before continuing."],
+    ["Gmail authentication required", "Authenticate Gmail before continuing."],
+  ])("suppresses explicit disconnected or authentication-required wording: %s", (title, summary) => {
+    const result = reconcileItemsWithContextAuthority([outputItem({ title, summary })], connected);
+
+    expect(result).toEqual({ items: [], suppressedCount: 1 });
+  });
+
+  it.each([
     {
       name: "unknown target",
       title: "Reconnect Jira",

--- a/packages/server/src/agents/context-authority.test.ts
+++ b/packages/server/src/agents/context-authority.test.ts
@@ -293,8 +293,18 @@ describe("context authority reconciliation", () => {
     ["Gmail has a connection issue", "Gmail is not connected."],
     ["Authentication required: Google Calendar", "Reconnect Google Calendar before continuing."],
     ["Reconnect both Google Calendar and Gmail", "Google Calendar and Gmail are not connected."],
+    ["Reconnect both Google Calendar & Gmail", "Google Calendar and Gmail are not connected."],
   ])("suppresses explicit disconnected or authentication-required wording: %s", (title, summary) => {
     const result = reconcileItemsWithContextAuthority([outputItem({ title, summary })], connected);
+
+    expect(result).toEqual({ items: [], suppressedCount: 1 });
+  });
+
+  it("suppresses a colon-only authentication-required claim", () => {
+    const result = reconcileItemsWithContextAuthority(
+      [outputItem({ title: "Authentication required: Google Calendar", summary: "" })],
+      connected,
+    );
 
     expect(result).toEqual({ items: [], suppressedCount: 1 });
   });

--- a/packages/server/src/agents/context-authority.test.ts
+++ b/packages/server/src/agents/context-authority.test.ts
@@ -259,6 +259,7 @@ describe("context authority reconciliation", () => {
     ["Gmail authentication required", "Authenticate Gmail before continuing."],
     ["Gmail isn't connected", "Reconnect Gmail before continuing."],
     ["Gmail connection issue", "Reconnect to Gmail because authentication is required."],
+    ["Gmail has a connection issue", "Gmail is not connected."],
   ])("suppresses explicit disconnected or authentication-required wording: %s", (title, summary) => {
     const result = reconcileItemsWithContextAuthority([outputItem({ title, summary })], connected);
 
@@ -285,6 +286,11 @@ describe("context authority reconciliation", () => {
       name: "mixed concrete and generic targets",
       title: "Reconnect Gmail",
       summary: "Both integrations require authentication.",
+    },
+    {
+      name: "mixed concrete and singular generic targets",
+      title: "Reconnect Gmail and the integration",
+      summary: "Gmail and the integration are not connected.",
     },
     {
       name: "token prefix collision",

--- a/packages/server/src/agents/context-authority.ts
+++ b/packages/server/src/agents/context-authority.ts
@@ -56,9 +56,10 @@ const CORRECTION_PATTERNS = [
 
 const CONNECTION_CLAIM_PATTERNS = [
   /(.{1,120}?)\s+(?:is|are)\s+(?:not|no longer)\s+(?:connected|authenticated|authorized)\b/giu,
+  /(.{1,120}?)\s+(?:is|are)\s+disconnected\b/giu,
   /\b(?:connect|reconnect|authenticate|reauthorize|authorize)\s+(.{1,120}?)(?=\b(?:before|after|to|so that|because|for)\b|[.;!?]|$)/giu,
   /(.{1,120}?)\s+(?:needs?|requires?)\s+(?:authentication|authorization|reauthorization|reconnection)\b/giu,
-  /(.{1,120}?)\s+(?:credentials?|tokens?|authorization|authentication)\s+(?:are|is)\s+(?:missing|expired|invalid|required)\b/giu,
+  /(.{1,120}?)\s+(?:credentials?|tokens?|authorization|authentication)\s+(?:(?:are|is)\s+)?(?:missing|expired|invalid|required)\b/giu,
   /\b(?:authentication|authorization|reauthorization)\s+(?:is\s+)?required\s+(?:for|on)\s+(.{1,120}?)(?=[.;!?]|$)/giu,
 ];
 

--- a/packages/server/src/agents/context-authority.ts
+++ b/packages/server/src/agents/context-authority.ts
@@ -1,0 +1,417 @@
+import type { Kysely } from "kysely";
+import type { AgentOutputItemInput } from "../db/repositories/agent-outputs";
+import { createConnectorRepository } from "../db/repositories/connectors";
+import type { DB } from "../db/schema";
+import type { IntegrationConnection, IntegrationStatus } from "../integrations/types";
+
+export type ContextAuthorityReadStatus = "available" | "absent" | "unavailable";
+export type ContextAuthorityAppSource = "connector" | "integration";
+
+export interface ContextAuthorityApp {
+  key: string;
+  names: string[];
+  aliases: string[];
+  source: ContextAuthorityAppSource;
+  updatedAt: string | null;
+}
+
+export interface ContextAuthoritySection {
+  status: ContextAuthorityReadStatus;
+  apps: ContextAuthorityApp[];
+}
+
+export interface ContextAuthoritySnapshot {
+  capturedAt: string;
+  connectors: ContextAuthoritySection;
+  integrations: ContextAuthoritySection;
+  connectedApps: ContextAuthorityApp[];
+}
+
+export interface BuildContextAuthorityInput {
+  db: Kysely<DB>;
+  userId: string;
+  userEmail: string | null;
+  userName: string;
+  now: Date;
+  getIntegrationStatus?: () => Promise<IntegrationStatus>;
+}
+
+export interface ContextAuthorityReconciliation {
+  items: AgentOutputItemInput[];
+  suppressedCount: number;
+}
+
+type ClaimMatch = {
+  start: number;
+  end: number;
+  target: string;
+};
+
+const CORRECTION_PATTERNS = [
+  /\b(?:incorrect|incorrectly|wrong|wrongly|stale|outdated)\b/iu,
+  /\b(?:already|now)\s+(?:connected|authenticated|authorized|fixed|resolved)\b/iu,
+  /\b(?:fixed|resolved|corrected)\b/iu,
+  /\bno longer (?:true|needed|required|a problem|an issue)\b/iu,
+];
+
+const CONNECTION_CLAIM_PATTERNS = [
+  /(.{1,120}?)\s+(?:is|are)\s+(?:not|no longer)\s+(?:connected|authenticated|authorized)\b/giu,
+  /\b(?:connect|reconnect|authenticate|reauthorize|authorize)\s+(.{1,120}?)(?=\b(?:before|after|to|so that|because|for)\b|[.;!?]|$)/giu,
+  /(.{1,120}?)\s+(?:needs?|requires?)\s+(?:authentication|authorization|reauthorization|reconnection)\b/giu,
+  /(.{1,120}?)\s+(?:credentials?|tokens?|authorization|authentication)\s+(?:are|is)\s+(?:missing|expired|invalid|required)\b/giu,
+  /\b(?:authentication|authorization|reauthorization)\s+(?:is\s+)?required\s+(?:for|on)\s+(.{1,120}?)(?=[.;!?]|$)/giu,
+];
+
+const GENERIC_TARGETS = new Set([
+  "app",
+  "application",
+  "account",
+  "connection",
+  "connector",
+  "integration",
+  "both",
+  "both apps",
+  "both applications",
+  "both accounts",
+  "both connections",
+  "both connectors",
+  "both integrations",
+  "these apps",
+  "these applications",
+  "these accounts",
+  "these connections",
+  "these connectors",
+  "these integrations",
+  "the apps",
+  "the applications",
+  "the accounts",
+  "the connections",
+  "the connectors",
+  "the integrations",
+  "them",
+  "it",
+]);
+
+const CONNECTION_CONTEXT_WORDS = new Set([
+  "account",
+  "accounts",
+  "app",
+  "application",
+  "applications",
+  "apps",
+  "authentication",
+  "authorization",
+  "authorized",
+  "connected",
+  "connection",
+  "connections",
+  "connector",
+  "connectors",
+  "credential",
+  "credentials",
+  "integration",
+  "integrations",
+  "issue",
+  "login",
+  "remediation",
+  "required",
+  "status",
+  "token",
+  "tokens",
+]);
+
+const ALLOWED_RESIDUAL_WORDS = new Set([
+  "a",
+  "after",
+  "again",
+  "and",
+  "are",
+  "as",
+  "at",
+  "before",
+  "because",
+  "brief",
+  "continue",
+  "continuing",
+  "data",
+  "for",
+  "from",
+  "in",
+  "is",
+  "it",
+  "needed",
+  "of",
+  "on",
+  "or",
+  "prepare",
+  "preparing",
+  "proceed",
+  "proceeding",
+  "required",
+  "run",
+  "so",
+  "source",
+  "sources",
+  "summary",
+  "sync",
+  "syncing",
+  "that",
+  "the",
+  "this",
+  "to",
+  "use",
+  "using",
+  "with",
+]);
+
+function normalizePhrase(value: string): string {
+  return value
+    .normalize("NFKC")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLocaleLowerCase("en-US");
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function aliasesForNames(names: string[]): string[] {
+  const aliases: string[] = [];
+  for (const name of names) {
+    const normalized = normalizePhrase(name);
+    if (!normalized) continue;
+    const words = normalized.split(" ");
+    for (let index = 0; index < words.length; index += 1) {
+      const suffix = words.slice(index).join(" ");
+      if (index === 0 || suffix.replaceAll(" ", "").length >= 5) {
+        aliases.push(suffix, suffix.replaceAll(" ", ""));
+      }
+    }
+  }
+  return uniqueStrings(aliases);
+}
+
+function connectorApp(row: {
+  connector_type: string;
+  last_synced_at: string | null;
+  updated_at: string;
+}): ContextAuthorityApp {
+  const name = row.connector_type.trim();
+  return {
+    key: `connector:${normalizePhrase(name).replaceAll(" ", "_")}`,
+    names: [name],
+    aliases: aliasesForNames([name]),
+    source: "connector",
+    updatedAt: row.last_synced_at ?? row.updated_at,
+  };
+}
+
+function integrationNames(connection: IntegrationConnection): string[] {
+  return uniqueStrings(
+    [connection.appId, connection.appName, connection.app?.nameSlug, connection.app?.name]
+      .map((value) => value?.trim() ?? "")
+      .filter(Boolean),
+  );
+}
+
+function integrationApp(connection: IntegrationConnection): ContextAuthorityApp {
+  const names = integrationNames(connection);
+  return {
+    key: `integration:${normalizePhrase(connection.appId).replaceAll(" ", "-")}`,
+    names,
+    aliases: aliasesForNames(names),
+    source: "integration",
+    updatedAt: connection.connectedAt ?? connection.createdAt ?? null,
+  };
+}
+
+async function loadConnectorAuthority(input: BuildContextAuthorityInput): Promise<ContextAuthoritySection> {
+  try {
+    const rows = await createConnectorRepository(input.db).listConnectedAuthorityStatesByOwner(input.userId);
+    const apps = rows.map(connectorApp).sort((left, right) => left.key.localeCompare(right.key));
+    return { status: apps.length > 0 ? "available" : "absent", apps };
+  } catch {
+    return { status: "unavailable", apps: [] };
+  }
+}
+
+async function loadIntegrationAuthority(input: BuildContextAuthorityInput): Promise<ContextAuthoritySection> {
+  if (!input.getIntegrationStatus) return { status: "absent", apps: [] };
+  try {
+    const status = await input.getIntegrationStatus();
+    if (status.kind === "absent") return { status: "absent", apps: [] };
+    if (status.kind === "load_failed" || !input.userEmail) return { status: "unavailable", apps: [] };
+    const connections = await status.provider.listConnections(input.userEmail, input.userName);
+    const apps = connections
+      .filter(
+        (connection) => connection.status === "active" && connection.healthy !== false && connection.canUse !== false,
+      )
+      .map(integrationApp)
+      .sort((left, right) => left.key.localeCompare(right.key));
+    return { status: "available", apps };
+  } catch {
+    return { status: "unavailable", apps: [] };
+  }
+}
+
+export async function buildContextAuthoritySnapshot(
+  input: BuildContextAuthorityInput,
+): Promise<ContextAuthoritySnapshot> {
+  const [connectors, integrations] = await Promise.all([
+    loadConnectorAuthority(input),
+    loadIntegrationAuthority(input),
+  ]);
+  return {
+    capturedAt: input.now.toISOString(),
+    connectors,
+    integrations,
+    connectedApps: [...connectors.apps, ...integrations.apps].sort((left, right) => left.key.localeCompare(right.key)),
+  };
+}
+
+function isReadStatus(value: unknown): value is ContextAuthorityReadStatus {
+  return value === "available" || value === "absent" || value === "unavailable";
+}
+
+function isAppSource(value: unknown): value is ContextAuthorityAppSource {
+  return value === "connector" || value === "integration";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isAuthorityApp(value: unknown): value is ContextAuthorityApp {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const app = value as Record<string, unknown>;
+  return (
+    typeof app.key === "string" &&
+    isStringArray(app.names) &&
+    isStringArray(app.aliases) &&
+    isAppSource(app.source) &&
+    (typeof app.updatedAt === "string" || app.updatedAt === null)
+  );
+}
+
+function isAuthoritySection(value: unknown): value is ContextAuthoritySection {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const section = value as Record<string, unknown>;
+  return (
+    isReadStatus(section.status) && Array.isArray(section.apps) && section.apps.every((app) => isAuthorityApp(app))
+  );
+}
+
+export function readContextAuthoritySnapshot(value: unknown): ContextAuthoritySnapshot | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const snapshot = value as Record<string, unknown>;
+  if (typeof snapshot.capturedAt !== "string") return null;
+  if (!isAuthoritySection(snapshot.connectors) || !isAuthoritySection(snapshot.integrations)) return null;
+  if (!Array.isArray(snapshot.connectedApps) || !snapshot.connectedApps.every(isAuthorityApp)) return null;
+  return value as ContextAuthoritySnapshot;
+}
+
+function cleanTarget(value: string): string {
+  return normalizePhrase(value)
+    .replace(/^(?:a|an|the|my|our)\s+/u, "")
+    .replace(/\s+(?:apps?|applications?|accounts?|integrations?|connections?|connectors?)$/u, "")
+    .trim();
+}
+
+function targetFragments(value: string): string[] {
+  return value
+    .split(/\s*(?:,|&|\/|\band\b)\s*/iu)
+    .map(cleanTarget)
+    .filter(Boolean);
+}
+
+function findClaimMatches(text: string): ClaimMatch[] {
+  const matches: ClaimMatch[] = [];
+  for (const pattern of CONNECTION_CLAIM_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      if (match.index === undefined || !match[1]) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        target: match[1],
+      });
+    }
+  }
+  return matches.sort((left, right) => left.start - right.start || right.end - left.end);
+}
+
+function residualText(text: string, matches: ClaimMatch[]): string {
+  const ranges: Array<{ start: number; end: number }> = [];
+  for (const match of matches) {
+    const previous = ranges.at(-1);
+    if (!previous || match.start > previous.end) {
+      ranges.push({ start: match.start, end: match.end });
+    } else {
+      previous.end = Math.max(previous.end, match.end);
+    }
+  }
+  let cursor = 0;
+  let residual = "";
+  for (const range of ranges) {
+    residual += ` ${text.slice(cursor, range.start)}`;
+    cursor = range.end;
+  }
+  residual += ` ${text.slice(cursor)}`;
+  return normalizePhrase(residual);
+}
+
+function isGenericConnectionContext(text: string): boolean {
+  const tokens = normalizePhrase(text).split(" ").filter(Boolean);
+  return tokens.length > 0 && tokens.length <= 5 && tokens.every((token) => CONNECTION_CONTEXT_WORDS.has(token));
+}
+
+function isConnectionOnlyText(text: string, matches: ClaimMatch[]): boolean {
+  if (matches.length === 0) return isGenericConnectionContext(text);
+  const residualTokens = residualText(text, matches).split(" ").filter(Boolean);
+  return residualTokens.every((token) => ALLOWED_RESIDUAL_WORDS.has(token));
+}
+
+function appMatchesTarget(app: ContextAuthorityApp, target: string): boolean {
+  const normalized = cleanTarget(target);
+  const compact = normalized.replaceAll(" ", "");
+  return app.aliases.some((alias) => alias === normalized || alias === compact);
+}
+
+function isObsoleteConnectionClaim(
+  item: Pick<AgentOutputItemInput, "title" | "summary" | "actionPrompt">,
+  snapshot: ContextAuthoritySnapshot,
+): boolean {
+  if (snapshot.connectors.status === "unavailable" || snapshot.integrations.status === "unavailable") return false;
+  if (snapshot.connectedApps.length === 0) return false;
+  const texts = [item.title, item.summary, item.actionPrompt].filter(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+  if (texts.some((text) => CORRECTION_PATTERNS.some((pattern) => pattern.test(text)))) return false;
+  const textMatches = texts.map((text) => ({ text, matches: findClaimMatches(text) }));
+  if (textMatches.some(({ text, matches }) => !isConnectionOnlyText(text, matches))) return false;
+  const targets = textMatches.flatMap(({ matches }) => matches.flatMap((match) => targetFragments(match.target)));
+  const concreteTargets = uniqueStrings(targets.filter((target) => !GENERIC_TARGETS.has(target)));
+  if (concreteTargets.length === 0) return false;
+  return concreteTargets.every((target) => snapshot.connectedApps.some((app) => appMatchesTarget(app, target)));
+}
+
+export function reconcileItemsWithContextAuthority(
+  items: AgentOutputItemInput[],
+  snapshot: ContextAuthoritySnapshot | null,
+): ContextAuthorityReconciliation {
+  if (!snapshot) return { items, suppressedCount: 0 };
+  const retained: AgentOutputItemInput[] = [];
+  let suppressedCount = 0;
+  for (const item of items) {
+    if (isObsoleteConnectionClaim(item, snapshot)) {
+      suppressedCount += 1;
+    } else {
+      retained.push(item);
+    }
+  }
+  return { items: retained, suppressedCount };
+}

--- a/packages/server/src/agents/context-authority.ts
+++ b/packages/server/src/agents/context-authority.ts
@@ -61,7 +61,7 @@ const CONNECTION_CLAIM_PATTERNS = [
   /\b(?:connect|reconnect|authenticate|reauthorize|authorize)\s+(?:to\s+)?(.{1,120}?)(?=\b(?:before|after|to|so that|because|for)\b|[.;!?]|$)/giu,
   /(.{1,120}?)\s+(?:needs?|requires?)\s+(?:authentication|authorization|reauthorization|reconnection)\b/giu,
   /(.{1,120}?)\s+(?:credentials?|tokens?|authorization|authentication)\s+(?:(?:are|is)\s+)?(?:missing|expired|invalid|required)\b/giu,
-  /\b(?:authentication|authorization|reauthorization)\s+(?:is\s+)?required\s+(?:for|on)\s+(.{1,120}?)(?=[.;!?]|$)/giu,
+  /\b(?:authentication|authorization|reauthorization)\s+(?:is\s+)?required(?:(?:\s+(?:for|on)\s+)|(?:\s*[:—-]\s*))(.{1,120}?)(?=[.;!?]|$)/giu,
 ];
 
 const GENERIC_TARGETS = new Set([
@@ -332,7 +332,7 @@ function cleanTarget(value: string): string {
 
 function targetFragments(value: string): string[] {
   return value
-    .replace(/^\s*both\s+(?=.+\s+and\s+)/iu, "")
+    .replace(/^\s*both\s+(?=.+(?:\s+and\s+|\s*&\s*))/iu, "")
     .split(/\s*(?:,|&|\/|\band\b)\s*/iu)
     .map(cleanTarget)
     .filter(Boolean);

--- a/packages/server/src/agents/context-authority.ts
+++ b/packages/server/src/agents/context-authority.ts
@@ -56,8 +56,9 @@ const CORRECTION_PATTERNS = [
 
 const CONNECTION_CLAIM_PATTERNS = [
   /(.{1,120}?)\s+(?:is|are)\s+(?:not|no longer)\s+(?:connected|authenticated|authorized)\b/giu,
+  /(.{1,120}?)\s+(?:isn['’]t|aren['’]t)\s+(?:connected|authenticated|authorized)\b/giu,
   /(.{1,120}?)\s+(?:is|are)\s+disconnected\b/giu,
-  /\b(?:connect|reconnect|authenticate|reauthorize|authorize)\s+(.{1,120}?)(?=\b(?:before|after|to|so that|because|for)\b|[.;!?]|$)/giu,
+  /\b(?:connect|reconnect|authenticate|reauthorize|authorize)\s+(?:to\s+)?(.{1,120}?)(?=\b(?:before|after|to|so that|because|for)\b|[.;!?]|$)/giu,
   /(.{1,120}?)\s+(?:needs?|requires?)\s+(?:authentication|authorization|reauthorization|reconnection)\b/giu,
   /(.{1,120}?)\s+(?:credentials?|tokens?|authorization|authentication)\s+(?:(?:are|is)\s+)?(?:missing|expired|invalid|required)\b/giu,
   /\b(?:authentication|authorization|reauthorization)\s+(?:is\s+)?required\s+(?:for|on)\s+(.{1,120}?)(?=[.;!?]|$)/giu,
@@ -129,6 +130,8 @@ const ALLOWED_RESIDUAL_WORDS = new Set([
   "are",
   "as",
   "at",
+  "authentication",
+  "authorization",
   "before",
   "because",
   "brief",
@@ -342,7 +345,12 @@ function findClaimMatches(text: string): ClaimMatch[] {
       });
     }
   }
-  return matches.sort((left, right) => left.start - right.start || right.end - left.end);
+  const selected: ClaimMatch[] = [];
+  for (const match of matches.sort((left, right) => left.start - right.start || left.end - right.end)) {
+    if (selected.some((candidate) => match.start < candidate.end && match.end > candidate.start)) continue;
+    selected.push(match);
+  }
+  return selected;
 }
 
 function residualText(text: string, matches: ClaimMatch[]): string {
@@ -370,10 +378,38 @@ function isGenericConnectionContext(text: string): boolean {
   return tokens.length > 0 && tokens.length <= 5 && tokens.every((token) => CONNECTION_CONTEXT_WORDS.has(token));
 }
 
-function isConnectionOnlyText(text: string, matches: ClaimMatch[]): boolean {
-  if (matches.length === 0) return isGenericConnectionContext(text);
+function containsTokenSequence(tokens: string[], sequence: string[]): number {
+  if (sequence.length === 0 || sequence.length > tokens.length) return -1;
+  for (let index = 0; index <= tokens.length - sequence.length; index += 1) {
+    if (sequence.every((token, offset) => tokens[index + offset] === token)) return index;
+  }
+  return -1;
+}
+
+function isKnownAppConnectionContext(text: string, snapshot: ContextAuthoritySnapshot): boolean {
+  const tokens = normalizePhrase(text).split(" ").filter(Boolean);
+  if (tokens.length === 0 || tokens.length > 8) return false;
+  return snapshot.connectedApps.some((app) =>
+    app.aliases.some((alias) => {
+      const aliasTokens = normalizePhrase(alias).split(" ").filter(Boolean);
+      const aliasIndex = containsTokenSequence(tokens, aliasTokens);
+      if (aliasIndex === -1) return false;
+      const remaining = tokens.filter((_, index) => index < aliasIndex || index >= aliasIndex + aliasTokens.length);
+      return remaining.length > 0 && remaining.every((token) => CONNECTION_CONTEXT_WORDS.has(token));
+    }),
+  );
+}
+
+function isConnectionOnlyText(text: string, matches: ClaimMatch[], snapshot: ContextAuthoritySnapshot): boolean {
+  if (matches.length === 0) {
+    return isGenericConnectionContext(text) || isKnownAppConnectionContext(text, snapshot);
+  }
   const residualTokens = residualText(text, matches).split(" ").filter(Boolean);
   return residualTokens.every((token) => ALLOWED_RESIDUAL_WORDS.has(token));
+}
+
+function minimumConcreteTargetsForGeneric(target: string): number {
+  return /^(?:both|these|those|the|them)\b/u.test(target) ? 2 : 1;
 }
 
 function appMatchesTarget(app: ContextAuthorityApp, target: string): boolean {
@@ -393,10 +429,15 @@ function isObsoleteConnectionClaim(
   );
   if (texts.some((text) => CORRECTION_PATTERNS.some((pattern) => pattern.test(text)))) return false;
   const textMatches = texts.map((text) => ({ text, matches: findClaimMatches(text) }));
-  if (textMatches.some(({ text, matches }) => !isConnectionOnlyText(text, matches))) return false;
+  if (textMatches.some(({ text, matches }) => !isConnectionOnlyText(text, matches, snapshot))) return false;
   const targets = textMatches.flatMap(({ matches }) => matches.flatMap((match) => targetFragments(match.target)));
-  const concreteTargets = uniqueStrings(targets.filter((target) => !GENERIC_TARGETS.has(target)));
+  const normalizedTargets = uniqueStrings(targets);
+  const genericTargets = normalizedTargets.filter((target) => GENERIC_TARGETS.has(target));
+  const concreteTargets = normalizedTargets.filter((target) => !GENERIC_TARGETS.has(target));
   if (concreteTargets.length === 0) return false;
+  if (genericTargets.some((target) => concreteTargets.length < minimumConcreteTargetsForGeneric(target))) {
+    return false;
+  }
   return concreteTargets.every((target) => snapshot.connectedApps.some((app) => appMatchesTarget(app, target)));
 }
 

--- a/packages/server/src/agents/context-authority.ts
+++ b/packages/server/src/agents/context-authority.ts
@@ -170,6 +170,8 @@ const ALLOWED_RESIDUAL_WORDS = new Set([
   "with",
 ]);
 
+const NON_APPLICATION_ALIASES = new Set(["oauth", "oauth2", "oidc", "openid", "saml", "sso"]);
+
 function normalizePhrase(value: string): string {
   return value
     .normalize("NFKC")
@@ -193,6 +195,7 @@ function aliasesForNames(names: string[]): string[] {
     const words = normalized.split(" ");
     for (let index = 0; index < words.length; index += 1) {
       const suffix = words.slice(index).join(" ");
+      if (NON_APPLICATION_ALIASES.has(suffix)) continue;
       if (index === 0 || suffix.replaceAll(" ", "").length >= 5) {
         aliases.push(suffix, suffix.replaceAll(" ", ""));
       }
@@ -329,6 +332,7 @@ function cleanTarget(value: string): string {
 
 function targetFragments(value: string): string[] {
   return value
+    .replace(/^\s*both\s+(?=.+\s+and\s+)/iu, "")
     .split(/\s*(?:,|&|\/|\band\b)\s*/iu)
     .map(cleanTarget)
     .filter(Boolean);

--- a/packages/server/src/agents/context-authority.ts
+++ b/packages/server/src/agents/context-authority.ts
@@ -95,6 +95,7 @@ const GENERIC_TARGETS = new Set([
 ]);
 
 const CONNECTION_CONTEXT_WORDS = new Set([
+  "a",
   "account",
   "accounts",
   "app",
@@ -111,6 +112,7 @@ const CONNECTION_CONTEXT_WORDS = new Set([
   "connectors",
   "credential",
   "credentials",
+  "has",
   "integration",
   "integrations",
   "issue",
@@ -409,7 +411,9 @@ function isConnectionOnlyText(text: string, matches: ClaimMatch[], snapshot: Con
 }
 
 function minimumConcreteTargetsForGeneric(target: string): number {
-  return /^(?:both|these|those|the|them)\b/u.test(target) ? 2 : 1;
+  if (target === "it") return 1;
+  if (target === "both" || target === "them") return 2;
+  return Number.POSITIVE_INFINITY;
 }
 
 function appMatchesTarget(app: ContextAuthorityApp, target: string): boolean {

--- a/packages/server/src/agents/definitions/conversation-summary.test.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.test.ts
@@ -1,5 +1,5 @@
 import type { Kysely, Selectable } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentOutputItemInput, AgentSourceConfig } from "../../db/repositories/agent-outputs";
 import type { DB, UsersTable } from "../../db/schema";
 import { createTestConfig, createTestDb, createTestLogger } from "../../test-utils";
@@ -146,6 +146,69 @@ describe("conversationSummaryDefinition", () => {
       supportsWhatsAppGroups: true,
     });
     expect(conversationSummaryDefinition.requiresKnowledgeRefs).toBe(false);
+    expect(conversationSummaryDefinition.usesContextAuthority).toBe(true);
+  });
+
+  it("suppresses only obsolete connection-only items and logs an aggregate count", async () => {
+    const db = await createTestDb();
+    const connectedApp = {
+      key: "integration:gmail",
+      names: ["gmail"],
+      aliases: ["gmail"],
+      source: "integration",
+      updatedAt: NOW.toISOString(),
+    };
+    const items = [
+      outputItem({
+        sectionKey: "task_candidates",
+        title: "Reconnect Gmail",
+        summary: "Gmail is not connected.",
+        label: "action_item",
+      }),
+      outputItem({
+        title: "Connection correction",
+        summary: "The previous summary was stale; Gmail is already connected.",
+      }),
+      outputItem({
+        title: "Gmail is not connected and Acme renewal is at risk",
+        summary: "Reconnect Gmail, and ask the account owner to review the renewal.",
+      }),
+    ];
+    const info = vi.fn();
+    try {
+      const result = await conversationSummaryDefinition.reconcileItems?.({
+        db,
+        items,
+        runtimeContext: {
+          contextAuthority: {
+            capturedAt: NOW.toISOString(),
+            connectors: { status: "absent", apps: [] },
+            integrations: { status: "available", apps: [connectedApp] },
+            connectedApps: [connectedApp],
+          },
+        },
+        logger: { info } as never,
+      });
+
+      expect(result?.map((item) => item.title)).toEqual([
+        "Connection correction",
+        "Gmail is not connected and Acme renewal is at risk",
+      ]);
+      expect(info).toHaveBeenCalledWith(
+        {
+          event: "agent_context_authority_reconciliation",
+          agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+          suppressedCount: 1,
+        },
+        "Agent: context authority reconciliation complete",
+      );
+      const serializedLogs = JSON.stringify(info.mock.calls);
+      expect(serializedLogs).not.toContain("Gmail");
+      expect(serializedLogs).not.toContain("Connect");
+      expect(serializedLogs).not.toContain("Acme");
+    } finally {
+      await db.destroy();
+    }
   });
 
   it("carries parent hints from the same output into promoted action-item tasks", async () => {

--- a/packages/server/src/agents/definitions/conversation-summary.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.ts
@@ -8,6 +8,7 @@ import {
 import { type StoredConversationMessage, createConversationRepository } from "../../db/repositories/conversations";
 import { createTaskRepository } from "../../db/repositories/tasks";
 import type { DB } from "../../db/schema";
+import { readContextAuthoritySnapshot, reconcileItemsWithContextAuthority } from "../context-authority";
 import type {
   AgentApiItem,
   AgentDefinition,
@@ -249,6 +250,7 @@ const CONVERSATION_SUMMARY_INSTRUCTIONS = [
   "",
   "Generate a concise summary from the configured Slack channels and WhatsApp groups in the runtime context.",
   "The runtime context contains the complete source material available for this run. Do not use external knowledge or infer facts that are not supported by those messages.",
+  "Runtime context `contextAuthority` is server-owned current state. Do not report a confirmed-connected app as disconnected or requiring authentication. `absent` or `unavailable` does not prove disconnection.",
   "Call WriteAgentOutput exactly once when the summary is ready.",
   "",
   "Output shape:",
@@ -481,8 +483,24 @@ export const conversationSummaryDefinition: AgentDefinition = {
   allowedTools: CONVERSATION_SUMMARY_ALLOWED_TOOLS,
   itemsPerSectionRange: { min: 1, max: 12 },
   requiresKnowledgeRefs: false,
+  usesContextAuthority: true,
   buildInstructions,
   buildRuntimeContext: buildConversationSummaryRuntimeContext,
+  reconcileItems: async ({ items, runtimeContext, logger }) => {
+    const reconciled = reconcileItemsWithContextAuthority(
+      items,
+      readContextAuthoritySnapshot(runtimeContext.contextAuthority),
+    );
+    logger?.info(
+      {
+        event: "agent_context_authority_reconciliation",
+        agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+        suppressedCount: reconciled.suppressedCount,
+      },
+      "Agent: context authority reconciliation complete",
+    );
+    return reconciled.items;
+  },
   enrichItems,
   onOutputSaved,
   toApiItem,

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -1,5 +1,5 @@
 import type { Kysely, Selectable } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentOutputItemInput } from "../../db/repositories/agent-outputs";
 import type { DB, UsersTable } from "../../db/schema";
 import { createTestDb } from "../../test-utils";
@@ -707,5 +707,73 @@ describe("dailyBriefDefinition.reconcileItems", () => {
     });
 
     expect(result).toBe(items);
+  });
+
+  it("suppresses only obsolete connection-only items before existing reconciliation", async () => {
+    const connectedApp = {
+      key: "connector:google_calendar",
+      names: ["google_calendar"],
+      aliases: ["google calendar", "googlecalendar", "calendar"],
+      source: "connector",
+      updatedAt: NOW.toISOString(),
+    };
+    const items: AgentOutputItemInput[] = [
+      {
+        sectionKey: "todos",
+        title: "Connect Google Calendar",
+        summary: "Google Calendar is not connected.",
+        priority: "medium",
+        label: "todo",
+        knowledgeRefs: { entityIds: ["project-1"], fileIds: [] },
+        sortOrder: 0,
+      },
+      {
+        sectionKey: "customer_updates",
+        title: "Connection correction",
+        summary: "The prior brief was wrong; Google Calendar is already connected.",
+        priority: "medium",
+        label: "warm",
+        knowledgeRefs: { entityIds: ["project-1"], fileIds: [] },
+        sortOrder: 0,
+      },
+      {
+        sectionKey: "customer_updates",
+        title: "Calendar access and customer risk",
+        summary: "Google Calendar is not connected, and Acme renewal needs review.",
+        priority: "high",
+        label: "at_risk",
+        knowledgeRefs: { entityIds: ["project-1"], fileIds: [] },
+        sortOrder: 0,
+      },
+    ];
+    const info = vi.fn();
+
+    const result = await dailyBriefDefinition.reconcileItems?.({
+      db,
+      items,
+      runtimeContext: {
+        sections: ["todos", "customer_updates"],
+        contextAuthority: {
+          capturedAt: NOW.toISOString(),
+          connectors: { status: "available", apps: [connectedApp] },
+          integrations: { status: "absent", apps: [] },
+          connectedApps: [connectedApp],
+        },
+      },
+      logger: { info } as never,
+    });
+
+    expect(result?.map((item) => item.title)).toEqual(["Connection correction", "Calendar access and customer risk"]);
+    expect(info).toHaveBeenCalledWith(
+      {
+        event: "agent_context_authority_reconciliation",
+        agentKey: dailyBriefDefinition.key,
+        suppressedCount: 1,
+      },
+      "Agent: context authority reconciliation complete",
+    );
+    const serializedLogs = JSON.stringify(info.mock.calls);
+    expect(serializedLogs).not.toContain("Google Calendar");
+    expect(serializedLogs).not.toContain("Acme");
   });
 });

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -14,6 +14,7 @@ import { createUserRepository } from "../../db/repositories/users";
 import type { DB } from "../../db/schema";
 import { parseOnceSchedule } from "../../scheduler/parse-once";
 import { parseTimestampMs } from "../../timestamps";
+import { readContextAuthoritySnapshot, reconcileItemsWithContextAuthority } from "../context-authority";
 import type {
   AgentApiItem,
   AgentDefinition,
@@ -630,6 +631,7 @@ const DAILY_BRIEF_INSTRUCTIONS = [
   "",
   "Generate a concise Daily Brief from indexed organizational knowledge.",
   "Use the existing Sketch knowledge tools first. Search broadly, resolve relevant entities, then drill into entities and files only where needed.",
+  "Runtime context `contextAuthority` is server-owned current state. Do not report a confirmed-connected app as disconnected or requiring authentication. `absent` or `unavailable` does not prove disconnection.",
   "Call WriteAgentOutput exactly once when the complete brief is ready.",
   "",
   "Output shape:",
@@ -1075,6 +1077,7 @@ export const dailyBriefDefinition: AgentDefinition = {
   allowedTools: DAILY_BRIEF_ALLOWED_TOOLS,
   itemsPerSectionRange: { min: 1, max: 10 },
   requiresKnowledgeRefs: true,
+  usesContextAuthority: true,
   buildInstructions,
   buildRuntimeContext: async (params) => {
     const [dailyBriefCandidateContext, todaysMeetings] = await Promise.all([
@@ -1083,10 +1086,22 @@ export const dailyBriefDefinition: AgentDefinition = {
     ]);
     return { dailyBriefCandidateContext, todaysMeetings };
   },
-  reconcileItems: async ({ items, runtimeContext }) => {
+  reconcileItems: async ({ items, runtimeContext, logger }) => {
+    const authorityReconciled = reconcileItemsWithContextAuthority(
+      items,
+      readContextAuthoritySnapshot(runtimeContext.contextAuthority),
+    );
+    logger?.info(
+      {
+        event: "agent_context_authority_reconciliation",
+        agentKey: DAILY_BRIEF_AGENT_KEY,
+        suppressedCount: authorityReconciled.suppressedCount,
+      },
+      "Agent: context authority reconciliation complete",
+    );
     const sections = Array.isArray(runtimeContext.sections) ? (runtimeContext.sections as string[]) : [];
-    if (!sections.includes(DAILY_BRIEF_MEETINGS_SECTION_KEY)) return items;
-    return reconcileMeetingItems(items, parseTodaysMeetings(runtimeContext.todaysMeetings));
+    if (!sections.includes(DAILY_BRIEF_MEETINGS_SECTION_KEY)) return authorityReconciled.items;
+    return reconcileMeetingItems(authorityReconciled.items, parseTodaysMeetings(runtimeContext.todaysMeetings));
   },
   enrichItems,
   toApiItem,

--- a/packages/server/src/agents/run/contracts.ts
+++ b/packages/server/src/agents/run/contracts.ts
@@ -14,7 +14,7 @@ import type {
 import type { createSettingsRepository } from "../../db/repositories/settings";
 import type { createUserRepository } from "../../db/repositories/users";
 import type { DB, UsersTable } from "../../db/schema";
-import type { IntegrationProvider } from "../../integrations/types";
+import type { IntegrationProvider, IntegrationStatus } from "../../integrations/types";
 import type { Logger } from "../../logger";
 import type { QueueManager } from "../../queue";
 import type { SlackBot } from "../../slack/bot";
@@ -44,6 +44,7 @@ export interface AgentRunServiceDeps {
   runScheduledAgent: (params: RunAgentParams, admission?: AgentRunAdmissionOptions) => Promise<RunAgentResult>;
   buildMcpServers?: (email: string | null) => Promise<Record<string, McpServerConfig>>;
   loadIntegrationProvider?: () => Promise<IntegrationProvider | null>;
+  getIntegrationStatus?: () => Promise<IntegrationStatus>;
   queueManager?: QueueManager;
   outputDelivery?: AgentOutputDeliveryPublisher;
   getSlack?: () => Pick<SlackBot, "isUserInChannel" | "listChannels"> | null;

--- a/packages/server/src/agents/run/generation.ts
+++ b/packages/server/src/agents/run/generation.ts
@@ -12,6 +12,7 @@ import type {
   AgentRouteDestination,
   AgentSourceConfig,
 } from "../../db/repositories/agent-outputs";
+import { buildContextAuthoritySnapshot } from "../context-authority";
 import { requireAgentDefinition } from "../registry";
 import type { AgentDefinition } from "../types";
 import { AgentDeliveryTargetError } from "./contracts";
@@ -59,11 +60,19 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         user.auth_role === "admin" && adminCanReadAllFiles
           ? undefined
           : await this.deps.users.getAllEmailsForUser(user.id);
-      const [sameDayPrevious, previousDay, definitionContext] = await Promise.all([
-        this.getPreviousOutputForContext(def, user, output.output_date, scope),
-        this.getPreviousOutputForContext(def, user, addDays(output.output_date, -1), scope),
-        def.buildRuntimeContext
-          ? def.buildRuntimeContext({
+      const contextAuthorityPromise = def.usesContextAuthority
+        ? buildContextAuthoritySnapshot({
+            db: this.deps.db,
+            userId: user.id,
+            userEmail: user.email,
+            userName: user.name,
+            now,
+            getIntegrationStatus: this.deps.getIntegrationStatus,
+          })
+        : Promise.resolve(undefined);
+      const definitionContextPromise = def.buildRuntimeContext
+        ? contextAuthorityPromise.then((contextAuthority) =>
+            def.buildRuntimeContext?.({
               db: this.deps.db,
               user,
               outputDate: output.output_date,
@@ -71,6 +80,7 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
               now,
               adminCanReadAllFiles,
               contentUserEmails,
+              contextAuthority,
               agentConfig: {
                 enabledSections: routeSections,
                 maxItemsPerSection: routeMaxItemsPerSection,
@@ -83,9 +93,28 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
                 deliveryPlatform: deliveryPlatformForRoute(scope.route, scope.sources),
                 createTasks: config.createTasks,
               },
-            })
-          : Promise.resolve({}),
+            }),
+          )
+        : Promise.resolve({});
+      const [sameDayPrevious, previousDay, contextAuthority, definitionContext] = await Promise.all([
+        this.getPreviousOutputForContext(def, user, output.output_date, scope),
+        this.getPreviousOutputForContext(def, user, addDays(output.output_date, -1), scope),
+        contextAuthorityPromise,
+        definitionContextPromise,
       ]);
+      if (contextAuthority) {
+        this.deps.logger.info(
+          {
+            event: "agent_context_authority_snapshot",
+            agentKey: def.key,
+            connectorReadStatus: contextAuthority.connectors.status,
+            integrationReadStatus: contextAuthority.integrations.status,
+            connectedConnectorCount: contextAuthority.connectors.apps.length,
+            connectedIntegrationCount: contextAuthority.integrations.apps.length,
+          },
+          "Agent: context authority snapshot captured",
+        );
+      }
       const runtimeContext: Record<string, unknown> = {
         agentKey: def.key,
         agentVersion: def.version,
@@ -100,6 +129,7 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         createTasks: config.createTasks,
         sameDayPreviousOutput: this.formatOutputForContext(sameDayPrevious),
         previousDayOutput: this.formatOutputForContext(previousDay),
+        ...(contextAuthority ? { contextAuthority } : {}),
         ...definitionContext,
       };
       if (def.augmentRuntimeContext) {
@@ -364,7 +394,12 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
             internalSectionKeys.has(item.sectionKey),
         );
         const reconciled = def.reconcileItems
-          ? await def.reconcileItems({ db: this.deps.db, items: filtered, runtimeContext: params.runtimeContext })
+          ? await def.reconcileItems({
+              db: this.deps.db,
+              items: filtered,
+              runtimeContext: params.runtimeContext,
+              logger: this.deps.logger,
+            })
           : filtered;
         const itemsForHooks = await def.enrichItems(this.deps.db, reconciled);
         const visibleItems = itemsForHooks.filter(

--- a/packages/server/src/agents/run/lifecycle.isolated.test.ts
+++ b/packages/server/src/agents/run/lifecycle.isolated.test.ts
@@ -433,6 +433,99 @@ describe("AgentRunService", () => {
     expect(contexts[row.id].focus).toBe("Prioritize urgent work");
   });
 
+  it("captures one fail-open authority snapshot for an opted-in scheduled run without logging sensitive values", async () => {
+    const tasks: Array<() => Promise<void>> = [];
+    const users = createUserRepository(db);
+    const user = await users.create({ name: "Agent User", email: "user@example.com" });
+    await db
+      .insertInto("connector_configs")
+      .values({
+        id: "authority-connector-sensitive-id",
+        connector_type: "google_calendar",
+        auth_type: "oauth",
+        credentials: "authority-secret-credential",
+        sync_status: "active",
+        created_by: user.id,
+      })
+      .execute();
+    const contexts: Record<string, unknown>[] = [];
+    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+      contexts.push(runtimeContextFromUserMessage(params.userMessage));
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Daily Brief", summary: "Summary" },
+        rawPayload: {
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Daily Brief", summary: "Summary" },
+          items: [],
+        },
+        items: [],
+      });
+      return successfulRunResult();
+    });
+    const info = vi.fn();
+    const logger = {
+      info,
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      child: vi.fn(),
+    } as unknown as AgentRunServiceDeps["logger"];
+    const getIntegrationStatus = vi.fn(async () => {
+      throw new Error("provider failure with authority-secret-provider-value");
+    });
+    const definition = dailyBriefDefinition as typeof dailyBriefDefinition & { usesContextAuthority?: boolean };
+    const previousUsesContextAuthority = definition.usesContextAuthority;
+    definition.usesContextAuthority = true;
+    try {
+      const service = createService(db, tasks, {
+        runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+        logger,
+        getIntegrationStatus,
+      } as Partial<AgentRunServiceDeps>);
+
+      const [row] = await service.requestGenerationForUser({
+        agentKey: DAILY_BRIEF_AGENT_KEY,
+        userId: user.id,
+        outputDate: OUTPUT_DATE,
+        triggerType: "scheduled",
+      });
+      if (!row) throw new Error("Expected a generated output row");
+      await tasks[0]();
+    } finally {
+      definition.usesContextAuthority = previousUsesContextAuthority;
+    }
+
+    expect(getIntegrationStatus).toHaveBeenCalledTimes(1);
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.contextAuthority).toMatchObject({
+      connectors: {
+        status: "available",
+        apps: [expect.objectContaining({ key: "connector:google_calendar" })],
+      },
+      integrations: { status: "unavailable", apps: [] },
+    });
+    expect(info).toHaveBeenCalledWith(
+      {
+        event: "agent_context_authority_snapshot",
+        agentKey: DAILY_BRIEF_AGENT_KEY,
+        connectorReadStatus: "available",
+        integrationReadStatus: "unavailable",
+        connectedConnectorCount: 1,
+        connectedIntegrationCount: 0,
+      },
+      "Agent: context authority snapshot captured",
+    );
+    const serializedLogs = JSON.stringify(info.mock.calls);
+    expect(serializedLogs).not.toContain("authority-connector-sensitive-id");
+    expect(serializedLogs).not.toContain("authority-secret-credential");
+    expect(serializedLogs).not.toContain("authority-secret-provider-value");
+    expect(serializedLogs).not.toContain("google_calendar");
+  });
+
   it("suppresses recent failed scheduled attempts during the schedule window", async () => {
     const tasks: Array<() => Promise<void>> = [];
     const users = createUserRepository(db);

--- a/packages/server/src/agents/run/lifecycle.isolated.test.ts
+++ b/packages/server/src/agents/run/lifecycle.isolated.test.ts
@@ -433,98 +433,101 @@ describe("AgentRunService", () => {
     expect(contexts[row.id].focus).toBe("Prioritize urgent work");
   });
 
-  it("captures one fail-open authority snapshot for an opted-in scheduled run without logging sensitive values", async () => {
-    const tasks: Array<() => Promise<void>> = [];
-    const users = createUserRepository(db);
-    const user = await users.create({ name: "Agent User", email: "user@example.com" });
-    await db
-      .insertInto("connector_configs")
-      .values({
-        id: "authority-connector-sensitive-id",
-        connector_type: "google_calendar",
-        auth_type: "oauth",
-        credentials: "authority-secret-credential",
-        sync_status: "active",
-        created_by: user.id,
-      })
-      .execute();
-    const contexts: Record<string, unknown>[] = [];
-    const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
-      contexts.push(runtimeContextFromUserMessage(params.userMessage));
-      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
-      await params.agentOutputWriter.write({
-        outputDate: OUTPUT_DATE,
-        timezone: "UTC",
-        masthead: { title: "Daily Brief", summary: "Summary" },
-        rawPayload: {
+  it.each(["scheduled", "manual"] as const)(
+    "captures one fail-open authority snapshot for an opted-in $triggerType run without logging sensitive values",
+    async (triggerType) => {
+      const tasks: Array<() => Promise<void>> = [];
+      const users = createUserRepository(db);
+      const user = await users.create({ name: "Agent User", email: "user@example.com" });
+      await db
+        .insertInto("connector_configs")
+        .values({
+          id: "authority-connector-sensitive-id",
+          connector_type: "google_calendar",
+          auth_type: "oauth",
+          credentials: "authority-secret-credential",
+          sync_status: "active",
+          created_by: user.id,
+        })
+        .execute();
+      const contexts: Record<string, unknown>[] = [];
+      const runAgent = vi.fn(async (params: Parameters<AgentRunServiceDeps["runAgent"]>[0]) => {
+        contexts.push(runtimeContextFromUserMessage(params.userMessage));
+        if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+        await params.agentOutputWriter.write({
           outputDate: OUTPUT_DATE,
           timezone: "UTC",
           masthead: { title: "Daily Brief", summary: "Summary" },
+          rawPayload: {
+            outputDate: OUTPUT_DATE,
+            timezone: "UTC",
+            masthead: { title: "Daily Brief", summary: "Summary" },
+            items: [],
+          },
           items: [],
+        });
+        return successfulRunResult();
+      });
+      const info = vi.fn();
+      const logger = {
+        info,
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        child: vi.fn(),
+      } as unknown as AgentRunServiceDeps["logger"];
+      const getIntegrationStatus = vi.fn(async () => {
+        throw new Error("provider failure with authority-secret-provider-value");
+      });
+      const definition = dailyBriefDefinition as typeof dailyBriefDefinition & { usesContextAuthority?: boolean };
+      const previousUsesContextAuthority = definition.usesContextAuthority;
+      definition.usesContextAuthority = true;
+      try {
+        const service = createService(db, tasks, {
+          runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
+          logger,
+          getIntegrationStatus,
+        } as Partial<AgentRunServiceDeps>);
+
+        const [row] = await service.requestGenerationForUser({
+          agentKey: DAILY_BRIEF_AGENT_KEY,
+          userId: user.id,
+          outputDate: OUTPUT_DATE,
+          triggerType,
+        });
+        if (!row) throw new Error("Expected a generated output row");
+        await tasks[0]();
+      } finally {
+        definition.usesContextAuthority = previousUsesContextAuthority;
+      }
+
+      expect(getIntegrationStatus).toHaveBeenCalledTimes(1);
+      expect(contexts).toHaveLength(1);
+      expect(contexts[0]?.contextAuthority).toMatchObject({
+        connectors: {
+          status: "available",
+          apps: [expect.objectContaining({ key: "connector:google_calendar" })],
         },
-        items: [],
+        integrations: { status: "unavailable", apps: [] },
       });
-      return successfulRunResult();
-    });
-    const info = vi.fn();
-    const logger = {
-      info,
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-      child: vi.fn(),
-    } as unknown as AgentRunServiceDeps["logger"];
-    const getIntegrationStatus = vi.fn(async () => {
-      throw new Error("provider failure with authority-secret-provider-value");
-    });
-    const definition = dailyBriefDefinition as typeof dailyBriefDefinition & { usesContextAuthority?: boolean };
-    const previousUsesContextAuthority = definition.usesContextAuthority;
-    definition.usesContextAuthority = true;
-    try {
-      const service = createService(db, tasks, {
-        runAgent: runAgent as unknown as AgentRunServiceDeps["runAgent"],
-        logger,
-        getIntegrationStatus,
-      } as Partial<AgentRunServiceDeps>);
-
-      const [row] = await service.requestGenerationForUser({
-        agentKey: DAILY_BRIEF_AGENT_KEY,
-        userId: user.id,
-        outputDate: OUTPUT_DATE,
-        triggerType: "scheduled",
-      });
-      if (!row) throw new Error("Expected a generated output row");
-      await tasks[0]();
-    } finally {
-      definition.usesContextAuthority = previousUsesContextAuthority;
-    }
-
-    expect(getIntegrationStatus).toHaveBeenCalledTimes(1);
-    expect(contexts).toHaveLength(1);
-    expect(contexts[0]?.contextAuthority).toMatchObject({
-      connectors: {
-        status: "available",
-        apps: [expect.objectContaining({ key: "connector:google_calendar" })],
-      },
-      integrations: { status: "unavailable", apps: [] },
-    });
-    expect(info).toHaveBeenCalledWith(
-      {
-        event: "agent_context_authority_snapshot",
-        agentKey: DAILY_BRIEF_AGENT_KEY,
-        connectorReadStatus: "available",
-        integrationReadStatus: "unavailable",
-        connectedConnectorCount: 1,
-        connectedIntegrationCount: 0,
-      },
-      "Agent: context authority snapshot captured",
-    );
-    const serializedLogs = JSON.stringify(info.mock.calls);
-    expect(serializedLogs).not.toContain("authority-connector-sensitive-id");
-    expect(serializedLogs).not.toContain("authority-secret-credential");
-    expect(serializedLogs).not.toContain("authority-secret-provider-value");
-    expect(serializedLogs).not.toContain("google_calendar");
-  });
+      expect(info).toHaveBeenCalledWith(
+        {
+          event: "agent_context_authority_snapshot",
+          agentKey: DAILY_BRIEF_AGENT_KEY,
+          connectorReadStatus: "available",
+          integrationReadStatus: "unavailable",
+          connectedConnectorCount: 1,
+          connectedIntegrationCount: 0,
+        },
+        "Agent: context authority snapshot captured",
+      );
+      const serializedLogs = JSON.stringify(info.mock.calls);
+      expect(serializedLogs).not.toContain("authority-connector-sensitive-id");
+      expect(serializedLogs).not.toContain("authority-secret-credential");
+      expect(serializedLogs).not.toContain("authority-secret-provider-value");
+      expect(serializedLogs).not.toContain("google_calendar");
+    },
+  );
 
   it("suppresses recent failed scheduled attempts during the schedule window", async () => {
     const tasks: Array<() => Promise<void>> = [];

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -12,6 +12,7 @@ import type {
 import type { createUserRepository } from "../db/repositories/users";
 import type { DB, UsersTable } from "../db/schema";
 import type { Logger } from "../logger";
+import type { ContextAuthoritySnapshot } from "./context-authority";
 
 /**
  * Context handed to {@link AgentDefinition.augmentRuntimeContext}. The engine builds
@@ -91,6 +92,7 @@ export interface AgentRuntimeContextParams {
   now: Date;
   adminCanReadAllFiles: boolean;
   contentUserEmails: string[] | undefined;
+  contextAuthority?: ContextAuthoritySnapshot;
   agentConfig?: {
     enabledSections: Record<string, boolean>;
     maxItemsPerSection: number;
@@ -128,6 +130,8 @@ export interface AgentDefinition {
   itemsPerSectionRange: { min: number; max: number };
   /** When true, every output item must cite at least one known entity or file. */
   requiresKnowledgeRefs: boolean;
+  /** When true, the run receives one fresh server-built connector authority snapshot. */
+  usesContextAuthority?: boolean;
   /**
    * Fully static instruction string. Per-user values (enabled sections, item cap,
    * focus) are NOT interpolated here; they flow through the runtime context in the
@@ -149,6 +153,7 @@ export interface AgentDefinition {
     db: Kysely<DB>;
     items: AgentOutputItemInput[];
     runtimeContext: Record<string, unknown>;
+    logger?: Logger;
   }): Promise<AgentOutputItemInput[]>;
   /** Normalize a stored item into its API representation (label/action/displayRef fallbacks). */
   toApiItem(item: AgentStoredItem): AgentApiItem;

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -602,6 +602,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     runScheduledAgent: trackedScheduledRunAgent,
     buildMcpServers,
     loadIntegrationProvider,
+    getIntegrationStatus,
     queueManager,
     outputDelivery: agentOutputDelivery,
     getSlack: () => slack,

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -177,6 +177,16 @@ export function createConnectorRepository(db: Kysely<DB>, encryptionKey?: string
       return rows.map((row) => decodeConnectorConfigRow(row, encryptionKey));
     },
 
+    async listConnectedAuthorityStatesByOwner(createdBy: string) {
+      return db
+        .selectFrom("connector_configs")
+        .select(["connector_type", "sync_status", "last_synced_at", "updated_at"])
+        .where("created_by", "=", createdBy)
+        .where("sync_status", "in", ["active", "syncing"])
+        .orderBy("connector_type", "asc")
+        .execute();
+    },
+
     /**
      * Archive all connectors owned by a user — flip to disabled and scrub credentials.
      * Used when a user is removed from the workspace. Their indexed_files remain so


### PR DESCRIPTION
## Summary
- Prevent scheduled Summarizer and Daily Brief output from telling clients to reconnect or reauthenticate applications that current server-owned connector state confirms are connected.
- Add an agent-definition capability enabled only for Summarizer and Daily Brief; no tenant feature flag is required.
- Capture one authority snapshot per run and enforce the correction during server-side item reconciliation.

## Implementation Details
- Read owner-scoped local connector configurations in `active` or `syncing` state without selecting credentials.
- Read integration-provider connections only when they are active, healthy, and permitted.
- Preserve independent `available`, `absent`, and `unavailable` read states. Any failed authority read fails open and retains model output.
- Derive token-aware application aliases generically from connector/provider metadata while excluding generic authentication mechanisms such as OAuth.
- Suppress only connection/authentication-remediation-only items when every concrete referenced application is authoritatively connected.
- Preserve unknown or mixed targets, mixed-content items, corrective statements, and claims whose authority is incomplete.
- Record snapshot availability/counts and suppression counts without item text, identifiers, credentials, or message content.

## Verification
- `pnpm --filter @sketch/server exec vitest run src/agents/context-authority.test.ts src/agents/definitions/conversation-summary.test.ts src/agents/definitions/daily-brief.test.ts src/agents/run/lifecycle.isolated.test.ts` - passed (63 tests)
- `pnpm lint` - passed (1,186 files)
- `pnpm typecheck` - passed
- `pnpm test` - passed, including the full server and web suites
- `pnpm build` - passed

## Risk / Rollout
- The filter is deliberately conservative: unavailable reads, unresolved targets, mixed targets, mixed substantive content, and meta-corrections remain visible.
- Current main consumes reconciled `agent_output_items`, so rewriting or persisting reconciled raw payloads is not required for this immediate hotfix.
- Task durability hardening remains a separate follow-up. Before enabling PR #385 transition seeding, rejected raw candidates must be prevented from becoming seeds by either porting the reconciled-raw fix or making seeding consume reconciled items.
- No migrations, task repositories/lifecycle changes, reminder reconciliation, seed transitions, production mutation, or PR #385 dependencies are included.
