### PR TITLE
fix: preserve encryption key when updating connector scope

### DIFF
--- a/packages/server/src/api/connectors-authz.test.ts
+++ b/packages/server/src/api/connectors-authz.test.ts
@@ -234,6 +234,35 @@ describe("Connectors API — authorization", () => {
       expect(res.status).toBe(200);
     });
 
+    it("owner can save scope for an encrypted managed Google Calendar connector", async () => {
+      const encryptionKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      const encryptedApp = createApp(db, createTestConfig({ ENCRYPTION_KEY: encryptionKey }), { logger });
+      const encryptedCookie = await login(encryptedApp, MEMBER_EMAIL);
+      const cfg = await createConnectorRepository(db, encryptionKey).createConfig({
+        connectorType: "google_calendar",
+        authType: "oauth",
+        credentials: JSON.stringify({ type: "oauth", access_token: "stub" }),
+        credentialSource: "canvas",
+        createdBy: memberId,
+      });
+
+      const res = await encryptedApp.request(`/api/connectors/${cfg.id}/scope`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Cookie: encryptedCookie },
+        body: JSON.stringify({ scopeConfig: { calendarIds: ["primary"] } }),
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({
+        connector: {
+          id: cfg.id,
+          connectorType: "google_calendar",
+          scopeConfig: { calendarIds: ["primary"] },
+          syncStatus: "pending",
+        },
+      });
+    });
+
     it("admin → 200 on PATCH /:id/scope org-wide connector", async () => {
       const cfg = await insertConfig(db, { connectorType: "notion", createdBy: memberId });
       const res = await app.request(`/api/connectors/${cfg.id}/scope`, {

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -2238,7 +2238,7 @@ export function connectorRoutes(
     }
 
     const requestedScope = await db.transaction().execute(async (trx) => {
-      const txConnectorRepo = createConnectorRepository(trx);
+      const txConnectorRepo = createConnectorRepository(trx, appConfig?.ENCRYPTION_KEY);
       const scope =
         config.connector_type === "whatsapp"
           ? await applyWhatsAppGroupScope({ db: trx, scopeConfig: parsed.data.scopeConfig })


### PR DESCRIPTION
## Summary
- fix connector scope updates for encrypted managed credentials
- restore Google Calendar file-connector scope saves that were returning HTTP 500
- add endpoint-level regression coverage for encrypted Canvas-managed OAuth credentials

## Implementation Details
- pass the configured `ENCRYPTION_KEY` to the transaction-scoped connector repository
- verify `PATCH /api/connectors/:id/scope` returns 200 and preserves the selected calendar IDs
- no database, migration, configuration, UI, or external-provider changes

## Verification
- `pnpm biome check` - passed
- `pnpm typecheck` - passed
- targeted connector scope tests - 113 passed
- `pnpm test` - 4,816 passed, 20 skipped
- `pnpm build` - passed
- independent code review - no actionable findings

## Risk / Rollout
- low-risk one-line dependency propagation fix
- affects transaction-scoped connector updates only
- existing encrypted connector data is not rewritten
