### PR TITLE
feat(web): open active projects from the daily brief

### DIFF
--- a/packages/web/src/components/brief/brief-item-row.tsx
+++ b/packages/web/src/components/brief/brief-item-row.tsx
@@ -59,7 +59,7 @@ export function BriefItemRow({
         ) : null}
       </button>
 
-      <div className="hidden min-w-0 shrink-0 items-center justify-end py-2.5 sm:flex">
+      <div className="flex min-w-0 shrink-0 items-center justify-end py-2.5">
         {item.actionPrompt ? (
           <BriefActionButton label={actionLabel} onClick={() => onOpenChat(item.actionPrompt as string)} />
         ) : null}

--- a/packages/web/src/components/brief/daily-brief.isolated.test.tsx
+++ b/packages/web/src/components/brief/daily-brief.isolated.test.tsx
@@ -24,7 +24,7 @@ function meetingItem(id: string, title: string, startTime: string): DailyBriefIt
   };
 }
 
-function projectItem(id: string, title: string, entityId: string): DailyBriefItem {
+function projectItem(id: string, title: string, entityId: string, actionPrompt: string | null = null): DailyBriefItem {
   return {
     id,
     sectionKey: "active_projects",
@@ -35,7 +35,7 @@ function projectItem(id: string, title: string, entityId: string): DailyBriefIte
     displayRef: null,
     actionType: null,
     actionLabel: null,
-    actionPrompt: null,
+    actionPrompt,
     sourceUrl: null,
     structuredPayload: null,
     knowledgeRefs: { entityIds: [entityId], fileIds: [] },
@@ -107,5 +107,17 @@ describe("DailyBrief Now / Next marker", () => {
     fireEvent.click(screen.getByRole("button", { name: "Atlas rollout" }));
 
     expect(screen.getByTestId("open-stack")).toHaveTextContent("entity-project-1");
+  });
+
+  it("keeps active-project chat actions available alongside entity navigation", () => {
+    const activeProject = projectItem("project-item", "Atlas rollout", "entity-project-1", "Catch me up on Atlas");
+    const onOpenChat = vi.fn();
+    renderWithProviders(<DailyBrief brief={briefWith([], [activeProject])} running={false} onOpenChat={onOpenChat} />);
+
+    const action = screen.getByRole("button", { name: "Catch me up" });
+    expect(action.parentElement).not.toHaveClass("hidden");
+    fireEvent.click(action);
+
+    expect(onOpenChat).toHaveBeenCalledWith("Catch me up on Atlas");
   });
 });

--- a/packages/web/src/components/brief/daily-brief.isolated.test.tsx
+++ b/packages/web/src/components/brief/daily-brief.isolated.test.tsx
@@ -1,5 +1,7 @@
 import type { DailyBrief as DailyBriefData, DailyBriefItem } from "@/lib/api";
-import { act, render, screen, within } from "@testing-library/react";
+import { useEntityUi } from "@/lib/entity-ui";
+import { renderWithProviders } from "@/test/utils";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DailyBrief } from "./daily-brief";
 
@@ -22,7 +24,26 @@ function meetingItem(id: string, title: string, startTime: string): DailyBriefIt
   };
 }
 
-function briefWith(meetings: DailyBriefItem[]): DailyBriefData {
+function projectItem(id: string, title: string, entityId: string): DailyBriefItem {
+  return {
+    id,
+    sectionKey: "active_projects",
+    title,
+    summary: "",
+    priority: "medium",
+    label: "Project",
+    displayRef: null,
+    actionType: null,
+    actionLabel: null,
+    actionPrompt: null,
+    sourceUrl: null,
+    structuredPayload: null,
+    knowledgeRefs: { entityIds: [entityId], fileIds: [] },
+    sortOrder: 0,
+  };
+}
+
+function briefWith(meetings: DailyBriefItem[], activeProjects: DailyBriefItem[] = []): DailyBriefData {
   return {
     id: "brief-1",
     userId: "user-1",
@@ -31,8 +52,13 @@ function briefWith(meetings: DailyBriefItem[]): DailyBriefData {
     status: "ready",
     generatedAt: null,
     masthead: null,
-    sections: { meetings, todos: [], customer_updates: [], active_projects: [] },
+    sections: { meetings, todos: [], customer_updates: [], active_projects: activeProjects },
   };
+}
+
+function StackProbe() {
+  const ui = useEntityUi();
+  return <div data-testid="open-stack">{ui.stack.join(",")}</div>;
 }
 
 function rowWithBadge(): HTMLElement {
@@ -67,5 +93,19 @@ describe("DailyBrief Now / Next marker", () => {
     });
 
     expect(within(rowWithBadge()).getByText("Design review")).toBeInTheDocument();
+  });
+
+  it("opens active-project items through their first entity reference", () => {
+    const activeProject = projectItem("project-item", "Atlas rollout", "entity-project-1");
+    renderWithProviders(
+      <>
+        <DailyBrief brief={briefWith([], [activeProject])} running={false} onOpenChat={() => {}} />
+        <StackProbe />
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Atlas rollout" }));
+
+    expect(screen.getByTestId("open-stack")).toHaveTextContent("entity-project-1");
   });
 });

--- a/packages/web/src/components/brief/daily-brief.tsx
+++ b/packages/web/src/components/brief/daily-brief.tsx
@@ -1,4 +1,5 @@
 import type { DailyBrief as DailyBriefData, DailyBriefItem } from "@/lib/api";
+import { useEntityUiOptional } from "@/lib/entity-ui";
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
 import { BriefDetailDrawer } from "./brief-detail-drawer";
@@ -73,7 +74,24 @@ export function DailyBrief({
   onOpenChat: (prompt: string) => void;
 }) {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const entityUi = useEntityUiOptional();
   const nextMeetingId = useNextMeetingId(brief.sections.meetings ?? []);
+
+  /**
+   * Active-project rows deep-link into project detail — the shared entity
+   * drawer — via the item's first entity reference. This is the daily path
+   * into a project. Every other section opens the brief detail sheet.
+   */
+  const openItem = (item: DailyBriefItem) => {
+    if (item.sectionKey === "active_projects" && entityUi) {
+      const projectEntityId = item.knowledgeRefs.entityIds[0];
+      if (projectEntityId) {
+        entityUi.openEntity(projectEntityId);
+        return;
+      }
+    }
+    setSelectedItemId(item.id);
+  };
   const subtitle =
     brief.masthead?.summary ?? brief.masthead?.title ?? "Today across your to-dos, customers, and projects.";
   const visibleSections = enabledSections
@@ -138,7 +156,7 @@ export function DailyBrief({
                       key={item.id}
                       item={item}
                       isLast={index === items.length - 1}
-                      onOpenDetail={() => setSelectedItemId(item.id)}
+                      onOpenDetail={() => openItem(item)}
                       onOpenChat={onOpenChat}
                     />
                   ))}


### PR DESCRIPTION
## Summary

- open active-project brief rows in the shared entity drawer using the first entity reference
- preserve the existing brief-detail behavior for every other section and for project items without an entity reference
- add regression coverage for project entity navigation

## Validation

- pnpm biome check
- pnpm typecheck
- pnpm test: 4,104 server tests and 386 web tests passed; 20 live-provider tests skipped
- pnpm build