### PR TITLE
Add live task state to Daily Brief items

### DIFF
--- a/packages/server/src/agent/tools/agent-output.test.ts
+++ b/packages/server/src/agent/tools/agent-output.test.ts
@@ -2,6 +2,34 @@ import { describe, expect, it } from "vitest";
 import { writeAgentOutputSchema } from "./agent-output";
 
 describe("writeAgentOutputSchema", () => {
+  it("strips model-provided canonical task link fields", () => {
+    const result = writeAgentOutputSchema.parse({
+      outputDate: "2026-07-17",
+      timezone: "UTC",
+      masthead: {
+        title: "Daily Brief",
+        summary: "Summary",
+      },
+      items: [
+        {
+          sectionKey: "todos",
+          title: "Forged task link",
+          summary: "The model must not establish canonical identity.",
+          priority: "medium",
+          label: "todo",
+          canonicalTaskId: "task-forged",
+          taskId: "task-forged",
+          structuredPayload: { taskId: "task-payload" },
+          knowledgeRefs: { entityIds: [], fileIds: [] },
+        },
+      ],
+    });
+
+    expect(result.items[0]).not.toHaveProperty("canonicalTaskId");
+    expect(result.items[0]).not.toHaveProperty("taskId");
+    expect(result.items[0]?.structuredPayload).toEqual({ taskId: "task-payload" });
+  });
+
   it("rejects serialized payloads larger than 256 KiB", () => {
     const result = writeAgentOutputSchema.safeParse({
       outputDate: "2026-07-16",

--- a/packages/server/src/agents/definitions/conversation-summary.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.ts
@@ -667,6 +667,7 @@ function readRuntimeStringArray(value: unknown): string[] {
 function toApiItem(item: AgentStoredItem): AgentApiItem {
   return {
     id: item.id,
+    taskId: item.task_id,
     sectionKey: item.section_key,
     title: item.title,
     summary: item.summary,

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Kysely, Selectable } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type AgentOutputItemInput,
   type AgentRoute,
@@ -9,7 +9,7 @@ import {
 import { createTaskRepository } from "../../db/repositories/tasks";
 import { createUserRepository } from "../../db/repositories/users";
 import type { DB, UsersTable } from "../../db/schema";
-import { createTestConfig, createTestDb } from "../../test-utils";
+import { createTestConfig, createTestDb, createTestLogger } from "../../test-utils";
 import {
   DAILY_BRIEF_ENTITY_WINDOW_DAYS,
   DAILY_BRIEF_EVIDENCE_WINDOW_DAYS,
@@ -143,6 +143,244 @@ describe("dailyBriefDefinition.buildInstructions", () => {
     expect(instructions).toContain("active_projects:");
 
     expect(instructions).not.toMatch(/at most \d+ items/);
+  });
+});
+
+describe("dailyBriefDefinition.onOutputSaved task linking", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUser(db);
+    await db.updateTable("users").set({ email_verified_at: NOW.toISOString() }).where("id", "=", "user-1").execute();
+    await db
+      .insertInto("entities")
+      .values({
+        id: "person-1",
+        name: "Agent User",
+        source_type: "person",
+        subtype: null,
+        aliases: null,
+        metadata: JSON.stringify({ email: "agent@example.com" }),
+        source_ref_id: null,
+        status: "confirmed",
+        hotness: 0,
+        created_at: NOW.toISOString(),
+        updated_at: NOW.toISOString(),
+        ai_brief: null,
+      })
+      .execute();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function persistItems(items: AgentOutputItemInput[]) {
+    const repo = createAgentOutputRepository(db);
+    const running = await repo.createRunning({
+      agentKey: "daily_brief",
+      agentVersion: "test",
+      userId: "user-1",
+      outputDate: "2026-07-17",
+      timezone: "UTC",
+      triggerType: "manual",
+    });
+    const refs = await repo.completeOutput({
+      outputId: running.row.id,
+      masthead: { title: "Daily Brief", summary: "Summary" },
+      rawPayload: {},
+      items,
+    });
+    return {
+      outputId: running.row.id,
+      persistedItems: refs.map((ref, index) => ({ id: ref.id, item: items[index] })),
+    };
+  }
+
+  function todo(
+    title: string,
+    options: {
+      projectId?: string;
+      fileIds?: string[];
+      canonicalTaskId?: string;
+      sortOrder?: number;
+    } = {},
+  ): AgentOutputItemInput {
+    return {
+      sectionKey: "todos",
+      title,
+      summary: `${title} snapshot`,
+      priority: "medium",
+      label: "todo",
+      canonicalTaskId: options.canonicalTaskId,
+      structuredPayload: {
+        assigneeEntityId: "person-1",
+        assigneeName: "Agent User",
+      },
+      knowledgeRefs: {
+        entityIds: options.projectId ? [options.projectId] : [],
+        fileIds: options.fileIds ?? ["file-1"],
+      },
+      sortOrder: options.sortOrder ?? 0,
+    };
+  }
+
+  async function runHook(params: {
+    outputId: string;
+    persistedItems: Array<{ id: string; item: AgentOutputItemInput }>;
+    items?: AgentOutputItemInput[];
+    logger?: ReturnType<typeof createTestLogger>;
+  }) {
+    await dailyBriefDefinition.onOutputSaved?.({
+      db,
+      config: createTestConfig(),
+      logger: params.logger ?? createTestLogger(),
+      userId: "user-1",
+      outputId: params.outputId,
+      items: params.items ?? params.persistedItems.map((entry) => entry.item),
+      persistedItems: params.persistedItems,
+      createTasks: true,
+      runtimeContext: {},
+    });
+  }
+
+  it("links an upserted task to the exact persisted item", async () => {
+    await seedEntity(db, { id: "project-a", name: "Project A" });
+    const item = todo("Prepare launch plan", { projectId: "project-a" });
+    const persisted = await persistItems([item]);
+
+    await runHook(persisted);
+
+    const row = await db
+      .selectFrom("agent_output_items")
+      .innerJoin("tasks", "tasks.id", "agent_output_items.task_id")
+      .select(["agent_output_items.id", "tasks.parent_entity_id"])
+      .where("agent_output_items.id", "=", persisted.persistedItems[0].id)
+      .executeTakeFirstOrThrow();
+    expect(row).toEqual({ id: persisted.persistedItems[0].id, parent_entity_id: "project-a" });
+  });
+
+  it("links a collated structural task", async () => {
+    await seedEntity(db, { id: "project-a", name: "Project A" });
+    await db
+      .insertInto("tasks")
+      .values({
+        id: "structural-task",
+        parent_entity_id: "project-a",
+        source: "linear",
+        title: "Prepare launch plan",
+        normalized_title: "prepare launch plan",
+        status: "open",
+        status_authority: "external",
+        provenance: "structural",
+        source_task_id: "LIN-1",
+      })
+      .execute();
+    const persisted = await persistItems([todo("Prepare launch plan", { projectId: "project-a" })]);
+
+    await runHook(persisted);
+
+    await expect(
+      db
+        .selectFrom("agent_output_items")
+        .select("task_id")
+        .where("id", "=", persisted.persistedItems[0].id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ task_id: "structural-task" });
+  });
+
+  it("leaves skipped promotion unlinked", async () => {
+    const persisted = await persistItems([todo("No evidence task", { fileIds: [] })]);
+
+    await runHook(persisted);
+
+    await expect(
+      db
+        .selectFrom("agent_output_items")
+        .select("task_id")
+        .where("id", "=", persisted.persistedItems[0].id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ task_id: null });
+  });
+
+  it("rolls back task creation and leaves the item unlinked when promotion fails", async () => {
+    await seedEntity(db, { id: "project-a", name: "Project A" });
+    const persisted = await persistItems([todo("Fail promotion", { projectId: "project-a" })]);
+    await db.schema.dropTable("task_evidence").execute();
+    const logger = createTestLogger();
+    const warn = vi.spyOn(logger, "warn");
+
+    await runHook({ ...persisted, logger });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ outputId: persisted.outputId, userId: "user-1" }),
+      "Daily Brief: task promotion failed",
+    );
+    await expect(db.selectFrom("tasks").select("id").execute()).resolves.toEqual([]);
+    await expect(
+      db
+        .selectFrom("agent_output_items")
+        .select("task_id")
+        .where("id", "=", persisted.persistedItems[0].id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ task_id: null });
+  });
+
+  it("skips promotion for a server-linked durable item", async () => {
+    await db
+      .insertInto("tasks")
+      .values({
+        id: "durable-task",
+        source: "summary",
+        title: "Durable task",
+        normalized_title: "durable task",
+        status: "open",
+        status_authority: "local",
+        provenance: "summary",
+        source_task_id: "durable-task",
+        created_by_user_id: "user-1",
+      })
+      .execute();
+    const persisted = await persistItems([todo("Durable task", { canonicalTaskId: "durable-task" })]);
+    await db.schema.dropTable("task_evidence").execute();
+    const logger = createTestLogger();
+    const warn = vi.spyOn(logger, "warn");
+
+    await runHook({ ...persisted, logger });
+
+    expect(warn).not.toHaveBeenCalled();
+    await expect(
+      db
+        .selectFrom("agent_output_items")
+        .select("task_id")
+        .where("id", "=", persisted.persistedItems[0].id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ task_id: "durable-task" });
+  });
+
+  it("attaches same-title todos to their exact persisted ids without title matching", async () => {
+    await seedEntity(db, { id: "project-a", name: "Project A" });
+    await seedEntity(db, { id: "project-b", name: "Project B" });
+    const items = [
+      todo("Send revised proposal", { projectId: "project-a", sortOrder: 0 }),
+      todo("Send revised proposal", { projectId: "project-b", sortOrder: 1 }),
+    ];
+    const persisted = await persistItems(items);
+
+    await runHook(persisted);
+
+    const rows = await db
+      .selectFrom("agent_output_items")
+      .innerJoin("tasks", "tasks.id", "agent_output_items.task_id")
+      .select(["agent_output_items.id", "tasks.parent_entity_id"])
+      .where("agent_output_items.agent_output_id", "=", persisted.outputId)
+      .orderBy("agent_output_items.sort_order", "asc")
+      .execute();
+    expect(rows).toEqual([
+      { id: persisted.persistedItems[0].id, parent_entity_id: "project-a" },
+      { id: persisted.persistedItems[1].id, parent_entity_id: "project-b" },
+    ]);
   });
 });
 

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -883,6 +883,7 @@ async function enrichItems(db: Kysely<DB>, items: AgentOutputItemInput[]): Promi
 function toApiItem(item: AgentStoredItem): AgentApiItem {
   return {
     id: item.id,
+    taskId: item.task_id,
     sectionKey: item.section_key,
     title: item.title,
     summary: item.summary,

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -1651,17 +1651,48 @@ function buildFollowupReminderView(
 
 async function onOutputSaved(args: AgentOutputSavedArgs): Promise<void> {
   if (!args.createTasks) return;
-  const taskRepo = createTaskRepository(args.db);
-  for (const item of args.items) {
-    if (item.sectionKey !== "todos") continue;
+  if (!args.persistedItems) {
+    const taskRepo = createTaskRepository(args.db);
+    for (const item of args.items) {
+      if (item.sectionKey !== "todos" || item.canonicalTaskId) continue;
+      try {
+        await taskRepo.promoteBriefTask({
+          userId: args.userId,
+          todo: item,
+          knowledgeRefs: item.knowledgeRefs,
+        });
+      } catch (err) {
+        args.logger.warn({ err, outputId: args.outputId, userId: args.userId }, "Daily Brief: task promotion failed");
+      }
+    }
+    return;
+  }
+
+  for (const persisted of args.persistedItems) {
+    const item = persisted.item;
+    if (item.sectionKey !== "todos" || item.canonicalTaskId) continue;
     try {
-      await taskRepo.promoteBriefTask({
-        userId: args.userId,
-        todo: item,
-        knowledgeRefs: item.knowledgeRefs,
+      await args.db.transaction().execute(async (trx) => {
+        const result = await createTaskRepository(trx).promoteBriefTask({
+          userId: args.userId,
+          todo: item,
+          knowledgeRefs: item.knowledgeRefs,
+        });
+        if (result.status === "skipped") return;
+        const linked = await createAgentOutputRepository(trx).linkItemToTask({
+          outputId: args.outputId,
+          itemId: persisted.id,
+          taskId: result.taskId,
+        });
+        if (linked === "missing") {
+          throw new Error(`Persisted Daily Brief item is missing: ${persisted.id}`);
+        }
       });
     } catch (err) {
-      args.logger.warn({ err, outputId: args.outputId, userId: args.userId }, "Daily Brief: task promotion failed");
+      args.logger.warn(
+        { err, outputId: args.outputId, itemId: persisted.id, userId: args.userId },
+        "Daily Brief: task promotion failed",
+      );
     }
   }
 }

--- a/packages/server/src/agents/followup-reminder.test.ts
+++ b/packages/server/src/agents/followup-reminder.test.ts
@@ -63,11 +63,14 @@ describe("reconcileFollowupReminderItems", () => {
     ]);
     expect(result[1]).toMatchObject({
       label: "todo",
+      canonicalTaskId: "task-1",
       structuredPayload: { serverOwnedFollowup: true, taskId: "task-1", trackingState: "durable" },
       knowledgeRefs: { entityIds: ["project-1", "person-1"], fileIds: [] },
     });
+    expect(result[2]).not.toHaveProperty("canonicalTaskId");
     expect(result[2]?.summary).toContain("Track S4E9");
     expect(result[2]?.summary).toContain("Dismiss S4E9");
+    expect(result[3]).toMatchObject({ canonicalTaskId: "task-2" });
     expect(result[3]?.summary).toContain("Confirm done R7K2");
     expect(result[3]?.summary).toContain("Keep open R7K2");
   });

--- a/packages/server/src/agents/followup-reminder.ts
+++ b/packages/server/src/agents/followup-reminder.ts
@@ -80,6 +80,7 @@ function durableTaskItem(task: FollowupReminderTask, sortOrder: number): AgentOu
     actionType: "chat",
     actionLabel: "Plan with Sketch",
     actionPrompt: `Help me plan the next step for "${task.title}".`,
+    canonicalTaskId: task.taskId,
     structuredPayload: {
       serverOwnedFollowup: true,
       taskId: task.taskId,
@@ -104,6 +105,7 @@ function recommendationItem(recommendation: FollowupReminderRecommendation, sort
     actionType: "chat",
     actionLabel: "Review with Sketch",
     actionPrompt: `Review whether "${recommendation.title}" is complete.`,
+    canonicalTaskId: recommendation.taskId,
     structuredPayload: {
       serverOwnedFollowup: true,
       taskId: recommendation.taskId,

--- a/packages/server/src/agents/output-renderer.test.ts
+++ b/packages/server/src/agents/output-renderer.test.ts
@@ -10,6 +10,7 @@ const sections: AgentSectionDef[] = [
 function item(overrides: Partial<AgentApiItem> = {}): AgentApiItem {
   return {
     id: "item-1",
+    taskId: null,
     sectionKey: "todos",
     title: "Follow up with Acme",
     summary: "Acme asked for the launch timeline.",

--- a/packages/server/src/agents/routes-task-hydration.test.ts
+++ b/packages/server/src/agents/routes-task-hydration.test.ts
@@ -1,0 +1,394 @@
+import { Hono } from "hono";
+import type { Selectable } from "kysely";
+import { describe, expect, it, vi } from "vitest";
+import type { TaskAccessContext } from "../api/task-access";
+import { createTaskRepository } from "../db/repositories/tasks";
+import type { TasksTable } from "../db/schema";
+import { createTestDb, createTestLogger } from "../test-utils";
+import { DAILY_BRIEF_AGENT_KEY, dailyBriefDefinition } from "./definitions/daily-brief";
+import { MAX_BRIEF_TASK_LINKS, dailyBriefRoutes, hydrateDailyBriefTaskState } from "./routes";
+import type { AgentOutputApi, AgentRunService } from "./service";
+
+const ACCESS: TaskAccessContext = {
+  userId: "user-1",
+  viewer: { email: "user@example.com", isAdmin: false },
+  assigneeEntityIds: [],
+  canReadAllLocalTasks: false,
+  canEditAllLocalTasks: false,
+};
+
+function task(overrides: Partial<Selectable<TasksTable>> = {}): Selectable<TasksTable> {
+  return {
+    id: "task-1",
+    parent_entity_id: null,
+    parent_source_ref: null,
+    parent_name: null,
+    source: "summary",
+    external_ref: null,
+    title: "Current task title",
+    normalized_title: "current task title",
+    status: "in_progress",
+    status_raw: "in_progress",
+    status_authority: "local",
+    assignee_entity_id: null,
+    assignee_name: null,
+    proposed_assignee_name: null,
+    priority: "high",
+    due_at: null,
+    provenance: "summary",
+    source_task_id: "summary-task-1",
+    created_by_user_id: "user-1",
+    status_changed_at: "2026-07-17T09:00:00.000Z",
+    completed_at: null,
+    valid_from: "2026-07-17T08:00:00.000Z",
+    valid_to: null,
+    milestone_series_key: null,
+    source_platform: "slack",
+    source_conversation_id: 42,
+    source_provider_thread_id: "thread-1",
+    source_anchor_key: "slack:42:thread-1",
+    origin_agent_output_id: "summary-output-1",
+    created_at: "2026-07-17T08:00:00.000Z",
+    updated_at: "2026-07-17T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function item(id: string, sectionKey: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    sectionKey,
+    title: `Snapshot ${id}`,
+    summary: `Snapshot summary ${id}`,
+    priority: "medium",
+    label: "open",
+    displayRef: null,
+    actionType: null,
+    actionLabel: null,
+    actionPrompt: null,
+    sourceUrl: null,
+    structuredPayload: null,
+    knowledgeRefs: { entityIds: [], fileIds: [] },
+    sortOrder: 0,
+    taskId: null,
+    ...overrides,
+  };
+}
+
+function output(sections: Record<string, ReturnType<typeof item>[]>, userId = "user-1"): AgentOutputApi {
+  return {
+    id: "brief-1",
+    agentKey: DAILY_BRIEF_AGENT_KEY,
+    userId,
+    outputDate: "2026-07-17",
+    timezone: "UTC",
+    status: "completed",
+    sourceKey: "",
+    sourceLabel: null,
+    generatedAt: "2026-07-17T08:00:00.000Z",
+    masthead: null,
+    sections,
+  };
+}
+
+describe("hydrateDailyBriefTaskState", () => {
+  it("prefers canonical links, loads duplicate ids once, and overlays current task state", async () => {
+    const loadVisibleTasks = vi.fn(async () => [task()]);
+    const result = await hydrateDailyBriefTaskState({
+      output: output({
+        todos: [
+          item("item-1", "todos", {
+            taskId: "task-1",
+            structuredPayload: {
+              serverOwnedFollowup: true,
+              trackingState: "durable",
+              taskId: "conflicting-task",
+            },
+          }),
+          item("item-2", "todos", { taskId: "task-1" }),
+        ],
+      }),
+      userId: "user-1",
+      access: ACCESS,
+      loadVisibleTasks,
+      logger: createTestLogger(),
+    });
+
+    expect(loadVisibleTasks).toHaveBeenCalledOnce();
+    expect(loadVisibleTasks).toHaveBeenCalledWith(["task-1"], ACCESS);
+    expect(result.sections.todos).toEqual([
+      expect.objectContaining({
+        id: "item-1",
+        title: "Snapshot item-1",
+        taskId: "task-1",
+        task: expect.objectContaining({
+          id: "task-1",
+          title: "Current task title",
+          status: "in_progress",
+          canEditStatus: true,
+        }),
+      }),
+      expect.objectContaining({ id: "item-2", taskId: "task-1", task: expect.objectContaining({ id: "task-1" }) }),
+    ]);
+  });
+
+  it("accepts only strict owner-scoped legacy shapes with live summary provenance", async () => {
+    const loadVisibleTasks = vi.fn(async (ids: string[]) =>
+      ids.map((id) =>
+        task(
+          id === "forged-task"
+            ? { id, provenance: "brief", source_anchor_key: null }
+            : { id, source_task_id: `source-${id}` },
+        ),
+      ),
+    );
+    const result = await hydrateDailyBriefTaskState({
+      output: output({
+        todos: [
+          item("durable", "todos", {
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "legacy-durable" },
+          }),
+          item("ordinary", "todos", { structuredPayload: { taskId: "ordinary-task" } }),
+          item("forged", "todos", {
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "forged-task" },
+          }),
+          item("malformed", "todos", {
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "  " },
+          }),
+        ],
+        looks_resolved: [
+          item("resolved", "looks_resolved", {
+            structuredPayload: {
+              serverOwnedFollowup: true,
+              trackingState: "looks_resolved",
+              recommendationId: "recommendation-1",
+              taskId: "legacy-resolved",
+            },
+          }),
+        ],
+        untracked_followups: [
+          item("untracked", "untracked_followups", {
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "untracked-task" },
+          }),
+        ],
+      }),
+      userId: "user-1",
+      access: ACCESS,
+      loadVisibleTasks,
+      logger: createTestLogger(),
+    });
+
+    expect(loadVisibleTasks).toHaveBeenCalledWith(["legacy-durable", "forged-task", "legacy-resolved"], ACCESS);
+    expect(result.sections.todos).toEqual([
+      expect.objectContaining({
+        id: "durable",
+        taskId: "legacy-durable",
+        task: expect.objectContaining({ id: "legacy-durable" }),
+      }),
+      expect.objectContaining({ id: "ordinary", taskId: null, task: null }),
+      expect.objectContaining({ id: "forged", taskId: null, task: null }),
+      expect.objectContaining({ id: "malformed", taskId: null, task: null }),
+    ]);
+    expect(result.sections.looks_resolved[0]).toEqual(
+      expect.objectContaining({ taskId: "legacy-resolved", task: expect.objectContaining({ id: "legacy-resolved" }) }),
+    );
+    expect(result.sections.untracked_followups[0]).toEqual(expect.objectContaining({ taskId: null, task: null }));
+  });
+
+  it("does not expose canonical or legacy ids when the task is missing, expired, or invisible", async () => {
+    const result = await hydrateDailyBriefTaskState({
+      output: output({
+        todos: [
+          item("canonical", "todos", { taskId: "hidden-canonical" }),
+          item("legacy", "todos", {
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "hidden-legacy" },
+          }),
+        ],
+      }),
+      userId: "user-1",
+      access: ACCESS,
+      loadVisibleTasks: vi.fn(async () => []),
+      logger: createTestLogger(),
+    });
+
+    expect(result.sections.todos).toEqual([
+      expect.objectContaining({ id: "canonical", taskId: null, task: null }),
+      expect.objectContaining({ id: "legacy", taskId: null, task: null }),
+    ]);
+  });
+
+  it("rejects legacy fallback when the authenticated reader does not own the brief", async () => {
+    const loadVisibleTasks = vi.fn(async () => [task({ id: "legacy-task" })]);
+    const result = await hydrateDailyBriefTaskState({
+      output: output(
+        {
+          todos: [
+            item("legacy", "todos", {
+              structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "legacy-task" },
+            }),
+          ],
+        },
+        "another-user",
+      ),
+      userId: "user-1",
+      access: ACCESS,
+      loadVisibleTasks,
+      logger: createTestLogger(),
+    });
+
+    expect(loadVisibleTasks).not.toHaveBeenCalled();
+    expect(result.sections.todos[0]).toEqual(expect.objectContaining({ taskId: null, task: null }));
+  });
+
+  it("caps unique candidates and logs count-only hydration classifications", async () => {
+    const logger = createTestLogger();
+    const debug = vi.spyOn(logger, "debug");
+    const loadVisibleTasks = vi.fn(async (ids: string[]) => ids.map((id) => task({ id, source_task_id: id })));
+    const todos = Array.from({ length: MAX_BRIEF_TASK_LINKS + 1 }, (_, index) =>
+      item(`item-${index}`, "todos", {
+        structuredPayload: {
+          serverOwnedFollowup: true,
+          trackingState: "durable",
+          taskId: `legacy-${index}`,
+        },
+      }),
+    );
+
+    const result = await hydrateDailyBriefTaskState({
+      output: output({ todos }),
+      userId: "user-1",
+      access: ACCESS,
+      loadVisibleTasks,
+      logger,
+    });
+
+    expect(loadVisibleTasks.mock.calls[0]?.[0]).toHaveLength(MAX_BRIEF_TASK_LINKS);
+    expect(result.sections.todos[MAX_BRIEF_TASK_LINKS]).toEqual(expect.objectContaining({ taskId: null, task: null }));
+    expect(debug).toHaveBeenCalledWith(
+      {
+        event: "daily_brief_task_hydration",
+        outputId: "brief-1",
+        canonicalCandidates: 0,
+        legacyCandidates: MAX_BRIEF_TASK_LINKS + 1,
+        canonicalHydrated: 0,
+        legacyHydrated: MAX_BRIEF_TASK_LINKS,
+        rejectedLegacyCandidates: 0,
+        rejectedLegacyReasons: {},
+        overflowCandidates: 1,
+      },
+      "Daily Brief: hydrated live task links",
+    );
+  });
+});
+
+describe("Daily Brief task hydration routes", () => {
+  it("includes stored task ids in generic item shaping", () => {
+    const apiItem = dailyBriefDefinition.toApiItem({
+      id: "item-1",
+      agent_output_id: "brief-1",
+      task_id: "task-1",
+      section_key: "todos",
+      title: "Snapshot title",
+      summary: "Snapshot summary",
+      priority: "medium",
+      label: "open",
+      display_ref: null,
+      action_type: null,
+      action_label: null,
+      action_prompt: null,
+      knowledge_refs_json: "{}",
+      source_url: null,
+      structured_payload_json: null,
+      sort_order: 0,
+      created_at: "2026-07-17T08:00:00.000Z",
+      knowledgeRefs: { entityIds: [], fileIds: [] },
+      structuredPayload: null,
+    });
+
+    expect(apiItem.taskId).toBe("task-1");
+  });
+
+  it("hydrates current status through both latest and by-id endpoints", async () => {
+    const db = await createTestDb();
+    try {
+      await db
+        .insertInto("users")
+        .values({ id: "user-1", name: "User", email: "user@example.com", auth_role: "member" })
+        .execute();
+      const created = await createTaskRepository(db).upsertTask({
+        parentEntityId: null,
+        parentSourceRef: null,
+        parentName: null,
+        source: "summary",
+        externalRef: null,
+        title: "Current task title",
+        status: "open",
+        statusRaw: "action_item",
+        statusAuthority: "local",
+        assigneeEntityId: null,
+        assigneeName: null,
+        priority: "high",
+        dueAt: null,
+        provenance: "summary",
+        sourceTaskId: "route-task",
+        createdByUserId: "user-1",
+      });
+      const brief = output({ todos: [item("route-item", "todos", { taskId: created.taskId })] });
+      const service = {
+        resolveUserId: vi.fn(async () => "user-1"),
+        getLatestForUser: vi.fn(async () => ({
+          output: brief,
+          running: false,
+          outputDate: "2026-07-17",
+          timezone: "UTC",
+          enabledSections: ["todos"],
+        })),
+        getByIdForUser: vi.fn(async () => brief),
+      } as unknown as AgentRunService;
+      const app = new Hono();
+      app.use("*", async (c, next) => {
+        c.set("sub", "auth-user");
+        c.set("email", "user@example.com");
+        c.set("role", "member");
+        c.set("adminCanReadAllFiles", false);
+        await next();
+      });
+      app.route("/api/daily-briefs", dailyBriefRoutes(service, db, createTestLogger()));
+
+      const latest = await app.request("/api/daily-briefs");
+      expect(latest.status).toBe(200);
+      await expect(latest.json()).resolves.toMatchObject({
+        brief: { sections: { todos: [{ taskId: created.taskId, task: { status: "open" } }] } },
+      });
+
+      await db
+        .updateTable("tasks")
+        .set({
+          status: "done",
+          status_raw: "done",
+          completed_at: "2026-07-17T10:00:00.000Z",
+          updated_at: "2026-07-17T10:00:00.000Z",
+        })
+        .where("id", "=", created.taskId)
+        .execute();
+
+      const byId = await app.request("/api/daily-briefs/brief-1");
+      expect(byId.status).toBe(200);
+      await expect(byId.json()).resolves.toMatchObject({
+        brief: {
+          sections: {
+            todos: [
+              {
+                title: "Snapshot route-item",
+                taskId: created.taskId,
+                task: { title: "Current task title", status: "done", completedAt: "2026-07-17T10:00:00.000Z" },
+              },
+            ],
+          },
+        },
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
+});

--- a/packages/server/src/agents/routes-task-hydration.test.ts
+++ b/packages/server/src/agents/routes-task-hydration.test.ts
@@ -279,6 +279,56 @@ describe("hydrateDailyBriefTaskState", () => {
       "Daily Brief: hydrated live task links",
     );
   });
+
+  it("logs rejected legacy reason counts without item titles or content", async () => {
+    const logger = createTestLogger();
+    const debug = vi.spyOn(logger, "debug");
+    await hydrateDailyBriefTaskState({
+      output: output({
+        todos: [
+          item("ordinary", "todos", {
+            title: "Sensitive ordinary title",
+            structuredPayload: { taskId: "ordinary-task" },
+          }),
+          item("malformed", "todos", {
+            title: "Sensitive malformed title",
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: " " },
+          }),
+          item("missing", "todos", {
+            title: "Sensitive missing title",
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "missing-task" },
+          }),
+        ],
+        untracked_followups: [
+          item("untracked", "untracked_followups", {
+            title: "Sensitive untracked title",
+            structuredPayload: { serverOwnedFollowup: true, trackingState: "durable", taskId: "untracked-task" },
+          }),
+        ],
+      }),
+      userId: "user-1",
+      access: ACCESS,
+      loadVisibleTasks: vi.fn(async () => []),
+      logger,
+    });
+
+    expect(debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canonicalCandidates: 0,
+        legacyCandidates: 1,
+        legacyHydrated: 0,
+        rejectedLegacyCandidates: 4,
+        rejectedLegacyReasons: {
+          not_server_owned: 1,
+          malformed_task_id: 1,
+          invalid_section_shape: 1,
+          not_visible_or_missing: 1,
+        },
+      }),
+      "Daily Brief: hydrated live task links",
+    );
+    expect(JSON.stringify(debug.mock.calls[0]?.[0])).not.toContain("Sensitive");
+  });
 });
 
 describe("Daily Brief task hydration routes", () => {

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
-import type { Kysely } from "kysely";
+import type { Kysely, Selectable } from "kysely";
+import { type TaskAccessContext, resolveTaskAccessContext, toTaskDto } from "../api/task-access";
 import type {
   AgentDeliveryConfig,
   AgentDeliveryMention,
@@ -12,7 +13,9 @@ import type {
   AgentSourceConfig,
   AgentSourceKey,
 } from "../db/repositories/agent-outputs";
-import type { DB } from "../db/schema";
+import { createTaskRepository } from "../db/repositories/tasks";
+import type { DB, TasksTable } from "../db/schema";
+import type { Logger } from "../logger";
 import { CONVERSATION_SUMMARY_AGENT_KEY } from "./definitions/conversation-summary";
 import { DAILY_BRIEF_AGENT_KEY } from "./definitions/daily-brief";
 import { getAgentDefinition } from "./registry";
@@ -23,7 +26,183 @@ import {
   AgentSourceTargetError,
   type AgentViewerRole,
 } from "./service";
-import type { AgentDefinition } from "./types";
+import type { AgentApiItem, AgentDefinition } from "./types";
+
+export const MAX_BRIEF_TASK_LINKS = 100;
+
+export interface DailyBriefTaskState {
+  id: string;
+  title: string;
+  status: "open" | "in_progress" | "done" | "dropped";
+  statusRaw: string | null;
+  statusAuthority: string;
+  priority: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+  canEditStatus: boolean;
+  readonlyReason: "not_owner" | "external_authority" | null;
+}
+
+type HydratedDailyBriefItem = AgentApiItem & {
+  taskId: string | null;
+  task: DailyBriefTaskState | null;
+};
+
+type TaskLinkCandidate = {
+  taskId: string;
+  kind: "canonical" | "legacy";
+  overflow: boolean;
+};
+
+type LegacyRejectionReason =
+  | "owner_mismatch"
+  | "not_server_owned"
+  | "malformed_task_id"
+  | "invalid_section_shape"
+  | "invalid_task_provenance"
+  | "not_visible_or_missing";
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function legacyTaskLinkCandidate(
+  output: AgentOutputApi,
+  item: AgentApiItem,
+  userId: string,
+): { taskId: string } | { reason: LegacyRejectionReason } | null {
+  const payload = item.structuredPayload;
+  if (!payload || (!Object.hasOwn(payload, "taskId") && payload.serverOwnedFollowup !== true)) return null;
+  if (output.userId !== userId) return { reason: "owner_mismatch" };
+  if (payload.serverOwnedFollowup !== true) return { reason: "not_server_owned" };
+  const taskId = nonEmptyString(payload.taskId);
+  if (!taskId) return { reason: "malformed_task_id" };
+  const validTodo = item.sectionKey === "todos" && payload.trackingState === "durable";
+  const validResolved =
+    item.sectionKey === "looks_resolved" &&
+    payload.trackingState === "looks_resolved" &&
+    nonEmptyString(payload.recommendationId) !== null;
+  if (!validTodo && !validResolved) return { reason: "invalid_section_shape" };
+  return { taskId };
+}
+
+function toDailyBriefTaskState(task: Selectable<TasksTable>, access: TaskAccessContext): DailyBriefTaskState {
+  const dto = toTaskDto(task, access);
+  return {
+    id: dto.id,
+    title: dto.title,
+    status: dto.status as DailyBriefTaskState["status"],
+    statusRaw: dto.statusRaw,
+    statusAuthority: dto.statusAuthority,
+    priority: dto.priority,
+    completedAt: dto.completedAt,
+    updatedAt: dto.updatedAt,
+    canEditStatus: dto.canEditStatus,
+    readonlyReason: dto.readonlyReason,
+  };
+}
+
+export async function hydrateDailyBriefTaskState(params: {
+  output: AgentOutputApi;
+  userId: string;
+  access: TaskAccessContext;
+  loadVisibleTasks: (taskIds: string[], access: TaskAccessContext) => Promise<Selectable<TasksTable>[]>;
+  logger: Pick<Logger, "debug">;
+}): Promise<AgentOutputApi & { sections: Record<string, HydratedDailyBriefItem[]> }> {
+  const candidateByItem = new Map<AgentApiItem, TaskLinkCandidate>();
+  const idsToLoad: string[] = [];
+  const acceptedIds = new Set<string>();
+  const rejectedLegacyReasons: Partial<Record<LegacyRejectionReason, number>> = {};
+  let canonicalCandidates = 0;
+  let legacyCandidates = 0;
+  let rejectedLegacyCandidates = 0;
+  let overflowCandidates = 0;
+
+  const rejectLegacy = (reason: LegacyRejectionReason) => {
+    rejectedLegacyCandidates += 1;
+    rejectedLegacyReasons[reason] = (rejectedLegacyReasons[reason] ?? 0) + 1;
+  };
+
+  for (const items of Object.values(params.output.sections)) {
+    for (const item of items) {
+      let candidate: Omit<TaskLinkCandidate, "overflow"> | null = null;
+      if (item.taskId !== null && item.taskId !== undefined) {
+        const taskId = nonEmptyString(item.taskId);
+        if (taskId) {
+          canonicalCandidates += 1;
+          candidate = { taskId, kind: "canonical" };
+        }
+      } else {
+        const legacy = legacyTaskLinkCandidate(params.output, item, params.userId);
+        if (legacy && "reason" in legacy) {
+          rejectLegacy(legacy.reason);
+        } else if (legacy) {
+          legacyCandidates += 1;
+          candidate = { taskId: legacy.taskId, kind: "legacy" };
+        }
+      }
+      if (!candidate) continue;
+
+      let overflow = false;
+      if (!acceptedIds.has(candidate.taskId)) {
+        if (acceptedIds.size >= MAX_BRIEF_TASK_LINKS) {
+          overflow = true;
+          overflowCandidates += 1;
+        } else {
+          acceptedIds.add(candidate.taskId);
+          idsToLoad.push(candidate.taskId);
+        }
+      }
+      candidateByItem.set(item, { ...candidate, overflow });
+    }
+  }
+
+  const visibleTasks = idsToLoad.length === 0 ? [] : await params.loadVisibleTasks(idsToLoad, params.access);
+  const visibleById = new Map(visibleTasks.map((task) => [task.id, task]));
+  let canonicalHydrated = 0;
+  let legacyHydrated = 0;
+  const sections: Record<string, HydratedDailyBriefItem[]> = {};
+
+  for (const [sectionKey, items] of Object.entries(params.output.sections)) {
+    sections[sectionKey] = items.map((item) => {
+      const candidate = candidateByItem.get(item);
+      if (!candidate || candidate.overflow) return { ...item, taskId: null, task: null };
+      const task = visibleById.get(candidate.taskId);
+      if (!task) {
+        if (candidate.kind === "legacy") rejectLegacy("not_visible_or_missing");
+        return { ...item, taskId: null, task: null };
+      }
+      if (candidate.kind === "legacy" && (task.provenance !== "summary" || !task.source_anchor_key)) {
+        rejectLegacy("invalid_task_provenance");
+        return { ...item, taskId: null, task: null };
+      }
+      if (candidate.kind === "canonical") canonicalHydrated += 1;
+      else legacyHydrated += 1;
+      return {
+        ...item,
+        taskId: task.id,
+        task: toDailyBriefTaskState(task, params.access),
+      };
+    });
+  }
+
+  params.logger.debug(
+    {
+      event: "daily_brief_task_hydration",
+      outputId: params.output.id,
+      canonicalCandidates,
+      legacyCandidates,
+      canonicalHydrated,
+      legacyHydrated,
+      rejectedLegacyCandidates,
+      rejectedLegacyReasons,
+      overflowCandidates,
+    },
+    "Daily Brief: hydrated live task links",
+  );
+
+  return { ...params.output, sections };
+}
 
 async function getCurrentUserId(c: { get: (key: "sub" | "email") => string | undefined }, service: AgentRunService) {
   const sub = c.get("sub");
@@ -80,8 +259,20 @@ async function hasCalendarConnector(db: Kysely<DB>, userId: string): Promise<boo
   return Boolean(row);
 }
 
-export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>) {
+export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>, logger: Pick<Logger, "debug">) {
   const routes = new Hono();
+  const taskRepo = createTaskRepository(db);
+
+  const hydrate = async (c: Parameters<typeof resolveTaskAccessContext>[1], output: AgentOutputApi, userId: string) => {
+    const access = await resolveTaskAccessContext(db, c, userId);
+    return hydrateDailyBriefTaskState({
+      output,
+      userId,
+      access,
+      loadVisibleTasks: (taskIds, taskAccess) => taskRepo.listVisibleTasksByIds(taskIds, taskAccess),
+      logger,
+    });
+  };
 
   routes.get("/", async (c) => {
     const userId = await getCurrentUserId(c, service);
@@ -91,8 +282,9 @@ export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>) {
       service.getLatestForUser(DAILY_BRIEF_AGENT_KEY, userId, date),
       hasCalendarConnector(db, userId),
     ]);
+    const output = result.output ? await hydrate(c, result.output, userId) : null;
     return c.json({
-      brief: toBriefShape(result.output),
+      brief: toBriefShape(output),
       running: result.running,
       briefDate: result.outputDate,
       timezone: result.timezone,
@@ -106,7 +298,7 @@ export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>) {
     if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
     const output = await service.getByIdForUser(DAILY_BRIEF_AGENT_KEY, c.req.param("id"), userId);
     if (!output) return c.json({ error: { code: "NOT_FOUND", message: "Daily Brief not found" } }, 404);
-    return c.json({ brief: toBriefShape(output) });
+    return c.json({ brief: toBriefShape(await hydrate(c, output, userId)) });
   });
 
   routes.post("/", async (c) => {

--- a/packages/server/src/agents/run/generation.test.ts
+++ b/packages/server/src/agents/run/generation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { AgentOutputItemInput } from "../../db/repositories/agent-outputs";
-import { validateAgentOutputLimits } from "./generation";
+import type { AgentOutputItemInput, PersistedAgentOutputItemRef } from "../../db/repositories/agent-outputs";
+import { pairPersistedVisibleItems, validateAgentOutputLimits } from "./generation";
 
 function item(sectionKey: string, index: number): AgentOutputItemInput {
   return {
@@ -49,5 +49,28 @@ describe("validateAgentOutputLimits", () => {
         maxItemsPerSection: 10,
       }),
     ).toThrow("25-item");
+  });
+});
+
+describe("pairPersistedVisibleItems", () => {
+  it("pairs persisted ids with visible items by array position, not title", () => {
+    const items = [item("todos", 0), item("todos", 1)];
+    items[0].title = "Same title";
+    items[1].title = "Same title";
+    const refs: PersistedAgentOutputItemRef[] = [
+      { id: "item-a", sectionKey: "todos", sortOrder: 0 },
+      { id: "item-b", sectionKey: "todos", sortOrder: 1 },
+    ];
+
+    expect(pairPersistedVisibleItems(items, refs)).toEqual([
+      { id: "item-a", item: items[0] },
+      { id: "item-b", item: items[1] },
+    ]);
+  });
+
+  it("rejects a persisted-item mismatch instead of guessing", () => {
+    expect(() =>
+      pairPersistedVisibleItems([item("todos", 0)], [{ id: "wrong", sectionKey: "active_projects", sortOrder: 0 }]),
+    ).toThrow("persisted item mismatch");
   });
 });

--- a/packages/server/src/agents/run/generation.ts
+++ b/packages/server/src/agents/run/generation.ts
@@ -15,6 +15,7 @@ import type {
   AgentRoute,
   AgentRouteDestination,
   AgentSourceConfig,
+  PersistedAgentOutputItemRef,
 } from "../../db/repositories/agent-outputs";
 import { requireAgentDefinition } from "../registry";
 import type { AgentDefinition } from "../types";
@@ -30,6 +31,22 @@ import type { ScheduledRunAdmission } from "./queue";
 import { enabledSectionsForScope, maxItemsPerSectionForScope, sourceAsDelivery } from "./routing";
 
 const INTERNAL_OUTPUT_SECTION_ITEM_LIMIT = 25;
+
+export function pairPersistedVisibleItems(
+  items: AgentOutputItemInput[],
+  refs: PersistedAgentOutputItemRef[],
+): Array<{ id: string; item: AgentOutputItemInput }> {
+  if (items.length !== refs.length) {
+    throw new Error(`Agent output persisted item mismatch: expected ${items.length}, received ${refs.length}.`);
+  }
+  return refs.map((ref, index) => {
+    const item = items[index];
+    if (!item || item.sectionKey !== ref.sectionKey || item.sortOrder !== ref.sortOrder) {
+      throw new Error(`Agent output persisted item mismatch at index ${index}.`);
+    }
+    return { id: ref.id, item };
+  });
+}
 
 export function validateAgentOutputLimits(input: {
   items: AgentOutputItemInput[];
@@ -449,12 +466,13 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         await this.validateItemRefs(def, itemsForHooks);
         const rawPayload = rawPayloadWithRunMetadata(payload.rawPayload, params.runtimeContext);
         assertAgentOutputPayloadSize(rawPayload);
-        await this.repo.completeOutput({
+        const persistedRefs = await this.repo.completeOutput({
           outputId: params.outputId,
           masthead: payload.masthead,
           rawPayload,
           items: visibleItems,
         });
+        const persistedItems = pairPersistedVisibleItems(visibleItems, persistedRefs);
         if (def.onOutputSaved) {
           await def.onOutputSaved({
             db: this.deps.db,
@@ -463,6 +481,7 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
             userId: params.userId,
             outputId: params.outputId,
             items: itemsForHooks,
+            persistedItems,
             createTasks: params.createTasks,
             runtimeContext: params.runtimeContext,
           });

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -75,6 +75,7 @@ export interface AgentSourceConfigDef {
 
 export interface AgentApiItem {
   id: string;
+  taskId?: string | null;
   sectionKey: string;
   title: string;
   summary: string;

--- a/packages/server/src/agents/types.ts
+++ b/packages/server/src/agents/types.ts
@@ -40,6 +40,10 @@ export interface AgentOutputSavedArgs {
   userId: string;
   outputId: string;
   items: AgentOutputItemInput[];
+  persistedItems?: Array<{
+    id: string;
+    item: AgentOutputItemInput;
+  }>;
   createTasks: boolean;
   runtimeContext: Record<string, unknown>;
 }

--- a/packages/server/src/api/entities/task-routes.ts
+++ b/packages/server/src/api/entities/task-routes.ts
@@ -1,122 +1,25 @@
 import { Hono } from "hono";
-import type { Kysely, Selectable } from "kysely";
+import type { Kysely } from "kysely";
 import { createEntityRepository } from "../../db/repositories/entities";
 import { type TaskStatus, createTaskRepository } from "../../db/repositories/tasks";
-import { createUserRepository } from "../../db/repositories/users";
-import type { DB, TasksTable } from "../../db/schema";
-import { getContentViewer, getFileViewer, isAdmin } from "../auth-helpers";
-
-const TASK_STATUSES = new Set(["open", "in_progress", "done", "dropped"]);
-const DEFAULT_LIMIT = 100;
-const MAX_LIMIT = 200;
-
-function parseTaskLimit(value: string | undefined): number {
-  if (value === undefined) return DEFAULT_LIMIT;
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_LIMIT;
-  return Math.min(parsed, MAX_LIMIT);
-}
-
-function canEditTaskStatus(
-  task: Selectable<TasksTable>,
-  userId: string | undefined,
-  assigneeEntityIds: string[] = [],
-  canEditAllLocalTasks = false,
-): boolean {
-  const isCreator = Boolean(userId && task.created_by_user_id === userId);
-  const isAssignee = Boolean(task.assignee_entity_id && assigneeEntityIds.includes(task.assignee_entity_id));
-  const isAdminEditable = canEditAllLocalTasks && task.status_authority === "local";
-  return (
-    (isCreator || isAssignee || isAdminEditable) &&
-    task.status_authority === "local" &&
-    (task.provenance === "brief" || task.provenance === "summary")
-  );
-}
-
-type TaskCreator = { name: string; email: string | null };
-
-function readonlyReason(
-  task: Selectable<TasksTable>,
-  userId: string | undefined,
-  assigneeEntityIds: string[] = [],
-  canEditAllLocalTasks = false,
-): "not_owner" | "external_authority" | null {
-  if (canEditTaskStatus(task, userId, assigneeEntityIds, canEditAllLocalTasks)) return null;
-  if (task.status_authority === "external" || task.provenance === "structural") return "external_authority";
-  if (task.provenance === "brief" || task.provenance === "summary") return "not_owner";
-  return "external_authority";
-}
-
-async function loadTaskCreators(db: Kysely<DB>, tasks: Selectable<TasksTable>[]): Promise<Map<string, TaskCreator>> {
-  const ids = [...new Set(tasks.flatMap((task) => (task.created_by_user_id ? [task.created_by_user_id] : [])))];
-  if (ids.length === 0) return new Map();
-  const rows = await db.selectFrom("users").select(["id", "name", "email"]).where("id", "in", ids).execute();
-  return new Map(rows.map((row) => [row.id, { name: row.name, email: row.email }]));
-}
-
-function toTaskDto(
-  task: Selectable<TasksTable>,
-  userId: string | undefined,
-  creators: Map<string, TaskCreator> = new Map(),
-  assigneeEntityIds: string[] = [],
-  canEditAllLocalTasks = false,
-) {
-  const creator = task.created_by_user_id ? (creators.get(task.created_by_user_id) ?? null) : null;
-  const isOwnedByViewer = Boolean(userId && task.created_by_user_id === userId);
-  return {
-    id: task.id,
-    parentEntityId: task.parent_entity_id,
-    parentSourceRef: task.parent_source_ref,
-    parentName: task.parent_name,
-    source: task.source,
-    externalRef: task.external_ref,
-    title: task.title,
-    status: task.status,
-    statusRaw: task.status_raw,
-    statusAuthority: task.status_authority,
-    assigneeEntityId: task.assignee_entity_id,
-    assigneeName: task.assignee_name,
-    proposedAssigneeName: task.proposed_assignee_name,
-    priority: task.priority,
-    dueAt: task.due_at,
-    provenance: task.provenance,
-    sourceTaskId: task.source_task_id,
-    createdByUserId: task.created_by_user_id,
-    createdByUserName: creator?.name ?? null,
-    createdByUserEmail: creator?.email ?? null,
-    isOwnedByViewer,
-    readonlyReason: readonlyReason(task, userId, assigneeEntityIds, canEditAllLocalTasks),
-    completedAt: task.completed_at,
-    updatedAt: task.updated_at,
-    canEditStatus: canEditTaskStatus(task, userId, assigneeEntityIds, canEditAllLocalTasks),
-  };
-}
-
-async function loadViewerPersonEntityIds(
-  entityRepo: Pick<ReturnType<typeof createEntityRepository>, "getPersonEntitiesByEmail">,
-  userRepo: Pick<ReturnType<typeof createUserRepository>, "getVerifiedEmailsForUser">,
-  userId: string | undefined,
-  fallbackEmail: string | null,
-): Promise<string[]> {
-  const verifiedEmails = userId ? await userRepo.getVerifiedEmailsForUser(userId).catch(() => []) : [];
-  const emails = [...new Set([...verifiedEmails, ...(fallbackEmail ? [fallbackEmail] : [])])];
-  if (emails.length === 0) return [];
-  const peopleByEmail = await Promise.all(
-    emails.map((email) => entityRepo.getPersonEntitiesByEmail(email).catch(() => [])),
-  );
-  return [...new Set(peopleByEmail.flat().map((person) => person.id))];
-}
+import type { DB } from "../../db/schema";
+import { getFileViewer } from "../auth-helpers";
+import {
+  TASK_STATUSES,
+  canEditTaskStatus,
+  loadTaskCreators,
+  parseTaskLimit,
+  resolveTaskAccessContext,
+  toTaskDto,
+} from "../task-access";
 
 export function createTaskRoutes(db: Kysely<DB>) {
   const routes = new Hono();
   const entityRepo = createEntityRepository(db);
   const taskRepo = createTaskRepository(db);
-  const userRepo = createUserRepository(db);
 
   routes.get("/:id/tasks", async (c) => {
-    const userId = c.get("sub");
     const parentViewer = getFileViewer(c);
-    const taskViewer = getContentViewer(c);
     const entity = await entityRepo.getEntity(c.req.param("id"), parentViewer);
     if (!entity) return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
     const status = c.req.query("status");
@@ -124,19 +27,18 @@ export function createTaskRoutes(db: Kysely<DB>) {
       return c.json({ error: { code: "BAD_REQUEST", message: "Invalid status" } }, 400);
     }
     const limit = parseTaskLimit(c.req.query("limit"));
-    const assigneeEntityIds = await loadViewerPersonEntityIds(entityRepo, userRepo, userId, taskViewer.email);
-    const canEditAllLocalTasks = isAdmin(c);
+    const access = await resolveTaskAccessContext(db, c);
     const tasks = await taskRepo.listTasksByParent(entity.id, {
-      viewer: taskViewer,
-      userId,
-      assigneeEntityIds,
-      canReadAllLocalTasks: canEditAllLocalTasks,
+      viewer: access.viewer,
+      userId: access.userId,
+      assigneeEntityIds: access.assigneeEntityIds,
+      canReadAllLocalTasks: access.canReadAllLocalTasks,
       status: status as TaskStatus | undefined,
       limit,
     });
     const creators = await loadTaskCreators(db, tasks);
     return c.json({
-      tasks: tasks.map((task) => toTaskDto(task, userId, creators, assigneeEntityIds, canEditAllLocalTasks)),
+      tasks: tasks.map((task) => toTaskDto(task, access, creators)),
     });
   });
 
@@ -159,21 +61,20 @@ export function createTaskRoutes(db: Kysely<DB>) {
     if (!task || task.parent_entity_id !== entity.id) {
       return c.json({ error: { code: "NOT_FOUND", message: "Task not found" } }, 404);
     }
-    const assigneeEntityIds = await loadViewerPersonEntityIds(entityRepo, userRepo, userId, getContentViewer(c).email);
-    const canEditAllLocalTasks = isAdmin(c);
-    if (!canEditTaskStatus(task, userId, assigneeEntityIds, canEditAllLocalTasks)) {
+    const access = await resolveTaskAccessContext(db, c);
+    if (!canEditTaskStatus(task, access)) {
       return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
     }
     const updated = await taskRepo.updateLocalTaskStatus({
       taskId: task.id,
       userId,
-      assigneeEntityIds,
-      canEditAllLocalTasks,
+      assigneeEntityIds: access.assigneeEntityIds,
+      canEditAllLocalTasks: access.canEditAllLocalTasks,
       status: body.status as TaskStatus,
     });
     if (!updated) return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
     const creators = await loadTaskCreators(db, [updated]);
-    return c.json({ task: toTaskDto(updated, userId, creators, assigneeEntityIds, canEditAllLocalTasks) });
+    return c.json({ task: toTaskDto(updated, access, creators) });
   });
 
   return routes;

--- a/packages/server/src/api/task-access.ts
+++ b/packages/server/src/api/task-access.ts
@@ -1,0 +1,130 @@
+import type { Context } from "hono";
+import type { Kysely, Selectable } from "kysely";
+import { createEntityRepository } from "../db/repositories/entities";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB, TasksTable } from "../db/schema";
+import { type FileViewer, getContentViewer, isAdmin } from "./auth-helpers";
+
+export const TASK_STATUSES = new Set(["open", "in_progress", "done", "dropped"]);
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 200;
+
+export interface TaskAccessContext {
+  userId: string;
+  viewer: FileViewer;
+  assigneeEntityIds: string[];
+  canReadAllLocalTasks: boolean;
+  canEditAllLocalTasks: boolean;
+}
+
+export function parseTaskLimit(value: string | undefined): number {
+  if (value === undefined) return DEFAULT_LIMIT;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+export function canEditTaskStatus(
+  task: Selectable<TasksTable>,
+  access: Pick<TaskAccessContext, "userId" | "assigneeEntityIds" | "canEditAllLocalTasks">,
+): boolean {
+  const isCreator = task.created_by_user_id === access.userId;
+  const isAssignee = Boolean(task.assignee_entity_id && access.assigneeEntityIds.includes(task.assignee_entity_id));
+  const isAdminEditable = access.canEditAllLocalTasks && task.status_authority === "local";
+  return (
+    (isCreator || isAssignee || isAdminEditable) &&
+    task.status_authority === "local" &&
+    (task.provenance === "brief" || task.provenance === "summary")
+  );
+}
+
+export function readonlyReason(
+  task: Selectable<TasksTable>,
+  access: Pick<TaskAccessContext, "userId" | "assigneeEntityIds" | "canEditAllLocalTasks">,
+): "not_owner" | "external_authority" | null {
+  if (canEditTaskStatus(task, access)) return null;
+  if (task.status_authority === "external" || task.provenance === "structural") return "external_authority";
+  if (task.provenance === "brief" || task.provenance === "summary") return "not_owner";
+  return "external_authority";
+}
+
+type TaskCreator = { name: string; email: string | null };
+
+export async function loadTaskCreators(
+  db: Kysely<DB>,
+  tasks: Selectable<TasksTable>[],
+): Promise<Map<string, TaskCreator>> {
+  const ids = [...new Set(tasks.flatMap((task) => (task.created_by_user_id ? [task.created_by_user_id] : [])))];
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .selectFrom("users")
+    .select(["id", "name", "email"])
+    .where("id", "in", ids)
+    .limit(ids.length)
+    .execute();
+  return new Map(rows.map((row) => [row.id, { name: row.name, email: row.email }]));
+}
+
+export function toTaskDto(
+  task: Selectable<TasksTable>,
+  access: Pick<TaskAccessContext, "userId" | "assigneeEntityIds" | "canEditAllLocalTasks">,
+  creators: Map<string, TaskCreator> = new Map(),
+) {
+  const creator = task.created_by_user_id ? (creators.get(task.created_by_user_id) ?? null) : null;
+  return {
+    id: task.id,
+    parentEntityId: task.parent_entity_id,
+    parentSourceRef: task.parent_source_ref,
+    parentName: task.parent_name,
+    source: task.source,
+    externalRef: task.external_ref,
+    title: task.title,
+    status: task.status,
+    statusRaw: task.status_raw,
+    statusAuthority: task.status_authority,
+    assigneeEntityId: task.assignee_entity_id,
+    assigneeName: task.assignee_name,
+    proposedAssigneeName: task.proposed_assignee_name,
+    priority: task.priority,
+    dueAt: task.due_at,
+    provenance: task.provenance,
+    sourceTaskId: task.source_task_id,
+    createdByUserId: task.created_by_user_id,
+    createdByUserName: creator?.name ?? null,
+    createdByUserEmail: creator?.email ?? null,
+    isOwnedByViewer: task.created_by_user_id === access.userId,
+    readonlyReason: readonlyReason(task, access),
+    completedAt: task.completed_at,
+    updatedAt: task.updated_at,
+    canEditStatus: canEditTaskStatus(task, access),
+  };
+}
+
+export async function loadViewerPersonEntityIds(
+  db: Kysely<DB>,
+  userId: string,
+  fallbackEmail: string | null,
+): Promise<string[]> {
+  const entityRepo = createEntityRepository(db);
+  const userRepo = createUserRepository(db);
+  const verifiedEmails = await userRepo.getVerifiedEmailsForUser(userId).catch(() => []);
+  const emails = [...new Set([...verifiedEmails, ...(fallbackEmail ? [fallbackEmail] : [])])];
+  if (emails.length === 0) return [];
+  const peopleByEmail = await Promise.all(
+    emails.map((email) => entityRepo.getPersonEntitiesByEmail(email).catch(() => [])),
+  );
+  return [...new Set(peopleByEmail.flat().map((person) => person.id))];
+}
+
+export async function resolveTaskAccessContext(db: Kysely<DB>, c: Context): Promise<TaskAccessContext> {
+  const userId = c.get("sub");
+  const viewer = getContentViewer(c);
+  const admin = isAdmin(c);
+  return {
+    userId,
+    viewer,
+    assigneeEntityIds: await loadViewerPersonEntityIds(db, userId, viewer.email),
+    canReadAllLocalTasks: admin,
+    canEditAllLocalTasks: admin,
+  };
+}

--- a/packages/server/src/api/task-access.ts
+++ b/packages/server/src/api/task-access.ts
@@ -116,8 +116,12 @@ export async function loadViewerPersonEntityIds(
   return [...new Set(peopleByEmail.flat().map((person) => person.id))];
 }
 
-export async function resolveTaskAccessContext(db: Kysely<DB>, c: Context): Promise<TaskAccessContext> {
-  const userId = c.get("sub");
+export async function resolveTaskAccessContext(
+  db: Kysely<DB>,
+  c: Context,
+  resolvedUserId?: string,
+): Promise<TaskAccessContext> {
+  const userId = resolvedUserId ?? c.get("sub");
   const viewer = getContentViewer(c);
   const admin = isAdmin(c);
   return {

--- a/packages/server/src/api/tasks.test.ts
+++ b/packages/server/src/api/tasks.test.ts
@@ -1,0 +1,317 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hashPassword } from "../auth/password";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createTaskRepository } from "../db/repositories/tasks";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+
+const PASSWORD = "testpassword123";
+const ADMIN_EMAIL = "admin-tasks@test.com";
+const MEMBER_EMAIL = "member-tasks@test.com";
+const OTHER_EMAIL = "other-tasks@test.com";
+
+describe("GET/PATCH /api/tasks/:taskId", () => {
+  let db: Kysely<DB>;
+  let app: ReturnType<typeof createApp>;
+  let adminId: string;
+  let memberId: string;
+  let otherId: string;
+  let adminCookie: string;
+  let memberCookie: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    const settings = createSettingsRepository(db);
+    const users = createUserRepository(db);
+    await settings.create();
+    const passwordHash = await hashPassword(PASSWORD);
+    await users.create({
+      name: "Admin",
+      email: ADMIN_EMAIL,
+      emailVerified: true,
+      passwordHash,
+      authRole: "admin",
+    });
+    await users.create({
+      name: "Member",
+      email: MEMBER_EMAIL,
+      emailVerified: true,
+      passwordHash,
+      authRole: "member",
+    });
+    await users.create({
+      name: "Other",
+      email: OTHER_EMAIL,
+      emailVerified: true,
+      passwordHash,
+      authRole: "member",
+    });
+    await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+    adminId = (await users.findByEmail(ADMIN_EMAIL))?.id ?? "";
+    memberId = (await users.findByEmail(MEMBER_EMAIL))?.id ?? "";
+    otherId = (await users.findByEmail(OTHER_EMAIL))?.id ?? "";
+    await seedPerson(db, "person-member", "Member", MEMBER_EMAIL);
+    app = createApp(db, createTestConfig(), { logger: createTestLogger() });
+    adminCookie = await login(app, ADMIN_EMAIL);
+    memberCookie = await login(app, MEMBER_EMAIL);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("gets and updates a creator-owned null-parent local task", async () => {
+    const task = await createTaskRepository(db).upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Ownerless task",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "ownerless-task",
+      createdByUserId: memberId,
+    });
+
+    const get = await app.request(`/api/tasks/${task.taskId}`, { headers: { Cookie: memberCookie } });
+    const patch = await app.request(`/api/tasks/${task.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    });
+
+    expect(get.status).toBe(200);
+    await expect(get.json()).resolves.toMatchObject({
+      task: {
+        id: task.taskId,
+        parentEntityId: null,
+        status: "open",
+        isOwnedByViewer: true,
+        canEditStatus: true,
+        readonlyReason: null,
+      },
+    });
+    expect(patch.status).toBe(200);
+    await expect(patch.json()).resolves.toMatchObject({
+      task: { id: task.taskId, status: "done", statusRaw: "done", canEditStatus: true },
+    });
+  });
+
+  it("lets an assignee and admin update local tasks while hiding them from unrelated members", async () => {
+    const repo = createTaskRepository(db);
+    const assigned = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Assigned task",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: "person-member",
+      assigneeName: "Member",
+      priority: "high",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "assigned-task",
+      createdByUserId: adminId,
+    });
+    const privateTask = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Other private task",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "other-private-task",
+      createdByUserId: otherId,
+    });
+
+    const assigneeGet = await app.request(`/api/tasks/${assigned.taskId}`, { headers: { Cookie: memberCookie } });
+    const assigneePatch = await app.request(`/api/tasks/${assigned.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "in_progress" }),
+    });
+    const hiddenGet = await app.request(`/api/tasks/${privateTask.taskId}`, { headers: { Cookie: memberCookie } });
+    const hiddenPatch = await app.request(`/api/tasks/${privateTask.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    });
+    const adminPatch = await app.request(`/api/tasks/${privateTask.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    });
+
+    expect(assigneeGet.status).toBe(200);
+    await expect(assigneeGet.json()).resolves.toMatchObject({
+      task: { id: assigned.taskId, isOwnedByViewer: false, canEditStatus: true },
+    });
+    expect(assigneePatch.status).toBe(200);
+    expect(hiddenGet.status).toBe(404);
+    expect(hiddenPatch.status).toBe(404);
+    expect(adminPatch.status).toBe(200);
+  });
+
+  it("returns visible structural tasks as read-only", async () => {
+    await seedVisibleTaskFile(db, adminId);
+    const repo = createTaskRepository(db);
+    const structural = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "linear",
+      externalRef: "LIN-1",
+      title: "External task",
+      status: "in_progress",
+      statusRaw: "In Review",
+      statusAuthority: "external",
+      assigneeEntityId: null,
+      priority: null,
+      dueAt: null,
+      provenance: "structural",
+      sourceTaskId: "linear-task",
+    });
+    await repo.upsertEvidence(structural.taskId, "file", "task-file");
+
+    const get = await app.request(`/api/tasks/${structural.taskId}`, { headers: { Cookie: memberCookie } });
+    const patch = await app.request(`/api/tasks/${structural.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    });
+
+    expect(get.status).toBe(200);
+    await expect(get.json()).resolves.toMatchObject({
+      task: {
+        id: structural.taskId,
+        statusRaw: "In Review",
+        statusAuthority: "external",
+        canEditStatus: false,
+        readonlyReason: "external_authority",
+      },
+    });
+    expect(patch.status).toBe(403);
+  });
+
+  it("rejects invalid status and returns 404 for missing, expired, or invisible task ids", async () => {
+    const repo = createTaskRepository(db);
+    const expired = await repo.upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Expired task",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "expired-task",
+      createdByUserId: memberId,
+    });
+    await db
+      .updateTable("tasks")
+      .set({ valid_to: new Date().toISOString() })
+      .where("id", "=", expired.taskId)
+      .execute();
+
+    const invalid = await app.request(`/api/tasks/${expired.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "closed" }),
+    });
+    const missing = await app.request("/api/tasks/missing", { headers: { Cookie: memberCookie } });
+    const expiredGet = await app.request(`/api/tasks/${expired.taskId}`, { headers: { Cookie: memberCookie } });
+    const expiredPatch = await app.request(`/api/tasks/${expired.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    });
+
+    expect(invalid.status).toBe(400);
+    expect(missing.status).toBe(404);
+    expect(expiredGet.status).toBe(404);
+    expect(expiredPatch.status).toBe(404);
+  });
+});
+
+async function login(app: ReturnType<typeof createApp>, email: string): Promise<string> {
+  const response = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  });
+  return response.headers.get("set-cookie") ?? "";
+}
+
+async function seedPerson(db: Kysely<DB>, id: string, name: string, email: string): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name,
+      source_type: "person",
+      aliases: JSON.stringify([email]),
+      metadata: JSON.stringify({ email }),
+      status: "confirmed",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+}
+
+async function seedVisibleTaskFile(db: Kysely<DB>, ownerId: string): Promise<void> {
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: "task-connector",
+      connector_type: "google_drive",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: ownerId,
+    })
+    .execute();
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: "task-file",
+      connector_config_id: "task-connector",
+      provider_file_id: "task-file",
+      file_name: "Task evidence",
+      file_type: "doc",
+      content_category: "document",
+      source: "google_drive",
+      content_hash: "task-file-hash",
+      share_with_everyone: 1,
+      synced_at: new Date().toISOString(),
+    })
+    .execute();
+}

--- a/packages/server/src/api/tasks.ts
+++ b/packages/server/src/api/tasks.ts
@@ -1,0 +1,45 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { type TaskStatus, createTaskRepository } from "../db/repositories/tasks";
+import type { DB } from "../db/schema";
+import { TASK_STATUSES, canEditTaskStatus, loadTaskCreators, resolveTaskAccessContext, toTaskDto } from "./task-access";
+
+export function taskRoutes(db: Kysely<DB>) {
+  const routes = new Hono();
+  const taskRepo = createTaskRepository(db);
+
+  routes.get("/:taskId", async (c) => {
+    const access = await resolveTaskAccessContext(db, c);
+    const tasks = await taskRepo.listVisibleTasksByIds([c.req.param("taskId")], access);
+    const task = tasks[0];
+    if (!task) return c.json({ error: { code: "NOT_FOUND", message: "Task not found" } }, 404);
+    const creators = await loadTaskCreators(db, [task]);
+    return c.json({ task: toTaskDto(task, access, creators) });
+  });
+
+  routes.patch("/:taskId", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as { status?: unknown };
+    if (typeof body.status !== "string" || !TASK_STATUSES.has(body.status)) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "Invalid status" } }, 400);
+    }
+    const access = await resolveTaskAccessContext(db, c);
+    const tasks = await taskRepo.listVisibleTasksByIds([c.req.param("taskId")], access);
+    const task = tasks[0];
+    if (!task) return c.json({ error: { code: "NOT_FOUND", message: "Task not found" } }, 404);
+    if (!canEditTaskStatus(task, access)) {
+      return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
+    }
+    const updated = await taskRepo.updateLocalTaskStatus({
+      taskId: task.id,
+      userId: access.userId,
+      assigneeEntityIds: access.assigneeEntityIds,
+      canEditAllLocalTasks: access.canEditAllLocalTasks,
+      status: body.status as TaskStatus,
+    });
+    if (!updated) return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
+    const creators = await loadTaskCreators(db, [updated]);
+    return c.json({ task: toTaskDto(updated, access, creators) });
+  });
+
+  return routes;
+}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -150,6 +150,7 @@ import * as m147 from "./migrations/147-whatsapp-backfill-graph-admission";
 import * as m148 from "./migrations/148-whatsapp-pending-slices-index";
 import * as m149 from "./migrations/149-whatsapp-backfill-lifecycle-durability";
 import * as m150 from "./migrations/150-task-durability-steel-thread";
+import * as m151 from "./migrations/151-agent-output-item-task-links";
 import type { DB } from "./schema";
 
 /**
@@ -309,6 +310,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "148-whatsapp-pending-slices-index": m148,
           "149-whatsapp-backfill-lifecycle-durability": m149,
           "150-task-durability-steel-thread": m150,
+          "151-agent-output-item-task-links": m151,
         };
       },
     },

--- a/packages/server/src/db/migrations/151-agent-output-item-task-links.ts
+++ b/packages/server/src/db/migrations/151-agent-output-item-task-links.ts
@@ -1,0 +1,34 @@
+import { type Kysely, sql } from "kysely";
+
+const TABLE = "agent_output_items";
+const COLUMN = "task_id";
+const INDEX = "idx_agent_output_items_task_id";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const columns = await getColumns(db);
+  if (!columns) return;
+
+  if (!columns.has(COLUMN)) {
+    await db.schema
+      .alterTable(TABLE)
+      .addColumn(COLUMN, "text", (col) => col.references("tasks.id").onDelete("set null"))
+      .execute();
+  }
+
+  await sql`CREATE INDEX IF NOT EXISTS ${sql.ref(INDEX)} ON ${sql.table(TABLE)} (${sql.ref(COLUMN)})`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex(INDEX).ifExists().execute();
+
+  const columns = await getColumns(db);
+  if (columns?.has(COLUMN)) {
+    await db.schema.alterTable(TABLE).dropColumn(COLUMN).execute();
+  }
+}
+
+async function getColumns(db: Kysely<unknown>): Promise<Set<string> | null> {
+  const tables = await db.introspection.getTables();
+  const table = tables.find((candidate) => candidate.name === TABLE);
+  return table ? new Set(table.columns.map((column) => column.name)) : null;
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -20,7 +20,7 @@ import type { DB } from "../schema";
 import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
 
-const EXPECTED_MIGRATION_COUNT = 146;
+const EXPECTED_MIGRATION_COUNT = 147;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -181,6 +181,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[143]).toBe("148-whatsapp-pending-slices-index");
     expect(names[144]).toBe("149-whatsapp-backfill-lifecycle-durability");
     expect(names[145]).toBe("150-task-durability-steel-thread");
+    expect(names[146]).toBe("151-agent-output-item-task-links");
   });
 
   it("creates the bounded open-materializable partial index", async () => {
@@ -295,6 +296,109 @@ describe("runMigrations on Postgres — full sequence", () => {
         "idx_task_seed_candidates_route_state",
       ]),
     );
+  });
+
+  it("creates canonical agent output item task links and nulls them when the task is deleted", async () => {
+    const freshDb = await createTestPgDb();
+    try {
+      const columns = await sql<{
+        column_name: string;
+        data_type: string;
+        is_nullable: string;
+      }>`
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'agent_output_items'
+          AND column_name = 'task_id'
+      `.execute(freshDb);
+      expect(columns.rows).toEqual([{ column_name: "task_id", data_type: "text", is_nullable: "YES" }]);
+
+      const foreignKeys = await sql<{
+        column_name: string;
+        foreign_table_name: string;
+        foreign_column_name: string;
+        delete_rule: string;
+      }>`
+        SELECT
+          kcu.column_name,
+          ccu.table_name AS foreign_table_name,
+          ccu.column_name AS foreign_column_name,
+          rc.delete_rule
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+         AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.constraint_column_usage ccu
+          ON ccu.constraint_name = tc.constraint_name
+         AND ccu.table_schema = tc.table_schema
+        JOIN information_schema.referential_constraints rc
+          ON rc.constraint_name = tc.constraint_name
+         AND rc.constraint_schema = tc.table_schema
+        WHERE tc.table_schema = 'public'
+          AND tc.table_name = 'agent_output_items'
+          AND tc.constraint_type = 'FOREIGN KEY'
+          AND kcu.column_name = 'task_id'
+      `.execute(freshDb);
+      expect(foreignKeys.rows).toEqual([
+        {
+          column_name: "task_id",
+          foreign_table_name: "tasks",
+          foreign_column_name: "id",
+          delete_rule: "SET NULL",
+        },
+      ]);
+
+      const indexes = await sql<{ indexname: string }>`
+        SELECT indexname
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'agent_output_items'
+          AND indexname = 'idx_agent_output_items_task_id'
+      `.execute(freshDb);
+      expect(indexes.rows).toEqual([{ indexname: "idx_agent_output_items_task_id" }]);
+
+      await sql`
+        INSERT INTO users (id, name) VALUES ('task-link-user', 'Task Link User')
+      `.execute(freshDb);
+      await sql`
+        INSERT INTO agent_outputs (
+          id, agent_key, user_id, output_date, source_key, timezone, status,
+          trigger_type, agent_version
+        ) VALUES (
+          'task-link-output', 'daily_brief', 'task-link-user', '2026-07-17',
+          '__global__', 'UTC', 'completed', 'manual', 'test'
+        )
+      `.execute(freshDb);
+      await sql`
+        INSERT INTO tasks (
+          id, source, title, normalized_title, status, status_authority,
+          provenance, source_task_id
+        ) VALUES (
+          'task-link-task', 'brief', 'Linked task', 'linked task', 'open',
+          'local', 'brief', 'task-link-source'
+        )
+      `.execute(freshDb);
+      await sql`
+        INSERT INTO agent_output_items (
+          id, agent_output_id, section_key, title, summary, priority,
+          knowledge_refs_json, sort_order, task_id
+        ) VALUES (
+          'task-link-item', 'task-link-output', 'todos', 'Snapshot task',
+          'Snapshot summary', 'medium', '{"entityIds":[],"fileIds":[]}', 0,
+          'task-link-task'
+        )
+      `.execute(freshDb);
+
+      await sql`DELETE FROM tasks WHERE id = 'task-link-task'`.execute(freshDb);
+
+      const item = await sql<{ task_id: string | null }>`
+        SELECT task_id FROM agent_output_items WHERE id = 'task-link-item'
+      `.execute(freshDb);
+      expect(item.rows).toEqual([{ task_id: null }]);
+    } finally {
+      await freshDb.destroy();
+    }
   });
 
   it("creates the sub-entities table and current-row partial unique index", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -24,7 +24,7 @@ import * as m120 from "./120-agent-output-period-key";
 import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
 
-const EXPECTED_MIGRATION_COUNT = 146;
+const EXPECTED_MIGRATION_COUNT = 147;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -214,6 +214,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[143]).toBe("148-whatsapp-pending-slices-index");
     expect(names[144]).toBe("149-whatsapp-backfill-lifecycle-durability");
     expect(names[145]).toBe("150-task-durability-steel-thread");
+    expect(names[146]).toBe("151-agent-output-item-task-links");
   });
 
   it("creates the bounded open-materializable partial index", async () => {
@@ -350,6 +351,72 @@ describe("runMigrations — full sequence", () => {
         }),
       ]),
     );
+  });
+
+  it("creates canonical agent output item task links and nulls them when the task is deleted", async () => {
+    await sql`PRAGMA foreign_keys = ON`.execute(db);
+    await runMigrations(db, { quiet: true });
+
+    const columns = await sql<{ name: string; type: string; notnull: number }>`
+      PRAGMA table_info(agent_output_items)
+    `.execute(db);
+    expect(columns.rows).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "task_id", type: "TEXT", notnull: 0 })]),
+    );
+
+    const foreignKeys = await sql<{
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>`PRAGMA foreign_key_list(agent_output_items)`.execute(db);
+    expect(foreignKeys.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ table: "tasks", from: "task_id", to: "id", on_delete: "SET NULL" }),
+      ]),
+    );
+
+    const indexes = await sql<{ name: string }>`PRAGMA index_list(agent_output_items)`.execute(db);
+    expect(indexes.rows.map((row) => row.name)).toContain("idx_agent_output_items_task_id");
+
+    await sql`
+      INSERT INTO users (id, name) VALUES ('task-link-user', 'Task Link User')
+    `.execute(db);
+    await sql`
+      INSERT INTO agent_outputs (
+        id, agent_key, user_id, output_date, source_key, timezone, status,
+        trigger_type, agent_version
+      ) VALUES (
+        'task-link-output', 'daily_brief', 'task-link-user', '2026-07-17',
+        '__global__', 'UTC', 'completed', 'manual', 'test'
+      )
+    `.execute(db);
+    await sql`
+      INSERT INTO tasks (
+        id, source, title, normalized_title, status, status_authority,
+        provenance, source_task_id
+      ) VALUES (
+        'task-link-task', 'brief', 'Linked task', 'linked task', 'open',
+        'local', 'brief', 'task-link-source'
+      )
+    `.execute(db);
+    await sql`
+      INSERT INTO agent_output_items (
+        id, agent_output_id, section_key, title, summary, priority,
+        knowledge_refs_json, sort_order, task_id
+      ) VALUES (
+        'task-link-item', 'task-link-output', 'todos', 'Snapshot task',
+        'Snapshot summary', 'medium', '{"entityIds":[],"fileIds":[]}', 0,
+        'task-link-task'
+      )
+    `.execute(db);
+
+    await sql`DELETE FROM tasks WHERE id = 'task-link-task'`.execute(db);
+
+    const item = await sql<{ task_id: string | null }>`
+      SELECT task_id FROM agent_output_items WHERE id = 'task-link-item'
+    `.execute(db);
+    expect(item.rows).toEqual([{ task_id: null }]);
   });
 
   it("migration 140 retires unassigned local agent tasks without touching structural tasks", async () => {

--- a/packages/server/src/db/repositories/agent-outputs-pg.integration.test.ts
+++ b/packages/server/src/db/repositories/agent-outputs-pg.integration.test.ts
@@ -118,6 +118,60 @@ describe("createAgentOutputRepository output scopes on Postgres", () => {
     expect(rows[0]?.items.map((item) => item.title)).toEqual(["Latest action"]);
     expect(rows.map((entry) => entry.output.id)).not.toContain(first);
   });
+
+  it("persists trusted direct links and returns item references on Postgres", async () => {
+    await db.insertInto("users").values({ id: "user-direct", name: "Direct User" }).execute();
+    await db
+      .insertInto("tasks")
+      .values({
+        id: "task-direct",
+        source: "brief",
+        title: "Direct task",
+        normalized_title: "direct task",
+        status: "open",
+        status_authority: "local",
+        provenance: "brief",
+        source_task_id: "direct-task",
+        created_by_user_id: "user-direct",
+      })
+      .execute();
+    const repo = createAgentOutputRepository(db);
+    const running = await repo.createRunning({
+      agentKey: "daily_brief",
+      agentVersion: "test",
+      userId: "user-direct",
+      outputDate: "2026-07-17",
+      timezone: "UTC",
+      triggerType: "manual",
+    });
+
+    const persisted = await repo.completeOutput({
+      outputId: running.row.id,
+      masthead: { title: "Brief", summary: "Summary" },
+      rawPayload: {},
+      items: [
+        {
+          sectionKey: "todos",
+          title: "Direct task",
+          summary: "Server-linked.",
+          priority: "medium",
+          label: "todo",
+          canonicalTaskId: "task-direct",
+          knowledgeRefs: { entityIds: [], fileIds: [] },
+          sortOrder: 0,
+        },
+      ],
+    });
+
+    expect(persisted).toEqual([{ id: expect.any(String), sectionKey: "todos", sortOrder: 0 }]);
+    await expect(
+      db
+        .selectFrom("agent_output_items")
+        .select(["id", "task_id"])
+        .where("agent_output_id", "=", running.row.id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ id: persisted[0]?.id, task_id: "task-direct" });
+  });
 });
 
 async function seedCompletedOutput(

--- a/packages/server/src/db/repositories/agent-outputs-pg.integration.test.ts
+++ b/packages/server/src/db/repositories/agent-outputs-pg.integration.test.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createTestPgDb } from "../../test-utils";
+import { dailyBriefDefinition } from "../../agents/definitions/daily-brief";
+import { createTestConfig, createTestLogger, createTestPgDb } from "../../test-utils";
 import type { DB } from "../schema";
 import type { AgentOutputItemInput } from "./agent-outputs";
 import { createAgentOutputRepository } from "./agent-outputs";
@@ -171,6 +172,90 @@ describe("createAgentOutputRepository output scopes on Postgres", () => {
         .where("agent_output_id", "=", running.row.id)
         .executeTakeFirstOrThrow(),
     ).resolves.toEqual({ id: persisted[0]?.id, task_id: "task-direct" });
+  });
+
+  it("promotes and links a persisted Brief todo in one Postgres transaction", async () => {
+    await db
+      .insertInto("users")
+      .values({
+        id: "user-link",
+        name: "Link User",
+        email: "link@example.com",
+        email_verified_at: "2026-07-17T00:00:00.000Z",
+      })
+      .execute();
+    await db
+      .insertInto("entities")
+      .values([
+        {
+          id: "person-link",
+          name: "Link User",
+          source_type: "person",
+          status: "confirmed",
+          hotness: 0,
+          metadata: JSON.stringify({ email: "link@example.com" }),
+          created_at: "2026-07-17T00:00:00.000Z",
+          updated_at: "2026-07-17T00:00:00.000Z",
+        },
+        {
+          id: "project-link",
+          name: "Link Project",
+          source_type: "project",
+          status: "confirmed",
+          hotness: 0,
+          created_at: "2026-07-17T00:00:00.000Z",
+          updated_at: "2026-07-17T00:00:00.000Z",
+        },
+      ])
+      .execute();
+    const repo = createAgentOutputRepository(db);
+    const running = await repo.createRunning({
+      agentKey: "daily_brief",
+      agentVersion: "test",
+      userId: "user-link",
+      outputDate: "2026-07-17",
+      timezone: "UTC",
+      triggerType: "manual",
+    });
+    const item: AgentOutputItemInput = {
+      sectionKey: "todos",
+      title: "Prepare Postgres launch plan",
+      summary: "Snapshot summary",
+      priority: "medium",
+      label: "todo",
+      structuredPayload: {
+        assigneeEntityId: "person-link",
+        assigneeName: "Link User",
+      },
+      knowledgeRefs: { entityIds: ["project-link"], fileIds: ["file-link"] },
+      sortOrder: 0,
+    };
+    const [persisted] = await repo.completeOutput({
+      outputId: running.row.id,
+      masthead: { title: "Brief", summary: "Summary" },
+      rawPayload: {},
+      items: [item],
+    });
+
+    await dailyBriefDefinition.onOutputSaved?.({
+      db,
+      config: createTestConfig({ DB_TYPE: "postgres" }),
+      logger: createTestLogger(),
+      userId: "user-link",
+      outputId: running.row.id,
+      items: [item],
+      persistedItems: [{ id: persisted.id, item }],
+      createTasks: true,
+      runtimeContext: {},
+    });
+
+    const linked = await db
+      .selectFrom("agent_output_items")
+      .innerJoin("tasks", "tasks.id", "agent_output_items.task_id")
+      .select(["agent_output_items.id", "tasks.parent_entity_id"])
+      .where("agent_output_items.id", "=", persisted.id)
+      .executeTakeFirstOrThrow();
+    expect(linked).toEqual({ id: persisted.id, parent_entity_id: "project-link" });
   });
 });
 

--- a/packages/server/src/db/repositories/agent-outputs.test.ts
+++ b/packages/server/src/db/repositories/agent-outputs.test.ts
@@ -170,6 +170,78 @@ describe("createAgentOutputRepository output scopes", () => {
     ]);
   });
 
+  it("links an exact persisted item idempotently without crossing outputs or overwriting conflicts", async () => {
+    await db.insertInto("users").values({ id: "user-1", name: "Agent User" }).execute();
+    await db
+      .insertInto("tasks")
+      .values([
+        {
+          id: "task-one",
+          source: "brief",
+          title: "Task one",
+          normalized_title: "task one",
+          status: "open",
+          status_authority: "local",
+          provenance: "brief",
+          source_task_id: "task-one",
+          created_by_user_id: "user-1",
+        },
+        {
+          id: "task-two",
+          source: "brief",
+          title: "Task two",
+          normalized_title: "task two",
+          status: "open",
+          status_authority: "local",
+          provenance: "brief",
+          source_task_id: "task-two",
+          created_by_user_id: "user-1",
+        },
+      ])
+      .execute();
+    const repo = createAgentOutputRepository(db);
+    const running = await repo.createRunning({
+      agentKey: "daily_brief",
+      agentVersion: "test",
+      userId: "user-1",
+      outputDate: "2026-07-17",
+      timezone: "UTC",
+      triggerType: "manual",
+    });
+    const [persisted] = await repo.completeOutput({
+      outputId: running.row.id,
+      masthead: { title: "Brief", summary: "Summary" },
+      rawPayload: {},
+      items: [
+        {
+          sectionKey: "todos",
+          title: "Link me",
+          summary: "Link by id.",
+          priority: "medium",
+          label: "todo",
+          knowledgeRefs: { entityIds: [], fileIds: [] },
+          sortOrder: 0,
+        },
+      ],
+    });
+
+    await expect(
+      repo.linkItemToTask({ outputId: "other-output", itemId: persisted.id, taskId: "task-one" }),
+    ).resolves.toBe("missing");
+    await expect(
+      repo.linkItemToTask({ outputId: running.row.id, itemId: persisted.id, taskId: "task-one" }),
+    ).resolves.toBe("linked");
+    await expect(
+      repo.linkItemToTask({ outputId: running.row.id, itemId: persisted.id, taskId: "task-one" }),
+    ).resolves.toBe("already_linked");
+    await expect(
+      repo.linkItemToTask({ outputId: running.row.id, itemId: persisted.id, taskId: "task-two" }),
+    ).rejects.toThrow("different task");
+    await expect(
+      db.selectFrom("agent_output_items").select("task_id").where("id", "=", persisted.id).executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ task_id: "task-one" });
+  });
+
   it("lists bounded completed outputs for a user and agent since a timestamp oldest first with items", async () => {
     const repo = createAgentOutputRepository(db);
     const base = {

--- a/packages/server/src/db/repositories/agent-outputs.test.ts
+++ b/packages/server/src/db/repositories/agent-outputs.test.ts
@@ -98,6 +98,78 @@ describe("createAgentOutputRepository output scopes", () => {
     expect(await repo.findById("daily_brief", running.row.id)).toMatchObject({ trigger_type: "manual" });
   });
 
+  it("persists only trusted direct task links and returns stable persisted item references", async () => {
+    await db.insertInto("users").values({ id: "user-1", name: "Agent User" }).execute();
+    await db
+      .insertInto("tasks")
+      .values({
+        id: "task-direct",
+        source: "brief",
+        title: "Direct task",
+        normalized_title: "direct task",
+        status: "open",
+        status_authority: "local",
+        provenance: "brief",
+        source_task_id: "direct-task",
+        created_by_user_id: "user-1",
+      })
+      .execute();
+    const repo = createAgentOutputRepository(db);
+    const running = await repo.createRunning({
+      agentKey: "daily_brief",
+      agentVersion: "test",
+      userId: "user-1",
+      outputDate: "2026-07-17",
+      timezone: "UTC",
+      triggerType: "manual",
+    });
+
+    const persisted = await repo.completeOutput({
+      outputId: running.row.id,
+      masthead: { title: "Brief", summary: "Summary" },
+      rawPayload: {},
+      items: [
+        {
+          sectionKey: "todos",
+          title: "Direct task",
+          summary: "Server-linked.",
+          priority: "medium",
+          label: "todo",
+          canonicalTaskId: "task-direct",
+          structuredPayload: { taskId: "task-payload-conflict" },
+          knowledgeRefs: { entityIds: [], fileIds: [] },
+          sortOrder: 0,
+        },
+        {
+          sectionKey: "todos",
+          title: "Payload-only task",
+          summary: "Model payload is not trusted.",
+          priority: "medium",
+          label: "todo",
+          structuredPayload: { taskId: "task-direct", canonicalTaskId: "task-direct" },
+          knowledgeRefs: { entityIds: [], fileIds: [] },
+          sortOrder: 1,
+        },
+      ],
+    });
+
+    expect(persisted).toEqual([
+      { id: expect.any(String), sectionKey: "todos", sortOrder: 0 },
+      { id: expect.any(String), sectionKey: "todos", sortOrder: 1 },
+    ]);
+    expect(persisted[0]?.id).not.toBe(persisted[1]?.id);
+    const rows = await db
+      .selectFrom("agent_output_items")
+      .select(["id", "task_id", "sort_order"])
+      .where("agent_output_id", "=", running.row.id)
+      .orderBy("sort_order", "asc")
+      .execute();
+    expect(rows).toEqual([
+      { id: persisted[0]?.id, task_id: "task-direct", sort_order: 0 },
+      { id: persisted[1]?.id, task_id: null, sort_order: 1 },
+    ]);
+  });
+
   it("lists bounded completed outputs for a user and agent since a timestamp oldest first with items", async () => {
     const repo = createAgentOutputRepository(db);
     const base = {

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -1094,6 +1094,43 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
       }));
     },
 
+    async linkItemToTask(params: {
+      outputId: string;
+      itemId: string;
+      taskId: string;
+    }): Promise<"linked" | "already_linked" | "missing"> {
+      const existing = await db
+        .selectFrom("agent_output_items")
+        .select("task_id")
+        .where("id", "=", params.itemId)
+        .where("agent_output_id", "=", params.outputId)
+        .executeTakeFirst();
+      if (!existing) return "missing";
+      if (existing.task_id === params.taskId) return "already_linked";
+      if (existing.task_id) {
+        throw new Error(`Agent output item is already linked to a different task: ${params.itemId}`);
+      }
+
+      const updated = await db
+        .updateTable("agent_output_items")
+        .set({ task_id: params.taskId })
+        .where("id", "=", params.itemId)
+        .where("agent_output_id", "=", params.outputId)
+        .where("task_id", "is", null)
+        .executeTakeFirst();
+      if (affectedRows(updated) > 0) return "linked";
+
+      const raced = await db
+        .selectFrom("agent_output_items")
+        .select("task_id")
+        .where("id", "=", params.itemId)
+        .where("agent_output_id", "=", params.outputId)
+        .executeTakeFirst();
+      if (!raced) return "missing";
+      if (raced.task_id === params.taskId) return "already_linked";
+      throw new Error(`Agent output item is already linked to a different task: ${params.itemId}`);
+    },
+
     async markFailed(outputId: string, message: string): Promise<void> {
       await db
         .updateTable("agent_outputs")

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -36,7 +36,14 @@ export interface AgentOutputItemInput {
   actionPrompt?: string | null;
   sourceUrl?: string | null;
   structuredPayload?: AgentStructuredPayload | null;
+  canonicalTaskId?: string | null;
   knowledgeRefs: AgentKnowledgeRefs;
+  sortOrder: number;
+}
+
+export interface PersistedAgentOutputItemRef {
+  id: string;
+  sectionKey: string;
   sortOrder: number;
 }
 
@@ -1036,8 +1043,27 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
       rawPayload: unknown;
       items: AgentOutputItemInput[];
       agentRunId?: string | null;
-    }): Promise<void> {
+    }): Promise<PersistedAgentOutputItemRef[]> {
       const now = new Date().toISOString();
+      const rows: NewAgentOutputItem[] = params.items.map((item) => ({
+        id: randomUUID(),
+        agent_output_id: params.outputId,
+        task_id: item.canonicalTaskId ?? null,
+        section_key: item.sectionKey,
+        title: item.title,
+        summary: item.summary,
+        priority: item.priority,
+        label: item.label,
+        display_ref: item.displayRef ?? null,
+        action_type: item.actionType ?? null,
+        action_label: item.actionLabel ?? null,
+        action_prompt: item.actionPrompt ?? null,
+        knowledge_refs_json: JSON.stringify(item.knowledgeRefs),
+        source_url: item.sourceUrl ?? null,
+        structured_payload_json: item.structuredPayload ? JSON.stringify(item.structuredPayload) : null,
+        sort_order: item.sortOrder,
+        created_at: now,
+      }));
       await db.transaction().execute(async (trx) => {
         const updated = await trx
           .updateTable("agent_outputs")
@@ -1057,28 +1083,15 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
           throw new Error("Agent output generation is no longer running.");
         }
         await trx.deleteFrom("agent_output_items").where("agent_output_id", "=", params.outputId).execute();
-        if (params.items.length > 0) {
-          const rows: NewAgentOutputItem[] = params.items.map((item) => ({
-            id: randomUUID(),
-            agent_output_id: params.outputId,
-            section_key: item.sectionKey,
-            title: item.title,
-            summary: item.summary,
-            priority: item.priority,
-            label: item.label,
-            display_ref: item.displayRef ?? null,
-            action_type: item.actionType ?? null,
-            action_label: item.actionLabel ?? null,
-            action_prompt: item.actionPrompt ?? null,
-            knowledge_refs_json: JSON.stringify(item.knowledgeRefs),
-            source_url: item.sourceUrl ?? null,
-            structured_payload_json: item.structuredPayload ? JSON.stringify(item.structuredPayload) : null,
-            sort_order: item.sortOrder,
-            created_at: now,
-          }));
+        if (rows.length > 0) {
           await trx.insertInto("agent_output_items").values(rows).execute();
         }
       });
+      return rows.map((row) => ({
+        id: String(row.id),
+        sectionKey: String(row.section_key),
+        sortOrder: Number(row.sort_order),
+      }));
     },
 
     async markFailed(outputId: string, message: string): Promise<void> {

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -44,6 +44,13 @@ export interface TaskListOptions {
   limit?: number;
 }
 
+export interface TaskAccessOptions {
+  viewer: FileViewer;
+  userId?: string | null;
+  assigneeEntityIds?: string[];
+  canReadAllLocalTasks?: boolean;
+}
+
 export interface PromoteBriefTaskInput {
   userId: string;
   todo: AgentOutputItemInput;
@@ -366,6 +373,20 @@ export function createTaskRepository(db: Kysely<DB>) {
         .limit(opts.limit ?? 100);
       if (opts.status) query = query.where("tasks.status", "=", opts.status);
       return query.execute();
+    },
+
+    async listVisibleTasksByIds(taskIds: string[], opts: TaskAccessOptions): Promise<Selectable<TasksTable>[]> {
+      const ids = [...new Set(taskIds)].filter(Boolean);
+      if (ids.length === 0) return [];
+      if (ids.length > 100) throw new Error("Task visibility batch exceeds 100 ids.");
+      return visibleTaskQuery(db, opts.viewer, {
+        userId: opts.userId,
+        assigneeEntityIds: opts.assigneeEntityIds,
+        canReadAllLocalTasks: opts.canReadAllLocalTasks === true,
+      })
+        .where("tasks.id", "in", ids)
+        .limit(ids.length)
+        .execute();
     },
 
     async loadOpenDurableTasksForBrief(opts: LoadOpenDurableTasksForBriefOptions): Promise<Selectable<TasksTable>[]> {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -740,6 +740,7 @@ export interface AgentOutputsTable {
 export interface AgentOutputItemsTable {
   id: string;
   agent_output_id: string;
+  task_id: string | null;
   section_key: string;
   title: string;
   summary: string;

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -38,6 +38,7 @@ import { entityReviewRoutes } from "./entities/review";
 
 import { oauthRoutes } from "./api/oauth";
 import { systemRoutes } from "./api/system";
+import { taskRoutes } from "./api/tasks";
 import { usageRoutes } from "./api/usage";
 import { userRoutes } from "./api/users";
 import { watiWebhookRoutes } from "./api/wati-webhook";
@@ -551,6 +552,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     );
   }
   app.route("/api/entities", entityRoutes(db, { logger, config }));
+  app.route("/api/tasks", taskRoutes(db));
   app.route("/api/projects", createProjectRoutes(db));
   app.route("/api/products", productRoutes(db));
   app.route("/api/entity-review", entityReviewRoutes(db, { logger }));

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -513,7 +513,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   app.route("/api/mcp-servers", mcpServerRoutes(mcpServers, users));
   app.route("/api/workspace/summary", workspaceSummaryRoutes({ db, config, users, mcpServers }));
   if (deps?.agentRunService) {
-    app.route("/api/daily-briefs", dailyBriefRoutes(deps.agentRunService, db));
+    app.route("/api/daily-briefs", dailyBriefRoutes(deps.agentRunService, db, logger));
     app.route("/api/agents", agentRoutes(deps.agentRunService));
   }
   app.route("/api/workspace", createWorkspaceApi({ config }));

--- a/packages/web/src/components/brief/brief-detail-drawer.tsx
+++ b/packages/web/src/components/brief/brief-detail-drawer.tsx
@@ -1,10 +1,21 @@
-import type { DailyBriefItem, DailyBriefMeetingAttendee } from "@/lib/api";
+import type { DailyBriefItem, DailyBriefMeetingAttendee, DailyBriefTaskState, TaskStatus } from "@/lib/api";
 import { EntityChip, useEntityUiOptional } from "@/lib/entity-ui";
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@sketch/ui/components/select";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@sketch/ui/components/sheet";
+import { cn } from "@sketch/ui/lib/utils";
 import { BriefActionButton } from "./brief-action-button";
 import { labelMeta, refChips, sourceLinkLabel } from "./item-metadata";
 import { formatMeetingTime } from "./meeting-row";
+import {
+  BRIEF_TASK_STATUS_OPTIONS,
+  briefTaskExternalStatus,
+  briefTaskReadonlyReason,
+  briefTaskStatusTone,
+  formatBriefTaskStatus,
+  getBriefItemTask,
+} from "./task-overlay";
 
 function drawerTitle(item: DailyBriefItem): string {
   if (item.sectionKey === "todos" && item.displayRef) return `${item.displayRef} \u00b7 ${item.title}`;
@@ -30,11 +41,15 @@ export function BriefDetailDrawer({
   timezone,
   onClose,
   onOpenChat,
+  onUpdateTaskStatus,
+  updatingTaskId,
 }: {
   item: DailyBriefItem | null;
   timezone: string;
   onClose: () => void;
   onOpenChat: (prompt: string) => void;
+  onUpdateTaskStatus?: (taskId: string, status: TaskStatus) => void;
+  updatingTaskId?: string | null;
 }) {
   return (
     <Sheet open={item !== null} onOpenChange={(open) => !open && onClose()}>
@@ -45,7 +60,12 @@ export function BriefDetailDrawer({
           item.sectionKey === "meetings" ? (
             <MeetingDrawerBody item={item} timezone={timezone} onOpenChat={onOpenChat} />
           ) : (
-            <DrawerBody item={item} onOpenChat={onOpenChat} />
+            <DrawerBody
+              item={item}
+              onOpenChat={onOpenChat}
+              onUpdateTaskStatus={onUpdateTaskStatus}
+              updatingTaskId={updatingTaskId}
+            />
           )
         ) : null}
       </SheetContent>
@@ -53,10 +73,21 @@ export function BriefDetailDrawer({
   );
 }
 
-function DrawerBody({ item, onOpenChat }: { item: DailyBriefItem; onOpenChat: (prompt: string) => void }) {
+function DrawerBody({
+  item,
+  onOpenChat,
+  onUpdateTaskStatus,
+  updatingTaskId,
+}: {
+  item: DailyBriefItem;
+  onOpenChat: (prompt: string) => void;
+  onUpdateTaskStatus?: (taskId: string, status: TaskStatus) => void;
+  updatingTaskId?: string | null;
+}) {
   const meta = labelMeta(item);
   const chips = refChips(item);
   const actionLabel = item.actionLabel ?? "Ask Sketch";
+  const task = getBriefItemTask(item);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -76,6 +107,15 @@ function DrawerBody({ item, onOpenChat }: { item: DailyBriefItem; onOpenChat: (p
             <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Context</p>
             <p className="text-[13px] leading-relaxed text-muted-foreground">{item.summary}</p>
           </div>
+
+          {task ? (
+            <CurrentTaskSection
+              task={task}
+              snapshotTitle={item.title}
+              onUpdateTaskStatus={onUpdateTaskStatus}
+              updating={updatingTaskId === task.id}
+            />
+          ) : null}
 
           {chips.length > 0 ? (
             <div>
@@ -190,6 +230,114 @@ function MeetingDrawerBody({
       ) : null}
     </div>
   );
+}
+
+function formatCompactRelative(iso: string | null): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const diff = Date.now() - then;
+  const absDays = Math.floor(Math.abs(diff) / 86_400_000);
+  if (absDays <= 0) return "today";
+  const label = absDays === 1 ? "1d ago" : `${absDays}d ago`;
+  return diff < 0 ? `in ${absDays === 1 ? "1d" : `${absDays}d`}` : label;
+}
+
+function formatCompactDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 10);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/**
+ * Compact "Current task" section for non-meeting brief items that carry a live
+ * task overlay. Shows the live status (editable Select when canEditStatus, a
+ * passive pill otherwise), the current task title only when it diverges from
+ * the snapshot title, priority, and useful updated/completed metadata. Snapshot
+ * fields (title/summary) are always preserved above this section.
+ */
+function CurrentTaskSection({
+  task,
+  snapshotTitle,
+  onUpdateTaskStatus,
+  updating,
+}: {
+  task: DailyBriefTaskState;
+  snapshotTitle: string;
+  onUpdateTaskStatus?: (taskId: string, status: TaskStatus) => void;
+  updating: boolean;
+}) {
+  const tone = briefTaskStatusTone(task.status);
+  const showChangedTitle = task.title && task.title !== snapshotTitle;
+  const externalStatus = briefTaskExternalStatus(task);
+  const reason = briefTaskReadonlyReason(task);
+  const updatedRelative = formatCompactRelative(task.updatedAt);
+  const completedDate = task.completedAt ? formatCompactDate(task.completedAt) : null;
+  const canEdit = task.canEditStatus && onUpdateTaskStatus;
+
+  return (
+    <div className="rounded-md border-[0.5px] border-border/70 bg-muted/20 px-3 py-3">
+      <p className="mb-2.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Current task</p>
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        {canEdit ? (
+          <Select
+            value={task.status}
+            onValueChange={(value) => onUpdateTaskStatus?.(task.id, value as TaskStatus)}
+            disabled={updating}
+          >
+            <SelectTrigger aria-label={`${task.title} status`} className="h-8 w-full text-xs sm:w-44">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {BRIEF_TASK_STATUS_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Badge variant="outline" className={cn("max-w-full text-[10px]", tone.text)}>
+            <span className={cn("mr-1 inline-block size-1.5 rounded-full", tone.dot)} aria-hidden />
+            {formatBriefTaskStatus(task.status)}
+          </Badge>
+        )}
+        {task.priority ? (
+          <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground/80">
+            {task.priority}
+          </span>
+        ) : null}
+      </div>
+
+      {showChangedTitle ? <p className="mt-2 text-[13px] leading-snug text-foreground">{task.title}</p> : null}
+
+      {externalStatus ? (
+        <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground/70">
+          Source status: {externalStatus}
+        </p>
+      ) : null}
+
+      {reason ? <p className="mt-2 text-[11px] leading-snug text-muted-foreground">{reason}</p> : null}
+
+      {updatedRelative || completedDate ? (
+        <p className="mt-2 font-mono text-[10px] tabular-nums text-muted-foreground/70">
+          {buildTaskMetadataLine(completedDate, updatedRelative)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function buildTaskMetadataLine(completedDate: string | null, updatedRelative: string | null): string {
+  const parts: string[] = [];
+  if (completedDate) parts.push(`Completed ${completedDate}`);
+  if (updatedRelative) parts.push(updatedDateLabel(updatedRelative, completedDate));
+  return parts.join(" \u00b7 ");
+}
+
+function updatedDateLabel(updatedRelative: string, completedDate: string | null): string {
+  return completedDate ? `updated ${updatedRelative}` : `Updated ${updatedRelative}`;
 }
 
 function AttendeeRow({ attendee }: { attendee: DailyBriefMeetingAttendee }) {

--- a/packages/web/src/components/brief/brief-item-row.tsx
+++ b/packages/web/src/components/brief/brief-item-row.tsx
@@ -2,6 +2,7 @@ import type { DailyBriefItem } from "@/lib/api";
 import { cn } from "@sketch/ui/lib/utils";
 import { BriefActionButton } from "./brief-action-button";
 import { actionLabelForItem, labelMeta } from "./item-metadata";
+import { briefTaskExternalStatus, briefTaskStatusTone, formatBriefTaskStatus, getBriefItemTask } from "./task-overlay";
 
 export function BriefItemRow({
   item,
@@ -17,6 +18,10 @@ export function BriefItemRow({
   const meta = labelMeta(item);
   const actionLabel = actionLabelForItem(item);
   const hasLabelColumn = item.sectionKey !== "active_projects";
+  const task = getBriefItemTask(item);
+  const liveLabel = task ? formatBriefTaskStatus(task.status) : null;
+  const tone = task ? briefTaskStatusTone(task.status) : null;
+  const externalStatus = task ? briefTaskExternalStatus(task) : null;
 
   return (
     <article
@@ -47,14 +52,36 @@ export function BriefItemRow({
 
         <span className="min-w-0">
           <span className="block truncate text-[13px] font-medium leading-snug text-foreground">{item.title}</span>
+          {liveLabel ? (
+            <span
+              className={cn(
+                "mt-0.5 flex min-w-0 items-center gap-1.5 font-mono text-[9.5px] uppercase tracking-[0.06em] sm:hidden",
+                tone?.text,
+              )}
+            >
+              <span className={cn("size-1.5 shrink-0 rounded-full", tone?.dot)} aria-hidden />
+              <span className="truncate">
+                {liveLabel}
+                {externalStatus ? <span className="ml-1 normal-case tracking-normal">· {externalStatus}</span> : null}
+              </span>
+            </span>
+          ) : null}
         </span>
 
         {hasLabelColumn ? (
           <span className="hidden w-[112px] min-w-0 items-center gap-1.5 pl-3 font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground/80 sm:flex">
-            {item.sectionKey === "todos" ? (
+            {liveLabel ? (
+              <>
+                <span className={cn("size-1.5 shrink-0 rounded-full", tone?.dot)} aria-hidden />
+                <span className={cn("truncate", tone?.text)}>
+                  {liveLabel}
+                  {externalStatus ? <span className="ml-1 normal-case tracking-normal">· {externalStatus}</span> : null}
+                </span>
+              </>
+            ) : item.sectionKey === "todos" ? (
               <span className={cn("size-1.5 shrink-0 rounded-full", meta.dot)} aria-hidden />
             ) : null}
-            <span className="truncate">{meta.label}</span>
+            {!liveLabel ? <span className="truncate">{meta.label}</span> : null}
           </span>
         ) : null}
       </button>

--- a/packages/web/src/components/brief/brief-task-links.test.tsx
+++ b/packages/web/src/components/brief/brief-task-links.test.tsx
@@ -16,13 +16,7 @@
  *    every brief item whose taskId matches the returned task, preserving
  *    snapshot fields and replacing only the task overlay.
  */
-import type {
-  DailyBrief as DailyBriefData,
-  DailyBriefItem,
-  DailyBriefResponse,
-  DailyBriefTaskState,
-  TaskStatus,
-} from "@/lib/api";
+import type { DailyBrief as DailyBriefData, DailyBriefItem, DailyBriefResponse, DailyBriefTaskState } from "@/lib/api";
 import { renderWithProviders } from "@/test/utils";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/packages/web/src/components/brief/brief-task-links.test.tsx
+++ b/packages/web/src/components/brief/brief-task-links.test.tsx
@@ -103,7 +103,6 @@ describe("Brief row live task status", () => {
 
     const row = screen.getByRole("button", { name: /Snapshot title/ });
     expect(within(row).getAllByText(formatBriefTaskStatus("in_progress")).length).toBeGreaterThan(0);
-    // The generated todo label ("Todo") must not win over the live overlay.
     expect(within(row).queryByText("Todo")).not.toBeInTheDocument();
   });
 

--- a/packages/web/src/components/brief/brief-task-links.test.tsx
+++ b/packages/web/src/components/brief/brief-task-links.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * Live Brief Task Links — focused front-end slice.
+ *
+ * Contract:
+ *  - DailyBriefItem may carry optional `taskId` + `task` (live-state overlay).
+ *    Missing values must normalize safely for mixed-version compatibility.
+ *  - The Brief row keeps the snapshot title and, when `task` is present, shows
+ *    the normalized live status instead of the generated todo label. No Select
+ *    inside the row button.
+ *  - The detail drawer renders a compact "Current task" section when `task`
+ *    exists: live status (editable Select when canEditStatus, passive pill
+ *    otherwise), current task title only when different from the snapshot,
+ *    priority, and updated/completed metadata. Read-only rows show a concise
+ *    reason and no Select.
+ *  - Home owns the status mutation and a pure cache-overlay helper updates
+ *    every brief item whose taskId matches the returned task, preserving
+ *    snapshot fields and replacing only the task overlay.
+ */
+import type {
+  DailyBrief as DailyBriefData,
+  DailyBriefItem,
+  DailyBriefResponse,
+  DailyBriefTaskState,
+  TaskStatus,
+} from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DailyBrief } from "./daily-brief";
+import { applyTaskOverlayToBriefResponse, formatBriefTaskStatus } from "./task-overlay";
+
+function baseTask(overrides: Partial<DailyBriefTaskState> = {}): DailyBriefTaskState {
+  return {
+    id: "task-1",
+    title: "Live task title",
+    status: "in_progress",
+    statusRaw: null,
+    statusAuthority: "local",
+    priority: "medium",
+    completedAt: null,
+    updatedAt: "2026-07-17T10:00:00.000Z",
+    canEditStatus: true,
+    readonlyReason: null,
+    ...overrides,
+  };
+}
+
+function todoItem(id: string, title: string, task?: DailyBriefTaskState | null): DailyBriefItem {
+  return {
+    id,
+    sectionKey: "todos",
+    title,
+    summary: "Snapshot summary",
+    priority: "high",
+    label: "todo",
+    displayRef: "KG-12",
+    actionType: null,
+    actionLabel: null,
+    actionPrompt: "Plan this",
+    sourceUrl: null,
+    structuredPayload: null,
+    knowledgeRefs: { entityIds: [], fileIds: [] },
+    sortOrder: 0,
+    taskId: task ? task.id : null,
+    task,
+  };
+}
+
+function briefWithTodos(todos: DailyBriefItem[]): DailyBriefData {
+  return {
+    id: "brief-1",
+    userId: "user-1",
+    briefDate: "2026-07-17",
+    timezone: "UTC",
+    status: "ready",
+    generatedAt: null,
+    masthead: null,
+    sections: {
+      meetings: [],
+      todos,
+      untracked_followups: [],
+      looks_resolved: [],
+      customer_updates: [],
+      active_projects: [],
+    },
+  };
+}
+
+function emptyResponse(brief: DailyBriefData): DailyBriefResponse {
+  return {
+    brief,
+    running: false,
+    briefDate: brief.briefDate,
+    timezone: brief.timezone,
+  };
+}
+
+describe("Brief row live task status", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the normalized live status instead of the generated todo label", () => {
+    const task = baseTask({ status: "in_progress" });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    const row = screen.getByRole("button", { name: /Snapshot title/ });
+    expect(within(row).getAllByText(formatBriefTaskStatus("in_progress")).length).toBeGreaterThan(0);
+    // The generated todo label ("Todo") must not win over the live overlay.
+    expect(within(row).queryByText("Todo")).not.toBeInTheDocument();
+  });
+
+  it("keeps the snapshot title even when the live task title differs", () => {
+    const task = baseTask({ title: "Different live title" });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    expect(screen.getByRole("button", { name: /Snapshot title/ })).toBeInTheDocument();
+    expect(screen.queryByText("Different live title")).not.toBeInTheDocument();
+  });
+
+  it("does not render an interactive status control inside the row button", () => {
+    const task = baseTask();
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    const row = screen.getByRole("button", { name: /Snapshot title/ });
+    expect(within(row).queryByRole("combobox")).not.toBeInTheDocument();
+  });
+});
+
+describe("Brief detail drawer Current task section", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the current task title only when it differs from the snapshot title", async () => {
+    const user = userEvent.setup();
+    const task = baseTask({ title: "Different live title" });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: /Snapshot title/ }));
+
+    expect(await screen.findByText("Current task")).toBeInTheDocument();
+    expect(screen.getByText("Different live title")).toBeInTheDocument();
+  });
+
+  it("renders an editable status select and updates status through the callback", async () => {
+    const user = userEvent.setup();
+    const task = baseTask({ id: "task-edit", status: "open" });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+    const onUpdateTaskStatus = vi.fn();
+
+    renderWithProviders(
+      <DailyBrief brief={brief} running={false} onOpenChat={() => {}} onUpdateTaskStatus={onUpdateTaskStatus} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Snapshot title/ }));
+    const combobox = await screen.findByRole("combobox", { name: /Live task title status/ });
+    await user.click(combobox);
+    await user.click(await screen.findByRole("option", { name: "Done" }));
+
+    expect(onUpdateTaskStatus).toHaveBeenCalledWith("task-edit", "done");
+  });
+
+  it("disables the status select while that task is updating", async () => {
+    const user = userEvent.setup();
+    const task = baseTask({ id: "task-busy" });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+
+    renderWithProviders(
+      <DailyBrief
+        brief={brief}
+        running={false}
+        onOpenChat={() => {}}
+        onUpdateTaskStatus={() => {}}
+        updatingTaskId="task-busy"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Snapshot title/ }));
+    const combobox = await screen.findByRole("combobox", { name: /Live task title status/ });
+    expect(combobox).toBeDisabled();
+  });
+
+  it("shows a passive pill and external-authority reason instead of a select", async () => {
+    const user = userEvent.setup();
+    const task = baseTask({
+      canEditStatus: false,
+      readonlyReason: "external_authority",
+      statusAuthority: "external",
+      statusRaw: "In Review",
+    });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: /Snapshot title/ }));
+    await screen.findByText("Current task");
+    const drawer = screen.getByRole("dialog");
+    expect(within(drawer).queryByRole("combobox")).not.toBeInTheDocument();
+    expect(within(drawer).getByText(formatBriefTaskStatus("in_progress"))).toBeInTheDocument();
+    expect(within(drawer).getByText(/managed by the source system/i)).toBeInTheDocument();
+  });
+
+  it("shows a not_owner reason when read-only due to ownership", async () => {
+    const user = userEvent.setup();
+    const task = baseTask({
+      canEditStatus: false,
+      readonlyReason: "not_owner",
+    });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", task)]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: /Snapshot title/ }));
+    await screen.findByText("Current task");
+    const drawer = screen.getByRole("dialog");
+    expect(within(drawer).queryByRole("combobox")).not.toBeInTheDocument();
+    expect(within(drawer).getByText(/creator, assignee, or an admin/i)).toBeInTheDocument();
+  });
+});
+
+describe("Missing-field compatibility", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders safely when items omit taskId/task entirely (legacy payloads)", () => {
+    const legacyItem: DailyBriefItem = {
+      id: "legacy-1",
+      sectionKey: "todos",
+      title: "Legacy todo",
+      summary: "",
+      priority: "medium",
+      label: "todo",
+      displayRef: null,
+      actionType: null,
+      actionLabel: null,
+      actionPrompt: null,
+      sourceUrl: null,
+      structuredPayload: null,
+      knowledgeRefs: { entityIds: [], fileIds: [] },
+      sortOrder: 0,
+    };
+    const brief = briefWithTodos([legacyItem]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    expect(screen.getByRole("button", { name: /Legacy todo/ })).toBeInTheDocument();
+  });
+
+  it("renders safely when a task overlay is present but partial fields are missing", () => {
+    const partialTask = {
+      ...baseTask(),
+      priority: null,
+      completedAt: null,
+      updatedAt: "2026-07-17T10:00:00.000Z",
+    } as DailyBriefTaskState;
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot title", partialTask)]);
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    expect(screen.getByRole("button", { name: /Snapshot title/ })).toBeInTheDocument();
+  });
+});
+
+describe("applyTaskOverlayToBriefResponse (cache overlay updater)", () => {
+  it("replaces the task overlay on every brief item whose taskId matches, preserving snapshot fields", () => {
+    const taskA = baseTask({ id: "task-shared", status: "open" });
+    const taskB = baseTask({ id: "task-other", status: "open" });
+    const brief = briefWithTodos([
+      todoItem("t-1", "Snapshot A", taskA),
+      todoItem("t-2", "Snapshot B", taskB),
+      todoItem("t-3", "Snapshot A2", taskA),
+    ]);
+    const response = emptyResponse(brief);
+
+    const updated = applyTaskOverlayToBriefResponse(response, {
+      ...taskA,
+      status: "done",
+      completedAt: "2026-07-17T12:00:00.000Z",
+      updatedAt: "2026-07-17T12:00:00.000Z",
+    });
+
+    const todos = updated.brief?.sections.todos ?? [];
+    expect(todos[0].taskId).toBe("task-shared");
+    expect(todos[0].title).toBe("Snapshot A");
+    expect(todos[0].task?.status).toBe("done");
+    expect(todos[0].task?.completedAt).toBe("2026-07-17T12:00:00.000Z");
+    expect(todos[1].taskId).toBe("task-other");
+    expect(todos[1].task?.status).toBe("open");
+    expect(todos[2].taskId).toBe("task-shared");
+    expect(todos[2].title).toBe("Snapshot A2");
+    expect(todos[2].task?.status).toBe("done");
+  });
+
+  it("matches overlays across all sections, not only todos", () => {
+    const task = baseTask({ id: "task-x", status: "open" });
+    const brief: DailyBriefData = {
+      ...briefWithTodos([todoItem("t-1", "Snapshot todo", task)]),
+      sections: {
+        meetings: [],
+        todos: [todoItem("t-1", "Snapshot todo", task)],
+        untracked_followups: [{ ...todoItem("f-1", "Snapshot followup", task), sectionKey: "untracked_followups" }],
+        looks_resolved: [],
+        customer_updates: [],
+        active_projects: [],
+      },
+    };
+    const response = emptyResponse(brief);
+
+    const updated = applyTaskOverlayToBriefResponse(response, { ...task, status: "dropped" });
+
+    expect(updated.brief?.sections.todos[0].task?.status).toBe("dropped");
+    expect(updated.brief?.sections.untracked_followups[0].task?.status).toBe("dropped");
+  });
+
+  it("leaves the brief unchanged when no taskId matches", () => {
+    const task = baseTask({ id: "task-shared", status: "open" });
+    const brief = briefWithTodos([todoItem("t-1", "Snapshot", task)]);
+    const response = emptyResponse(brief);
+
+    const updated = applyTaskOverlayToBriefResponse(response, { ...baseTask({ id: "task-unknown" }), status: "done" });
+
+    expect(updated.brief?.sections.todos[0].task?.status).toBe("open");
+  });
+
+  it("returns the response unchanged when there is no brief", () => {
+    const response: DailyBriefResponse = { brief: null, running: false, briefDate: "2026-07-17", timezone: "UTC" };
+    const updated = applyTaskOverlayToBriefResponse(response, baseTask({ status: "done" }));
+    expect(updated).toBe(response);
+  });
+});

--- a/packages/web/src/components/brief/daily-brief.tsx
+++ b/packages/web/src/components/brief/daily-brief.tsx
@@ -1,4 +1,4 @@
-import type { DailyBrief as DailyBriefData, DailyBriefItem } from "@/lib/api";
+import type { DailyBrief as DailyBriefData, DailyBriefItem, TaskStatus } from "@/lib/api";
 import { useEntityUiOptional } from "@/lib/entity-ui";
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
@@ -64,6 +64,8 @@ export function DailyBrief({
   enabledSections,
   calendarConnected,
   onOpenChat,
+  onUpdateTaskStatus,
+  updatingTaskId,
 }: {
   brief: DailyBriefData;
   running: boolean;
@@ -72,6 +74,10 @@ export function DailyBrief({
   /** Whether the reader has a calendar connected — drives the meetings empty state. */
   calendarConnected?: boolean;
   onOpenChat: (prompt: string) => void;
+  /** Status-update handler owned by Home; passed through to the detail drawer. */
+  onUpdateTaskStatus?: (taskId: string, status: TaskStatus) => void;
+  /** taskId currently being updated, to disable its control; null when idle. */
+  updatingTaskId?: string | null;
 }) {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const entityUi = useEntityUiOptional();
@@ -178,6 +184,8 @@ export function DailyBrief({
         timezone={brief.timezone}
         onClose={() => setSelectedItemId(null)}
         onOpenChat={onOpenChat}
+        onUpdateTaskStatus={onUpdateTaskStatus}
+        updatingTaskId={updatingTaskId}
       />
     </div>
   );

--- a/packages/web/src/components/brief/task-overlay.ts
+++ b/packages/web/src/components/brief/task-overlay.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure helpers for the Live Brief Task Links slice.
+ *
+ * These are extracted from the component tree so the cache-overlay update
+ * logic (and the status formatting it shares with the row + drawer) can be
+ * unit-tested without rendering Home or wiring a router.
+ */
+import type { DailyBrief, DailyBriefItem, DailyBriefResponse, DailyBriefTaskState, TaskStatus } from "@/lib/api";
+
+export const BRIEF_TASK_STATUS_OPTIONS: Array<{ value: TaskStatus; label: string }> = [
+  { value: "open", label: "Open" },
+  { value: "in_progress", label: "In progress" },
+  { value: "done", label: "Done" },
+  { value: "dropped", label: "Dropped" },
+];
+
+export function formatBriefTaskStatus(status: string): string {
+  return BRIEF_TASK_STATUS_OPTIONS.find((option) => option.value === status)?.label ?? status.replace(/_/g, " ");
+}
+
+/** Tailwind classes for the live-status pill/dot keyed by status. */
+export function briefTaskStatusTone(status: TaskStatus): { dot: string; text: string } {
+  switch (status) {
+    case "in_progress":
+      return { dot: "bg-amber-400", text: "text-amber-600 dark:text-amber-400" };
+    case "done":
+      return { dot: "bg-emerald-500", text: "text-emerald-600 dark:text-emerald-400" };
+    case "dropped":
+      return { dot: "bg-muted-foreground/40", text: "text-muted-foreground line-through" };
+    default:
+      return { dot: "bg-muted-foreground/40", text: "text-muted-foreground" };
+  }
+}
+
+/** Supplementary source text shown only for externally-authoritative status. */
+export function briefTaskExternalStatus(task: DailyBriefTaskState): string | null {
+  if (task.statusAuthority === "external" && task.statusRaw) return task.statusRaw;
+  return null;
+}
+
+/** Concise reason copy for a read-only task overlay. */
+export function briefTaskReadonlyReason(task: DailyBriefTaskState): string | null {
+  if (task.readonlyReason === "external_authority") return "Managed by the source system and read-only here.";
+  if (task.readonlyReason === "not_owner") return "Only the creator, assignee, or an admin can change this status.";
+  return null;
+}
+
+/** Return a usable live overlay only when both the canonical id and task are present. */
+export function getBriefItemTask(item: DailyBriefItem): DailyBriefTaskState | null {
+  return item.taskId && item.task ? item.task : null;
+}
+
+const BRIEF_SECTION_KEYS = [
+  "meetings",
+  "todos",
+  "untracked_followups",
+  "looks_resolved",
+  "customer_updates",
+  "active_projects",
+] as const;
+
+/**
+ * Replace the `task` overlay on every brief item whose `taskId` matches the
+ * given task's id, preserving all snapshot fields (title/summary/label/etc.).
+ *
+ * Returns the same response object reference when there is no brief, so callers
+ * can short-circuit without allocating.
+ */
+export function applyTaskOverlayToBriefResponse(
+  response: DailyBriefResponse,
+  task: DailyBriefTaskState,
+): DailyBriefResponse {
+  if (!response.brief) return response;
+  return { ...response, brief: applyTaskOverlayToBrief(response.brief, task) };
+}
+
+export function applyTaskOverlayToBrief(brief: DailyBrief, task: DailyBriefTaskState): DailyBrief {
+  let changed = false;
+  const sections = { ...brief.sections } as DailyBrief["sections"];
+  for (const key of BRIEF_SECTION_KEYS) {
+    const items = sections[key];
+    if (!items || items.length === 0) continue;
+    const nextItems = items.map((item) => {
+      if (item.taskId && item.taskId === task.id) {
+        changed = true;
+        return { ...item, task };
+      }
+      return item;
+    });
+    sections[key] = nextItems;
+  }
+  return changed ? { ...brief, sections } : brief;
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -530,7 +530,7 @@ export interface EntityRelationEvidenceResponse {
 
 export type TaskStatus = "open" | "in_progress" | "done" | "dropped";
 
-export interface EntityTask {
+export interface Task {
   id: string;
   parentEntityId: string | null;
   parentSourceRef: string | null;
@@ -557,6 +557,8 @@ export interface EntityTask {
   updatedAt: string;
   canEditStatus: boolean;
 }
+
+export type EntityTask = Task;
 
 export interface EntityTimelineItem {
   fileId: string;
@@ -1057,6 +1059,31 @@ export interface DailyBriefMeetingPayload {
   attendees: DailyBriefMeetingAttendee[];
 }
 
+/**
+ * Live task-state overlay attached to a Daily Brief item.
+ *
+ * Mirrors the authoritative task record (e.g. an EntityTask) but only carries
+ * the fields the Brief surface needs to render status and ownership. All fields
+ * are optional-safe at the type level via `DailyBriefItem.task` being nullable;
+ * this interface itself describes a fully-populated overlay.
+ */
+export interface DailyBriefTaskState {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  /** Raw status string from the source system; supplementary for external authority. */
+  statusRaw: string | null;
+  /** "local" when Sketch owns the status, "external" when a source system does. */
+  statusAuthority: string;
+  priority: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+  /** Whether the viewer is allowed to mutate the status from the Brief. */
+  canEditStatus: boolean;
+  /** Why the status is read-only for the viewer, when it is. */
+  readonlyReason: "not_owner" | "external_authority" | null;
+}
+
 export interface DailyBriefItem {
   id: string;
   sectionKey: "meetings" | "todos" | "untracked_followups" | "looks_resolved" | "customer_updates" | "active_projects";
@@ -1072,6 +1099,10 @@ export interface DailyBriefItem {
   structuredPayload: DailyBriefMeetingPayload | null;
   knowledgeRefs: DailyBriefKnowledgeRefs;
   sortOrder: number;
+  /** Links this brief item to a live task; absent on legacy/partial payloads. */
+  taskId?: string | null;
+  /** Live task-state overlay; absent on legacy/partial payloads. */
+  task?: DailyBriefTaskState | null;
 }
 
 export interface DailyBrief {
@@ -2731,6 +2762,19 @@ export const api = {
           lastRunAt: string | null;
         }[];
       }>(`/api/usage/summary${qs ? `?${qs}` : ""}`);
+    },
+  },
+  tasks: {
+    /** Fetch the live task record for a single task id. GET /api/tasks/:taskId */
+    get(taskId: string) {
+      return request<{ task: Task }>(`/api/tasks/${encodeURIComponent(taskId)}`);
+    },
+    /** Update a task's status. PATCH /api/tasks/:taskId — returns the updated task. */
+    updateStatus(taskId: string, status: TaskStatus) {
+      return request<{ task: Task }>(`/api/tasks/${encodeURIComponent(taskId)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status }),
+      });
     },
   },
   workspace: {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -1,5 +1,7 @@
 import { DailyBriefEmptyState } from "@/components/brief/brief-empty-state";
 import { DailyBrief } from "@/components/brief/daily-brief";
+import { applyTaskOverlayToBriefResponse } from "@/components/brief/task-overlay";
+import type { DailyBriefResponse, TaskStatus } from "@/lib/api";
 import { api } from "@/lib/api";
 import { chatPrefillTargetFromPrompt } from "@/lib/chat-target";
 import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
@@ -8,7 +10,7 @@ import { createRoute, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { dashboardRoute } from "./dashboard";
 
-const DAILY_BRIEF_QUERY_KEY = ["daily-brief", "latest"];
+export const DAILY_BRIEF_QUERY_KEY = ["daily-brief", "latest"];
 
 export const homeRoute = createRoute({
   getParentRoute: () => dashboardRoute,
@@ -38,6 +40,23 @@ export function HomePage() {
   const brief = briefQuery.data?.brief ?? null;
   const running = briefQuery.data?.running || generateMutation.isPending;
 
+  const updateTaskStatusMutation = useMutation({
+    mutationFn: ({ taskId, status }: { taskId: string; status: TaskStatus }) => api.tasks.updateStatus(taskId, status),
+    onSuccess: ({ task }) => {
+      queryClient.setQueryData<DailyBriefResponse>(DAILY_BRIEF_QUERY_KEY, (current) =>
+        current ? applyTaskOverlayToBriefResponse(current, task) : current,
+      );
+      void queryClient.invalidateQueries({ queryKey: DAILY_BRIEF_QUERY_KEY });
+      toast.success("Task status updated");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to update task status");
+    },
+  });
+  const updatingTaskId = updateTaskStatusMutation.isPending
+    ? (updateTaskStatusMutation.variables?.taskId ?? null)
+    : null;
+
   return (
     <TabContentContainer className="mx-auto box-border min-h-[calc(100vh-3rem)] max-w-4xl px-5 py-10 sm:px-10 md:min-h-screen">
       {brief ? (
@@ -49,6 +68,8 @@ export function HomePage() {
           onOpenChat={(prompt) => {
             void navigate(chatPrefillTargetFromPrompt(prompt));
           }}
+          onUpdateTaskStatus={(taskId, status) => updateTaskStatusMutation.mutate({ taskId, status })}
+          updatingTaskId={updatingTaskId}
         />
       ) : (
         <DailyBriefEmptyState

--- a/packages/web/src/test/msw.ts
+++ b/packages/web/src/test/msw.ts
@@ -331,6 +331,73 @@ export const handlers = [
     });
   }),
 
+  http.get("/api/tasks/:taskId", ({ params }) => {
+    const taskId = String(params.taskId);
+    return HttpResponse.json({
+      task: {
+        id: taskId,
+        parentEntityId: null,
+        parentSourceRef: null,
+        parentName: null,
+        source: "summary",
+        externalRef: null,
+        title: "Linked Brief task",
+        status: "open",
+        statusRaw: "open",
+        statusAuthority: "local",
+        assigneeEntityId: null,
+        assigneeName: null,
+        proposedAssigneeName: null,
+        priority: "medium",
+        dueAt: null,
+        provenance: "summary",
+        sourceTaskId: taskId,
+        createdByUserId: "user-1",
+        createdByUserName: "Test User",
+        createdByUserEmail: "user@example.com",
+        isOwnedByViewer: true,
+        readonlyReason: null,
+        completedAt: null,
+        updatedAt: "2026-07-17T10:00:00.000Z",
+        canEditStatus: true,
+      },
+    });
+  }),
+
+  http.patch("/api/tasks/:taskId", async ({ params, request }) => {
+    const taskId = String(params.taskId);
+    const body = (await request.json()) as { status: string };
+    return HttpResponse.json({
+      task: {
+        id: taskId,
+        parentEntityId: null,
+        parentSourceRef: null,
+        parentName: null,
+        source: "summary",
+        externalRef: null,
+        title: "Linked Brief task",
+        status: body.status,
+        statusRaw: body.status,
+        statusAuthority: "local",
+        assigneeEntityId: null,
+        assigneeName: null,
+        proposedAssigneeName: null,
+        priority: "medium",
+        dueAt: null,
+        provenance: "summary",
+        sourceTaskId: taskId,
+        createdByUserId: "user-1",
+        createdByUserName: "Test User",
+        createdByUserEmail: "user@example.com",
+        isOwnedByViewer: true,
+        readonlyReason: null,
+        completedAt: body.status === "done" ? "2026-07-17T10:00:00.000Z" : null,
+        updatedAt: "2026-07-17T10:00:00.000Z",
+        canEditStatus: true,
+      },
+    });
+  }),
+
   http.put("/api/entities/:id/members/:fileId", () => {
     return HttpResponse.json({ ok: true });
   }),


### PR DESCRIPTION
## Summary

- persist a canonical relationship between Daily Brief output items and durable tasks
- overlay current, permission-filtered task state when reading an existing Brief
- let authorized users update linked task status directly from the Brief, including parentless tasks

Depends on #385. This PR is temporarily based on `feat/durable-conversation-followups-385-corrected` so reviewers see only the Live Brief task-link diff. Retarget to `main` after #385 merges.

## Implementation Details

- adds migration 146 with nullable `agent_output_items.task_id`, an indexed foreign key to `tasks.id`, and `ON DELETE SET NULL`
- introduces a server-only canonical task-link field that cannot be populated by model-provided structured payload
- carries persisted output-item IDs into post-save hooks so promoted and collated Brief todos link to the exact task returned by `promoteBriefTask`
- keeps task promotion, evidence persistence, and output-item linking transactional and idempotent
- extracts shared task visibility, editability, creator, and DTO behavior from entity-scoped routes
- adds parent-independent `GET` and `PATCH /api/tasks/:taskId` endpoints without broadening authorization
- hydrates all linked Brief tasks through one bounded, deduplicated query and suppresses inaccessible task IDs
- supports strict transitional hydration for existing server-owned #385 payloads while canonical links take precedence
- renders live task state in Brief rows and drawers, with editable and read-only states plus cache-safe status mutations
- preserves generated Brief titles, summaries, evidence, and actions as snapshot content

## Verification

- `pnpm exec biome check .` — passed, 1,202 files checked
- `pnpm typecheck` — passed
- `pnpm test` — passed: server 4,319 tests; web 399 tests; 20 live-provider tests skipped by normal gates
- `pnpm build` — passed with existing tsdown option and web chunk-size warnings
- focused server task-link, migration, hydration, global task API, and frontend regressions — passed
- SQLite and PGlite/Postgres migration, foreign-key, transactional-linking, and `SET NULL` coverage — passed
- browser QA passed at desktop and mobile widths for editable tasks, external read-only tasks, legacy fallback, untracked items, mutation/refetch, console, and network behavior
- authenticated API QA covered success paths, invalid status, forbidden updates, private/missing tasks, expiry, deletion, and identity non-disclosure

## Risk / Rollout

- merge #385 before this PR and retarget this PR to `main`
- the legacy `structuredPayload.taskId` fallback is intentionally strict, read-only, permission-filtered, and temporary
- no title-based task inference or broad historical backfill is performed
- old Brief responses remain compatible when `taskId` and `task` are absent
- existing build-size and tsdown warnings are unchanged
