### PR TITLE
fix: seed combined routes from member outputs

### DIFF
--- a/packages/server/src/agents/definitions/conversation-summary.ts
+++ b/packages/server/src/agents/definitions/conversation-summary.ts
@@ -271,6 +271,9 @@ export async function buildConversationSummaryRuntimeContext(
       userId: params.user.id,
       routeId,
       sourceKey,
+      sourceKeys: params.agentConfig.sources.map(
+        (source) => `${source.platform}:${source.targetType}:${source.targetId}`,
+      ),
       allowedConversationIds: conversationIds,
       now: params.now.toISOString(),
     });

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -151,6 +151,7 @@ import * as m148 from "./migrations/148-whatsapp-pending-slices-index";
 import * as m149 from "./migrations/149-whatsapp-backfill-lifecycle-durability";
 import * as m150 from "./migrations/150-task-durability-steel-thread";
 import * as m151 from "./migrations/151-agent-output-item-task-links";
+import * as m152 from "./migrations/152-reseed-combined-durability-routes";
 import type { DB } from "./schema";
 
 /**
@@ -311,6 +312,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "149-whatsapp-backfill-lifecycle-durability": m149,
           "150-task-durability-steel-thread": m150,
           "151-agent-output-item-task-links": m151,
+          "152-reseed-combined-durability-routes": m152,
         };
       },
     },

--- a/packages/server/src/db/migrations/152-reseed-combined-durability-routes.ts
+++ b/packages/server/src/db/migrations/152-reseed-combined-durability-routes.ts
@@ -1,0 +1,15 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE task_durability_route_state
+    SET mode = 'hybrid',
+        seed_state = 'pending',
+        seed_reviewed_at = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE source_key LIKE 'route:%'
+      AND seed_state = 'reviewed'
+  `.execute(db);
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -20,7 +20,7 @@ import type { DB } from "../schema";
 import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
 
-const EXPECTED_MIGRATION_COUNT = 147;
+const EXPECTED_MIGRATION_COUNT = 148;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -23,8 +23,9 @@ import * as m119 from "./119-agent-outputs-source-scope";
 import * as m120 from "./120-agent-output-period-key";
 import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
+import * as combinedDurabilityReseedMigration from "./152-reseed-combined-durability-routes";
 
-const EXPECTED_MIGRATION_COUNT = 147;
+const EXPECTED_MIGRATION_COUNT = 148;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -215,6 +216,80 @@ describe("runMigrations — full sequence", () => {
     expect(names[144]).toBe("149-whatsapp-backfill-lifecycle-durability");
     expect(names[145]).toBe("150-task-durability-steel-thread");
     expect(names[146]).toBe("151-agent-output-item-task-links");
+    expect(names[147]).toBe("152-reseed-combined-durability-routes");
+  });
+
+  it("resets reviewed combined durability routes for member-source reseeding", async () => {
+    await runMigrations(db, { quiet: true });
+    await db.insertInto("users").values({ id: "reseed-user", name: "Reseed User" }).execute();
+    await db
+      .insertInto("task_durability_route_state")
+      .values([
+        {
+          agent_key: "conversation_summary",
+          user_id: "reseed-user",
+          route_id: "combined-reviewed",
+          source_key: "route:combined",
+          mode: "durable_only",
+          seed_state: "reviewed",
+          seed_reviewed_at: "2026-07-01T00:00:00.000Z",
+          incremental_success_at: "2026-07-02T00:00:00.000Z",
+        },
+        {
+          agent_key: "conversation_summary",
+          user_id: "reseed-user",
+          route_id: "direct-reviewed",
+          source_key: "slack:channel:C_DIRECT",
+          mode: "durable_only",
+          seed_state: "reviewed",
+          seed_reviewed_at: "2026-07-01T00:00:00.000Z",
+          incremental_success_at: "2026-07-02T00:00:00.000Z",
+        },
+        {
+          agent_key: "conversation_summary",
+          user_id: "reseed-user",
+          route_id: "combined-pending",
+          source_key: "route:pending",
+          mode: "hybrid",
+          seed_state: "pending",
+          seed_reviewed_at: null,
+          incremental_success_at: null,
+        },
+      ])
+      .execute();
+
+    await combinedDurabilityReseedMigration.up(db as unknown as Kysely<unknown>);
+
+    await expect(
+      db
+        .selectFrom("task_durability_route_state")
+        .select(["route_id", "mode", "seed_state", "seed_reviewed_at", "incremental_success_at"])
+        .where("user_id", "=", "reseed-user")
+        .orderBy("route_id", "asc")
+        .execute(),
+    ).resolves.toEqual([
+      {
+        route_id: "combined-pending",
+        mode: "hybrid",
+        seed_state: "pending",
+        seed_reviewed_at: null,
+        incremental_success_at: null,
+      },
+      {
+        route_id: "combined-reviewed",
+        mode: "hybrid",
+        seed_state: "pending",
+        seed_reviewed_at: null,
+        incremental_success_at: "2026-07-02T00:00:00.000Z",
+      },
+      {
+        route_id: "direct-reviewed",
+        mode: "durable_only",
+        seed_state: "reviewed",
+        seed_reviewed_at: "2026-07-01T00:00:00.000Z",
+        incremental_success_at: "2026-07-02T00:00:00.000Z",
+      },
+    ]);
   });
 
   it("creates the bounded open-materializable partial index", async () => {

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -964,6 +964,31 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
       return outputsWithItems(rows);
     },
 
+    async listCompletedForScopesSince(
+      agentKey: string,
+      userId: string,
+      sourceKeys: string[],
+      sinceIso: string,
+      options: { limit?: number } = {},
+    ): Promise<AgentOutputWithItems[]> {
+      const scopes = [...new Set(sourceKeys.filter(Boolean))];
+      if (scopes.length === 0) return [];
+      const limit = Math.max(1, Math.min(options.limit ?? 10, 50));
+      const rows = await db
+        .selectFrom("agent_outputs")
+        .selectAll()
+        .where("agent_key", "=", agentKey)
+        .where("user_id", "=", userId)
+        .where("source_key", "in", scopes)
+        .where("status", "=", "completed")
+        .where(sql<boolean>`COALESCE(generated_at, updated_at) > ${sinceIso}`)
+        .orderBy(sql<string>`COALESCE(generated_at, updated_at)`, "desc")
+        .orderBy("id", "desc")
+        .limit(limit)
+        .execute();
+      return outputsWithItems(rows);
+    },
+
     async listCompletedForHumanUsers(
       agentKey: string,
       options: { limit?: number; cursor?: string | null } = {},

--- a/packages/server/src/db/repositories/task-durability-transition.test.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.test.ts
@@ -236,6 +236,58 @@ describe("createTaskDurabilityTransitionRepository", () => {
     ).resolves.toMatchObject({ status: "accepted" });
   });
 
+  it("does not reseed a member-source candidate already accepted on another route", async () => {
+    const conversationId = await seedConversation(db, "slack", "C_MEMBER");
+    const messageId = await seedMessage(db, conversationId, {
+      providerMessageId: "tracked-member-route-message",
+      threadId: "tracked-member-route-thread",
+    });
+    const memberSourceKey = "slack:channel:C_MEMBER";
+    await seedOutput(createAgentOutputRepository(db), db, {
+      sourceKey: memberSourceKey,
+      generatedAt: "2026-07-15T12:00:00.000Z",
+      title: "Already tracked member task",
+      messageIds: [messageId],
+    });
+    const repo = createTaskDurabilityTransitionRepository(db);
+    await repo.ensureRouteTransition({
+      agentKey: AGENT_KEY,
+      userId: USER_ID,
+      routeId: "member-route",
+      sourceKey: memberSourceKey,
+      allowedConversationIds: [conversationId],
+      now: NOW,
+    });
+    const seed = await db
+      .selectFrom("task_seed_candidates")
+      .select("review_code")
+      .where("route_id", "=", "member-route")
+      .executeTakeFirstOrThrow();
+    await expect(
+      repo.reviewSeedCandidate({
+        userId: USER_ID,
+        code: seed.review_code,
+        decision: "track",
+        surface: "slack",
+        now: NOW,
+      }),
+    ).resolves.toMatchObject({ status: "accepted" });
+
+    await expect(
+      repo.ensureRouteTransition({
+        agentKey: AGENT_KEY,
+        userId: USER_ID,
+        routeId: ROUTE_ID,
+        sourceKey: "route:combined",
+        sourceKeys: [memberSourceKey],
+        allowedConversationIds: [conversationId],
+        now: NOW,
+      }),
+    ).resolves.toMatchObject({ createdCount: 0, pendingCount: 0, seedState: "reviewed" });
+    await expect(countRows(db, "task_seed_candidates")).resolves.toBe(1);
+    await expect(countRows(db, "tasks")).resolves.toBe(1);
+  });
+
   it("automatically reviews a successful seed with no valid candidates", async () => {
     const result = await createTaskDurabilityTransitionRepository(db).ensureRouteTransition({
       agentKey: AGENT_KEY,

--- a/packages/server/src/db/repositories/task-durability-transition.test.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.test.ts
@@ -359,6 +359,79 @@ describe("createTaskDurabilityTransitionRepository", () => {
     ]);
   });
 
+  it("keeps a same-title member seed reviewable when its parent differs from an active task", async () => {
+    const conversationId = await seedConversation(db, "slack", "C_MEMBER");
+    const memberSourceKey = "slack:channel:C_MEMBER";
+    const alphaMessageId = await seedMessage(db, conversationId, {
+      providerMessageId: "alpha-member-route-message",
+      threadId: "shared-parent-route-thread",
+    });
+    await seedOutput(createAgentOutputRepository(db), db, {
+      sourceKey: memberSourceKey,
+      generatedAt: "2026-07-14T12:00:00.000Z",
+      title: "Prepare launch notes",
+      messageIds: [alphaMessageId],
+      owner: "Mina",
+      parentName: "Project Alpha",
+    });
+    const repo = createTaskDurabilityTransitionRepository(db);
+    await repo.ensureRouteTransition({
+      agentKey: AGENT_KEY,
+      userId: USER_ID,
+      routeId: "member-route",
+      sourceKey: memberSourceKey,
+      allowedConversationIds: [conversationId],
+      now: NOW,
+    });
+    const alphaSeed = await db
+      .selectFrom("task_seed_candidates")
+      .select("review_code")
+      .where("route_id", "=", "member-route")
+      .executeTakeFirstOrThrow();
+    await repo.reviewSeedCandidate({
+      userId: USER_ID,
+      code: alphaSeed.review_code,
+      decision: "track",
+      surface: "slack",
+      now: NOW,
+    });
+
+    const betaMessageId = await seedMessage(db, conversationId, {
+      providerMessageId: "beta-member-route-message",
+      threadId: "shared-parent-route-thread",
+    });
+    await seedOutput(createAgentOutputRepository(db), db, {
+      sourceKey: memberSourceKey,
+      generatedAt: "2026-07-15T12:00:00.000Z",
+      title: "Prepare launch notes",
+      messageIds: [betaMessageId],
+      owner: "Mina",
+      parentName: "Project Beta",
+    });
+
+    await expect(
+      repo.ensureRouteTransition({
+        agentKey: AGENT_KEY,
+        userId: USER_ID,
+        routeId: ROUTE_ID,
+        sourceKey: "route:combined",
+        sourceKeys: [memberSourceKey],
+        allowedConversationIds: [conversationId],
+        now: NOW,
+      }),
+    ).resolves.toMatchObject({ createdCount: 1, pendingCount: 1, seedState: "pending" });
+    await expect(
+      db
+        .selectFrom("task_seed_candidates")
+        .select(["proposed_assignee_name", "review_state", "title"])
+        .orderBy("review_state", "asc")
+        .execute(),
+    ).resolves.toEqual([
+      { proposed_assignee_name: "Mina", review_state: "accepted", title: "Prepare launch notes" },
+      { proposed_assignee_name: "Mina", review_state: "pending", title: "Prepare launch notes" },
+    ]);
+  });
+
   it("automatically reviews a successful seed with no valid candidates", async () => {
     const result = await createTaskDurabilityTransitionRepository(db).ensureRouteTransition({
       agentKey: AGENT_KEY,
@@ -1207,6 +1280,7 @@ async function seedOutput(
     messageIds: number[];
     sourceKey?: string;
     owner?: string;
+    parentName?: string;
     rawItems?: AgentOutputItemInput[];
   },
 ): Promise<string> {
@@ -1226,6 +1300,7 @@ async function seedOutput(
     sourceLabels: [sourceKey],
   };
   if (params.owner) structuredPayload.owner = params.owner;
+  if (params.parentName) structuredPayload.parentName = params.parentName;
   await repo.completeOutput({
     outputId: running.row.id,
     masthead: { title: "Summary", summary: "Summary" },

--- a/packages/server/src/db/repositories/task-durability-transition.test.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.test.ts
@@ -288,6 +288,77 @@ describe("createTaskDurabilityTransitionRepository", () => {
     await expect(countRows(db, "tasks")).resolves.toBe(1);
   });
 
+  it("keeps a same-title member seed reviewable when its proposed owner differs from an active task", async () => {
+    const conversationId = await seedConversation(db, "slack", "C_MEMBER");
+    const memberSourceKey = "slack:channel:C_MEMBER";
+    const minaMessageId = await seedMessage(db, conversationId, {
+      providerMessageId: "mina-member-route-message",
+      threadId: "shared-member-route-thread",
+    });
+    await seedOutput(createAgentOutputRepository(db), db, {
+      sourceKey: memberSourceKey,
+      generatedAt: "2026-07-14T12:00:00.000Z",
+      title: "Prepare launch notes",
+      messageIds: [minaMessageId],
+      owner: "Mina",
+    });
+    const repo = createTaskDurabilityTransitionRepository(db);
+    await repo.ensureRouteTransition({
+      agentKey: AGENT_KEY,
+      userId: USER_ID,
+      routeId: "member-route",
+      sourceKey: memberSourceKey,
+      allowedConversationIds: [conversationId],
+      now: NOW,
+    });
+    const minaSeed = await db
+      .selectFrom("task_seed_candidates")
+      .select("review_code")
+      .where("route_id", "=", "member-route")
+      .executeTakeFirstOrThrow();
+    await repo.reviewSeedCandidate({
+      userId: USER_ID,
+      code: minaSeed.review_code,
+      decision: "track",
+      surface: "slack",
+      now: NOW,
+    });
+
+    const tanushMessageId = await seedMessage(db, conversationId, {
+      providerMessageId: "tanush-member-route-message",
+      threadId: "shared-member-route-thread",
+    });
+    await seedOutput(createAgentOutputRepository(db), db, {
+      sourceKey: memberSourceKey,
+      generatedAt: "2026-07-15T12:00:00.000Z",
+      title: "Prepare launch notes",
+      messageIds: [tanushMessageId],
+      owner: "Tanush",
+    });
+
+    await expect(
+      repo.ensureRouteTransition({
+        agentKey: AGENT_KEY,
+        userId: USER_ID,
+        routeId: ROUTE_ID,
+        sourceKey: "route:combined",
+        sourceKeys: [memberSourceKey],
+        allowedConversationIds: [conversationId],
+        now: NOW,
+      }),
+    ).resolves.toMatchObject({ createdCount: 1, pendingCount: 1, seedState: "pending" });
+    await expect(
+      db
+        .selectFrom("task_seed_candidates")
+        .select(["proposed_assignee_name", "review_state"])
+        .orderBy("proposed_assignee_name", "asc")
+        .execute(),
+    ).resolves.toEqual([
+      { proposed_assignee_name: "Mina", review_state: "accepted" },
+      { proposed_assignee_name: "Tanush", review_state: "pending" },
+    ]);
+  });
+
   it("automatically reviews a successful seed with no valid candidates", async () => {
     const result = await createTaskDurabilityTransitionRepository(db).ensureRouteTransition({
       agentKey: AGENT_KEY,

--- a/packages/server/src/db/repositories/task-durability-transition.test.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.test.ts
@@ -194,6 +194,48 @@ describe("createTaskDurabilityTransitionRepository", () => {
     expect(result).toMatchObject({ createdCount: 0, skippedCount: 1, pendingCount: 0, seedState: "reviewed" });
   });
 
+  it("seeds combined routes from recent member-source outputs", async () => {
+    const conversationId = await seedConversation(db, "slack", "C_MEMBER");
+    const messageId = await seedMessage(db, conversationId, {
+      providerMessageId: "member-route-message",
+      threadId: "member-route-thread",
+    });
+    const memberSourceKey = "slack:channel:C_MEMBER";
+    await seedOutput(createAgentOutputRepository(db), db, {
+      sourceKey: memberSourceKey,
+      generatedAt: "2026-07-15T12:00:00.000Z",
+      title: "Member source task",
+      messageIds: [messageId],
+    });
+
+    const result = await createTaskDurabilityTransitionRepository(db).ensureRouteTransition({
+      agentKey: AGENT_KEY,
+      userId: USER_ID,
+      routeId: ROUTE_ID,
+      sourceKey: "route:combined",
+      sourceKeys: [memberSourceKey],
+      allowedConversationIds: [conversationId],
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({ createdCount: 1, skippedCount: 0, pendingCount: 1, seedState: "pending" });
+    const seed = await db
+      .selectFrom("task_seed_candidates")
+      .select(["review_code", "source_key", "title"])
+      .executeTakeFirstOrThrow();
+    expect(seed).toMatchObject({ source_key: "route:combined", title: "Member source task" });
+
+    await expect(
+      createTaskDurabilityTransitionRepository(db).reviewSeedCandidate({
+        userId: USER_ID,
+        code: seed.review_code,
+        decision: "track",
+        surface: "slack",
+        now: NOW,
+      }),
+    ).resolves.toMatchObject({ status: "accepted" });
+  });
+
   it("automatically reviews a successful seed with no valid candidates", async () => {
     const result = await createTaskDurabilityTransitionRepository(db).ensureRouteTransition({
       agentKey: AGENT_KEY,

--- a/packages/server/src/db/repositories/task-durability-transition.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.ts
@@ -812,7 +812,7 @@ async function persistSeedCandidate(
 
   const activeTasks = await db
     .selectFrom("tasks")
-    .select(["assignee_name", "proposed_assignee_name"])
+    .select(["assignee_name", "proposed_assignee_name", "parent_entity_id", "parent_source_ref", "parent_name"])
     .where("source", "=", "summary")
     .where("created_by_user_id", "=", input.userId)
     .where("normalized_title", "=", normalizeName(resolved.candidate.title))
@@ -820,7 +820,14 @@ async function persistSeedCandidate(
     .where("valid_to", "is", null)
     .where("status", "in", ["open", "in_progress"])
     .execute();
-  if (activeTasks.some((task) => seedOwnerMatchesTask(resolved.proposedAssigneeName, task))) return false;
+  if (
+    activeTasks.some(
+      (task) =>
+        seedOwnerMatchesTask(resolved.proposedAssigneeName, task) &&
+        seedParentMatchesTask(resolved.candidate.structuredPayload, task),
+    )
+  )
+    return false;
 
   const existing = await db
     .selectFrom("task_seed_candidates")
@@ -887,6 +894,23 @@ function seedOwnerMatchesTask(
   if (!taskName) return true;
   if (!proposedAssigneeName) return false;
   return normalizeName(taskName) === normalizeName(proposedAssigneeName);
+}
+
+function seedParentMatchesTask(
+  payload: Record<string, unknown> | null | undefined,
+  task: { parent_entity_id: string | null; parent_source_ref: string | null; parent_name: string | null },
+): boolean {
+  const parentEntityId = readIdentityString(payload?.parentEntityId);
+  if (parentEntityId) return task.parent_entity_id === parentEntityId;
+  const parentSourceRef = readIdentityString(payload?.parentSourceRef);
+  if (parentSourceRef) return task.parent_source_ref === parentSourceRef;
+  const parentName = readIdentityString(payload?.parentName);
+  if (parentName) return task.parent_name !== null && normalizeName(task.parent_name) === normalizeName(parentName);
+  return task.parent_entity_id === null && task.parent_source_ref === null && task.parent_name === null;
+}
+
+function readIdentityString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 async function generateReviewCode(db: Transaction<DB>): Promise<string> {

--- a/packages/server/src/db/repositories/task-durability-transition.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.ts
@@ -810,17 +810,17 @@ async function persistSeedCandidate(
     .executeTakeFirst();
   if (accepted) return false;
 
-  const activeTask = await db
+  const activeTasks = await db
     .selectFrom("tasks")
-    .select("id")
+    .select(["assignee_name", "proposed_assignee_name"])
     .where("source", "=", "summary")
     .where("created_by_user_id", "=", input.userId)
     .where("normalized_title", "=", normalizeName(resolved.candidate.title))
     .where("source_anchor_key", "=", resolved.anchor.key)
     .where("valid_to", "is", null)
     .where("status", "in", ["open", "in_progress"])
-    .executeTakeFirst();
-  if (activeTask) return false;
+    .execute();
+  if (activeTasks.some((task) => seedOwnerMatchesTask(resolved.proposedAssigneeName, task))) return false;
 
   const existing = await db
     .selectFrom("task_seed_candidates")
@@ -877,6 +877,16 @@ async function persistSeedCandidate(
     }
   }
   throw new Error("Unable to allocate a unique task seed review code.");
+}
+
+function seedOwnerMatchesTask(
+  proposedAssigneeName: string | null,
+  task: { assignee_name: string | null; proposed_assignee_name: string | null },
+): boolean {
+  const taskName = task.proposed_assignee_name ?? task.assignee_name;
+  if (!taskName) return true;
+  if (!proposedAssigneeName) return false;
+  return normalizeName(taskName) === normalizeName(proposedAssigneeName);
 }
 
 async function generateReviewCode(db: Transaction<DB>): Promise<string> {

--- a/packages/server/src/db/repositories/task-durability-transition.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.ts
@@ -800,6 +800,28 @@ async function persistSeedCandidate(
   resolved: ResolvedSeedCandidate,
   now: string,
 ): Promise<boolean> {
+  const accepted = await db
+    .selectFrom("task_seed_candidates")
+    .select("id")
+    .where("agent_key", "=", input.agentKey)
+    .where("user_id", "=", input.userId)
+    .where("evidence_fingerprint", "=", resolved.evidenceFingerprint)
+    .where("review_state", "=", "accepted")
+    .executeTakeFirst();
+  if (accepted) return false;
+
+  const activeTask = await db
+    .selectFrom("tasks")
+    .select("id")
+    .where("source", "=", "summary")
+    .where("created_by_user_id", "=", input.userId)
+    .where("normalized_title", "=", normalizeName(resolved.candidate.title))
+    .where("source_anchor_key", "=", resolved.anchor.key)
+    .where("valid_to", "is", null)
+    .where("status", "in", ["open", "in_progress"])
+    .executeTakeFirst();
+  if (activeTask) return false;
+
   const existing = await db
     .selectFrom("task_seed_candidates")
     .select("id")

--- a/packages/server/src/db/repositories/task-durability-transition.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.ts
@@ -31,6 +31,7 @@ export interface EnsureRouteTransitionInput {
   userId: string;
   routeId: string;
   sourceKey: string;
+  sourceKeys?: string[];
   allowedConversationIds?: number[];
   now: ClockValue;
 }
@@ -213,7 +214,7 @@ export function createTaskDurabilityTransitionRepository(db: Kysely<DB>) {
           userId: input.userId,
           routeId: input.routeId,
           sourceKey: input.sourceKey,
-          sourceKeys: [],
+          sourceKeys: input.sourceKeys ?? [],
           allowedConversationIds: input.allowedConversationIds,
         },
         now,
@@ -235,10 +236,11 @@ export function createTaskDurabilityTransitionRepository(db: Kysely<DB>) {
 
       try {
         const since = sevenDayBoundary(now);
-        const outputs = await outputRepo.listCompletedForScopeSince(
+        const seedSourceKeys = eligibleSeedSourceKeys(input.sourceKey, input.sourceKeys);
+        const outputs = await outputRepo.listCompletedForScopesSince(
           input.agentKey,
           input.userId,
-          input.sourceKey,
+          seedSourceKeys,
           since,
           { limit: SEED_OUTPUT_LIMIT },
         );
@@ -251,6 +253,7 @@ export function createTaskDurabilityTransitionRepository(db: Kysely<DB>) {
             candidate,
             input.sourceKey,
             input.allowedConversationIds ? new Set(input.allowedConversationIds) : null,
+            seedSourceKeys,
           );
           if (value) resolved.push(value);
           else skippedCount += 1;
@@ -377,7 +380,9 @@ export function createTaskDurabilityTransitionRepository(db: Kysely<DB>) {
               )
             : null;
           sourceCandidate = output
-            ? await findOriginatingCandidate(trx, output, seed.evidence_fingerprint, seed.source_key)
+            ? await findOriginatingCandidate(trx, output, seed.evidence_fingerprint, seed.source_key, null, [
+                output.output.source_key,
+              ])
             : null;
           if (!sourceCandidate) {
             await trx
@@ -719,7 +724,14 @@ async function reconcileInvalidPendingCandidates(
       ? await createAgentOutputRepository(db).getByIdForUser(route.agentKey, seed.origin_agent_output_id, route.userId)
       : null;
     const resolved = output
-      ? await findOriginatingCandidate(db, output, seed.evidence_fingerprint, seed.source_key, allowedConversationIds)
+      ? await findOriginatingCandidate(
+          db,
+          output,
+          seed.evidence_fingerprint,
+          seed.source_key,
+          allowedConversationIds,
+          route.sourceKeys,
+        )
       : null;
     if (resolved?.anchor.key === seed.source_anchor_key) continue;
     const deleted = await db
@@ -870,10 +882,11 @@ async function findOriginatingCandidate(
   fingerprint: string,
   sourceKey: string,
   allowedConversationIds: Set<number> | null = null,
+  sourceKeys: string[] = [],
 ): Promise<ResolvedSeedCandidate | null> {
   if (!output) return null;
   for (const candidate of extractSummarizerSeedCandidates([output])) {
-    const resolved = await resolveSeedCandidate(db, candidate, sourceKey, allowedConversationIds);
+    const resolved = await resolveSeedCandidate(db, candidate, sourceKey, allowedConversationIds, sourceKeys);
     if (resolved?.evidenceFingerprint === fingerprint) return resolved;
   }
   return null;
@@ -884,8 +897,9 @@ async function resolveSeedCandidate(
   candidate: SummarizerSeedCandidate,
   sourceKey: string,
   allowedConversationIds: Set<number> | null = null,
+  sourceKeys: string[] = [],
 ): Promise<ResolvedSeedCandidate | null> {
-  if (candidate.sourceKey !== sourceKey) return null;
+  if (!eligibleSeedSourceKeys(sourceKey, sourceKeys).includes(candidate.sourceKey)) return null;
   const messageIds = readInternalMessageIds(candidate.structuredPayload);
   if (!messageIds) return null;
   const messages = (await db
@@ -909,7 +923,7 @@ async function resolveSeedCandidate(
   for (const message of messages) {
     if (message.platform !== "slack" && message.platform !== "whatsapp") return null;
     if (allowedConversationIds && !allowedConversationIds.has(message.conversation_id)) return null;
-    if (!messageMatchesSourceKey(message, sourceKey)) return null;
+    if (!messageMatchesSourceKey(message, candidate.sourceKey)) return null;
     const providerThreadId =
       message.platform === "slack" && message.is_thread_reply === 1 ? message.provider_thread_id : null;
     const key = sourceAnchorKey(message.platform, message.conversation_id, providerThreadId);
@@ -931,6 +945,13 @@ async function resolveSeedCandidate(
     evidenceFingerprint: createEvidenceFingerprint(candidate.title, anchor.key, messageIds),
     proposedAssigneeName,
   };
+}
+
+function eligibleSeedSourceKeys(routeSourceKey: string, sourceKeys: string[] = []): string[] {
+  const members = routeSourceKey.startsWith("route:")
+    ? sourceKeys.filter((sourceKey) => parseDirectSourceKey(sourceKey) !== null)
+    : [];
+  return [...new Set([routeSourceKey, ...members])];
 }
 
 function readInternalMessageIds(payload: Record<string, unknown> | null | undefined): number[] | null {


### PR DESCRIPTION
## Summary\n\n- seed combined durability routes from recent outputs across their active member sources\n- validate and revalidate member-source evidence against the combined route scope\n- preserve the global ten-output seed limit across all eligible scopes\n- add regression coverage for seeding and accepting a member-sourced candidate\n\nAddresses the delayed Codex review on #395.\n\n## Validation\n\n- pnpm biome check\n- pnpm typecheck\n- pnpm test (server: 4,398 passed / 20 skipped; web: 406 passed)\n- pnpm build