### PR TITLE
fix: capture WhatsApp reconnect appends

### DIFF
--- a/packages/server/src/db/repositories/conversations.integration.test.ts
+++ b/packages/server/src/db/repositories/conversations.integration.test.ts
@@ -177,6 +177,54 @@ function runRepositorySuite(label: string, getDb: () => Promise<Kysely<DB>>, opt
       await expect(repo.findMessageByEventKey(eventKey)).resolves.toMatchObject({ id: pn.row.id, eventKey });
     });
 
+    it("reconciles a legacy bot reply when fresh history replays it as from-me", async () => {
+      const repo = createConversationRepository(db);
+      const conversation = await repo.getOrCreate({
+        platform: "whatsapp",
+        kind: "group",
+        providerConversationId: "group@g.us",
+      });
+      const botReply = await repo.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: "OUTBOUND-1",
+        senderJid: "bot",
+        senderName: "Sketch",
+        text: "reply",
+        isBot: true,
+        source: "live",
+      });
+
+      const replay = await repo.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: "OUTBOUND-1",
+        eventKey: "outbound-event-key",
+        senderJid: "",
+        senderName: "Unknown",
+        text: "reply",
+        providerFromMe: true,
+        source: "history",
+        backfillRangeId: "initial-range",
+      });
+
+      expect(replay.inserted).toBe(false);
+      expect(replay.row).toMatchObject({
+        id: botReply.row.id,
+        eventKey: "outbound-event-key",
+        isBot: true,
+        providerFromMe: true,
+        source: "live",
+        backfillRangeId: "initial-range",
+      });
+      await expect(
+        db
+          .selectFrom("conversation_messages")
+          .select(({ fn }) => fn.countAll<number>().as("count"))
+          .where("conversation_id", "=", conversation.id)
+          .where("provider_message_id", "=", "OUTBOUND-1")
+          .executeTakeFirstOrThrow(),
+      ).resolves.toEqual({ count: 1 });
+    });
+
     it("finds the latest message by provider message id within a conversation", async () => {
       const repo = createConversationRepository(db);
       const conversation = await repo.getOrCreate({

--- a/packages/server/src/db/repositories/conversations.ts
+++ b/packages/server/src/db/repositories/conversations.ts
@@ -153,6 +153,17 @@ async function findExistingMessage(db: ConversationDb, data: ConversationMessage
       .executeTakeFirst();
     if (byEventKey) return byEventKey;
   }
+  if (data.source === "history" && data.providerFromMe && !data.isBot) {
+    const legacyOutbound = await db
+      .selectFrom("conversation_messages")
+      .selectAll()
+      .where("conversation_id", "=", data.conversationId)
+      .where("provider_message_id", "=", data.providerMessageId)
+      .where("is_bot", "=", 1)
+      .orderBy("id", "asc")
+      .executeTakeFirst();
+    if (legacyOutbound) return legacyOutbound;
+  }
   return legacyMessageUniqueWhere(db, data).executeTakeFirst();
 }
 
@@ -183,6 +194,20 @@ function whatsappPhoneSenderCandidates(phoneE164?: string | null): string[] {
 }
 
 export function createConversationRepository(db: ConversationDb) {
+  async function reconcileOutboundIdentity(
+    row: ConversationMessageRow,
+    data: ConversationMessageInsert,
+  ): Promise<ConversationMessageRow> {
+    if (!row.is_bot || !data.providerFromMe || !data.eventKey) return row;
+    await db
+      .updateTable("conversation_messages")
+      .set({ event_key: data.eventKey, provider_from_me: 1 })
+      .where("id", "=", row.id)
+      .where("event_key", "is", null)
+      .execute();
+    return db.selectFrom("conversation_messages").selectAll().where("id", "=", row.id).executeTakeFirstOrThrow();
+  }
+
   async function stampBackfillRangeIfUnowned(
     row: ConversationMessageRow,
     backfillRangeId: string | null | undefined,
@@ -202,7 +227,8 @@ export function createConversationRepository(db: ConversationDb) {
   ): Promise<{ row: StoredConversationMessage; inserted: boolean }> {
     const existing = await findExistingMessage(db, data);
     if (existing) {
-      return { row: toStored(await stampBackfillRangeIfUnowned(existing, data.backfillRangeId)), inserted: false };
+      const reconciled = await reconcileOutboundIdentity(existing, data);
+      return { row: toStored(await stampBackfillRangeIfUnowned(reconciled, data.backfillRangeId)), inserted: false };
     }
 
     const receivedAt = data.receivedAt ?? new Date().toISOString();
@@ -234,7 +260,8 @@ export function createConversationRepository(db: ConversationDb) {
     } catch {
       const row = await findExistingMessage(db, data);
       if (row) {
-        return { row: toStored(await stampBackfillRangeIfUnowned(row, data.backfillRangeId)), inserted: false };
+        const reconciled = await reconcileOutboundIdentity(row, data);
+        return { row: toStored(await stampBackfillRangeIfUnowned(reconciled, data.backfillRangeId)), inserted: false };
       }
       throw new Error("Failed to insert conversation message");
     }

--- a/packages/server/src/whatsapp/adapter.isolated.test.ts
+++ b/packages/server/src/whatsapp/adapter.isolated.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { PROMPT_TOO_LONG_RECOVERY_MESSAGE, PROMPT_TOO_LONG_SHARED_RECOVERY_MESSAGE } from "../agent/errors";
 import { NEW_SESSION_CONFIRMATIONS } from "../commands";
+import { createWhatsAppEventKey } from "../db/repositories/whatsapp-inbound-events";
 import { type Attachment, downloadWhatsAppMedia } from "../files";
 import { QueueManager } from "../queue";
 import { createTestConfig, flush } from "../test-utils";
@@ -1238,6 +1239,15 @@ describe("whatsapp/adapter", () => {
       expect(mock.startComposing).toHaveBeenCalledWith("1234567890@s.whatsapp.net");
       expect(mock.sendText).toHaveBeenCalledWith("1234567890@s.whatsapp.net", "hello back");
       expect(mock.stopComposing).toHaveBeenCalledWith("1234567890@s.whatsapp.net");
+      expect(deps.repos.conversations.insertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerMessageId: "sent-1",
+          eventKey: createWhatsAppEventKey("1234567890@s.whatsapp.net", "sent-1", true),
+          isBot: true,
+          providerFromMe: true,
+          source: "live",
+        }),
+      );
     });
 
     it("does not send DM tool progress by default", async () => {

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -28,6 +28,7 @@ import type { createInboxMessagesRepository } from "../db/repositories/inbox-mes
 import { type createSettingsRepository, parseOrgContext } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
 import type { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
+import { createWhatsAppEventKey } from "../db/repositories/whatsapp-inbound-events";
 import type { DB } from "../db/schema";
 import { type Attachment, extensionToMime } from "../files";
 import { appendIntegrationConnectionLinks } from "../integrations/connection-links";
@@ -406,19 +407,22 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
     botName?: string | null;
     connectionKey?: string | null;
   }) => {
-    const providerMessageId = params.sent?.providerMessageId;
+    const sent = params.sent;
+    const providerMessageId = sent?.providerMessageId;
     if (!providerMessageId) return;
-    const providerTimestamp = validWhatsAppProviderTimestamp(params.sent?.providerTimestamp);
+    const providerTimestamp = validWhatsAppProviderTimestamp(sent.providerTimestamp);
 
     await repos.conversations.insertMessage({
       conversationId: params.conversationId,
       providerMessageId,
+      eventKey: createWhatsAppEventKey(sent.providerConversationId, providerMessageId, true),
       senderJid: "bot",
       senderName: params.botName ?? "Sketch",
       isBot: true,
       addressedToSketch: false,
       text: params.text,
       providerTimestamp: providerTimestamp ?? null,
+      providerFromMe: true,
       source: "live",
       connectionKey: params.connectionKey ?? null,
     });

--- a/packages/server/src/whatsapp/bot.isolated.test.ts
+++ b/packages/server/src/whatsapp/bot.isolated.test.ts
@@ -941,13 +941,15 @@ describe("WhatsAppBot handleGroupMessage LID resolution", () => {
     (bot as unknown as { registerMessageHandler: () => void }).registerMessageHandler();
 
     const captured: unknown[] = [];
-    bot.onMessage(async (msg) => {
+    const capturedMetadata: unknown[] = [];
+    bot.onMessage(async (msg, metadata) => {
       captured.push(msg);
+      capturedMetadata.push(metadata);
     });
 
     const fire = (payload: unknown) => handlers.get("messages.upsert")?.(payload);
 
-    return { bot, fire, captured };
+    return { bot, fire, captured, capturedMetadata };
   }
 
   function makeGroupMsg(participantJid: string): proto.IWebMessageInfo {
@@ -1005,6 +1007,22 @@ describe("WhatsAppBot handleGroupMessage LID resolution", () => {
     const msg = captured[0] as { type: string; senderPhone: string | null };
     expect(msg.type).toBe("group");
     expect(msg.senderPhone).toBeNull();
+  });
+
+  it("forwards an offline append once when a normal notify overlaps", async () => {
+    const { fire, captured, capturedMetadata } = createBotWithMockSocket(async () => "+15550001111");
+
+    await fire({
+      type: "append",
+      messages: [makeGroupMsg("86702773280883@lid")],
+    });
+    await fire({
+      type: "notify",
+      messages: [makeGroupMsg("86702773280883@lid")],
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(capturedMetadata).toEqual([{ socketGeneration: 0, upsertType: "append" }]);
   });
 });
 

--- a/packages/server/src/whatsapp/bot.ts
+++ b/packages/server/src/whatsapp/bot.ts
@@ -37,6 +37,7 @@ import { collectWhatsAppGroupParticipants, toParticipantInputs } from "./group-p
 import type { WhatsAppGroupMetadata as ProviderWhatsAppGroupMetadata } from "./provider";
 
 const ECHO_TTL_MS = 60_000;
+const INBOUND_DEDUPE_TTL_MS = 60_000;
 const COMPOSING_INTERVAL_MS = 5_000;
 const COMPOSING_TTL_MS = 3 * 60_000;
 const WATCHDOG_INTERVAL_MS = 60_000;
@@ -90,6 +91,7 @@ export type WhatsAppMessage = WhatsAppDmMessage | WhatsAppGroupMessage;
 
 export interface WhatsAppCaptureMetadata {
   socketGeneration: number;
+  upsertType?: "notify" | "append";
 }
 
 export type WhatsAppMessageHandler = (message: WhatsAppMessage, metadata: WhatsAppCaptureMetadata) => Promise<void>;
@@ -157,6 +159,7 @@ export class WhatsAppBot {
   private handler: WhatsAppMessageHandler | null = null;
   private historyHandler: WhatsAppHistoryMessagesHandler | null = null;
   private recentlySent = new Set<string>();
+  private recentlyReceived = new Set<string>();
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private activeSocketGeneration = 0;
@@ -744,7 +747,8 @@ export class WhatsAppBot {
         return;
       }
 
-      if (type !== "notify") return;
+      if (type !== "notify" && type !== "append") return;
+      const metadata: WhatsAppCaptureMetadata = { socketGeneration, upsertType: type };
 
       for (const msg of messages) {
         if (!msg.message) continue;
@@ -767,9 +771,9 @@ export class WhatsAppBot {
         if (!text && !hasMedia) continue;
 
         if (isGroup) {
-          await this.handleGroupMessage(msg, jid, text, messageType, hasMedia, socketGeneration);
+          await this.handleGroupMessage(msg, jid, text, messageType, hasMedia, metadata);
         } else {
-          await this.handleDmMessage(msg, jid, isStandardDm, text, messageType, hasMedia, socketGeneration);
+          await this.handleDmMessage(msg, jid, isStandardDm, text, messageType, hasMedia, metadata);
         }
       }
     });
@@ -782,7 +786,7 @@ export class WhatsAppBot {
     text: string | null,
     messageType: string | undefined,
     hasMedia: boolean,
-    socketGeneration: number,
+    metadata: WhatsAppCaptureMetadata,
   ): Promise<void> {
     let phoneNumber: string | null = null;
 
@@ -798,21 +802,23 @@ export class WhatsAppBot {
 
     if (this.handler) {
       const quotedMessage = extractQuotedMessage(msg.message ? extractContextInfo(msg.message) : undefined);
-      this.lastMessageAt = Date.now();
-      await this.handler(
-        {
-          type: "dm",
-          text: text ?? "",
-          phoneNumber,
-          jid,
-          messageId: msg.key?.id ?? "",
-          pushName: msg.pushName ?? "Unknown",
-          rawMessage: msg,
-          mediaType: hasMedia ? (messageType ?? undefined) : undefined,
-          ...(quotedMessage ? { quotedMessage } : {}),
-        },
-        { socketGeneration },
-      );
+      await this.dispatchInboundOnce(msg, async () => {
+        this.lastMessageAt = Date.now();
+        await this.handler?.(
+          {
+            type: "dm",
+            text: text ?? "",
+            phoneNumber,
+            jid,
+            messageId: msg.key?.id ?? "",
+            pushName: msg.pushName ?? "Unknown",
+            rawMessage: msg,
+            mediaType: hasMedia ? (messageType ?? undefined) : undefined,
+            ...(quotedMessage ? { quotedMessage } : {}),
+          },
+          metadata,
+        );
+      });
     }
   }
 
@@ -822,13 +828,35 @@ export class WhatsAppBot {
     text: string | null,
     messageType: string | undefined,
     hasMedia: boolean,
-    socketGeneration: number,
+    metadata: WhatsAppCaptureMetadata,
   ): Promise<void> {
     const groupMessage = await this.buildGroupMessage(msg, groupJid, text, messageType, hasMedia);
     if (groupMessage && this.handler) {
-      this.lastMessageAt = Date.now();
-      await this.handler(groupMessage, { socketGeneration });
+      await this.dispatchInboundOnce(msg, async () => {
+        this.lastMessageAt = Date.now();
+        await this.handler?.(groupMessage, metadata);
+      });
     }
+  }
+
+  private async dispatchInboundOnce(msg: proto.IWebMessageInfo, dispatch: () => Promise<void>): Promise<void> {
+    const providerMessageId = msg.key?.id;
+    const providerConversationId = msg.key?.remoteJid;
+    if (!providerMessageId || !providerConversationId) {
+      await dispatch();
+      return;
+    }
+    const key = `${providerConversationId}\u001f${providerMessageId}\u001f${String(Boolean(msg.key?.fromMe))}`;
+    if (this.recentlyReceived.has(key)) return;
+    this.recentlyReceived.add(key);
+    try {
+      await dispatch();
+    } catch (error) {
+      this.recentlyReceived.delete(key);
+      throw error;
+    }
+    const expiry = setTimeout(() => this.recentlyReceived.delete(key), INBOUND_DEDUPE_TTL_MS);
+    expiry.unref?.();
   }
 
   /**

--- a/packages/server/src/whatsapp/gateway/capture.integration.test.ts
+++ b/packages/server/src/whatsapp/gateway/capture.integration.test.ts
@@ -162,6 +162,56 @@ describe("WhatsApp gateway Baileys absorption capture", () => {
     expect(liveRows).toEqual([{ kind: "message", event_key: liveKey }]);
   });
 
+  it("captures append then notify overlap once as promoted reconnect history", async () => {
+    const capture = new WhatsAppGatewayCapture({
+      db,
+      logger: createTestLogger(),
+      stagingDir: join(directory, "staging"),
+      maxFileBytes: 1024,
+      getSocket: () => null,
+      rememberMessage: () => undefined,
+      isInitialSyncGeneration: () => false,
+      wake: async () => undefined,
+      onPersistFailure: () => undefined,
+      leaseGeneration: 4,
+    });
+    const appendFirst = groupMessage("append-first", new Date().toISOString());
+    const notifyFirst = groupMessage("notify-first", new Date().toISOString());
+
+    await capture.captureMessage(appendFirst, { socketGeneration: 2, upsertType: "append" });
+    await capture.captureMessage(appendFirst, { socketGeneration: 2, upsertType: "notify" });
+    await capture.captureMessage(notifyFirst, { socketGeneration: 2, upsertType: "notify" });
+    await capture.captureMessage(notifyFirst, { socketGeneration: 2, upsertType: "append" });
+
+    await expect(
+      db.selectFrom("whatsapp_inbound_events").select(["kind", "provider_message_id"]).orderBy("id", "asc").execute(),
+    ).resolves.toEqual([
+      { kind: "history_message", provider_message_id: "append-first" },
+      { kind: "message", provider_message_id: "notify-first" },
+    ]);
+  });
+
+  it("does not promote offline append traffic during a fresh pairing generation", async () => {
+    const capture = new WhatsAppGatewayCapture({
+      db,
+      logger: createTestLogger(),
+      stagingDir: join(directory, "staging"),
+      maxFileBytes: 1024,
+      getSocket: () => null,
+      rememberMessage: () => undefined,
+      isInitialSyncGeneration: () => true,
+      wake: async () => undefined,
+      onPersistFailure: () => undefined,
+    });
+
+    await capture.captureMessage(groupMessage("initial-append", new Date().toISOString()), {
+      socketGeneration: 1,
+      upsertType: "append",
+    });
+
+    await expect(db.selectFrom("whatsapp_inbound_events").select("id").execute()).resolves.toEqual([]);
+  });
+
   it("emits initial-sync history sets as batch rows without history_message rows", async () => {
     const capture = new WhatsAppGatewayCapture({
       db,

--- a/packages/server/src/whatsapp/gateway/capture.integration.test.ts
+++ b/packages/server/src/whatsapp/gateway/capture.integration.test.ts
@@ -191,6 +191,34 @@ describe("WhatsApp gateway Baileys absorption capture", () => {
     ]);
   });
 
+  it("stages media for promoted reconnect append messages", async () => {
+    const capture = new WhatsAppGatewayCapture({
+      db,
+      logger: createTestLogger(),
+      stagingDir: join(directory, "staging"),
+      maxFileBytes: 1024,
+      getSocket: () => null,
+      rememberMessage: () => undefined,
+      isInitialSyncGeneration: () => false,
+      wake: async () => undefined,
+      onPersistFailure: () => undefined,
+    });
+    const media = groupMessage("append-media", new Date().toISOString());
+    media.mediaType = "imageMessage";
+
+    await capture.captureMessage(media, { socketGeneration: 2, upsertType: "append" });
+
+    const row = await db.selectFrom("whatsapp_inbound_events").select(["kind", "envelope"]).executeTakeFirstOrThrow();
+    const envelope = JSON.parse(row.envelope) as {
+      message: { stagedMediaRef: unknown; mediaStagingError: string | null };
+    };
+    expect(row.kind).toBe("history_message");
+    expect(envelope.message).toMatchObject({
+      stagedMediaRef: null,
+      mediaStagingError: "WhatsApp socket unavailable for media staging",
+    });
+  });
+
   it("does not promote offline append traffic during a fresh pairing generation", async () => {
     const capture = new WhatsAppGatewayCapture({
       db,

--- a/packages/server/src/whatsapp/gateway/capture.ts
+++ b/packages/server/src/whatsapp/gateway/capture.ts
@@ -35,6 +35,11 @@ interface PreparedHistoryMessage {
   oversized: boolean;
 }
 
+interface PrepareMessageEnvelopeOptions {
+  timestamp?: string;
+  stageMedia?: boolean;
+}
+
 export interface WhatsAppGatewayCaptureDeps {
   db: Kysely<DB>;
   logger: Logger;
@@ -151,6 +156,7 @@ export class WhatsAppGatewayCapture {
         message,
         kind,
         createWhatsAppConnectionKey(this.deps.leaseGeneration ?? 0, metadata.socketGeneration),
+        { stageMedia: kind === "message" || metadata.upsertType === "append" },
       );
       const result = await this.events.insert({
         kind,
@@ -253,7 +259,7 @@ export class WhatsAppGatewayCapture {
     connectionKey: string,
     timestamp: string,
   ): Promise<PreparedHistoryMessage> {
-    let envelope = await this.prepareMessageEnvelope(message, "history_message", connectionKey, timestamp);
+    let envelope = await this.prepareMessageEnvelope(message, "history_message", connectionKey, { timestamp });
     let oversized = byteLength(envelope) > WHATSAPP_HISTORY_CHUNK_MAX_BYTES - HISTORY_CHUNK_SIZE_RESERVE_BYTES;
     if (oversized) {
       envelope = whatsAppMessageEnvelopeSchema.parse({
@@ -269,8 +275,9 @@ export class WhatsAppGatewayCapture {
     message: WhatsAppMessage,
     kind: "message" | "history_message",
     connectionKey: string,
-    timestamp = providerTimestamp(message, this.now),
+    options: PrepareMessageEnvelopeOptions = {},
   ): Promise<WhatsAppMessageEnvelope> {
+    const timestamp = options.timestamp ?? providerTimestamp(message, this.now);
     const identity = rawProviderIdentity(message);
     const eventKey = createWhatsAppEventKey(
       identity.providerConversationId,
@@ -285,7 +292,8 @@ export class WhatsAppGatewayCapture {
         ...(eventKey ? { eventKey } : {}),
       });
     }
-    const staged = kind === "message" ? await this.stageMedia(message) : { ref: null, error: null };
+    const staged =
+      (options.stageMedia ?? kind === "message") ? await this.stageMedia(message) : { ref: null, error: null };
     return whatsAppMessageEnvelopeSchema.parse({
       version: "1.0",
       kind,

--- a/packages/server/src/whatsapp/gateway/capture.ts
+++ b/packages/server/src/whatsapp/gateway/capture.ts
@@ -138,6 +138,8 @@ export class WhatsAppGatewayCapture {
     metadata: WhatsAppCaptureMetadata = { socketGeneration: 0 },
   ): Promise<void> {
     const identity = rawProviderIdentity(message);
+    if (metadata.upsertType === "append" && this.deps.isInitialSyncGeneration()) return;
+    const kind = metadata.upsertType === "append" ? "history_message" : "message";
     const eventKey = createWhatsAppEventKey(
       identity.providerConversationId,
       identity.providerMessageId ?? "",
@@ -147,11 +149,11 @@ export class WhatsAppGatewayCapture {
       if (eventKey && (await this.events.findByEventKey(eventKey))) return;
       const envelope = await this.prepareMessageEnvelope(
         message,
-        "message",
+        kind,
         createWhatsAppConnectionKey(this.deps.leaseGeneration ?? 0, metadata.socketGeneration),
       );
       const result = await this.events.insert({
-        kind: "message",
+        kind,
         origin: "gateway",
         eventKey,
         providerMessageId: identity.providerMessageId,

--- a/packages/server/src/whatsapp/inbound-consumer.test.ts
+++ b/packages/server/src/whatsapp/inbound-consumer.test.ts
@@ -437,6 +437,7 @@ describe("WhatsAppInboundConsumer", () => {
       ["boundary-live-first", "2026-07-15T08:27:00.000Z"],
       ["boundary-live-second", "2026-07-15T08:28:00.000Z"],
     ]);
+    const adoptPassiveHistory = vi.fn(async () => undefined);
     const consumer = new WhatsAppInboundConsumer({
       db,
       logger: createTestLogger(),
@@ -470,6 +471,11 @@ describe("WhatsAppInboundConsumer", () => {
           return true;
         },
       }),
+      backfillWorker: {
+        correlateOnDemandSession: async () => false,
+        handleOnDemandResponse: async () => false,
+        adoptPassiveHistory,
+      },
     });
 
     consumer.start();
@@ -507,6 +513,8 @@ describe("WhatsAppInboundConsumer", () => {
       kind: "initial",
       upper_bound_at: "2026-07-15T08:27:00.000Z",
     });
+    expect(adoptPassiveHistory).toHaveBeenCalledTimes(1);
+    expect(adoptPassiveHistory).toHaveBeenCalledWith(["120363000000001@g.us"]);
   });
 
   it("terminally consumes a Baileys DM when the configured DM provider is Wati", async () => {

--- a/packages/server/src/whatsapp/inbound-consumer.ts
+++ b/packages/server/src/whatsapp/inbound-consumer.ts
@@ -278,6 +278,9 @@ export class WhatsAppInboundConsumer {
       },
     });
     if (!captureCommitted && !(await this.events.markCaptured(row.id, claimToken))) return;
+    if (envelope.kind === "history_message" && message.kind === "group") {
+      await this.options.backfillWorker?.adoptPassiveHistory([message.target.groupId]);
+    }
     if (envelope.fromMe) {
       if (!(await this.events.markConsumed(row.id, claimToken))) return;
       this.options.logger.warn(

--- a/packages/server/src/whatsapp/providers/baileys.test.ts
+++ b/packages/server/src/whatsapp/providers/baileys.test.ts
@@ -5,7 +5,9 @@ import { phoneE164ToWhatsAppJid } from "../provider";
 import { createBaileysWhatsAppProviders } from "./baileys";
 
 function createMockBot() {
-  let messageHandler: ((message: unknown, metadata: { socketGeneration: number }) => Promise<void>) | null = null;
+  let messageHandler:
+    | ((message: unknown, metadata: { socketGeneration: number; upsertType?: "notify" | "append" }) => Promise<void>)
+    | null = null;
   let historyHandler: ((messages: unknown[], metadata: { socketGeneration: number }) => Promise<unknown>) | null = null;
   const bot = {
     isConnected: true,
@@ -32,8 +34,8 @@ function createMockBot() {
   return {
     bot,
     facade: new InProcessSocketFacade(bot as never, createTestLogger()),
-    emit: async (message: unknown, socketGeneration = 1) => {
-      await messageHandler?.(message, { socketGeneration });
+    emit: async (message: unknown, socketGeneration = 1, upsertType: "notify" | "append" = "notify") => {
+      await messageHandler?.(message, { socketGeneration, upsertType });
     },
     emitHistory: async (messages: unknown[], socketGeneration = 1) => {
       await historyHandler?.(messages, { socketGeneration });
@@ -232,5 +234,48 @@ describe("createBaileysWhatsAppProviders", () => {
       [expect.objectContaining({ connectionKey: "000000000007:000000000020" })],
       expect.objectContaining({ socketGeneration: 20 }),
     );
+  });
+
+  it("routes in-process append messages through history handling instead of the live adapter", async () => {
+    const { bot, facade, emit } = createMockBot();
+    const providers = createBaileysWhatsAppProviders(facade, bot as never, createTestLogger(), {
+      getLeaseGeneration: () => 7,
+    });
+    const liveHandler = vi.fn();
+    const historyHandler = vi.fn(async () => ({ persisted: 1, skippedOld: 0, skippedDup: 0 }));
+    providers.inboundProvider.onMessage(liveHandler);
+    providers.inboundProvider.onHistoryMessages?.(historyHandler);
+
+    await emit(
+      {
+        type: "group",
+        text: "missed message",
+        jid: "group@g.us",
+        messageId: "append-1",
+        pushName: "Alice",
+        rawMessage: {
+          key: {
+            id: "append-1",
+            remoteJid: "group@g.us",
+            participant: "15551234567@s.whatsapp.net",
+            fromMe: false,
+          },
+          messageTimestamp: 1_700_000_000,
+        },
+        isMentioned: true,
+        senderJid: "15551234567@s.whatsapp.net",
+        senderPhone: "+15551234567",
+      },
+      20,
+      "append",
+    );
+
+    expect(liveHandler).not.toHaveBeenCalled();
+    expect(historyHandler).toHaveBeenCalledWith([
+      expect.objectContaining({
+        providerMessageId: "append-1",
+        connectionKey: "000000000007:000000000020",
+      }),
+    ]);
   });
 });

--- a/packages/server/src/whatsapp/providers/baileys.ts
+++ b/packages/server/src/whatsapp/providers/baileys.ts
@@ -7,6 +7,7 @@ import type { WhatsAppHistoryMessagesHandler, WhatsAppMessage, WhatsAppMessageHa
 import { createWhatsAppConnectionKey } from "../connection-key";
 import type { WhatsAppQuotedRef, WhatsAppSocketFacade } from "../facade-contract";
 import {
+  type WhatsAppHistoryMessagesHandler as ProviderWhatsAppHistoryMessagesHandler,
   WHATSAPP_BAILEYS_PROVIDER_ID,
   type WhatsAppCapabilities,
   type WhatsAppDmProvider,
@@ -62,6 +63,7 @@ export function createBaileysWhatsAppProviders(
   logger: Logger,
   options: { getLeaseGeneration?: () => number | null } = {},
 ): BaileysWhatsAppProviders {
+  let appendHistoryHandler: ProviderWhatsAppHistoryMessagesHandler | null = null;
   const connectionKey = (socketGeneration: number): string | null => {
     const leaseGeneration = options.getLeaseGeneration?.();
     return leaseGeneration === null || leaseGeneration === undefined
@@ -223,7 +225,7 @@ export function createBaileysWhatsAppProviders(
     inboundProvider: {
       id: WHATSAPP_BAILEYS_PROVIDER_ID,
       onMessage(handler) {
-        inboundSource.onMessage((message, metadata) => {
+        inboundSource.onMessage(async (message, metadata) => {
           const normalized = normalizeBaileysInboundMessage(message, connectionKey(metadata.socketGeneration));
           rememberMessage(
             whatsapp,
@@ -231,10 +233,15 @@ export function createBaileysWhatsAppProviders(
             normalized.providerMessageId,
             normalized.rawProviderPayload,
           );
-          return handler(normalized);
+          if (metadata.upsertType === "append") {
+            await appendHistoryHandler?.([normalized]);
+            return;
+          }
+          await handler(normalized);
         });
       },
       onHistoryMessages(handler) {
+        appendHistoryHandler = handler;
         inboundSource.onHistoryMessages((messages, metadata) => {
           const historyConnectionKey = connectionKey(metadata.socketGeneration);
           const normalized = messages.map((message) => normalizeBaileysInboundMessage(message, historyConnectionKey));


### PR DESCRIPTION
## What changed

- accept Baileys `append` upserts during ordinary reconnects
- persist reconnect appends as `history_message` events without moving the live boundary
- stage media before promoted reconnect appends enter the durable history queue
- deduplicate overlapping `append` and `notify` delivery in-process and through the durable event key
- route in-process `append` traffic through history handling so it cannot trigger the live adapter
- adopt passive reconnect history immediately so the matching backfill gap can proceed
- ignore append promotion during a fresh pairing generation
- persist live WhatsApp bot replies with their canonical outbound event identity
- reconcile pre-backfill bot replies when fresh history replays them as `fromMe`

## Root cause

Baileys delivers messages missed during a temporary disconnect as `messages.upsert` with type `append`. The WhatsApp bot accepted only `notify`, so the missed message was discarded and its reconnect gap remained `awaiting_anchor`. Promoting append rows to history also disabled media staging even though those reconnect messages remain actionable.

During fresh pairing, Baileys also replays previously sent Sketch replies as outbound history. Live bot replies were stored without `providerFromMe` or an event key, so the history copy did not match the existing conversation row.

The in-process provider discarded the Baileys upsert classification after normalization, allowing `append` history to enter the live adapter and potentially trigger agents for old messages.

## Impact

Ordinary gateway disconnect/reconnect now captures each missed message once, preserves history provenance and attachments, and allows the reconnect backfill range to complete. Fresh pairing deduplicates both new and pre-backfill Sketch replies while retaining opposite-direction messages. In-process append traffic remains passive history rather than live agent input. No cleanup migration is included because backfill has not been deployed to tenants.

## Validation

- 100 focused adapter and SQLite/Postgres repository tests passed for the outbound replay fix
- 16 gateway capture integration tests passed, including reconnect append media staging
- in-process provider regression proves append messages use history handling while notify remains live
- full lint and typecheck passed
- full test suite passed: 4,571 tests, with 20 live-provider tests skipped
- production build passed
- live temporary disconnect test captured one missed group message exactly once
- live fresh-pair test reproduced the outbound replay mismatch before the fix and confirmed the affected provider identities
