### PR TITLE
Add inline follow-up review actions to Daily Brief

### DIFF
--- a/docs/manual-testing/INLINE_FOLLOWUP_REVIEW_ACTIONS.md
+++ b/docs/manual-testing/INLINE_FOLLOWUP_REVIEW_ACTIONS.md
@@ -1,0 +1,298 @@
+# Inline Follow-up Review Actions — Manual Testing Guide
+
+Use this guide to manually verify the inline Daily Brief review workflow introduced by PR #398.
+
+## Prerequisites
+
+- Run the `feat/inline-followup-review-actions` branch.
+- Start the local stack and confirm Sketch is available at `http://localhost:5173`.
+- Sign in as the user receiving the fixture. The examples below use `tanush@canvasx.ai`.
+- Run commands from the Sketch repository root.
+
+The fixture command creates an online SQLite backup before changing data. It uses a deterministic, user-scoped namespace and resets only records created by this fixture.
+
+## Seed a fresh fixture
+
+```bash
+pnpm fixture:inline-followup-review -- seed \
+  --db "$PWD/data/sketch.db" \
+  --user-email tanush@canvasx.ai
+```
+
+The command prints:
+
+- The backup path.
+- The fixture Daily Brief ID.
+- Three completion-recommendation IDs.
+- Two seed-candidate IDs.
+
+Open or refresh:
+
+```text
+http://localhost:5173/home
+```
+
+Do not generate another Daily Brief during the test. A newer real brief can replace the fixture as the latest brief. Rerun the seed command if that happens.
+
+## Expected fixture inventory
+
+### Untracked follow-ups
+
+| Card | Expected initial presentation |
+| --- | --- |
+| `QA: Send launch recap to the customer` | `Discuss with Sketch`, then grouped `Track` and `Dismiss` |
+| `QA: Remove duplicate launch reminder` | `Discuss with Sketch`, then grouped `Track` and `Dismiss` |
+| `QA: Legacy chat-only follow-up` | Only `Discuss with Sketch`; no review controls |
+
+### Looks resolved
+
+| Card | Expected initial presentation |
+| --- | --- |
+| `QA: Confirm completed launch checklist` | `Review with Sketch`, then grouped `Mark as done` and `Keep open`; task status `Open` |
+| `QA: Keep customer handoff open` | `Review with Sketch`, then grouped `Mark as done` and `Keep open`; task status `Open` |
+| `QA: Review an expired completion suggestion` | `Review expired` and `Review with Sketch`; no review controls |
+
+If the expected initial state is missing, rerun the seed command and refresh the page.
+
+## Pass A — Inline row actions
+
+### A1. Mark a completion recommendation done
+
+1. Find `QA: Confirm completed launch checklist`.
+2. Click `Mark as done`.
+3. Observe the card while the request is running.
+
+Expected:
+
+- The grouped review controls are disabled and `Updating…` appears beneath them.
+- A success toast says the follow-up was marked done.
+- The card displays `Marked done`.
+- The live task status becomes `Done`.
+- `Mark as done` and `Keep open` no longer appear.
+
+Refresh the page.
+
+Expected after refresh:
+
+- `Marked done` persists.
+- The task remains `Done`.
+- Mutation controls do not return.
+
+### A2. Keep a completion recommendation open
+
+1. Find `QA: Keep customer handoff open`.
+2. Click `Keep open`.
+
+Expected:
+
+- The grouped review controls are briefly disabled and `Updating…` appears beneath them.
+- A success toast says the follow-up was kept open.
+- The card displays `Kept open`.
+- The linked task remains `Open`.
+- Mutation controls disappear.
+
+Refresh and confirm the outcome persists.
+
+### A3. Track a reconstructed follow-up
+
+1. Find `QA: Send launch recap to the customer`.
+2. Click `Track`.
+
+Expected:
+
+- The grouped review controls are briefly disabled and `Updating…` appears beneath them.
+- A success toast says the follow-up was tracked.
+- The card displays `Tracked`.
+- A canonical task appears with status `Open`.
+- `Track` and `Dismiss` disappear.
+
+Refresh and confirm the tracked state and task overlay persist.
+
+### A4. Dismiss a reconstructed follow-up
+
+1. Find `QA: Remove duplicate launch reminder`.
+2. Click `Dismiss`.
+
+Expected:
+
+- The grouped review controls are briefly disabled and `Updating…` appears beneath them.
+- A success toast says the follow-up was dismissed.
+- The card displays `Dismissed`.
+- `Track` and `Dismiss` disappear.
+- No task is created for the dismissed card.
+
+Refresh and confirm the dismissed state persists.
+
+### A5. Verify non-actionable cards
+
+For `QA: Review an expired completion suggestion`:
+
+- Confirm `Review expired` is visible.
+- Confirm `Mark as done` and `Keep open` are absent.
+- Confirm `Review with Sketch` remains available.
+
+For `QA: Legacy chat-only follow-up`:
+
+- Confirm `Track` and `Dismiss` are absent.
+- Confirm no review identity or terminal state is displayed.
+- Confirm `Discuss with Sketch` remains available.
+
+## Pass B — Detail drawer actions
+
+Reseed the fixture before this pass:
+
+```bash
+pnpm fixture:inline-followup-review -- seed \
+  --db "$PWD/data/sketch.db" \
+  --user-email tanush@canvasx.ai
+```
+
+Refresh the Home page.
+
+For one completion card and one seed card:
+
+1. Click the card body to open its detail drawer.
+2. Confirm the same review controls appear in the drawer.
+3. Apply an action from the drawer.
+
+Expected:
+
+- The drawer disables the grouped review controls and displays `Updating…` beneath them during the request.
+- The resulting terminal label and task state match the row behavior.
+- The drawer remains coherent after the mutation.
+- Closing the drawer reveals the same terminal state on the row.
+
+Clicking an inline review action directly on a row must not accidentally open the drawer.
+
+## Pass C — Keyboard and responsive behavior
+
+Reseed before repeating action tests when necessary.
+
+### Keyboard
+
+1. Use Tab to move through the row controls.
+2. Activate each review button with Enter or Space.
+
+Expected:
+
+- Every action is keyboard reachable.
+- Focus indicators remain visible.
+- Focus order follows the visible controls.
+- The action is applied once.
+- `Updating…` is announced as a live status by screen-reader tooling.
+
+### Mobile layout
+
+Test at approximately 375 px width.
+
+Expected:
+
+- Review and chat controls wrap without overlapping.
+- No horizontal page scrolling is introduced.
+- Card titles and task statuses remain readable.
+- Detail drawer controls remain reachable.
+
+## Pass D — Retry and conflict behavior
+
+The seed command prints the resource IDs needed for these checks. Run requests from an authenticated browser console so the current Sketch session supplies authentication.
+
+### Same-decision retry
+
+After marking a completion recommendation done, repeat:
+
+```js
+await fetch("/api/task-completion-recommendations/<recommendation-id>", {
+  method: "PATCH",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ decision: "confirm_done" }),
+}).then(async (response) => ({ status: response.status, body: await response.json() }));
+```
+
+Expected:
+
+- Status `200`.
+- Review remains `accepted`.
+- Task remains `done`.
+- No duplicate mutation is created.
+
+### Opposite-decision retry
+
+Against the same recommendation:
+
+```js
+await fetch("/api/task-completion-recommendations/<recommendation-id>", {
+  method: "PATCH",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ decision: "keep_open" }),
+}).then(async (response) => ({ status: response.status, body: await response.json() }));
+```
+
+Expected:
+
+- Status `409`.
+- Error code `REVIEW_ALREADY_DECIDED`.
+- Review and task state remain unchanged.
+
+The same pattern applies to seed candidates using `/api/task-seed-candidates/<candidate-id>` and the `track` or `dismiss` decisions.
+
+### Invalid decision
+
+```js
+await fetch("/api/task-seed-candidates/<candidate-id>", {
+  method: "PATCH",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ decision: "invalid" }),
+}).then(async (response) => ({ status: response.status, body: await response.json() }));
+```
+
+Expected:
+
+- Status `400`.
+- Error code `INVALID_DECISION`.
+
+## Pass E — Error recovery
+
+1. Seed a fresh fixture and load the Home page.
+2. Make the Sketch backend temporarily unavailable.
+3. Click one pending review action.
+
+Expected:
+
+- An error toast appears.
+- The UI does not retain a false terminal outcome.
+- Controls recover after the backend returns and the brief refetches.
+
+Restart the stack, reseed the fixture, and refresh before continuing.
+
+## Reset or remove the fixture
+
+Reset every card to its initial state:
+
+```bash
+pnpm fixture:inline-followup-review -- seed \
+  --db "$PWD/data/sketch.db" \
+  --user-email tanush@canvasx.ai
+```
+
+Remove all fixture-owned records:
+
+```bash
+pnpm fixture:inline-followup-review -- clear \
+  --db "$PWD/data/sketch.db" \
+  --user-email tanush@canvasx.ai
+```
+
+Both commands create a backup before changing the database.
+
+## Pass criteria
+
+- All four direct decisions produce the correct terminal outcome.
+- Outcomes persist after refresh and through the detail drawer.
+- The tracked seed returns a visible canonical task.
+- The dismissed seed creates no task.
+- Expired and legacy items never expose invalid controls.
+- Same-decision retries are idempotent.
+- Opposite decisions return a conflict without changing state.
+- No authorization details, review identities, or inaccessible task IDs leak.
+- Desktop, mobile, keyboard, and screen-reader behavior remain usable.
+- No new frontend console errors or backend errors appear.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:unit": "pnpm -r test:unit",
     "test:integration": "pnpm -r --workspace-concurrency=1 test:integration",
     "test:changed": "pnpm -r test:changed",
+    "fixture:inline-followup-review": "bash scripts/with-node-version.sh tsx packages/server/src/scripts/inline-followup-review-fixture.ts",
     "otter:check": "tsx scripts/otter-check.ts",
     "recompute:entity-hotness": "tsx scripts/recompute-entity-hotness.ts",
     "worktree:create": "tsx scripts/worktree.ts create",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,8 @@
     "test:unit": "vitest run --project unit --project unit-isolated --passWithNoTests",
     "test:integration": "vitest run --project integration --passWithNoTests",
     "test:changed": "vitest run --changed --project unit --project unit-isolated --passWithNoTests",
-    "test:watch": "vitest --project unit --project unit-isolated"
+    "test:watch": "vitest --project unit --project unit-isolated",
+    "fixture:inline-followup-review": "bash ../../scripts/with-node-version.sh tsx src/scripts/inline-followup-review-fixture.ts"
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^5.0.10",

--- a/packages/server/src/agents/definitions/daily-brief.test.ts
+++ b/packages/server/src/agents/definitions/daily-brief.test.ts
@@ -2188,7 +2188,7 @@ describe("dailyBriefDefinition.augmentRuntimeContext", () => {
       mode: "hybrid",
       untracked: [
         {
-          candidateId: "SEED1234",
+          candidateId: "pending-seed",
           title: "Follow up with Acme",
           reviewCode: "SEED1234",
           sourceKey,

--- a/packages/server/src/agents/definitions/daily-brief.ts
+++ b/packages/server/src/agents/definitions/daily-brief.ts
@@ -1598,7 +1598,7 @@ function buildFollowupReminderView(
     }
   }
   const transitionItems = transition.untracked.map((item) => ({
-    candidateId: item.code,
+    candidateId: item.id,
     title: item.title,
     summary: item.label,
     reviewCode: item.code,

--- a/packages/server/src/agents/followup-review-routes.test.ts
+++ b/packages/server/src/agents/followup-review-routes.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTaskRepository } from "../db/repositories/tasks";
 import type { DB } from "../db/schema";
@@ -19,7 +19,10 @@ describe("follow-up review routes", () => {
     db = await createTestDb();
     await db
       .insertInto("users")
-      .values({ id: "user-1", name: "User", email: "user@example.com", auth_role: "member" })
+      .values([
+        { id: "user-1", name: "User", email: "user@example.com", auth_role: "member" },
+        { id: "user-2", name: "Other", email: "other@example.com", auth_role: "member" },
+      ])
       .execute();
     const created = await createTaskRepository(db).upsertTask({
       parentEntityId: null,
@@ -59,6 +62,31 @@ describe("follow-up review routes", () => {
       .execute();
 
     const app = reviewApp(db, "user-1");
+    const invalid = await app.request("/api/task-completion-recommendations/recommendation-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decision: "dismiss" }),
+    });
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toMatchObject({ error: { code: "INVALID_DECISION" } });
+
+    const unauthorized = await reviewApp(db, "user-2").request(
+      "/api/task-completion-recommendations/recommendation-1",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "confirm_done" }),
+      },
+    );
+    const missing = await app.request("/api/task-completion-recommendations/missing", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decision: "confirm_done" }),
+    });
+    expect(unauthorized.status).toBe(404);
+    expect(missing.status).toBe(404);
+    expect(await unauthorized.json()).toEqual(await missing.json());
+
     const request = (decision: "confirm_done" | "keep_open") =>
       app.request("/api/task-completion-recommendations/recommendation-1", {
         method: "PATCH",
@@ -83,6 +111,128 @@ describe("follow-up review routes", () => {
     const conflict = await request("keep_open");
     expect(conflict.status).toBe(409);
     await expect(conflict.json()).resolves.toMatchObject({ error: { code: "REVIEW_ALREADY_DECIDED" } });
+  });
+
+  it("returns REVIEW_STALE when a completion review has expired", async () => {
+    db = await createTestDb();
+    await db
+      .insertInto("users")
+      .values({ id: "user-1", name: "User", email: "user@example.com", auth_role: "member" })
+      .execute();
+    const created = await createTaskRepository(db).upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Expired completion review",
+      status: "open",
+      statusRaw: "open",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "expired-summary-task",
+      createdByUserId: "user-1",
+    });
+    await db
+      .insertInto("task_completion_recommendations")
+      .values({
+        id: "expired-recommendation",
+        task_id: created.taskId,
+        proposed_status: "done",
+        review_code: "EXPIRED1",
+        evidence_fingerprint: "expired-fingerprint",
+        origin_agent_output_id: null,
+        rationale: "This recommendation is too old.",
+        expires_at: "2026-07-19T00:00:00.000Z",
+        reviewed_at: null,
+        reviewed_by_user_id: null,
+        review_surface: null,
+      })
+      .execute();
+
+    const response = await reviewApp(db, "user-1").request(
+      "/api/task-completion-recommendations/expired-recommendation",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "confirm_done" }),
+      },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "REVIEW_STALE" } });
+  });
+
+  it("revalidates completion authority inside the transaction without disclosing the review", async () => {
+    db = await createTestDb();
+    await db
+      .insertInto("users")
+      .values([
+        { id: "user-1", name: "User", email: "user@example.com", auth_role: "member" },
+        { id: "user-2", name: "Other", email: "other@example.com", auth_role: "member" },
+      ])
+      .execute();
+    const created = await createTaskRepository(db).upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Authority changes during review",
+      status: "open",
+      statusRaw: "open",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "authority-change-task",
+      createdByUserId: "user-1",
+    });
+    await db
+      .insertInto("task_completion_recommendations")
+      .values({
+        id: "authority-change-review",
+        task_id: created.taskId,
+        proposed_status: "done",
+        review_code: "AUTH1234",
+        evidence_fingerprint: "authority-change",
+        origin_agent_output_id: null,
+        rationale: "Authority will change before completion.",
+        expires_at: "2099-01-01T00:00:00.000Z",
+        reviewed_at: null,
+        reviewed_by_user_id: null,
+        review_surface: null,
+      })
+      .execute();
+    await sql`
+      CREATE TRIGGER change_task_owner_during_review
+      AFTER UPDATE OF review_state ON task_completion_recommendations
+      WHEN NEW.id = 'authority-change-review' AND NEW.review_state = 'accepted'
+      BEGIN
+        UPDATE tasks SET created_by_user_id = 'user-2' WHERE id = NEW.task_id;
+      END
+    `.execute(db);
+
+    const app = reviewApp(db, "user-1");
+    const response = await app.request("/api/task-completion-recommendations/authority-change-review", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decision: "confirm_done" }),
+    });
+    const missing = await app.request("/api/task-completion-recommendations/missing", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decision: "confirm_done" }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual(await missing.json());
   });
 
   it("keeps seed review owner-scoped and makes dismiss retries idempotent", async () => {

--- a/packages/server/src/agents/followup-review-routes.test.ts
+++ b/packages/server/src/agents/followup-review-routes.test.ts
@@ -1,0 +1,180 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTaskRepository } from "../db/repositories/tasks";
+import type { DB } from "../db/schema";
+import { createTestDb } from "../test-utils";
+import { followupReviewRoutes } from "./routes";
+import type { AgentRunService } from "./service";
+
+describe("follow-up review routes", () => {
+  let db: Kysely<DB> | null = null;
+
+  afterEach(async () => {
+    await db?.destroy();
+    db = null;
+  });
+
+  it("applies a completion decision once, accepts the same retry, and rejects the opposite retry", async () => {
+    db = await createTestDb();
+    await db
+      .insertInto("users")
+      .values({ id: "user-1", name: "User", email: "user@example.com", auth_role: "member" })
+      .execute();
+    const created = await createTaskRepository(db).upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Ship follow-up actions",
+      status: "open",
+      statusRaw: "open",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "high",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "summary-task-1",
+      createdByUserId: "user-1",
+    });
+    await db
+      .insertInto("task_completion_recommendations")
+      .values({
+        id: "recommendation-1",
+        task_id: created.taskId,
+        proposed_status: "done",
+        review_code: "DONE1234",
+        evidence_fingerprint: "fingerprint-1",
+        origin_agent_output_id: null,
+        rationale: "The conversation says this shipped.",
+        expires_at: "2026-07-22T00:00:00.000Z",
+        reviewed_at: null,
+        reviewed_by_user_id: null,
+        review_surface: null,
+        created_at: "2026-07-20T00:00:00.000Z",
+        updated_at: "2026-07-20T00:00:00.000Z",
+      })
+      .execute();
+
+    const app = reviewApp(db, "user-1");
+    const request = (decision: "confirm_done" | "keep_open") =>
+      app.request("/api/task-completion-recommendations/recommendation-1", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision }),
+      });
+
+    const first = await request("confirm_done");
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({
+      review: { kind: "completion", id: "recommendation-1", state: "accepted", canReview: false },
+      task: { id: created.taskId, status: "done" },
+    });
+
+    const retry = await request("confirm_done");
+    expect(retry.status).toBe(200);
+    await expect(retry.json()).resolves.toMatchObject({
+      review: { state: "accepted" },
+      task: { status: "done" },
+    });
+
+    const conflict = await request("keep_open");
+    expect(conflict.status).toBe(409);
+    await expect(conflict.json()).resolves.toMatchObject({ error: { code: "REVIEW_ALREADY_DECIDED" } });
+  });
+
+  it("keeps seed review owner-scoped and makes dismiss retries idempotent", async () => {
+    db = await createTestDb();
+    await db
+      .insertInto("users")
+      .values([
+        { id: "user-1", name: "User", email: "user@example.com", auth_role: "member" },
+        { id: "user-2", name: "Other", email: "other@example.com", auth_role: "member" },
+      ])
+      .execute();
+    const conversation = await db
+      .insertInto("conversations")
+      .values({
+        platform: "slack",
+        kind: "channel",
+        provider_conversation_id: "C123",
+        display_name: "Launch",
+        last_seen_message_id: null,
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+    await db
+      .insertInto("task_durability_route_state")
+      .values({
+        agent_key: "conversation-summary",
+        user_id: "user-1",
+        route_id: "route-1",
+        source_key: "slack:channel:C123",
+        seed_started_at: null,
+        seed_reviewed_at: null,
+        incremental_success_at: null,
+        last_error: null,
+      })
+      .execute();
+    await db
+      .insertInto("task_seed_candidates")
+      .values({
+        id: "candidate-1",
+        agent_key: "conversation-summary",
+        user_id: "user-1",
+        route_id: "route-1",
+        source_key: "slack:channel:C123",
+        origin_agent_output_id: null,
+        origin_agent_output_item_id: null,
+        title: "Follow up on launch",
+        normalized_title: "follow up on launch",
+        proposed_assignee_name: null,
+        source_platform: "slack",
+        source_conversation_id: conversation.id,
+        source_provider_thread_id: null,
+        source_anchor_key: `slack:${conversation.id}:root`,
+        evidence_fingerprint: "seed-fingerprint-1",
+        review_code: "SEED1234",
+        accepted_task_id: null,
+        reviewed_at: null,
+        reviewed_by_user_id: null,
+      })
+      .execute();
+
+    const foreign = await reviewApp(db, "user-2").request("/api/task-seed-candidates/candidate-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decision: "dismiss" }),
+    });
+    expect(foreign.status).toBe(404);
+
+    const app = reviewApp(db, "user-1");
+    const request = (decision: "track" | "dismiss") =>
+      app.request("/api/task-seed-candidates/candidate-1", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision }),
+      });
+    expect((await request("dismiss")).status).toBe(200);
+    expect((await request("dismiss")).status).toBe(200);
+    const conflict = await request("track");
+    expect(conflict.status).toBe(409);
+    await expect(conflict.json()).resolves.toMatchObject({ error: { code: "REVIEW_ALREADY_DECIDED" } });
+  });
+});
+
+function reviewApp(db: Kysely<DB>, userId: string) {
+  const service = { resolveUserId: vi.fn(async () => userId) } as unknown as AgentRunService;
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("sub", `auth-${userId}`);
+    c.set("email", `${userId}@example.com`);
+    c.set("role", "member");
+    c.set("adminCanReadAllFiles", false);
+    await next();
+  });
+  app.route("/api", followupReviewRoutes(service, db));
+  return app;
+}

--- a/packages/server/src/agents/routes-task-hydration.test.ts
+++ b/packages/server/src/agents/routes-task-hydration.test.ts
@@ -383,7 +383,103 @@ describe("Daily Brief task hydration routes", () => {
         sourceTaskId: "route-task",
         createdByUserId: "user-1",
       });
-      const brief = output({ todos: [item("route-item", "todos", { taskId: created.taskId })] });
+      await db
+        .insertInto("task_completion_recommendations")
+        .values({
+          id: "recommendation-1",
+          task_id: created.taskId,
+          proposed_status: "done",
+          review_code: "DONE1234",
+          evidence_fingerprint: "fingerprint-1",
+          origin_agent_output_id: null,
+          rationale: "The task appears complete.",
+          expires_at: "2026-07-22T00:00:00.000Z",
+          reviewed_at: null,
+          reviewed_by_user_id: null,
+          review_surface: null,
+          created_at: "2026-07-17T08:00:00.000Z",
+          updated_at: "2026-07-17T08:00:00.000Z",
+        })
+        .execute();
+      const acceptedTask = await createTaskRepository(db).upsertTask({
+        parentEntityId: null,
+        parentSourceRef: null,
+        parentName: null,
+        source: "summary",
+        externalRef: null,
+        title: "Accepted reconstructed follow-up",
+        status: "open",
+        statusRaw: "open",
+        statusAuthority: "local",
+        assigneeEntityId: null,
+        assigneeName: null,
+        priority: "medium",
+        dueAt: null,
+        provenance: "summary",
+        sourceTaskId: "accepted-seed-task",
+        createdByUserId: "user-1",
+      });
+      const conversation = await db
+        .insertInto("conversations")
+        .values({
+          platform: "slack",
+          kind: "channel",
+          provider_conversation_id: "C_SEED",
+          display_name: "Seed",
+          last_seen_message_id: null,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await db
+        .insertInto("task_seed_candidates")
+        .values({
+          id: "candidate-1",
+          agent_key: "conversation-summary",
+          user_id: "user-1",
+          route_id: "route-1",
+          source_key: "slack:channel:C_SEED",
+          origin_agent_output_id: null,
+          origin_agent_output_item_id: null,
+          title: "Accepted reconstructed follow-up",
+          normalized_title: "accepted reconstructed follow-up",
+          proposed_assignee_name: null,
+          source_platform: "slack",
+          source_conversation_id: conversation.id,
+          source_provider_thread_id: null,
+          source_anchor_key: `slack:${conversation.id}:root`,
+          evidence_fingerprint: "seed-fingerprint",
+          review_code: "SEED1234",
+          review_state: "accepted",
+          accepted_task_id: acceptedTask.taskId,
+          reviewed_at: "2026-07-17T09:00:00.000Z",
+          reviewed_by_user_id: "user-1",
+        })
+        .execute();
+      const brief = output({
+        todos: [item("route-item", "todos", { taskId: created.taskId })],
+        untracked_followups: [
+          item("seed-item", "untracked_followups", {
+            structuredPayload: {
+              serverOwnedFollowup: true,
+              trackingState: "untracked",
+              candidateId: "candidate-1",
+              reviewCode: "SEED1234",
+            },
+          }),
+        ],
+        looks_resolved: [
+          item("review-item", "looks_resolved", {
+            taskId: created.taskId,
+            structuredPayload: {
+              serverOwnedFollowup: true,
+              trackingState: "looks_resolved",
+              recommendationId: "recommendation-1",
+              reviewCode: "DONE1234",
+              taskId: created.taskId,
+            },
+          }),
+        ],
+      });
       const service = {
         resolveUserId: vi.fn(async () => "user-1"),
         getLatestForUser: vi.fn(async () => ({
@@ -408,19 +504,59 @@ describe("Daily Brief task hydration routes", () => {
       const latest = await app.request("/api/daily-briefs");
       expect(latest.status).toBe(200);
       await expect(latest.json()).resolves.toMatchObject({
-        brief: { sections: { todos: [{ taskId: created.taskId, task: { status: "open" } }] } },
+        brief: {
+          sections: {
+            todos: [{ taskId: created.taskId, task: { status: "open" } }],
+            looks_resolved: [
+              {
+                review: {
+                  kind: "completion",
+                  id: "recommendation-1",
+                  state: "pending",
+                  canReview: true,
+                },
+              },
+            ],
+            untracked_followups: [
+              {
+                taskId: acceptedTask.taskId,
+                task: { id: acceptedTask.taskId, status: "open" },
+                review: {
+                  kind: "seed",
+                  id: "candidate-1",
+                  state: "accepted",
+                  canReview: false,
+                  acceptedTaskId: acceptedTask.taskId,
+                },
+              },
+            ],
+          },
+        },
       });
 
-      await db
-        .updateTable("tasks")
-        .set({
-          status: "done",
-          status_raw: "done",
-          completed_at: "2026-07-17T10:00:00.000Z",
-          updated_at: "2026-07-17T10:00:00.000Z",
-        })
-        .where("id", "=", created.taskId)
-        .execute();
+      await db.transaction().execute(async (trx) => {
+        await trx
+          .updateTable("tasks")
+          .set({
+            status: "done",
+            status_raw: "done",
+            completed_at: "2026-07-17T10:00:00.000Z",
+            updated_at: "2026-07-17T10:00:00.000Z",
+          })
+          .where("id", "=", created.taskId)
+          .execute();
+        await trx
+          .updateTable("task_completion_recommendations")
+          .set({
+            review_state: "accepted",
+            reviewed_at: "2026-07-17T10:00:00.000Z",
+            reviewed_by_user_id: "user-1",
+            review_surface: "web",
+            updated_at: "2026-07-17T10:00:00.000Z",
+          })
+          .where("id", "=", "recommendation-1")
+          .execute();
+      });
 
       const byId = await app.request("/api/daily-briefs/brief-1");
       expect(byId.status).toBe(200);
@@ -432,6 +568,29 @@ describe("Daily Brief task hydration routes", () => {
                 title: "Snapshot route-item",
                 taskId: created.taskId,
                 task: { title: "Current task title", status: "done", completedAt: "2026-07-17T10:00:00.000Z" },
+              },
+            ],
+            looks_resolved: [
+              {
+                review: {
+                  kind: "completion",
+                  id: "recommendation-1",
+                  state: "accepted",
+                  canReview: false,
+                },
+              },
+            ],
+            untracked_followups: [
+              {
+                taskId: acceptedTask.taskId,
+                task: { id: acceptedTask.taskId, status: "open" },
+                review: {
+                  kind: "seed",
+                  id: "candidate-1",
+                  state: "accepted",
+                  canReview: false,
+                  acceptedTaskId: acceptedTask.taskId,
+                },
               },
             ],
           },

--- a/packages/server/src/agents/routes-task-hydration.test.ts
+++ b/packages/server/src/agents/routes-task-hydration.test.ts
@@ -600,4 +600,242 @@ describe("Daily Brief task hydration routes", () => {
       await db.destroy();
     }
   });
+
+  it("does not disclose an unauthorized completion review or an inaccessible accepted task", async () => {
+    const db = await createTestDb();
+    try {
+      await db
+        .insertInto("users")
+        .values([
+          { id: "user-1", name: "Reader", email: "reader@example.com", auth_role: "member" },
+          { id: "user-2", name: "Owner", email: "owner@example.com", auth_role: "member" },
+        ])
+        .execute();
+      const hiddenTask = await createTaskRepository(db).upsertTask({
+        parentEntityId: null,
+        parentSourceRef: null,
+        parentName: null,
+        source: "summary",
+        externalRef: null,
+        title: "Hidden task",
+        status: "open",
+        statusRaw: "open",
+        statusAuthority: "local",
+        assigneeEntityId: null,
+        assigneeName: null,
+        priority: "medium",
+        dueAt: null,
+        provenance: "summary",
+        sourceTaskId: "hidden-task",
+        createdByUserId: "user-2",
+      });
+      await db
+        .insertInto("task_completion_recommendations")
+        .values({
+          id: "hidden-recommendation",
+          task_id: hiddenTask.taskId,
+          proposed_status: "done",
+          review_code: "HIDDEN12",
+          evidence_fingerprint: "hidden-completion",
+          origin_agent_output_id: null,
+          rationale: "Private rationale.",
+          expires_at: "2099-01-01T00:00:00.000Z",
+          reviewed_at: null,
+          reviewed_by_user_id: null,
+          review_surface: null,
+        })
+        .execute();
+      const conversation = await db
+        .insertInto("conversations")
+        .values({
+          platform: "slack",
+          kind: "channel",
+          provider_conversation_id: "C_HIDDEN",
+          display_name: "Hidden",
+          last_seen_message_id: null,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await db
+        .insertInto("task_seed_candidates")
+        .values({
+          id: "accepted-hidden-candidate",
+          agent_key: "conversation-summary",
+          user_id: "user-1",
+          route_id: "route-hidden",
+          source_key: "slack:channel:C_HIDDEN",
+          origin_agent_output_id: null,
+          origin_agent_output_item_id: null,
+          title: "Accepted hidden task",
+          normalized_title: "accepted hidden task",
+          proposed_assignee_name: null,
+          source_platform: "slack",
+          source_conversation_id: conversation.id,
+          source_provider_thread_id: null,
+          source_anchor_key: `slack:${conversation.id}:root`,
+          evidence_fingerprint: "hidden-seed",
+          review_code: "HIDSEED1",
+          review_state: "accepted",
+          accepted_task_id: hiddenTask.taskId,
+          reviewed_at: "2026-07-20T00:00:00.000Z",
+          reviewed_by_user_id: "user-1",
+        })
+        .execute();
+      const brief = output({
+        looks_resolved: [
+          item("hidden-completion", "looks_resolved", {
+            taskId: hiddenTask.taskId,
+            structuredPayload: {
+              serverOwnedFollowup: true,
+              trackingState: "looks_resolved",
+              recommendationId: "hidden-recommendation",
+              reviewCode: "HIDDEN12",
+              taskId: hiddenTask.taskId,
+            },
+          }),
+        ],
+        untracked_followups: [
+          item("hidden-seed", "untracked_followups", {
+            structuredPayload: {
+              serverOwnedFollowup: true,
+              trackingState: "untracked",
+              candidateId: "accepted-hidden-candidate",
+              reviewCode: "HIDSEED1",
+            },
+          }),
+        ],
+      });
+      const service = {
+        resolveUserId: vi.fn(async () => "user-1"),
+        getLatestForUser: vi.fn(async () => ({
+          output: brief,
+          running: false,
+          outputDate: "2026-07-20",
+          timezone: "UTC",
+          enabledSections: ["looks_resolved", "untracked_followups"],
+        })),
+      } as unknown as AgentRunService;
+      const app = new Hono();
+      app.use("*", async (c, next) => {
+        c.set("sub", "auth-user");
+        c.set("email", "reader@example.com");
+        c.set("role", "member");
+        c.set("adminCanReadAllFiles", false);
+        await next();
+      });
+      app.route("/api/daily-briefs", dailyBriefRoutes(service, db, createTestLogger()));
+
+      const response = await app.request("/api/daily-briefs");
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        brief: {
+          sections: {
+            looks_resolved: [{ taskId: null, task: null, review: null }],
+            untracked_followups: [
+              {
+                taskId: null,
+                task: null,
+                review: {
+                  kind: "seed",
+                  id: "accepted-hidden-candidate",
+                  state: "accepted",
+                  acceptedTaskId: null,
+                },
+              },
+            ],
+          },
+        },
+      });
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it("hydrates at most one hundred review references and leaves overflow chat-only", async () => {
+    const db = await createTestDb();
+    try {
+      await db
+        .insertInto("users")
+        .values({ id: "user-1", name: "Reader", email: "reader@example.com", auth_role: "member" })
+        .execute();
+      const conversation = await db
+        .insertInto("conversations")
+        .values({
+          platform: "slack",
+          kind: "channel",
+          provider_conversation_id: "C_OVERFLOW",
+          display_name: "Overflow",
+          last_seen_message_id: null,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await db
+        .insertInto("task_seed_candidates")
+        .values(
+          Array.from({ length: 101 }, (_, index) => ({
+            id: `candidate-${index}`,
+            agent_key: "conversation-summary",
+            user_id: "user-1",
+            route_id: "route-overflow",
+            source_key: "slack:channel:C_OVERFLOW",
+            origin_agent_output_id: null,
+            origin_agent_output_item_id: null,
+            title: `Candidate ${index}`,
+            normalized_title: `candidate ${index}`,
+            proposed_assignee_name: null,
+            source_platform: "slack",
+            source_conversation_id: conversation.id,
+            source_provider_thread_id: null,
+            source_anchor_key: `slack:${conversation.id}:${index}`,
+            evidence_fingerprint: `overflow-${index}`,
+            review_code: `OVR${String(index).padStart(5, "0")}`,
+            accepted_task_id: null,
+            reviewed_at: null,
+            reviewed_by_user_id: null,
+          })),
+        )
+        .execute();
+      const brief = output({
+        untracked_followups: Array.from({ length: 101 }, (_, index) =>
+          item(`overflow-${index}`, "untracked_followups", {
+            structuredPayload: {
+              serverOwnedFollowup: true,
+              trackingState: "untracked",
+              candidateId: `candidate-${index}`,
+              reviewCode: `OVR${String(index).padStart(5, "0")}`,
+            },
+          }),
+        ),
+      });
+      const service = {
+        resolveUserId: vi.fn(async () => "user-1"),
+        getLatestForUser: vi.fn(async () => ({
+          output: brief,
+          running: false,
+          outputDate: "2026-07-20",
+          timezone: "UTC",
+          enabledSections: ["untracked_followups"],
+        })),
+      } as unknown as AgentRunService;
+      const app = new Hono();
+      app.use("*", async (c, next) => {
+        c.set("sub", "auth-user");
+        c.set("email", "reader@example.com");
+        c.set("role", "member");
+        c.set("adminCanReadAllFiles", false);
+        await next();
+      });
+      app.route("/api/daily-briefs", dailyBriefRoutes(service, db, createTestLogger()));
+
+      const response = await app.request("/api/daily-briefs");
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        brief: { sections: { untracked_followups: Array<{ review: unknown }> } };
+      };
+      expect(body.brief.sections.untracked_followups.slice(0, 100).every((entry) => entry.review !== null)).toBe(true);
+      expect(body.brief.sections.untracked_followups[100]?.review).toBeNull();
+    } finally {
+      await db.destroy();
+    }
+  });
 });

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Kysely, Selectable } from "kysely";
-import { type TaskAccessContext, resolveTaskAccessContext, toTaskDto } from "../api/task-access";
+import { type TaskAccessContext, canEditTaskStatus, resolveTaskAccessContext, toTaskDto } from "../api/task-access";
 import type {
   AgentDeliveryConfig,
   AgentDeliveryMention,
@@ -13,6 +13,8 @@ import type {
   AgentSourceConfig,
   AgentSourceKey,
 } from "../db/repositories/agent-outputs";
+import { createConversationFollowupsRepository } from "../db/repositories/conversation-followups";
+import { createTaskDurabilityTransitionRepository } from "../db/repositories/task-durability-transition";
 import { createTaskRepository } from "../db/repositories/tasks";
 import type { DB, TasksTable } from "../db/schema";
 import type { Logger } from "../logger";
@@ -29,6 +31,7 @@ import {
 import type { AgentApiItem, AgentDefinition } from "./types";
 
 export const MAX_BRIEF_TASK_LINKS = 100;
+export const MAX_BRIEF_REVIEW_LINKS = 100;
 
 export interface DailyBriefTaskState {
   id: string;
@@ -46,7 +49,23 @@ export interface DailyBriefTaskState {
 type HydratedDailyBriefItem = AgentApiItem & {
   taskId: string | null;
   task: DailyBriefTaskState | null;
+  review?: DailyBriefReviewState | null;
 };
+
+export type DailyBriefReviewState =
+  | {
+      kind: "completion";
+      id: string;
+      state: "pending" | "accepted" | "rejected" | "expired";
+      canReview: boolean;
+    }
+  | {
+      kind: "seed";
+      id: string;
+      state: "pending" | "accepted" | "dismissed";
+      canReview: boolean;
+      acceptedTaskId: string | null;
+    };
 
 type TaskLinkCandidate = {
   taskId: string;
@@ -108,7 +127,7 @@ export async function hydrateDailyBriefTaskState(params: {
   access: TaskAccessContext;
   loadVisibleTasks: (taskIds: string[], access: TaskAccessContext) => Promise<Selectable<TasksTable>[]>;
   logger: Pick<Logger, "debug">;
-}): Promise<AgentOutputApi & { sections: Record<string, HydratedDailyBriefItem[]> }> {
+}): Promise<Omit<AgentOutputApi, "sections"> & { sections: Record<string, HydratedDailyBriefItem[]> }> {
   const candidateByItem = new Map<AgentApiItem, TaskLinkCandidate>();
   const idsToLoad: string[] = [];
   const acceptedIds = new Set<string>();
@@ -204,6 +223,192 @@ export async function hydrateDailyBriefTaskState(params: {
   return { ...params.output, sections };
 }
 
+type ReviewReference =
+  | { kind: "completion"; id: string | null; code: string | null; overflow: boolean }
+  | { kind: "seed"; id: string | null; code: string | null; overflow: boolean };
+
+export async function hydrateDailyBriefState(params: {
+  db: Kysely<DB>;
+  output: AgentOutputApi;
+  userId: string;
+  access: TaskAccessContext;
+  loadVisibleTasks: (taskIds: string[], access: TaskAccessContext) => Promise<Selectable<TasksTable>[]>;
+  logger: Pick<Logger, "debug">;
+  now?: string;
+}): Promise<Omit<AgentOutputApi, "sections"> & { sections: Record<string, HydratedDailyBriefItem[]> }> {
+  const references = new Map<AgentApiItem, ReviewReference>();
+  const selectedReferenceKeys = new Set<string>();
+  const completionIds: string[] = [];
+  const completionCodes: string[] = [];
+  const seedIds: string[] = [];
+  const seedCodes: string[] = [];
+
+  if (params.output.userId === params.userId) {
+    for (const items of Object.values(params.output.sections)) {
+      for (const item of items) {
+        const payload = item.structuredPayload;
+        if (!payload || payload.serverOwnedFollowup !== true) continue;
+        let reference: Omit<ReviewReference, "overflow"> | null = null;
+        if (item.sectionKey === "looks_resolved" && payload.trackingState === "looks_resolved") {
+          const id = nonEmptyString(payload.recommendationId);
+          const code = nonEmptyString(payload.reviewCode);
+          if (id || code) reference = { kind: "completion", id, code };
+        } else if (item.sectionKey === "untracked_followups" && payload.trackingState === "untracked") {
+          const candidateId = nonEmptyString(payload.candidateId);
+          const reviewCode = nonEmptyString(payload.reviewCode);
+          const id = candidateId && candidateId !== reviewCode ? candidateId : null;
+          if (id || reviewCode) reference = { kind: "seed", id, code: reviewCode };
+        }
+        if (!reference) continue;
+        const key = `${reference.kind}:${reference.id ? `id:${reference.id}` : `code:${reference.code}`}`;
+        const overflow = !selectedReferenceKeys.has(key) && selectedReferenceKeys.size >= MAX_BRIEF_REVIEW_LINKS;
+        if (!overflow && !selectedReferenceKeys.has(key)) {
+          selectedReferenceKeys.add(key);
+          if (reference.kind === "completion") {
+            if (reference.id) completionIds.push(reference.id);
+            else if (reference.code) completionCodes.push(reference.code);
+          } else if (reference.id) seedIds.push(reference.id);
+          else if (reference.code) seedCodes.push(reference.code);
+        }
+        references.set(item, { ...reference, overflow });
+      }
+    }
+  }
+
+  const completionRows =
+    completionIds.length + completionCodes.length === 0
+      ? []
+      : await params.db
+          .selectFrom("task_completion_recommendations")
+          .innerJoin("tasks", "tasks.id", "task_completion_recommendations.task_id")
+          .selectAll("tasks")
+          .select([
+            "task_completion_recommendations.id as recommendation_id",
+            "task_completion_recommendations.review_code as recommendation_review_code",
+            "task_completion_recommendations.review_state as recommendation_review_state",
+            "task_completion_recommendations.expires_at as recommendation_expires_at",
+            "task_completion_recommendations.delivery_count as recommendation_delivery_count",
+          ])
+          .where((eb) =>
+            eb.or([
+              ...(completionIds.length > 0 ? [eb("task_completion_recommendations.id", "in", completionIds)] : []),
+              ...(completionCodes.length > 0
+                ? [eb("task_completion_recommendations.review_code", "in", completionCodes)]
+                : []),
+            ]),
+          )
+          .limit(completionIds.length + completionCodes.length)
+          .execute();
+  const completionById = new Map(completionRows.map((row) => [row.recommendation_id, row]));
+  const completionByCode = new Map(completionRows.map((row) => [row.recommendation_review_code, row]));
+
+  const seedRows =
+    seedIds.length + seedCodes.length === 0
+      ? []
+      : await params.db
+          .selectFrom("task_seed_candidates")
+          .select(["id", "review_code", "review_state", "accepted_task_id"])
+          .where("user_id", "=", params.userId)
+          .where((eb) =>
+            eb.or([
+              ...(seedIds.length > 0 ? [eb("id", "in", seedIds)] : []),
+              ...(seedCodes.length > 0 ? [eb("review_code", "in", seedCodes)] : []),
+            ]),
+          )
+          .limit(seedIds.length + seedCodes.length)
+          .execute();
+  const seedById = new Map(seedRows.map((row) => [row.id, row]));
+  const seedByCode = new Map(seedRows.map((row) => [row.review_code, row]));
+
+  const reviewByItem = new Map<AgentApiItem, DailyBriefReviewState>();
+  const now = params.now ?? new Date().toISOString();
+  const outputWithAcceptedTasks: AgentOutputApi = {
+    ...params.output,
+    sections: Object.fromEntries(
+      Object.entries(params.output.sections).map(([section, items]) => [
+        section,
+        items.map((item) => {
+          const reference = references.get(item);
+          if (!reference || reference.overflow) return item;
+          if (reference.kind === "completion") {
+            const row =
+              (reference.id ? completionById.get(reference.id) : undefined) ??
+              (reference.code ? completionByCode.get(reference.code) : undefined);
+            if (!row || !canEditTaskStatus(row, params.access)) return item;
+            const actionable =
+              row.valid_to === null &&
+              (row.status === "open" || row.status === "in_progress") &&
+              row.status_authority === "local" &&
+              (row.provenance === "summary" || row.provenance === "brief") &&
+              row.recommendation_expires_at > now &&
+              row.recommendation_delivery_count <= 3;
+            const state =
+              row.recommendation_review_state === "pending" && !actionable
+                ? "expired"
+                : row.recommendation_review_state;
+            if (state !== "pending" && state !== "accepted" && state !== "rejected" && state !== "expired") return item;
+            reviewByItem.set(item, {
+              kind: "completion",
+              id: row.recommendation_id,
+              state,
+              canReview: state === "pending",
+            });
+            return item;
+          }
+          const row =
+            (reference.id ? seedById.get(reference.id) : undefined) ??
+            (reference.code ? seedByCode.get(reference.code) : undefined);
+          if (
+            !row ||
+            (row.review_state !== "pending" && row.review_state !== "accepted" && row.review_state !== "dismissed")
+          ) {
+            return item;
+          }
+          reviewByItem.set(item, {
+            kind: "seed",
+            id: row.id,
+            state: row.review_state,
+            canReview: row.review_state === "pending",
+            acceptedTaskId: null,
+          });
+          return row.review_state === "accepted" && row.accepted_task_id
+            ? { ...item, taskId: row.accepted_task_id }
+            : item;
+        }),
+      ]),
+    ),
+  };
+
+  const hydrated = await hydrateDailyBriefTaskState({
+    output: outputWithAcceptedTasks,
+    userId: params.userId,
+    access: params.access,
+    loadVisibleTasks: params.loadVisibleTasks,
+    logger: params.logger,
+  });
+  const sections: Record<string, HydratedDailyBriefItem[]> = Object.fromEntries(
+    Object.entries(hydrated.sections).map(([section, items]) => [
+      section,
+      items.map((item, index) => {
+        const original = params.output.sections[section]?.[index];
+        const review = original ? reviewByItem.get(original) : undefined;
+        if (!review) return { ...item, review: null };
+        if (review.kind === "seed") {
+          return {
+            ...item,
+            review: {
+              ...review,
+              acceptedTaskId: review.state === "accepted" && item.task ? item.task.id : null,
+            },
+          };
+        }
+        return { ...item, review };
+      }),
+    ]),
+  );
+  return { ...hydrated, sections };
+}
+
 async function getCurrentUserId(c: { get: (key: "sub" | "email") => string | undefined }, service: AgentRunService) {
   const sub = c.get("sub");
   if (!sub) return null;
@@ -265,7 +470,8 @@ export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>, logge
 
   const hydrate = async (c: Parameters<typeof resolveTaskAccessContext>[1], output: AgentOutputApi, userId: string) => {
     const access = await resolveTaskAccessContext(db, c, userId);
-    return hydrateDailyBriefTaskState({
+    return hydrateDailyBriefState({
+      db,
       output,
       userId,
       access,
@@ -314,6 +520,92 @@ export function dailyBriefRoutes(service: AgentRunService, db: Kysely<DB>, logge
     });
     const row = rows[0] ?? null;
     return c.json({ generation: row ? { id: row.id, status: row.status, briefDate: row.output_date } : null }, 202);
+  });
+
+  return routes;
+}
+
+export function followupReviewRoutes(service: AgentRunService, db: Kysely<DB>) {
+  const routes = new Hono();
+  const followups = createConversationFollowupsRepository(db);
+  const transition = createTaskDurabilityTransitionRepository(db);
+  const tasks = createTaskRepository(db);
+
+  const taskState = async (taskId: string | undefined, access: TaskAccessContext) => {
+    if (!taskId) return null;
+    const task = (await tasks.listVisibleTasksByIds([taskId], access))[0];
+    return task ? toDailyBriefTaskState(task, access) : null;
+  };
+
+  routes.patch("/task-completion-recommendations/:recommendationId", async (c) => {
+    const userId = await getCurrentUserId(c, service);
+    if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
+    const body = (await c.req.json().catch(() => null)) as { decision?: unknown } | null;
+    if (body?.decision !== "confirm_done" && body?.decision !== "keep_open") {
+      return c.json({ error: { code: "INVALID_DECISION", message: "Invalid completion review decision" } }, 400);
+    }
+    const access = await resolveTaskAccessContext(db, c, userId);
+    const result = await followups.reviewRecommendationById({
+      id: c.req.param("recommendationId"),
+      action: body.decision,
+      userId,
+      assigneeEntityIds: access.assigneeEntityIds,
+      canEditAllLocalTasks: access.canEditAllLocalTasks,
+      surface: "web",
+      now: new Date().toISOString(),
+    });
+    if (result.status === "not_found" || result.status === "unauthorized") {
+      return c.json({ error: { code: "NOT_FOUND", message: "Review not found" } }, 404);
+    }
+    if (result.status === "stale") {
+      return c.json({ error: { code: "REVIEW_STALE", message: "Review is no longer actionable" } }, 409);
+    }
+    if (result.status === "already_reviewed" && result.decision !== body.decision) {
+      return c.json({ error: { code: "REVIEW_ALREADY_DECIDED", message: "Review already has another decision" } }, 409);
+    }
+    return c.json({
+      review: {
+        kind: "completion" as const,
+        id: c.req.param("recommendationId"),
+        state: body.decision === "confirm_done" ? ("accepted" as const) : ("rejected" as const),
+        canReview: false,
+      },
+      task: await taskState("taskId" in result ? result.taskId : undefined, access),
+    });
+  });
+
+  routes.patch("/task-seed-candidates/:candidateId", async (c) => {
+    const userId = await getCurrentUserId(c, service);
+    if (!userId) return c.json({ error: { code: "UNAUTHORIZED", message: "User not found" } }, 401);
+    const body = (await c.req.json().catch(() => null)) as { decision?: unknown } | null;
+    if (body?.decision !== "track" && body?.decision !== "dismiss") {
+      return c.json({ error: { code: "INVALID_DECISION", message: "Invalid seed review decision" } }, 400);
+    }
+    const access = await resolveTaskAccessContext(db, c, userId);
+    const result = await transition.reviewSeedCandidateById({
+      id: c.req.param("candidateId"),
+      userId,
+      decision: body.decision,
+      surface: "web",
+      now: new Date().toISOString(),
+    });
+    if (result.status === "not_found") {
+      return c.json({ error: { code: "NOT_FOUND", message: "Review not found" } }, 404);
+    }
+    if (result.status === "already_reviewed" && result.decision !== body.decision) {
+      return c.json({ error: { code: "REVIEW_ALREADY_DECIDED", message: "Review already has another decision" } }, 409);
+    }
+    const task = await taskState("taskId" in result ? result.taskId : undefined, access);
+    return c.json({
+      review: {
+        kind: "seed" as const,
+        id: c.req.param("candidateId"),
+        state: body.decision === "track" ? ("accepted" as const) : ("dismissed" as const),
+        canReview: false,
+        acceptedTaskId: task?.id ?? null,
+      },
+      task,
+    });
   });
 
   return routes;

--- a/packages/server/src/db/repositories/conversation-followups.ts
+++ b/packages/server/src/db/repositories/conversation-followups.ts
@@ -424,6 +424,67 @@ export function createConversationFollowupsRepository(db: Kysely<DB>) {
       }
     },
 
+    async reviewRecommendationById(input: {
+      id: string;
+      action: "confirm_done" | "keep_open";
+      userId: string;
+      assigneeEntityIds: string[];
+      surface: string;
+      now: string;
+      canEditAllLocalTasks?: boolean;
+    }) {
+      const load = () =>
+        db
+          .selectFrom("task_completion_recommendations")
+          .innerJoin("tasks", "tasks.id", "task_completion_recommendations.task_id")
+          .select([
+            "task_completion_recommendations.review_code",
+            "task_completion_recommendations.review_state",
+            "task_completion_recommendations.task_id",
+            "tasks.created_by_user_id",
+            "tasks.assignee_entity_id",
+          ])
+          .where("task_completion_recommendations.id", "=", input.id)
+          .executeTakeFirst();
+      const current = await load();
+      if (!current) return { status: "not_found" as const };
+      const authorized =
+        input.canEditAllLocalTasks === true ||
+        current.created_by_user_id === input.userId ||
+        Boolean(current.assignee_entity_id && input.assigneeEntityIds.includes(current.assignee_entity_id));
+      if (!authorized) return { status: "unauthorized" as const };
+      if (current.review_state !== "pending") {
+        if (current.review_state !== "accepted" && current.review_state !== "rejected") {
+          return { status: "stale" as const };
+        }
+        return {
+          status: "already_reviewed" as const,
+          decision: current.review_state === "accepted" ? ("confirm_done" as const) : ("keep_open" as const),
+          taskId: current.task_id,
+        };
+      }
+
+      const result = await createConversationFollowupsRepository(db).reviewRecommendation({
+        code: current.review_code,
+        action: input.action,
+        userId: input.userId,
+        assigneeEntityIds: input.assigneeEntityIds,
+        surface: input.surface,
+        now: input.now,
+        canEditAllLocalTasks: input.canEditAllLocalTasks,
+      });
+      if (result.status !== "stale") return result;
+      const raced = await load();
+      if (raced?.review_state === "accepted" || raced?.review_state === "rejected") {
+        return {
+          status: "already_reviewed" as const,
+          decision: raced.review_state === "accepted" ? ("confirm_done" as const) : ("keep_open" as const),
+          taskId: raced.task_id,
+        };
+      }
+      return result;
+    },
+
     async reviewRecommendation(input: {
       code: string;
       action: "confirm_done" | "keep_open";

--- a/packages/server/src/db/repositories/task-durability-transition.ts
+++ b/packages/server/src/db/repositories/task-durability-transition.ts
@@ -54,6 +54,14 @@ export interface ReviewSeedCandidateInput {
   now: ClockValue;
 }
 
+export interface ReviewSeedCandidateByIdInput {
+  userId: string;
+  id: string;
+  decision: SeedReviewDecision;
+  surface: SeedReviewSurface;
+  now: ClockValue;
+}
+
 export type SeedReviewResult =
   | { status: "not_found" }
   | {
@@ -102,6 +110,7 @@ export interface UserTaskDurabilityRoute {
 }
 
 export interface UserTaskDurabilityUntrackedItem {
+  id: string;
   code: string;
   title: string;
   label: string;
@@ -330,6 +339,23 @@ export function createTaskDurabilityTransitionRepository(db: Kysely<DB>) {
           lastError,
         };
       }
+    },
+
+    async reviewSeedCandidateById(input: ReviewSeedCandidateByIdInput): Promise<SeedReviewResult> {
+      const seed = await db
+        .selectFrom("task_seed_candidates")
+        .select("review_code")
+        .where("id", "=", input.id)
+        .where("user_id", "=", input.userId)
+        .executeTakeFirst();
+      if (!seed) return { status: "not_found" };
+      return createTaskDurabilityTransitionRepository(db).reviewSeedCandidate({
+        userId: input.userId,
+        code: seed.review_code,
+        decision: input.decision,
+        surface: input.surface,
+        now: input.now,
+      });
     },
 
     async reviewSeedCandidate(input: ReviewSeedCandidateInput): Promise<SeedReviewResult> {
@@ -645,6 +671,7 @@ export function createTaskDurabilityTransitionRepository(db: Kysely<DB>) {
           lastError: route.last_error,
         })),
         untracked: candidates.map((candidate) => ({
+          id: candidate.id,
           code: candidate.review_code,
           title: candidate.title,
           label: UNTRACKED_LABEL,

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -63,7 +63,7 @@ import { createSettingsRepository } from "./db/repositories/settings";
 import { createWhatsAppTemplateMappingRepository } from "./db/repositories/whatsapp-template-mappings";
 
 import type { McpServerConfig, RunAgentParams, RunAgentResult } from "./agent/runner";
-import { agentRoutes, dailyBriefRoutes } from "./agents/routes";
+import { agentRoutes, dailyBriefRoutes, followupReviewRoutes } from "./agents/routes";
 import type { AgentRunService } from "./agents/service";
 import { getSmtpConfig } from "./api/shared";
 import type { createAutomationRunsRepository } from "./db/repositories/automation-runs";
@@ -514,6 +514,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   app.route("/api/workspace/summary", workspaceSummaryRoutes({ db, config, users, mcpServers }));
   if (deps?.agentRunService) {
     app.route("/api/daily-briefs", dailyBriefRoutes(deps.agentRunService, db, logger));
+    app.route("/api", followupReviewRoutes(deps.agentRunService, db));
     app.route("/api/agents", agentRoutes(deps.agentRunService));
   }
   app.route("/api/workspace", createWorkspaceApi({ config }));

--- a/packages/server/src/scripts/inline-followup-review-fixture.test.ts
+++ b/packages/server/src/scripts/inline-followup-review-fixture.test.ts
@@ -1,0 +1,163 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { dailyBriefRoutes, followupReviewRoutes } from "../agents/routes";
+import { AgentRunService, type AgentRunServiceDeps } from "../agents/service";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import { clearInlineFollowupReviewFixture, seedInlineFollowupReviewFixture } from "./inline-followup-review-fixture";
+
+const USER_ID = "inline-followup-review-fixture-user";
+const OUTPUT_DATE = "2026-07-20";
+const NOW = "2026-07-20T10:00:00.000Z";
+
+describe("inline follow-up review fixture", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await db
+      .insertInto("users")
+      .values({
+        id: USER_ID,
+        name: "Fixture Reviewer",
+        email: "fixture-reviewer@example.com",
+        auth_role: "admin",
+        timezone: "UTC",
+      })
+      .execute();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("seeds a brief that can complete and track follow-ups through the public review routes", async () => {
+    const fixture = await seedInlineFollowupReviewFixture(db, { userId: USER_ID, now: NOW });
+    const app = createFixtureApp(db);
+
+    const latest = await app.request(`/api/daily-briefs?date=${OUTPUT_DATE}`);
+    expect(latest.status).toBe(200);
+    const body = (await latest.json()) as {
+      brief: {
+        sections: Record<
+          string,
+          Array<{
+            title: string;
+            review: { id: string; kind: string; state: string; canReview: boolean } | null;
+          }>
+        >;
+      };
+    };
+    expect(body.brief.sections.looks_resolved).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "QA: Confirm completed launch checklist",
+          review: expect.objectContaining({
+            id: fixture.completionRecommendationIds.confirmDone,
+            kind: "completion",
+            state: "pending",
+            canReview: true,
+          }),
+        }),
+      ]),
+    );
+    expect(body.brief.sections.untracked_followups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "QA: Send launch recap to the customer",
+          review: expect.objectContaining({
+            id: fixture.seedCandidateIds.track,
+            kind: "seed",
+            state: "pending",
+            canReview: true,
+          }),
+        }),
+      ]),
+    );
+
+    const completion = await app.request(
+      `/api/task-completion-recommendations/${fixture.completionRecommendationIds.confirmDone}`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "confirm_done" }),
+      },
+    );
+    expect(completion.status).toBe(200);
+    await expect(completion.json()).resolves.toMatchObject({
+      review: { state: "accepted", canReview: false },
+      task: { status: "done" },
+    });
+
+    const seed = await app.request(`/api/task-seed-candidates/${fixture.seedCandidateIds.track}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decision: "track" }),
+    });
+    expect(seed.status).toBe(200);
+    await expect(seed.json()).resolves.toMatchObject({
+      review: { state: "accepted", canReview: false },
+      task: { title: "QA: Send launch recap to the customer", status: "open" },
+    });
+  });
+
+  it("resets its own namespace without duplicating cards and can be cleared", async () => {
+    await seedInlineFollowupReviewFixture(db, { userId: USER_ID, now: NOW });
+    await seedInlineFollowupReviewFixture(db, { userId: USER_ID, now: NOW });
+    const app = createFixtureApp(db);
+
+    const latest = await app.request(`/api/daily-briefs?date=${OUTPUT_DATE}`);
+    const body = (await latest.json()) as {
+      brief: { sections: Record<string, Array<{ title: string }>> };
+    };
+    expect(body.brief.sections.looks_resolved?.map((item) => item.title)).toEqual([
+      "QA: Confirm completed launch checklist",
+      "QA: Keep customer handoff open",
+      "QA: Review an expired completion suggestion",
+    ]);
+    expect(body.brief.sections.untracked_followups?.map((item) => item.title)).toEqual([
+      "QA: Send launch recap to the customer",
+      "QA: Remove duplicate launch reminder",
+      "QA: Legacy chat-only follow-up",
+    ]);
+
+    await clearInlineFollowupReviewFixture(db, USER_ID);
+
+    const cleared = await app.request(`/api/daily-briefs?date=${OUTPUT_DATE}`);
+    await expect(cleared.json()).resolves.toMatchObject({ brief: null });
+  });
+
+  function createFixtureApp(database: Kysely<DB>) {
+    const runAgent = async () => {
+      throw new Error("Fixture tests do not run an agent.");
+    };
+    const service = new AgentRunService({
+      db: database,
+      config: createTestConfig(),
+      logger: createTestLogger(),
+      users: createUserRepository(database),
+      settings: createSettingsRepository(database),
+      runAgent: runAgent as AgentRunServiceDeps["runAgent"],
+      runScheduledAgent: runAgent as AgentRunServiceDeps["runScheduledAgent"],
+    });
+    const routeService = {
+      resolveUserId: async () => USER_ID,
+      getLatestForUser: service.getLatestForUser.bind(service),
+      getByIdForUser: service.getByIdForUser.bind(service),
+    } as unknown as AgentRunService;
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("sub", "fixture-auth-sub");
+      c.set("email", "fixture-reviewer@example.com");
+      c.set("role", "admin");
+      c.set("adminCanReadAllFiles", false);
+      await next();
+    });
+    app.route("/api/daily-briefs", dailyBriefRoutes(routeService, database, createTestLogger()));
+    app.route("/api", followupReviewRoutes(routeService, database));
+    return app;
+  }
+});

--- a/packages/server/src/scripts/inline-followup-review-fixture.ts
+++ b/packages/server/src/scripts/inline-followup-review-fixture.ts
@@ -1,0 +1,606 @@
+import { createHash } from "node:crypto";
+import { access } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect, sql } from "kysely";
+import { CONVERSATION_SUMMARY_AGENT_KEY } from "../agents/definitions/conversation-summary";
+import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION } from "../agents/definitions/daily-brief";
+import { localDateInTimezone } from "../agents/run/output-utils";
+import { createTaskDurabilityTransitionRepository } from "../db/repositories/task-durability-transition";
+import { createTaskRepository } from "../db/repositories/tasks";
+import type { DB } from "../db/schema";
+
+const FIXTURE_LABEL = "Inline follow-up review QA fixture";
+const COMPLETION_TITLES = {
+  confirmDone: "QA: Confirm completed launch checklist",
+  keepOpen: "QA: Keep customer handoff open",
+  expired: "QA: Review an expired completion suggestion",
+} as const;
+const SEED_TITLES = {
+  track: "QA: Send launch recap to the customer",
+  dismiss: "QA: Remove duplicate launch reminder",
+} as const;
+
+export interface InlineFollowupReviewFixtureOptions {
+  userId: string;
+  now?: Date | string;
+}
+
+export interface InlineFollowupReviewFixtureResult {
+  userId: string;
+  outputDate: string;
+  briefOutputId: string;
+  sourceOutputId: string;
+  completionRecommendationIds: {
+    confirmDone: string;
+    keepOpen: string;
+    expired: string;
+  };
+  seedCandidateIds: {
+    track: string;
+    dismiss: string;
+  };
+}
+
+function fixtureScope(userId: string): string {
+  return createHash("sha256").update(userId).digest("hex").slice(0, 12);
+}
+
+function fixtureIds(userId: string) {
+  const prefix = `qa-inline-followup-${fixtureScope(userId)}`;
+  return {
+    prefix,
+    briefOutputId: `${prefix}-brief`,
+    sourceOutputId: `${prefix}-source`,
+    routeId: `${prefix}-route`,
+    conversationProviderId: `QA_INLINE_FOLLOWUP_${fixtureScope(userId).toUpperCase()}`,
+    completionTaskSourceIds: {
+      confirmDone: `${prefix}-task-confirm-done`,
+      keepOpen: `${prefix}-task-keep-open`,
+      expired: `${prefix}-task-expired`,
+    },
+    completionRecommendationIds: {
+      confirmDone: `${prefix}-recommendation-confirm-done`,
+      keepOpen: `${prefix}-recommendation-keep-open`,
+      expired: `${prefix}-recommendation-expired`,
+    },
+  };
+}
+
+function reviewCode(seed: string): string {
+  return `QA${createHash("sha256").update(seed).digest("hex").slice(0, 6)}`.toUpperCase();
+}
+
+function toDate(value: Date | string | undefined): Date {
+  const date = value instanceof Date ? new Date(value) : new Date(value ?? Date.now());
+  if (Number.isNaN(date.getTime())) throw new Error("Fixture timestamp is invalid.");
+  return date;
+}
+
+function shiftDays(value: Date, days: number): string {
+  return new Date(value.getTime() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function fixtureItem(input: {
+  id: string;
+  outputId: string;
+  sectionKey: string;
+  title: string;
+  summary: string;
+  label: string;
+  actionLabel: string;
+  actionPrompt: string;
+  structuredPayload: Record<string, unknown>;
+  sortOrder: number;
+  taskId?: string | null;
+  now: string;
+}) {
+  return {
+    id: input.id,
+    agent_output_id: input.outputId,
+    task_id: input.taskId ?? null,
+    section_key: input.sectionKey,
+    title: input.title,
+    summary: input.summary,
+    priority: "medium",
+    label: input.label,
+    display_ref: "Manual QA",
+    action_type: "chat",
+    action_label: input.actionLabel,
+    action_prompt: input.actionPrompt,
+    knowledge_refs_json: JSON.stringify({ entityIds: [], fileIds: [] }),
+    source_url: null,
+    structured_payload_json: JSON.stringify(input.structuredPayload),
+    sort_order: input.sortOrder,
+    created_at: input.now,
+  };
+}
+
+/** Removes only records created by the inline follow-up review QA fixture for one user. */
+export async function clearInlineFollowupReviewFixture(db: Kysely<DB>, userId: string): Promise<void> {
+  const ids = fixtureIds(userId);
+  const taskRows = await db
+    .selectFrom("tasks")
+    .select("id")
+    .where("created_by_user_id", "=", userId)
+    .where((eb) =>
+      eb.or([
+        eb("source_task_id", "in", Object.values(ids.completionTaskSourceIds)),
+        eb("origin_agent_output_id", "=", ids.sourceOutputId),
+      ]),
+    )
+    .execute();
+  const taskIds = taskRows.map((row) => row.id);
+
+  await db.transaction().execute(async (trx) => {
+    await trx
+      .deleteFrom("task_seed_candidates")
+      .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+      .where("user_id", "=", userId)
+      .where("route_id", "=", ids.routeId)
+      .execute();
+    await trx
+      .deleteFrom("task_durability_route_state")
+      .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+      .where("user_id", "=", userId)
+      .where("route_id", "=", ids.routeId)
+      .execute();
+    await trx
+      .deleteFrom("task_completion_recommendations")
+      .where("id", "in", Object.values(ids.completionRecommendationIds))
+      .execute();
+    if (taskIds.length > 0) await trx.deleteFrom("tasks").where("id", "in", taskIds).execute();
+    await trx
+      .deleteFrom("agent_outputs")
+      .where("id", "in", [ids.briefOutputId, ids.sourceOutputId])
+      .where("user_id", "=", userId)
+      .execute();
+    const conversation = await trx
+      .selectFrom("conversations")
+      .select("id")
+      .where("platform", "=", "slack")
+      .where("kind", "=", "channel")
+      .where("provider_conversation_id", "=", ids.conversationProviderId)
+      .where("display_name", "=", FIXTURE_LABEL)
+      .executeTakeFirst();
+    if (conversation) {
+      await trx.deleteFrom("conversation_messages").where("conversation_id", "=", conversation.id).execute();
+      await trx.deleteFrom("conversations").where("id", "=", conversation.id).execute();
+    }
+  });
+}
+
+/** Seeds a repeatable Daily Brief fixture that is immediately actionable through the web review routes. */
+export async function seedInlineFollowupReviewFixture(
+  db: Kysely<DB>,
+  options: InlineFollowupReviewFixtureOptions,
+): Promise<InlineFollowupReviewFixtureResult> {
+  const nowDate = toDate(options.now);
+  const now = nowDate.toISOString();
+  const ids = fixtureIds(options.userId);
+  const user = await db
+    .selectFrom("users")
+    .select(["id", "name", "timezone"])
+    .where("id", "=", options.userId)
+    .executeTakeFirst();
+  if (!user) throw new Error(`User ${options.userId} does not exist.`);
+
+  await clearInlineFollowupReviewFixture(db, options.userId);
+
+  const timezone = user.timezone ?? "UTC";
+  const outputDate = localDateInTimezone(nowDate, timezone);
+  const conversation = await db
+    .insertInto("conversations")
+    .values({
+      platform: "slack",
+      kind: "channel",
+      provider_conversation_id: ids.conversationProviderId,
+      display_name: FIXTURE_LABEL,
+      last_seen_message_id: null,
+      created_at: now,
+      updated_at: now,
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+  const sourceKey = `slack:channel:${ids.conversationProviderId}`;
+  const messageRows = await db
+    .insertInto("conversation_messages")
+    .values(
+      Object.entries(SEED_TITLES).map(([key, title], index) => ({
+        conversation_id: conversation.id,
+        provider_message_id: `${ids.prefix}-message-${key}`,
+        event_key: null,
+        sender_jid: "fixture-sender",
+        sender_name: "Fixture Sender",
+        sender_user_id: null,
+        is_bot: 0,
+        addressed_to_sketch: 0,
+        text: title,
+        attachments: null,
+        provider_thread_id: null,
+        provider_parent_message_id: null,
+        is_thread_reply: 0,
+        provider_timestamp: new Date(nowDate.getTime() + index * 1000).toISOString(),
+        provider_from_me: 0,
+        received_at: new Date(nowDate.getTime() + index * 1000).toISOString(),
+        source: "live",
+        effective_at: new Date(nowDate.getTime() + index * 1000).toISOString(),
+        connection_key: null,
+        backfill_range_id: null,
+        created_at: now,
+      })),
+    )
+    .returning(["id", "provider_message_id"])
+    .execute();
+  const messageIdByKey = new Map(
+    messageRows.map((row) => [row.provider_message_id.endsWith("-track") ? "track" : "dismiss", row.id]),
+  );
+
+  await db
+    .insertInto("agent_outputs")
+    .values({
+      id: ids.sourceOutputId,
+      agent_key: CONVERSATION_SUMMARY_AGENT_KEY,
+      user_id: options.userId,
+      output_date: outputDate,
+      period_key: outputDate,
+      source_key: sourceKey,
+      source_label: "#inline-followup-qa",
+      timezone,
+      status: "completed",
+      trigger_type: "manual",
+      agent_version: "inline-followup-review-fixture-v1",
+      agent_run_id: null,
+      masthead_json: JSON.stringify({ title: "Fixture conversation summary", summary: FIXTURE_LABEL }),
+      raw_payload_json: JSON.stringify({ fixture: true }),
+      error_message: null,
+      generated_at: now,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await db
+    .insertInto("agent_output_items")
+    .values(
+      Object.entries(SEED_TITLES).map(([key, title], index) => ({
+        id: `${ids.prefix}-source-item-${key}`,
+        agent_output_id: ids.sourceOutputId,
+        task_id: null,
+        section_key: "action_items",
+        title,
+        summary:
+          key === "track"
+            ? "A valid reconstructed follow-up that should become a durable task."
+            : "A duplicate reconstructed follow-up that should be dismissed.",
+        priority: "medium",
+        label: "action_item",
+        display_ref: "#inline-followup-qa",
+        action_type: null,
+        action_label: null,
+        action_prompt: null,
+        knowledge_refs_json: JSON.stringify({ entityIds: [], fileIds: [] }),
+        source_url: null,
+        structured_payload_json: JSON.stringify({
+          messageIds: [messageIdByKey.get(key)],
+          sourceLabels: ["#inline-followup-qa"],
+        }),
+        sort_order: index,
+        created_at: now,
+      })),
+    )
+    .execute();
+
+  const transition = await createTaskDurabilityTransitionRepository(db).ensureRouteTransition({
+    agentKey: CONVERSATION_SUMMARY_AGENT_KEY,
+    userId: options.userId,
+    routeId: ids.routeId,
+    sourceKey,
+    sourceKeys: [sourceKey],
+    allowedConversationIds: [conversation.id],
+    now,
+  });
+  if (transition.createdCount !== 2) {
+    throw new Error(`Expected two seed candidates, created ${transition.createdCount}.`);
+  }
+  const seedRows = await db
+    .selectFrom("task_seed_candidates")
+    .select(["id", "title", "review_code"])
+    .where("agent_key", "=", CONVERSATION_SUMMARY_AGENT_KEY)
+    .where("user_id", "=", options.userId)
+    .where("route_id", "=", ids.routeId)
+    .execute();
+  const seedByTitle = new Map(seedRows.map((row) => [row.title, row]));
+  const trackSeed = seedByTitle.get(SEED_TITLES.track);
+  const dismissSeed = seedByTitle.get(SEED_TITLES.dismiss);
+  if (!trackSeed || !dismissSeed) throw new Error("Fixture seed candidates were not created.");
+
+  const tasks = createTaskRepository(db);
+  const completionTaskEntries = await Promise.all(
+    (Object.keys(COMPLETION_TITLES) as Array<keyof typeof COMPLETION_TITLES>).map(async (key) => {
+      const result = await tasks.upsertTask({
+        parentEntityId: null,
+        parentSourceRef: null,
+        parentName: null,
+        source: "summary",
+        externalRef: null,
+        title: COMPLETION_TITLES[key],
+        status: "open",
+        statusRaw: "open",
+        statusAuthority: "local",
+        assigneeEntityId: null,
+        assigneeName: null,
+        priority: "medium",
+        dueAt: null,
+        provenance: "summary",
+        sourceTaskId: ids.completionTaskSourceIds[key],
+        createdByUserId: options.userId,
+      });
+      return [key, result.taskId] as const;
+    }),
+  );
+  const completionTaskIds = Object.fromEntries(completionTaskEntries) as Record<keyof typeof COMPLETION_TITLES, string>;
+  await db
+    .insertInto("task_completion_recommendations")
+    .values(
+      (Object.keys(COMPLETION_TITLES) as Array<keyof typeof COMPLETION_TITLES>).map((key) => ({
+        id: ids.completionRecommendationIds[key],
+        task_id: completionTaskIds[key],
+        proposed_status: "done",
+        review_state: "pending",
+        review_code: reviewCode(`${ids.prefix}-${key}`),
+        evidence_fingerprint: `${ids.prefix}-evidence-${key}`,
+        origin_agent_output_id: ids.sourceOutputId,
+        rationale:
+          key === "expired"
+            ? "This recommendation intentionally expired before the manual QA session."
+            : "Fixture evidence suggests this follow-up may be complete.",
+        delivery_count: 0,
+        expires_at: key === "expired" ? shiftDays(nowDate, -1) : shiftDays(nowDate, 7),
+        reviewed_at: null,
+        reviewed_by_user_id: null,
+        review_surface: null,
+        created_at: now,
+        updated_at: now,
+      })),
+    )
+    .execute();
+
+  await db
+    .insertInto("agent_outputs")
+    .values({
+      id: ids.briefOutputId,
+      agent_key: DAILY_BRIEF_AGENT_KEY,
+      user_id: options.userId,
+      output_date: outputDate,
+      period_key: outputDate,
+      source_key: "",
+      source_label: null,
+      timezone,
+      status: "completed",
+      trigger_type: "manual",
+      agent_version: DAILY_BRIEF_AGENT_VERSION,
+      agent_run_id: null,
+      masthead_json: JSON.stringify({
+        title: "Inline follow-up review QA",
+        summary: "Deterministic manual-test data for completion recommendations and seed candidates.",
+        generatedFor: user.name,
+      }),
+      raw_payload_json: JSON.stringify({ fixture: true }),
+      error_message: null,
+      generated_at: now,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
+  await db
+    .insertInto("agent_output_items")
+    .values([
+      fixtureItem({
+        id: `${ids.prefix}-brief-confirm-done`,
+        outputId: ids.briefOutputId,
+        sectionKey: "looks_resolved",
+        title: COMPLETION_TITLES.confirmDone,
+        summary: "Use Mark as done to verify the task becomes done and the terminal label persists.",
+        label: "looks_resolved",
+        actionLabel: "Review with Sketch",
+        actionPrompt: `Confirm done ${reviewCode(`${ids.prefix}-confirmDone`)}`,
+        structuredPayload: {
+          serverOwnedFollowup: true,
+          trackingState: "looks_resolved",
+          recommendationId: ids.completionRecommendationIds.confirmDone,
+          reviewCode: reviewCode(`${ids.prefix}-confirmDone`),
+          taskId: completionTaskIds.confirmDone,
+        },
+        sortOrder: 0,
+        taskId: completionTaskIds.confirmDone,
+        now,
+      }),
+      fixtureItem({
+        id: `${ids.prefix}-brief-keep-open`,
+        outputId: ids.briefOutputId,
+        sectionKey: "looks_resolved",
+        title: COMPLETION_TITLES.keepOpen,
+        summary: "Use Keep open to verify rejection leaves the durable task actionable.",
+        label: "looks_resolved",
+        actionLabel: "Review with Sketch",
+        actionPrompt: `Keep open ${reviewCode(`${ids.prefix}-keepOpen`)}`,
+        structuredPayload: {
+          serverOwnedFollowup: true,
+          trackingState: "looks_resolved",
+          recommendationId: ids.completionRecommendationIds.keepOpen,
+          reviewCode: reviewCode(`${ids.prefix}-keepOpen`),
+          taskId: completionTaskIds.keepOpen,
+        },
+        sortOrder: 1,
+        taskId: completionTaskIds.keepOpen,
+        now,
+      }),
+      fixtureItem({
+        id: `${ids.prefix}-brief-expired`,
+        outputId: ids.briefOutputId,
+        sectionKey: "looks_resolved",
+        title: COMPLETION_TITLES.expired,
+        summary: "This item should render Review expired without mutation controls.",
+        label: "looks_resolved",
+        actionLabel: "Review with Sketch",
+        actionPrompt: `Confirm done ${reviewCode(`${ids.prefix}-expired`)}`,
+        structuredPayload: {
+          serverOwnedFollowup: true,
+          trackingState: "looks_resolved",
+          recommendationId: ids.completionRecommendationIds.expired,
+          reviewCode: reviewCode(`${ids.prefix}-expired`),
+          taskId: completionTaskIds.expired,
+        },
+        sortOrder: 2,
+        taskId: completionTaskIds.expired,
+        now,
+      }),
+      fixtureItem({
+        id: `${ids.prefix}-brief-track`,
+        outputId: ids.briefOutputId,
+        sectionKey: "untracked_followups",
+        title: SEED_TITLES.track,
+        summary: "Use Track to create and hydrate the canonical durable task.",
+        label: "untracked",
+        actionLabel: "Discuss with Sketch",
+        actionPrompt: `Track ${trackSeed.review_code}`,
+        structuredPayload: {
+          serverOwnedFollowup: true,
+          trackingState: "untracked",
+          candidateId: trackSeed.id,
+          reviewCode: trackSeed.review_code,
+        },
+        sortOrder: 0,
+        now,
+      }),
+      fixtureItem({
+        id: `${ids.prefix}-brief-dismiss`,
+        outputId: ids.briefOutputId,
+        sectionKey: "untracked_followups",
+        title: SEED_TITLES.dismiss,
+        summary: "Use Dismiss to verify the terminal outcome replaces mutation controls.",
+        label: "untracked",
+        actionLabel: "Discuss with Sketch",
+        actionPrompt: `Dismiss ${dismissSeed.review_code}`,
+        structuredPayload: {
+          serverOwnedFollowup: true,
+          trackingState: "untracked",
+          candidateId: dismissSeed.id,
+          reviewCode: dismissSeed.review_code,
+        },
+        sortOrder: 1,
+        now,
+      }),
+      fixtureItem({
+        id: `${ids.prefix}-brief-legacy`,
+        outputId: ids.briefOutputId,
+        sectionKey: "untracked_followups",
+        title: "QA: Legacy chat-only follow-up",
+        summary: "This item intentionally has no durable review record and should remain chat-only.",
+        label: "untracked",
+        actionLabel: "Discuss with Sketch",
+        actionPrompt: "Discuss the legacy follow-up",
+        structuredPayload: { trackingState: "untracked" },
+        sortOrder: 2,
+        now,
+      }),
+    ])
+    .execute();
+
+  return {
+    userId: options.userId,
+    outputDate,
+    briefOutputId: ids.briefOutputId,
+    sourceOutputId: ids.sourceOutputId,
+    completionRecommendationIds: ids.completionRecommendationIds,
+    seedCandidateIds: {
+      track: trackSeed.id,
+      dismiss: dismissSeed.id,
+    },
+  };
+}
+
+async function backupDatabase(dbPath: string): Promise<string> {
+  const stamp = new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
+  const backupPath = join(dirname(dbPath), `${basename(dbPath)}.inline-followup-review-${stamp}.bak`);
+  const source = new Database(dbPath, { readonly: true });
+  try {
+    await source.backup(backupPath);
+  } finally {
+    source.close();
+  }
+  return backupPath;
+}
+
+async function assertFixtureSchema(db: Kysely<DB>): Promise<void> {
+  const migrations = await sql<{ name: string }>`
+    SELECT name
+    FROM kysely_migration
+    WHERE name IN ('150-task-durability-steel-thread', '151-agent-output-item-task-links')
+  `.execute(db);
+  if (migrations.rows.length !== 2) {
+    throw new Error("Database is missing migrations 150 and 151 required by this fixture.");
+  }
+}
+
+async function findUserId(db: Kysely<DB>, userId?: string, userEmail?: string): Promise<string> {
+  if (!userId && !userEmail) throw new Error("Pass --user-id or --user-email.");
+  let query = db.selectFrom("users").select(["id", "email"]);
+  if (userId) query = query.where("id", "=", userId);
+  else query = query.where("email", "=", userEmail as string);
+  const user = await query.executeTakeFirst();
+  if (!user) throw new Error("Target user was not found.");
+  return user.id;
+}
+
+async function runCli(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args[0] === "--") args.shift();
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      db: { type: "string" },
+      "user-id": { type: "string" },
+      "user-email": { type: "string" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+  if (parsed.values.help) {
+    console.log(
+      "Usage: pnpm fixture:inline-followup-review -- <seed|clear> --db /absolute/path/sketch.db (--user-id ID | --user-email EMAIL)",
+    );
+    return;
+  }
+  const command = parsed.positionals[0] ?? "seed";
+  if (command !== "seed" && command !== "clear") throw new Error("Command must be seed or clear.");
+  const dbPath = parsed.values.db;
+  if (!dbPath || !isAbsolute(dbPath)) throw new Error("Pass an absolute SQLite path with --db.");
+  await access(dbPath);
+  const backupPath = await backupDatabase(dbPath);
+  const sqlite = new Database(dbPath);
+  sqlite.pragma("foreign_keys = ON");
+  const db = new Kysely<DB>({ dialect: new SqliteDialect({ database: sqlite }) });
+  try {
+    await assertFixtureSchema(db);
+    const userId = await findUserId(db, parsed.values["user-id"], parsed.values["user-email"]);
+    if (command === "clear") {
+      await clearInlineFollowupReviewFixture(db, userId);
+      console.log(JSON.stringify({ command, userId, backupPath }, null, 2));
+      return;
+    }
+    const result = await seedInlineFollowupReviewFixture(db, { userId });
+    console.log(JSON.stringify({ command, backupPath, ...result }, null, 2));
+  } finally {
+    await db.destroy();
+  }
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/packages/web/src/components/brief/brief-detail-drawer.tsx
+++ b/packages/web/src/components/brief/brief-detail-drawer.tsx
@@ -1,4 +1,11 @@
-import type { DailyBriefItem, DailyBriefMeetingAttendee, DailyBriefTaskState, TaskStatus } from "@/lib/api";
+import type {
+  DailyBriefItem,
+  DailyBriefMeetingAttendee,
+  DailyBriefReviewDecision,
+  DailyBriefReviewState,
+  DailyBriefTaskState,
+  TaskStatus,
+} from "@/lib/api";
 import { EntityChip, useEntityUiOptional } from "@/lib/entity-ui";
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { Badge } from "@sketch/ui/components/badge";
@@ -6,6 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@sketch/ui/components/sheet";
 import { cn } from "@sketch/ui/lib/utils";
 import { BriefActionButton } from "./brief-action-button";
+import { BriefFollowupReviewActions } from "./brief-followup-review-actions";
 import { labelMeta, refChips, sourceLinkLabel } from "./item-metadata";
 import { formatMeetingTime } from "./meeting-row";
 import {
@@ -43,6 +51,8 @@ export function BriefDetailDrawer({
   onOpenChat,
   onUpdateTaskStatus,
   updatingTaskId,
+  onReviewFollowup,
+  updatingReviewId,
 }: {
   item: DailyBriefItem | null;
   timezone: string;
@@ -50,6 +60,8 @@ export function BriefDetailDrawer({
   onOpenChat: (prompt: string) => void;
   onUpdateTaskStatus?: (taskId: string, status: TaskStatus) => void;
   updatingTaskId?: string | null;
+  onReviewFollowup?: (kind: DailyBriefReviewState["kind"], id: string, decision: DailyBriefReviewDecision) => void;
+  updatingReviewId?: string | null;
 }) {
   return (
     <Sheet open={item !== null} onOpenChange={(open) => !open && onClose()}>
@@ -65,6 +77,8 @@ export function BriefDetailDrawer({
               onOpenChat={onOpenChat}
               onUpdateTaskStatus={onUpdateTaskStatus}
               updatingTaskId={updatingTaskId}
+              onReviewFollowup={onReviewFollowup}
+              updatingReviewId={updatingReviewId}
             />
           )
         ) : null}
@@ -78,11 +92,15 @@ function DrawerBody({
   onOpenChat,
   onUpdateTaskStatus,
   updatingTaskId,
+  onReviewFollowup,
+  updatingReviewId,
 }: {
   item: DailyBriefItem;
   onOpenChat: (prompt: string) => void;
   onUpdateTaskStatus?: (taskId: string, status: TaskStatus) => void;
   updatingTaskId?: string | null;
+  onReviewFollowup?: (kind: DailyBriefReviewState["kind"], id: string, decision: DailyBriefReviewDecision) => void;
+  updatingReviewId?: string | null;
 }) {
   const meta = labelMeta(item);
   const chips = refChips(item);
@@ -135,8 +153,13 @@ function DrawerBody({
         </div>
       </div>
 
-      {item.actionPrompt || item.sourceUrl ? (
+      {item.review || item.actionPrompt || item.sourceUrl ? (
         <div className="flex flex-wrap items-center gap-2 border-t border-border/60 px-6 py-4">
+          <BriefFollowupReviewActions
+            review={item.review}
+            updating={updatingReviewId === item.review?.id}
+            onReview={onReviewFollowup}
+          />
           {item.actionPrompt ? (
             <BriefActionButton
               label={actionLabel}

--- a/packages/web/src/components/brief/brief-detail-drawer.tsx
+++ b/packages/web/src/components/brief/brief-detail-drawer.tsx
@@ -154,30 +154,34 @@ function DrawerBody({
       </div>
 
       {item.review || item.actionPrompt || item.sourceUrl ? (
-        <div className="flex flex-wrap items-center gap-2 border-t border-border/60 px-6 py-4">
+        <div className="flex flex-col items-start gap-2 border-t border-border/60 px-6 py-4">
+          {item.actionPrompt || item.sourceUrl ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {item.actionPrompt ? (
+                <BriefActionButton
+                  label={actionLabel}
+                  stopPropagation={false}
+                  onClick={() => onOpenChat(item.actionPrompt as string)}
+                />
+              ) : null}
+              {item.sourceUrl ? (
+                <a
+                  href={item.sourceUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-full border-[0.5px] border-border bg-transparent px-3 py-1 text-[12px] font-medium text-muted-foreground transition-colors hover:border-foreground/25 hover:bg-muted/50 hover:text-foreground"
+                >
+                  <ArrowSquareOutIcon size={13} weight="bold" aria-hidden />
+                  {sourceLinkLabel(item.sourceUrl)}
+                </a>
+              ) : null}
+            </div>
+          ) : null}
           <BriefFollowupReviewActions
             review={item.review}
             updating={updatingReviewId === item.review?.id}
             onReview={onReviewFollowup}
           />
-          {item.actionPrompt ? (
-            <BriefActionButton
-              label={actionLabel}
-              stopPropagation={false}
-              onClick={() => onOpenChat(item.actionPrompt as string)}
-            />
-          ) : null}
-          {item.sourceUrl ? (
-            <a
-              href={item.sourceUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-full border-[0.5px] border-border bg-transparent px-3 py-1 text-[12px] font-medium text-muted-foreground transition-colors hover:border-foreground/25 hover:bg-muted/50 hover:text-foreground"
-            >
-              <ArrowSquareOutIcon size={13} weight="bold" aria-hidden />
-              {sourceLinkLabel(item.sourceUrl)}
-            </a>
-          ) : null}
         </div>
       ) : null}
     </div>

--- a/packages/web/src/components/brief/brief-followup-review-actions.tsx
+++ b/packages/web/src/components/brief/brief-followup-review-actions.tsx
@@ -1,0 +1,68 @@
+import type { DailyBriefReviewDecision, DailyBriefReviewState } from "@/lib/api";
+import { cn } from "@sketch/ui/lib/utils";
+
+function terminalLabel(review: DailyBriefReviewState): string | null {
+  if (review.kind === "completion") {
+    if (review.state === "accepted") return "Marked done";
+    if (review.state === "rejected") return "Kept open";
+    if (review.state === "expired") return "Review expired";
+    return null;
+  }
+  if (review.state === "accepted") return "Tracked";
+  if (review.state === "dismissed") return "Dismissed";
+  return null;
+}
+
+export function BriefFollowupReviewActions({
+  review,
+  updating,
+  onReview,
+}: {
+  review: DailyBriefReviewState | null | undefined;
+  updating: boolean;
+  onReview?: (kind: DailyBriefReviewState["kind"], id: string, decision: DailyBriefReviewDecision) => void;
+}) {
+  if (!review) return null;
+  if (updating) {
+    return (
+      <output aria-live="polite" className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+        Updating…
+      </output>
+    );
+  }
+  const terminal = terminalLabel(review);
+  if (terminal) {
+    return <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">{terminal}</span>;
+  }
+  if (!review.canReview || !onReview) return null;
+  const actions: Array<{ label: string; decision: DailyBriefReviewDecision }> =
+    review.kind === "completion"
+      ? [
+          { label: "Mark done", decision: "confirm_done" },
+          { label: "Keep open", decision: "keep_open" },
+        ]
+      : [
+          { label: "Track", decision: "track" },
+          { label: "Dismiss", decision: "dismiss" },
+        ];
+  return (
+    <div className="flex flex-wrap justify-end gap-1.5">
+      {actions.map((action) => (
+        <button
+          key={action.decision}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onReview(review.kind, review.id, action.decision);
+          }}
+          className={cn(
+            "inline-flex shrink-0 items-center rounded-full border-[0.5px] border-border px-2.5 py-1",
+            "text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground",
+          )}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/components/brief/brief-followup-review-actions.tsx
+++ b/packages/web/src/components/brief/brief-followup-review-actions.tsx
@@ -1,4 +1,6 @@
 import type { DailyBriefReviewDecision, DailyBriefReviewState } from "@/lib/api";
+import { CheckIcon, XIcon } from "@phosphor-icons/react";
+import { Button } from "@sketch/ui/components/button";
 import { cn } from "@sketch/ui/lib/utils";
 
 function terminalLabel(review: DailyBriefReviewState): string | null {
@@ -23,46 +25,58 @@ export function BriefFollowupReviewActions({
   onReview?: (kind: DailyBriefReviewState["kind"], id: string, decision: DailyBriefReviewDecision) => void;
 }) {
   if (!review) return null;
-  if (updating) {
-    return (
-      <output aria-live="polite" className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
-        Updating…
-      </output>
-    );
-  }
   const terminal = terminalLabel(review);
   if (terminal) {
     return <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">{terminal}</span>;
   }
   if (!review.canReview || !onReview) return null;
-  const actions: Array<{ label: string; decision: DailyBriefReviewDecision }> =
+  const groupLabel = review.kind === "completion" ? "Completion review decision" : "Follow-up tracking decision";
+  const actions: Array<{
+    label: string;
+    decision: DailyBriefReviewDecision;
+    Icon: typeof CheckIcon;
+    tone: "accept" | "reject";
+  }> =
     review.kind === "completion"
       ? [
-          { label: "Mark done", decision: "confirm_done" },
-          { label: "Keep open", decision: "keep_open" },
+          { label: "Mark as done", decision: "confirm_done", Icon: CheckIcon, tone: "accept" },
+          { label: "Keep open", decision: "keep_open", Icon: XIcon, tone: "reject" },
         ]
       : [
-          { label: "Track", decision: "track" },
-          { label: "Dismiss", decision: "dismiss" },
+          { label: "Track", decision: "track", Icon: CheckIcon, tone: "accept" },
+          { label: "Dismiss", decision: "dismiss", Icon: XIcon, tone: "reject" },
         ];
   return (
-    <div className="flex flex-wrap justify-end gap-1.5">
-      {actions.map((action) => (
-        <button
-          key={action.decision}
-          type="button"
-          onClick={(event) => {
-            event.stopPropagation();
-            onReview(review.kind, review.id, action.decision);
-          }}
-          className={cn(
-            "inline-flex shrink-0 items-center rounded-full border-[0.5px] border-border px-2.5 py-1",
-            "text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground",
-          )}
-        >
-          {action.label}
-        </button>
-      ))}
-    </div>
+    <fieldset aria-label={groupLabel} aria-busy={updating} className="flex w-max max-w-full flex-col items-end gap-1">
+      <div className="inline-flex flex-nowrap items-center justify-end gap-1.5">
+        {actions.map((action) => (
+          <Button
+            key={action.decision}
+            type="button"
+            variant="ghost"
+            size="xs"
+            disabled={updating}
+            onClick={(event) => {
+              event.stopPropagation();
+              onReview(review.kind, review.id, action.decision);
+            }}
+            className={cn(
+              "h-7 min-w-0 rounded-full border-[0.5px] px-3 text-[11px] shadow-none focus-visible:ring-inset",
+              action.tone === "accept"
+                ? "border-emerald-500/15 bg-emerald-500/8 text-emerald-700/80 hover:bg-emerald-500/12 hover:text-emerald-800 dark:border-emerald-400/15 dark:bg-emerald-400/8 dark:text-emerald-400/75 dark:hover:bg-emerald-400/12 dark:hover:text-emerald-300"
+                : "border-red-500/15 bg-red-500/8 text-red-700/80 hover:bg-red-500/12 hover:text-red-800 dark:border-red-400/15 dark:bg-red-400/8 dark:text-red-400/75 dark:hover:bg-red-400/12 dark:hover:text-red-300",
+            )}
+          >
+            <action.Icon size={12} weight="bold" aria-hidden />
+            {action.label}
+          </Button>
+        ))}
+      </div>
+      {updating ? (
+        <output aria-live="polite" className="font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
+          Updating…
+        </output>
+      ) : null}
+    </fieldset>
   );
 }

--- a/packages/web/src/components/brief/brief-item-row.tsx
+++ b/packages/web/src/components/brief/brief-item-row.tsx
@@ -91,15 +91,15 @@ export function BriefItemRow({
         ) : null}
       </button>
 
-      <div className="flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-1.5 py-2.5">
+      <div className="flex min-w-0 shrink-0 flex-col items-end justify-center gap-1.5 py-2.5">
+        {item.actionPrompt ? (
+          <BriefActionButton label={actionLabel} onClick={() => onOpenChat(item.actionPrompt as string)} />
+        ) : null}
         <BriefFollowupReviewActions
           review={item.review}
           updating={updatingReviewId === item.review?.id}
           onReview={onReviewFollowup}
         />
-        {item.actionPrompt ? (
-          <BriefActionButton label={actionLabel} onClick={() => onOpenChat(item.actionPrompt as string)} />
-        ) : null}
       </div>
     </article>
   );

--- a/packages/web/src/components/brief/brief-item-row.tsx
+++ b/packages/web/src/components/brief/brief-item-row.tsx
@@ -1,6 +1,7 @@
-import type { DailyBriefItem } from "@/lib/api";
+import type { DailyBriefItem, DailyBriefReviewDecision, DailyBriefReviewState } from "@/lib/api";
 import { cn } from "@sketch/ui/lib/utils";
 import { BriefActionButton } from "./brief-action-button";
+import { BriefFollowupReviewActions } from "./brief-followup-review-actions";
 import { actionLabelForItem, labelMeta } from "./item-metadata";
 import { briefTaskExternalStatus, briefTaskStatusTone, formatBriefTaskStatus, getBriefItemTask } from "./task-overlay";
 
@@ -9,11 +10,15 @@ export function BriefItemRow({
   isLast,
   onOpenDetail,
   onOpenChat,
+  onReviewFollowup,
+  updatingReviewId,
 }: {
   item: DailyBriefItem;
   isLast: boolean;
   onOpenDetail: () => void;
   onOpenChat: (prompt: string) => void;
+  onReviewFollowup?: (kind: DailyBriefReviewState["kind"], id: string, decision: DailyBriefReviewDecision) => void;
+  updatingReviewId?: string | null;
 }) {
   const meta = labelMeta(item);
   const actionLabel = actionLabelForItem(item);
@@ -86,7 +91,12 @@ export function BriefItemRow({
         ) : null}
       </button>
 
-      <div className="flex min-w-0 shrink-0 items-center justify-end py-2.5">
+      <div className="flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-1.5 py-2.5">
+        <BriefFollowupReviewActions
+          review={item.review}
+          updating={updatingReviewId === item.review?.id}
+          onReview={onReviewFollowup}
+        />
         {item.actionPrompt ? (
           <BriefActionButton label={actionLabel} onClick={() => onOpenChat(item.actionPrompt as string)} />
         ) : null}

--- a/packages/web/src/components/brief/brief-task-links.test.tsx
+++ b/packages/web/src/components/brief/brief-task-links.test.tsx
@@ -132,7 +132,7 @@ describe("Brief row live task status", () => {
 });
 
 describe("Inline follow-up review actions", () => {
-  it("renders completion controls beside the chat action and reports the selected decision", async () => {
+  it("renders the chat action above one grouped completion decision and reports the selected choice", async () => {
     const user = userEvent.setup();
     const onReviewFollowup = vi.fn();
     const reviewItem = {
@@ -158,8 +158,20 @@ describe("Inline follow-up review actions", () => {
       <DailyBrief brief={brief} running={false} onOpenChat={() => {}} onReviewFollowup={onReviewFollowup} />,
     );
 
-    expect(screen.getByRole("button", { name: "Review with Sketch" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Mark done" }));
+    const row = screen.getByRole("button", { name: /Confirm launch is done/ }).closest("article");
+    expect(row).not.toBeNull();
+    const chatAction = within(row as HTMLElement).getByRole("button", { name: "Review with Sketch" });
+    const decisionGroup = within(row as HTMLElement).getByRole("group", {
+      name: "Completion review decision",
+    });
+    const markDone = within(decisionGroup).getByRole("button", { name: "Mark as done" });
+    expect(decisionGroup).not.toContainElement(chatAction);
+    const rowButtons = Array.from((row as HTMLElement).querySelectorAll("button"));
+    expect(rowButtons.indexOf(chatAction as HTMLButtonElement)).toBeLessThan(
+      rowButtons.indexOf(markDone as HTMLButtonElement),
+    );
+
+    await user.click(markDone);
     expect(onReviewFollowup).toHaveBeenCalledWith("completion", "recommendation-1", "confirm_done");
   });
 
@@ -187,6 +199,93 @@ describe("Inline follow-up review actions", () => {
 
     expect(screen.getByText("Dismissed")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Track" })).not.toBeInTheDocument();
+  });
+
+  it("groups seed decisions below the chat action and reports the selected choice", async () => {
+    const user = userEvent.setup();
+    const onReviewFollowup = vi.fn();
+    const reviewItem = {
+      ...todoItem("seed-1", "Follow up with Acme"),
+      sectionKey: "untracked_followups" as const,
+      actionLabel: "Discuss with Sketch",
+      review: {
+        kind: "seed" as const,
+        id: "candidate-1",
+        state: "pending" as const,
+        canReview: true,
+        acceptedTaskId: null,
+      },
+    };
+    const brief = {
+      ...briefWithTodos([]),
+      sections: {
+        ...briefWithTodos([]).sections,
+        untracked_followups: [reviewItem],
+      },
+    };
+
+    renderWithProviders(
+      <DailyBrief brief={brief} running={false} onOpenChat={() => {}} onReviewFollowup={onReviewFollowup} />,
+    );
+
+    const row = screen.getByRole("button", { name: /Follow up with Acme/ }).closest("article");
+    expect(row).not.toBeNull();
+    const chatAction = within(row as HTMLElement).getByRole("button", { name: "Discuss with Sketch" });
+    const decisionGroup = within(row as HTMLElement).getByRole("group", {
+      name: "Follow-up tracking decision",
+    });
+    const dismiss = within(decisionGroup).getByRole("button", { name: "Dismiss" });
+    expect(decisionGroup).not.toContainElement(chatAction);
+    const rowButtons = Array.from((row as HTMLElement).querySelectorAll("button"));
+    expect(rowButtons.indexOf(chatAction as HTMLButtonElement)).toBeLessThan(
+      rowButtons.indexOf(dismiss as HTMLButtonElement),
+    );
+
+    await user.click(dismiss);
+    expect(onReviewFollowup).toHaveBeenCalledWith("seed", "candidate-1", "dismiss");
+  });
+
+  it("keeps the chat action above the grouped review decision in the detail drawer", async () => {
+    const user = userEvent.setup();
+    const onReviewFollowup = vi.fn();
+    const reviewItem = {
+      ...todoItem("review-drawer-1", "Confirm drawer launch is done"),
+      sectionKey: "looks_resolved" as const,
+      actionLabel: "Review with Sketch",
+      review: {
+        kind: "completion" as const,
+        id: "recommendation-drawer-1",
+        state: "pending" as const,
+        canReview: true,
+      },
+    };
+    const brief = {
+      ...briefWithTodos([]),
+      sections: {
+        ...briefWithTodos([]).sections,
+        looks_resolved: [reviewItem],
+      },
+    };
+
+    renderWithProviders(
+      <DailyBrief brief={brief} running={false} onOpenChat={() => {}} onReviewFollowup={onReviewFollowup} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Confirm drawer launch is done/ }));
+    const drawer = await screen.findByRole("dialog");
+    const chatAction = within(drawer).getByRole("button", { name: "Review with Sketch" });
+    const decisionGroup = within(drawer).getByRole("group", {
+      name: "Completion review decision",
+    });
+    const keepOpen = within(decisionGroup).getByRole("button", { name: "Keep open" });
+    const drawerButtons = Array.from(drawer.querySelectorAll("button"));
+    expect(decisionGroup).not.toContainElement(chatAction);
+    expect(drawerButtons.indexOf(chatAction as HTMLButtonElement)).toBeLessThan(
+      drawerButtons.indexOf(keepOpen as HTMLButtonElement),
+    );
+
+    await user.click(keepOpen);
+    expect(onReviewFollowup).toHaveBeenCalledWith("completion", "recommendation-drawer-1", "keep_open");
   });
 });
 

--- a/packages/web/src/components/brief/brief-task-links.test.tsx
+++ b/packages/web/src/components/brief/brief-task-links.test.tsx
@@ -22,7 +22,11 @@ import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DailyBrief } from "./daily-brief";
-import { applyTaskOverlayToBriefResponse, formatBriefTaskStatus } from "./task-overlay";
+import {
+  applyReviewOverlayToBriefResponse,
+  applyTaskOverlayToBriefResponse,
+  formatBriefTaskStatus,
+} from "./task-overlay";
 
 function baseTask(overrides: Partial<DailyBriefTaskState> = {}): DailyBriefTaskState {
   return {
@@ -124,6 +128,65 @@ describe("Brief row live task status", () => {
 
     const row = screen.getByRole("button", { name: /Snapshot title/ });
     expect(within(row).queryByRole("combobox")).not.toBeInTheDocument();
+  });
+});
+
+describe("Inline follow-up review actions", () => {
+  it("renders completion controls beside the chat action and reports the selected decision", async () => {
+    const user = userEvent.setup();
+    const onReviewFollowup = vi.fn();
+    const reviewItem = {
+      ...todoItem("review-1", "Confirm launch is done"),
+      sectionKey: "looks_resolved" as const,
+      actionLabel: "Review with Sketch",
+      review: {
+        kind: "completion" as const,
+        id: "recommendation-1",
+        state: "pending" as const,
+        canReview: true,
+      },
+    };
+    const brief = {
+      ...briefWithTodos([]),
+      sections: {
+        ...briefWithTodos([]).sections,
+        looks_resolved: [reviewItem],
+      },
+    };
+
+    renderWithProviders(
+      <DailyBrief brief={brief} running={false} onOpenChat={() => {}} onReviewFollowup={onReviewFollowup} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Review with Sketch" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Mark done" }));
+    expect(onReviewFollowup).toHaveBeenCalledWith("completion", "recommendation-1", "confirm_done");
+  });
+
+  it("renders terminal review outcomes without mutation controls", () => {
+    const reviewItem = {
+      ...todoItem("seed-1", "Follow up with Acme"),
+      sectionKey: "untracked_followups" as const,
+      review: {
+        kind: "seed" as const,
+        id: "candidate-1",
+        state: "dismissed" as const,
+        canReview: false,
+        acceptedTaskId: null,
+      },
+    };
+    const brief = {
+      ...briefWithTodos([]),
+      sections: {
+        ...briefWithTodos([]).sections,
+        untracked_followups: [reviewItem],
+      },
+    };
+
+    renderWithProviders(<DailyBrief brief={brief} running={false} onOpenChat={() => {}} />);
+
+    expect(screen.getByText("Dismissed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Track" })).not.toBeInTheDocument();
   });
 });
 
@@ -330,5 +393,77 @@ describe("applyTaskOverlayToBriefResponse (cache overlay updater)", () => {
     const response: DailyBriefResponse = { brief: null, running: false, briefDate: "2026-07-17", timezone: "UTC" };
     const updated = applyTaskOverlayToBriefResponse(response, baseTask({ status: "done" }));
     expect(updated).toBe(response);
+  });
+});
+
+describe("applyReviewOverlayToBriefResponse", () => {
+  it("updates only live review and task overlays while preserving snapshot fields", () => {
+    const reviewItem = {
+      ...todoItem("seed-1", "Snapshot seed title"),
+      sectionKey: "untracked_followups" as const,
+      review: {
+        kind: "seed" as const,
+        id: "candidate-1",
+        state: "pending" as const,
+        canReview: true,
+        acceptedTaskId: null,
+      },
+    };
+    const brief = {
+      ...briefWithTodos([]),
+      sections: { ...briefWithTodos([]).sections, untracked_followups: [reviewItem] },
+    };
+    const task = baseTask({ id: "accepted-task", status: "open" });
+
+    const updated = applyReviewOverlayToBriefResponse(emptyResponse(brief), {
+      review: {
+        kind: "seed",
+        id: "candidate-1",
+        state: "accepted",
+        canReview: false,
+        acceptedTaskId: "accepted-task",
+      },
+      task,
+    });
+
+    const item = updated.brief?.sections.untracked_followups[0];
+    expect(item?.title).toBe("Snapshot seed title");
+    expect(item?.review).toMatchObject({ state: "accepted", acceptedTaskId: "accepted-task" });
+    expect(item?.taskId).toBe("accepted-task");
+    expect(item?.task).toEqual(task);
+  });
+
+  it("clears stale task identity when the reviewed task is no longer visible", () => {
+    const task = baseTask({ id: "hidden-task" });
+    const reviewItem = {
+      ...todoItem("seed-1", "Snapshot seed title", task),
+      sectionKey: "untracked_followups" as const,
+      review: {
+        kind: "seed" as const,
+        id: "candidate-1",
+        state: "pending" as const,
+        canReview: true,
+        acceptedTaskId: null,
+      },
+    };
+    const brief = {
+      ...briefWithTodos([]),
+      sections: { ...briefWithTodos([]).sections, untracked_followups: [reviewItem] },
+    };
+
+    const updated = applyReviewOverlayToBriefResponse(emptyResponse(brief), {
+      review: {
+        kind: "seed",
+        id: "candidate-1",
+        state: "accepted",
+        canReview: false,
+        acceptedTaskId: null,
+      },
+      task: null,
+    });
+
+    const item = updated.brief?.sections.untracked_followups[0];
+    expect(item?.taskId).toBeNull();
+    expect(item?.task).toBeNull();
   });
 });

--- a/packages/web/src/components/brief/daily-brief.tsx
+++ b/packages/web/src/components/brief/daily-brief.tsx
@@ -1,4 +1,10 @@
-import type { DailyBrief as DailyBriefData, DailyBriefItem, TaskStatus } from "@/lib/api";
+import type {
+  DailyBrief as DailyBriefData,
+  DailyBriefItem,
+  DailyBriefReviewDecision,
+  DailyBriefReviewState,
+  TaskStatus,
+} from "@/lib/api";
 import { useEntityUiOptional } from "@/lib/entity-ui";
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
@@ -66,6 +72,8 @@ export function DailyBrief({
   onOpenChat,
   onUpdateTaskStatus,
   updatingTaskId,
+  onReviewFollowup,
+  updatingReviewId,
 }: {
   brief: DailyBriefData;
   running: boolean;
@@ -78,6 +86,8 @@ export function DailyBrief({
   onUpdateTaskStatus?: (taskId: string, status: TaskStatus) => void;
   /** taskId currently being updated, to disable its control; null when idle. */
   updatingTaskId?: string | null;
+  onReviewFollowup?: (kind: DailyBriefReviewState["kind"], id: string, decision: DailyBriefReviewDecision) => void;
+  updatingReviewId?: string | null;
 }) {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const entityUi = useEntityUiOptional();
@@ -164,6 +174,8 @@ export function DailyBrief({
                       isLast={index === items.length - 1}
                       onOpenDetail={() => openItem(item)}
                       onOpenChat={onOpenChat}
+                      onReviewFollowup={onReviewFollowup}
+                      updatingReviewId={updatingReviewId}
                     />
                   ))}
                 </div>
@@ -186,6 +198,8 @@ export function DailyBrief({
         onOpenChat={onOpenChat}
         onUpdateTaskStatus={onUpdateTaskStatus}
         updatingTaskId={updatingTaskId}
+        onReviewFollowup={onReviewFollowup}
+        updatingReviewId={updatingReviewId}
       />
     </div>
   );

--- a/packages/web/src/components/brief/task-overlay.ts
+++ b/packages/web/src/components/brief/task-overlay.ts
@@ -5,7 +5,14 @@
  * logic (and the status formatting it shares with the row + drawer) can be
  * unit-tested without rendering Home or wiring a router.
  */
-import type { DailyBrief, DailyBriefItem, DailyBriefResponse, DailyBriefTaskState, TaskStatus } from "@/lib/api";
+import type {
+  DailyBrief,
+  DailyBriefItem,
+  DailyBriefResponse,
+  DailyBriefReviewMutationResponse,
+  DailyBriefTaskState,
+  TaskStatus,
+} from "@/lib/api";
 
 export const BRIEF_TASK_STATUS_OPTIONS: Array<{ value: TaskStatus; label: string }> = [
   { value: "open", label: "Open" },
@@ -90,4 +97,28 @@ export function applyTaskOverlayToBrief(brief: DailyBrief, task: DailyBriefTaskS
     sections[key] = nextItems;
   }
   return changed ? { ...brief, sections } : brief;
+}
+
+export function applyReviewOverlayToBriefResponse(
+  response: DailyBriefResponse,
+  result: DailyBriefReviewMutationResponse,
+): DailyBriefResponse {
+  if (!response.brief) return response;
+  let changed = false;
+  const sections = { ...response.brief.sections } as DailyBrief["sections"];
+  for (const key of BRIEF_SECTION_KEYS) {
+    const items = sections[key];
+    if (!items?.length) continue;
+    sections[key] = items.map((item) => {
+      if (item.review?.id !== result.review.id) return item;
+      changed = true;
+      return {
+        ...item,
+        review: result.review,
+        taskId: result.task?.id ?? null,
+        task: result.task,
+      };
+    });
+  }
+  return changed ? { ...response, brief: { ...response.brief, sections } } : response;
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1084,6 +1084,28 @@ export interface DailyBriefTaskState {
   readonlyReason: "not_owner" | "external_authority" | null;
 }
 
+export type DailyBriefReviewState =
+  | {
+      kind: "completion";
+      id: string;
+      state: "pending" | "accepted" | "rejected" | "expired";
+      canReview: boolean;
+    }
+  | {
+      kind: "seed";
+      id: string;
+      state: "pending" | "accepted" | "dismissed";
+      canReview: boolean;
+      acceptedTaskId: string | null;
+    };
+
+export type DailyBriefReviewDecision = "confirm_done" | "keep_open" | "track" | "dismiss";
+
+export interface DailyBriefReviewMutationResponse {
+  review: DailyBriefReviewState;
+  task: DailyBriefTaskState | null;
+}
+
 export interface DailyBriefItem {
   id: string;
   sectionKey: "meetings" | "todos" | "untracked_followups" | "looks_resolved" | "customer_updates" | "active_projects";
@@ -1103,6 +1125,8 @@ export interface DailyBriefItem {
   taskId?: string | null;
   /** Live task-state overlay; absent on legacy/partial payloads. */
   task?: DailyBriefTaskState | null;
+  /** Current durable follow-up review state; absent on legacy/partial payloads. */
+  review?: DailyBriefReviewState | null;
 }
 
 export interface DailyBrief {
@@ -1424,6 +1448,21 @@ export const api = {
     },
     get(id: string) {
       return request<{ brief: DailyBrief }>(`/api/daily-briefs/${id}`);
+    },
+    reviewCompletion(id: string, decision: "confirm_done" | "keep_open") {
+      return request<DailyBriefReviewMutationResponse>(
+        `/api/task-completion-recommendations/${encodeURIComponent(id)}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ decision }),
+        },
+      );
+    },
+    reviewSeed(id: string, decision: "track" | "dismiss") {
+      return request<DailyBriefReviewMutationResponse>(`/api/task-seed-candidates/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ decision }),
+      });
     },
     create(body?: { briefDate?: string }) {
       return request<{ generation: { id: string; status: string; briefDate: string } | null }>("/api/daily-briefs", {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -1,7 +1,7 @@
 import { DailyBriefEmptyState } from "@/components/brief/brief-empty-state";
 import { DailyBrief } from "@/components/brief/daily-brief";
-import { applyTaskOverlayToBriefResponse } from "@/components/brief/task-overlay";
-import type { DailyBriefResponse, TaskStatus } from "@/lib/api";
+import { applyReviewOverlayToBriefResponse, applyTaskOverlayToBriefResponse } from "@/components/brief/task-overlay";
+import type { DailyBriefResponse, DailyBriefReviewDecision, DailyBriefReviewState, TaskStatus } from "@/lib/api";
 import { api } from "@/lib/api";
 import { chatPrefillTargetFromPrompt } from "@/lib/chat-target";
 import { TabContentContainer } from "@sketch/ui/components/tab-content-container";
@@ -56,6 +56,45 @@ export function HomePage() {
   const updatingTaskId = updateTaskStatusMutation.isPending
     ? (updateTaskStatusMutation.variables?.taskId ?? null)
     : null;
+  const reviewMutation = useMutation({
+    mutationFn: ({
+      kind,
+      id,
+      decision,
+    }: {
+      kind: DailyBriefReviewState["kind"];
+      id: string;
+      decision: DailyBriefReviewDecision;
+    }) => {
+      if (kind === "completion" && (decision === "confirm_done" || decision === "keep_open")) {
+        return api.dailyBriefs.reviewCompletion(id, decision);
+      }
+      if (kind === "seed" && (decision === "track" || decision === "dismiss")) {
+        return api.dailyBriefs.reviewSeed(id, decision);
+      }
+      throw new Error("Invalid follow-up review decision");
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<DailyBriefResponse>(DAILY_BRIEF_QUERY_KEY, (current) =>
+        current ? applyReviewOverlayToBriefResponse(current, result) : current,
+      );
+      void queryClient.invalidateQueries({ queryKey: DAILY_BRIEF_QUERY_KEY });
+      toast.success(
+        result.review.kind === "completion"
+          ? result.review.state === "accepted"
+            ? "Follow-up marked done"
+            : "Follow-up kept open"
+          : result.review.state === "accepted"
+            ? "Follow-up tracked"
+            : "Follow-up dismissed",
+      );
+    },
+    onError: (error) => {
+      void queryClient.invalidateQueries({ queryKey: DAILY_BRIEF_QUERY_KEY });
+      toast.error(error instanceof Error ? error.message : "Failed to review follow-up");
+    },
+  });
+  const updatingReviewId = reviewMutation.isPending ? (reviewMutation.variables?.id ?? null) : null;
 
   return (
     <TabContentContainer className="mx-auto box-border min-h-[calc(100vh-3rem)] max-w-4xl px-5 py-10 sm:px-10 md:min-h-screen">
@@ -70,6 +109,8 @@ export function HomePage() {
           }}
           onUpdateTaskStatus={(taskId, status) => updateTaskStatusMutation.mutate({ taskId, status })}
           updatingTaskId={updatingTaskId}
+          onReviewFollowup={(kind, id, decision) => reviewMutation.mutate({ kind, id, decision })}
+          updatingReviewId={updatingReviewId}
         />
       ) : (
         <DailyBriefEmptyState


### PR DESCRIPTION
## Summary

Add inline review actions to Daily Brief follow-ups so users can resolve completion recommendations or track and dismiss untracked follow-ups without leaving the brief.

## Implementation Details

- Add authenticated PATCH endpoints for completion recommendations and seed candidates.
- Hydrate Daily Brief items with bounded, permission-aware review state and accepted task overlays.
- Preserve non-disclosure behavior for inaccessible reviews and tasks.
- Make matching retries idempotent and return conflicts for stale or contradictory decisions.
- Add inline and detail-drawer controls with loading states, terminal outcome labels, cache overlays, refreshes, and success/error feedback.
- Add route, hydration, authorization, retry, overflow, and UI coverage.
- No database migrations, configuration changes, or experimental feature flag.

## Verification

- `pnpm biome check` — passed
- `pnpm typecheck` — passed
- `pnpm test` — passed (4,415 server tests and 410 web tests; 20 live integration tests skipped)
- `pnpm build` — passed
- Repository pre-push checks — passed

## Risk / Rollout

- Review hydration is capped at 100 unique references per brief; overflow items remain chat-only.
- Mutations revalidate ownership and task authority and avoid revealing whether unauthorized reviews exist.
- Existing Daily Brief payloads remain compatible because review state is optional.
- The feature is enabled directly and does not use `EXPERIMENTAL_FLAG`.
