### PR TITLE
SKE-281: Fix Linear connector sign-in completion

### DIFF
--- a/packages/shared/src/integration-connectors.ts
+++ b/packages/shared/src/integration-connectors.ts
@@ -6,63 +6,120 @@ export type PersonalCanvasConnectorType =
   | "teams"
   | "fireflies";
 
-export interface PersonalCanvasConnectorMapping {
-  connectorType: PersonalCanvasConnectorType;
+export type OrganizationCanvasConnectorType = "linear";
+
+export type CanvasConnectorType = PersonalCanvasConnectorType | OrganizationCanvasConnectorType;
+
+export type CanvasConnectorCredentialScope = "personal" | "organization";
+
+export interface CanvasConnectorMapping<TConnector extends CanvasConnectorType = CanvasConnectorType> {
+  connectorType: TConnector;
   appSlug: string;
   aliases: string[];
+  credentialScope: CanvasConnectorCredentialScope;
 }
 
-export const PERSONAL_CANVAS_CONNECTOR_MAPPINGS: PersonalCanvasConnectorMapping[] = [
+export interface PersonalCanvasConnectorMapping extends CanvasConnectorMapping<PersonalCanvasConnectorType> {
+  credentialScope: "personal";
+}
+
+export interface OrganizationCanvasConnectorMapping extends CanvasConnectorMapping<OrganizationCanvasConnectorType> {
+  credentialScope: "organization";
+}
+
+const PERSONAL_CANVAS_CONNECTOR_MAPPING_VALUES: PersonalCanvasConnectorMapping[] = [
   {
     connectorType: "google_drive",
     appSlug: "google-drive-oauth",
     aliases: ["google-drive-oauth", "google-drive", "google_drive", "drive"],
+    credentialScope: "personal",
   },
   {
     connectorType: "google_calendar",
     appSlug: "google-calendar-oauth",
     aliases: ["google-calendar-oauth", "google-calendar", "google_calendar", "calendar"],
+    credentialScope: "personal",
   },
   {
     connectorType: "gmail",
     appSlug: "google-gmail-oauth",
     aliases: ["google-gmail-oauth", "google-gmail", "gmail"],
+    credentialScope: "personal",
   },
   {
     connectorType: "outlook",
     appSlug: "microsoft-outlook-oauth",
     aliases: ["microsoft-outlook-oauth", "microsoft-outlook", "outlook"],
+    credentialScope: "personal",
   },
   {
     connectorType: "teams",
     appSlug: "microsoft-teams-oauth",
     aliases: ["microsoft-teams-oauth", "microsoft-teams", "teams"],
+    credentialScope: "personal",
   },
   {
     connectorType: "fireflies",
     appSlug: "fireflies",
     aliases: ["fireflies", "fireflies-ai"],
+    credentialScope: "personal",
   },
 ];
+
+export const CANVAS_CONNECTOR_MAPPINGS: Array<PersonalCanvasConnectorMapping | OrganizationCanvasConnectorMapping> = [
+  ...PERSONAL_CANVAS_CONNECTOR_MAPPING_VALUES,
+  {
+    connectorType: "linear",
+    appSlug: "linear",
+    aliases: ["linear"],
+    credentialScope: "organization",
+  },
+];
+
+export const PERSONAL_CANVAS_CONNECTOR_MAPPINGS: PersonalCanvasConnectorMapping[] = CANVAS_CONNECTOR_MAPPINGS.filter(
+  (mapping): mapping is PersonalCanvasConnectorMapping => mapping.credentialScope === "personal",
+);
 
 function normalizeCanvasAppId(value: string): string {
   return value.trim().toLowerCase();
 }
 
-const connectorByAlias = new Map<string, PersonalCanvasConnectorType>(
-  PERSONAL_CANVAS_CONNECTOR_MAPPINGS.flatMap((mapping) =>
+const connectorByAlias = new Map<string, CanvasConnectorType>(
+  CANVAS_CONNECTOR_MAPPINGS.flatMap((mapping) =>
     mapping.aliases.map((alias) => [normalizeCanvasAppId(alias), mapping.connectorType] as const),
   ),
 );
 
-const appSlugByConnector = new Map<PersonalCanvasConnectorType, string>(
-  PERSONAL_CANVAS_CONNECTOR_MAPPINGS.map((mapping) => [mapping.connectorType, mapping.appSlug]),
+const mappingByConnector = new Map<
+  CanvasConnectorType,
+  PersonalCanvasConnectorMapping | OrganizationCanvasConnectorMapping
+>(CANVAS_CONNECTOR_MAPPINGS.map((mapping) => [mapping.connectorType, mapping]));
+
+const appSlugByConnector = new Map<CanvasConnectorType, string>(
+  CANVAS_CONNECTOR_MAPPINGS.map((mapping) => [mapping.connectorType, mapping.appSlug]),
 );
 
-export function personalCanvasConnectorTypeFromAppId(appId: string): PersonalCanvasConnectorType | null {
+export function canvasConnectorTypeFromAppId(appId: string): CanvasConnectorType | null {
   return connectorByAlias.get(normalizeCanvasAppId(appId)) ?? null;
 }
 
-export function canvasAppSlugForPersonalConnector(connectorType: PersonalCanvasConnectorType): string {
+export function canvasConnectorMappingForType(
+  connectorType: CanvasConnectorType | string,
+): PersonalCanvasConnectorMapping | OrganizationCanvasConnectorMapping | null {
+  return mappingByConnector.get(connectorType as CanvasConnectorType) ?? null;
+}
+
+export function canvasAppSlugForConnector(connectorType: CanvasConnectorType): string {
   return appSlugByConnector.get(connectorType) ?? connectorType;
+}
+
+export function personalCanvasConnectorTypeFromAppId(appId: string): PersonalCanvasConnectorType | null {
+  const connectorType = canvasConnectorTypeFromAppId(appId);
+  if (!connectorType) return null;
+  const mapping = canvasConnectorMappingForType(connectorType);
+  return mapping?.credentialScope === "personal" ? mapping.connectorType : null;
+}
+
+export function canvasAppSlugForPersonalConnector(connectorType: PersonalCanvasConnectorType): string {
+  return canvasAppSlugForConnector(connectorType);
 }

--- a/packages/web/src/routes/files/connector-picker.isolated.test.tsx
+++ b/packages/web/src/routes/files/connector-picker.isolated.test.tsx
@@ -217,6 +217,91 @@ describe("ConnectorPicker connector capabilities", () => {
     expect(screen.queryByText(/Canvas/)).not.toBeInTheDocument();
   });
 
+  it("detects a newly connected native Canvas account for the org-level Linear connector", async () => {
+    const user = userEvent.setup();
+    const importedBodies: unknown[] = [];
+    let linearConnected = false;
+    setupStatus();
+    vi.spyOn(window, "open").mockReturnValue({ closed: false } as Window);
+    server.use(
+      http.get("/api/mcp-servers", () =>
+        HttpResponse.json({
+          servers: [
+            {
+              id: "provider-1",
+              type: "canvas",
+              slug: "canvas",
+              displayName: "Canvas",
+              url: "http://canvas.test",
+              apiUrl: null,
+              credentials: "configured",
+              mode: "skill",
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        }),
+      ),
+      http.get("/api/mcp-servers/provider-1/connections", () =>
+        HttpResponse.json({
+          connections: linearConnected
+            ? [
+                {
+                  id: "secrets:admin-1:linear:linear",
+                  providerId: "provider-1",
+                  source: "canvas_user_secrets",
+                  appId: "linear",
+                  appName: "Linear",
+                  status: "active",
+                  accessLevel: "personal",
+                  isOwnedByViewer: true,
+                  createdAt: "2026-01-01T00:00:00Z",
+                },
+              ]
+            : [],
+        }),
+      ),
+      http.get("/api/connectors/credential-source", () =>
+        HttpResponse.json({
+          mode: "canvas",
+          canvasConfigured: true,
+          canvasCredentialImportConfigured: true,
+          publicKeyId: "key-1",
+        }),
+      ),
+      http.post("/api/connectors/canvas/connect", () =>
+        HttpResponse.json({ redirectUrl: "https://canvas.example.com/connect/secrets?token=test" }),
+      ),
+      http.post("/api/connectors/canvas/import", async ({ request }) => {
+        importedBodies.push(await request.json());
+        return HttpResponse.json({
+          connector: {
+            id: "linear-connector",
+            connectorType: "linear",
+            syncStatus: "pending",
+            alreadyConnected: false,
+          },
+        });
+      }),
+    );
+    renderPicker([]);
+
+    await user.click(await screen.findByRole("button", { name: /Browse all/i }));
+    await user.click(
+      within(connectorRowByDescription("Issues, projects, and roadmaps")).getByRole("button", { name: "Connect" }),
+    );
+    await user.click(await screen.findByRole("button", { name: "Connect account" }));
+
+    expect(await screen.findByText("Waiting for sign-in to finish...")).toBeInTheDocument();
+    linearConnected = true;
+
+    await waitFor(
+      () => expect(importedBodies).toEqual([{ connectorType: "linear", accountId: "secrets:admin-1:linear:linear" }]),
+      { timeout: 3500 },
+    );
+    expect(screen.queryByText("Waiting for sign-in to finish...")).not.toBeInTheDocument();
+  }, 10000);
+
   it("surfaces unfinished Google Calendar setup instead of looking connected", async () => {
     const user = userEvent.setup();
     setupStatus();

--- a/packages/web/src/routes/files/connector-picker.tsx
+++ b/packages/web/src/routes/files/connector-picker.tsx
@@ -17,8 +17,8 @@ import { INTEGRATIONS, type IntegrationDefinition, type IntegrationType, getInte
 import { useDashboardAuth } from "@/routes/dashboard";
 import {
   type IntegrationConnection,
-  PERSONAL_CANVAS_CONNECTOR_MAPPINGS,
-  personalCanvasConnectorTypeFromAppId,
+  canvasConnectorMappingForType,
+  canvasConnectorTypeFromAppId,
 } from "@sketch/shared";
 
 const SYNC_STATUS_PRECEDENCE: Record<string, number> = {
@@ -81,26 +81,38 @@ function connectorAdoptionSummary(connectedMemberCount: number, teamMemberCount:
   return `${connectedMemberCount.toLocaleString()} of ${denominator.toLocaleString()} ${memberLabel} connected`;
 }
 
-const PERSONAL_CANVAS_CONNECTOR_TYPES = new Set<IntegrationType>(
-  PERSONAL_CANVAS_CONNECTOR_MAPPINGS.map((mapping) => mapping.connectorType as IntegrationType),
-);
-
-function canResolveNativeCanvasConnection(definition: IntegrationDefinition | null): boolean {
-  return !!definition && definition.perUserAuth && PERSONAL_CANVAS_CONNECTOR_TYPES.has(definition.type);
+function canResolveNativeCanvasConnection(definition: IntegrationDefinition | null, isAdmin: boolean): boolean {
+  if (!definition) return false;
+  const mapping = canvasConnectorMappingForType(definition.type);
+  if (!mapping) return false;
+  if (mapping.credentialScope === "organization") return isAdmin && !definition.perUserAuth;
+  return definition.perUserAuth;
 }
 
 function nativeCanvasConnectionForIntegration(
   definition: IntegrationDefinition,
   connections: IntegrationConnection[],
+  isAdmin: boolean,
 ): IntegrationConnection | null {
+  const mapping = canvasConnectorMappingForType(definition.type);
+  if (!mapping) return null;
+
   return (
-    connections.find(
-      (connection) =>
-        connection.status === "active" &&
-        isNativeCanvasAppConnection(connection) &&
-        isOwnedOrPersonalAppConnection(connection) &&
-        personalCanvasConnectorTypeFromAppId(connection.appId) === definition.type,
-    ) ?? null
+    connections.find((connection) => {
+      if (
+        connection.status !== "active" ||
+        !isNativeCanvasAppConnection(connection) ||
+        canvasConnectorTypeFromAppId(connection.appId) !== definition.type
+      ) {
+        return false;
+      }
+      if (mapping.credentialScope === "organization") {
+        if (!isAdmin) return false;
+        if (connection.accessLevel === "organization") return connection.canUse !== false;
+        return connection.isOwnedByViewer !== false;
+      }
+      return isOwnedOrPersonalAppConnection(connection);
+    }) ?? null
   );
 }
 import {
@@ -209,7 +221,7 @@ export function ConnectorPicker({
   };
 
   const effectiveConnectingIntegration = forcedConnectIntegration ?? connectingIntegration;
-  const shouldResolveNativeCanvasConnection = canResolveNativeCanvasConnection(effectiveConnectingIntegration);
+  const shouldResolveNativeCanvasConnection = canResolveNativeCanvasConnection(effectiveConnectingIntegration, isAdmin);
   const integrationProvidersQuery = useQuery({
     queryKey: ["mcp-servers"],
     queryFn: () => api.mcpServers.list(),
@@ -224,7 +236,7 @@ export function ConnectorPicker({
   });
   const nativeCanvasConnection =
     effectiveConnectingIntegration && canvasConnectionsQuery.data
-      ? nativeCanvasConnectionForIntegration(effectiveConnectingIntegration, canvasConnectionsQuery.data)
+      ? nativeCanvasConnectionForIntegration(effectiveConnectingIntegration, canvasConnectionsQuery.data, isAdmin)
       : null;
   const canvasConnectionLookupPending =
     shouldResolveNativeCanvasConnection &&


### PR DESCRIPTION
## Summary

- Fix the Linear connector flow remaining stuck on “Waiting for sign-in to finish...” after a user saves an API key in the Canvas-hosted popup.
- Detect the newly published Linear Canvas account and automatically import its credential into the organization-level Sketch connector.
- Add regression coverage for the complete popup, polling, account detection, and import flow.

## Linear Scope

- Implements [SKE-281](https://linear.app/sketch-ai/issue/SKE-281/fix-linear-connector-sign-in-completion).
- Canvas AI already saves, publishes, and mints the Linear API-key credential correctly; the missing behavior was Sketch-side connection resolution.

## Implementation Details

- Extend `packages/shared/src/integration-connectors.ts` with shared Canvas connector credential-scope metadata.
- Register Linear as an organization-scoped Sketch connector while preserving the existing personal connector helpers used by other flows.
- Update `ConnectorPicker` so admins poll for Linear Canvas accounts even though Linear uses an organization-level Sketch credential.
- Accept either the admin's owned personal Canvas account or an organization-shared usable Linear account.
- Add a deterministic UI regression test that starts from the waiting state, exposes the connected account during polling, verifies the Canvas import request, and confirms the waiting state clears.
- No API, database, migration, configuration, background-job, prompt, or feature-flag changes.

## Verification

- `pnpm biome check` — passed; 1,245 files checked.
- `pnpm typecheck` — passed for shared, UI, server, and web packages.
- `pnpm test` — passed; 4,498 server tests and 407 web tests.
- `pnpm build` — passed for shared, UI, server, and web packages.
- Canvas AI targeted verification — passed for the hosted API-key form, connected-account publication, and Sketch credential minting.

## Risk / Rollout

- Low-risk frontend/shared-contract change scoped to Linear account resolution for admins.
- Existing personal Canvas connector behavior remains covered and unchanged.
- The test uses the real two-second polling interval to protect against regressions in the asynchronous completion path.
