### PR TITLE
SKE-284: Preserve failed WriteAgentOutput errors

### DIFF
--- a/packages/server/src/agent/runner-sdk-stream.test.ts
+++ b/packages/server/src/agent/runner-sdk-stream.test.ts
@@ -1,6 +1,11 @@
 import { readFile } from "node:fs/promises";
-import { describe, expect, it } from "vitest";
-import { extractAssistantText, extractAssistantTextDelta, replaySdkStreamMessages } from "./runner";
+import { describe, expect, it, vi } from "vitest";
+import {
+  extractAssistantText,
+  extractAssistantTextDelta,
+  recordSdkAgentOutputToolStarts,
+  replaySdkStreamMessages,
+} from "./runner";
 
 interface SdkStreamFixture {
   source: string;
@@ -245,5 +250,39 @@ describe("Claude Agent SDK stream fixture mapping", () => {
       },
     ]);
     expect(replay.toolCalls).toEqual([{ toolName: "Skill", skillName: "canvas", startedAt: 2, endedAt: 3 }]);
+  });
+
+  it("records malformed WriteAgentOutput calls before MCP schema validation", () => {
+    const replay = replaySdkStreamMessages([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "<TOOL_USE_ID_1>",
+              name: "mcp__sketch__WriteAgentOutput",
+              input: {
+                outputDate: "2026-07-21",
+                timezone: "UTC",
+                masthead: { title: "", summary: "Summary" },
+                items: [],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    const recordRejectedAttempt = vi.fn();
+
+    recordSdkAgentOutputToolStarts(
+      { recordRejectedAttempt, write: vi.fn() },
+      replay.toolStarts.map(({ toolName, input }) => ({ toolName, input })),
+    );
+
+    expect(recordRejectedAttempt).toHaveBeenCalledOnce();
+    expect(recordRejectedAttempt.mock.calls[0]?.[0]).toMatchObject({
+      issues: [expect.objectContaining({ path: ["masthead", "title"] })],
+    });
   });
 });

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -85,7 +85,7 @@ import {
   UploadCollector,
   createSketchMcpServer,
 } from "./sketch-tools";
-import type { AgentOutputWriter } from "./tools/agent-output";
+import { type AgentOutputWriter, recordRejectedWriteAgentOutputCall } from "./tools/agent-output";
 
 /**
  * A single tool invocation with timing. `startedAt`/`endedAt` are epoch ms:
@@ -110,6 +110,15 @@ export interface ToolUseProgressEvent {
   kind: "tool_use";
   toolName: string;
   input: Record<string, unknown>;
+}
+
+export function recordSdkAgentOutputToolStarts(
+  writer: AgentOutputWriter | undefined,
+  toolStarts: Array<{ toolName: string; input: Record<string, unknown> }>,
+): void {
+  for (const toolStart of toolStarts) {
+    recordRejectedWriteAgentOutputCall(writer, toolStart.toolName, toolStart.input);
+  }
 }
 
 export interface IntermediateTextProgressEvent {
@@ -1319,6 +1328,7 @@ async function runAgentWithClaudeSdk(params: RunAgentParams): Promise<RunAgentRe
 
     for await (const message of run) {
       const effects = applySdkStreamMessageMapping(sdkStreamState, message, Date.now());
+      recordSdkAgentOutputToolStarts(params.agentOutputWriter, effects.toolStarts);
 
       for (const nextSessionId of effects.sessionIds) {
         sessionId = nextSessionId;

--- a/packages/server/src/agent/runtime/custom-tools.test.ts
+++ b/packages/server/src/agent/runtime/custom-tools.test.ts
@@ -10,7 +10,13 @@ import { createAgentRuntimeCustomToolEffects, createDefaultAgentRuntimeCustomToo
 
 interface SmokeTool {
   inputSchema?: {
-    safeParse(value: unknown): { success: boolean };
+    safeParse?(value: unknown): { success: boolean };
+    validate?(value: unknown):
+      | PromiseLike<{ success: boolean; value?: Record<string, unknown> }>
+      | {
+          success: boolean;
+          value?: Record<string, unknown>;
+        };
   };
   execute?: (input: Record<string, unknown>, options: never) => Promise<unknown>;
   toModelOutput?: (options: { toolCallId: string; input: unknown; output: unknown }) => unknown;
@@ -72,6 +78,32 @@ describe("AI SDK custom Sketch tool provider", () => {
 
     expect(tools.mcp__sketch__TranscribeAudio).toBeDefined();
     expect(tools.mcp__sketch__VisualAnalysis).toBeDefined();
+  });
+
+  it("passes malformed agent output calls to the handler for rejection tracking", async () => {
+    const effects = createAgentRuntimeCustomToolEffects();
+    const provider = createDefaultAgentRuntimeCustomToolProvider({
+      effects,
+      transcriptionEnabled: false,
+      visionAnalysisEnabled: false,
+      visionConfig: null,
+    });
+    const recordRejectedAttempt = vi.fn();
+    const write = vi.fn();
+    const tools = await provider.createTools(params({ agentOutputWriter: { recordRejectedAttempt, write } }));
+    const writeTool = tools.mcp__sketch__WriteAgentOutput as SmokeTool;
+    const malformedInput = {
+      outputDate: "2026-07-04",
+      timezone: "UTC",
+      masthead: { title: "", summary: "Summary" },
+      items: [],
+    };
+
+    const validation = await writeTool.inputSchema?.validate?.(malformedInput);
+    expect(validation).toEqual({ success: true, value: malformedInput });
+    await expect(writeTool.execute?.(validation?.value ?? malformedInput, {} as never)).rejects.toThrow();
+    expect(recordRejectedAttempt).toHaveBeenCalledOnce();
+    expect(write).not.toHaveBeenCalled();
   });
 
   it("invokes the wrapped SDK handler and preserves upload side effects", async () => {
@@ -174,7 +206,10 @@ describe("AI SDK custom Sketch tool provider", () => {
     for (const [toolName, input] of Object.entries(smokeInputs)) {
       const toolDefinition = tools[toolName] as SmokeTool | undefined;
       expect(toolDefinition?.inputSchema, toolName).toBeDefined();
-      expect(toolDefinition?.inputSchema?.safeParse(input).success, toolName).toBe(true);
+      const validation = toolDefinition?.inputSchema?.safeParse
+        ? toolDefinition.inputSchema.safeParse(input)
+        : await toolDefinition?.inputSchema?.validate?.(input);
+      expect(validation?.success, toolName).toBe(true);
       const output = await toolDefinition?.execute?.(input, {} as never);
       await expect(
         Promise.resolve(toolDefinition?.toModelOutput?.({ toolCallId: `${toolName}-call`, input, output })),

--- a/packages/server/src/agent/runtime/custom-tools.ts
+++ b/packages/server/src/agent/runtime/custom-tools.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import { type JSONValue, type Tool, type ToolSet, tool } from "ai";
+import { type JSONValue, type Tool, type ToolSet, jsonSchema, tool } from "ai";
 import { z } from "zod/v4";
 import {
   type IntegrationProgressEventLike,
@@ -14,6 +14,7 @@ import {
   UploadCollector,
   createSketchMcpToolDefinitions,
 } from "../sketch-tools";
+import { WRITE_AGENT_OUTPUT_TOOL_NAME } from "../tools/agent-output";
 import type { SketchMcpDeps } from "../tools/types";
 import type { AgentRuntimeCustomToolProvider, AgentRuntimeToolEnd, AgentRuntimeToolStart } from "./contracts";
 
@@ -65,6 +66,15 @@ function toInputSchema(inputSchema: RuntimeSdkMcpToolDefinition["inputSchema"]) 
   return z.object(inputSchema);
 }
 
+function toRuntimeInputSchema(sdkTool: RuntimeSdkMcpToolDefinition) {
+  const inputSchema = toInputSchema(sdkTool.inputSchema);
+  if (sdkTool.name !== WRITE_AGENT_OUTPUT_TOOL_NAME) return inputSchema;
+  const advertisedSchema = z.toJSONSchema(inputSchema) as Parameters<typeof jsonSchema<Record<string, unknown>>>[0];
+  return jsonSchema<Record<string, unknown>>(advertisedSchema, {
+    validate: (value) => ({ success: true, value: value as Record<string, unknown> }),
+  });
+}
+
 function mcpToModelOutput({ output }: Parameters<ToolToModelOutput>[0]): ReturnType<ToolToModelOutput> {
   const result = output as { content?: unknown };
 
@@ -92,7 +102,7 @@ function mcpToModelOutput({ output }: Parameters<ToolToModelOutput>[0]): ReturnT
 function toAiSdkTool(sdkTool: RuntimeSdkMcpToolDefinition) {
   return tool({
     description: sdkTool.description,
-    inputSchema: toInputSchema(sdkTool.inputSchema),
+    inputSchema: toRuntimeInputSchema(sdkTool),
     execute: async (input) => sdkTool.handler(input, {}),
     toModelOutput: mcpToModelOutput,
   });

--- a/packages/server/src/agent/tools/agent-output.test.ts
+++ b/packages/server/src/agent/tools/agent-output.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { writeAgentOutputSchema } from "./agent-output";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod/v4";
+import { createWriteAgentOutputTool, recordRejectedWriteAgentOutputCall, writeAgentOutputSchema } from "./agent-output";
 
 describe("writeAgentOutputSchema", () => {
   it("strips model-provided canonical task link fields", () => {
@@ -42,5 +43,25 @@ describe("writeAgentOutputSchema", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it("records malformed calls observed before SDK schema validation", async () => {
+    const recordRejectedAttempt = vi.fn();
+    const write = vi.fn();
+    const writer = { recordRejectedAttempt, write };
+    const writeTool = createWriteAgentOutputTool(writer);
+    const malformedInput = {
+      outputDate: "2026-07-16",
+      timezone: "UTC",
+      masthead: { title: "", summary: "Summary" },
+      items: [],
+    };
+
+    expect(z.object(writeTool.inputSchema).safeParse(malformedInput).success).toBe(false);
+    recordRejectedWriteAgentOutputCall(writer, "mcp__sketch__WriteAgentOutput", malformedInput);
+    expect(recordRejectedAttempt).toHaveBeenCalledOnce();
+    await expect(writeTool.handler(malformedInput, {})).rejects.toThrow();
+    expect(recordRejectedAttempt).toHaveBeenCalledTimes(2);
+    expect(write).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/agent/tools/agent-output.ts
+++ b/packages/server/src/agent/tools/agent-output.ts
@@ -4,6 +4,7 @@ import type { AgentKnowledgeRefs, AgentMasthead, AgentOutputItemInput } from "..
 import type { ToolResult } from "./types";
 
 export const MAX_AGENT_OUTPUT_PAYLOAD_BYTES = 256 * 1024;
+export const WRITE_AGENT_OUTPUT_TOOL_NAME = "WriteAgentOutput";
 
 const knowledgeRefsSchema = z.object({
   entityIds: z.array(z.string()).default([]),
@@ -54,6 +55,7 @@ export const writeAgentOutputSchema = z
 export type WriteAgentOutputPayload = z.infer<typeof writeAgentOutputSchema>;
 
 export interface AgentOutputWriter {
+  recordRejectedAttempt?(error: unknown): void;
   write(payload: {
     outputDate: string;
     timezone: string;
@@ -61,6 +63,21 @@ export interface AgentOutputWriter {
     rawPayload: WriteAgentOutputPayload;
     items: AgentOutputItemInput[];
   }): Promise<void>;
+}
+
+export function recordRejectedWriteAgentOutputCall(
+  writer: AgentOutputWriter | undefined,
+  toolName: string,
+  input: unknown,
+): void {
+  if (
+    !writer?.recordRejectedAttempt ||
+    (toolName !== WRITE_AGENT_OUTPUT_TOOL_NAME && !toolName.endsWith(`__${WRITE_AGENT_OUTPUT_TOOL_NAME}`))
+  ) {
+    return;
+  }
+  const result = writeAgentOutputSchema.safeParse(input);
+  if (!result.success) writer.recordRejectedAttempt(result.error);
 }
 
 export function assertAgentOutputPayloadSize(payload: unknown): void {
@@ -112,14 +129,20 @@ function mapItems(payload: WriteAgentOutputPayload): AgentOutputItemInput[] {
  */
 export function createWriteAgentOutputTool(writer: AgentOutputWriter | undefined) {
   return tool(
-    "WriteAgentOutput",
+    WRITE_AGENT_OUTPUT_TOOL_NAME,
     "Validate and save the complete agent output. Call exactly once when the result is ready.",
     writeAgentOutputSchema.shape,
     async (args): Promise<ToolResult> => {
       if (!writer) {
         return { content: [{ type: "text", text: "WriteAgentOutput is not available for this run." }] };
       }
-      const payload = writeAgentOutputSchema.parse(args);
+      let payload: WriteAgentOutputPayload;
+      try {
+        payload = writeAgentOutputSchema.parse(args);
+      } catch (error) {
+        writer.recordRejectedAttempt?.(error);
+        throw error;
+      }
       await writer.write({
         outputDate: payload.outputDate,
         timezone: payload.timezone,

--- a/packages/server/src/agents/run/generation.ts
+++ b/packages/server/src/agents/run/generation.ts
@@ -101,6 +101,7 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
 
     let writeAttempted = false;
     let lastWriteError: string | null = null;
+    let lastWriteErrorAfterPersistence = false;
     let saved = false;
     const config = await this.resolveConfig(def, user.id);
     const scope = await this.resolveScopeForOutput(def, user, config, output);
@@ -191,8 +192,10 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         onAttempt: () => {
           writeAttempted = true;
         },
-        onRejected: (error) => {
+        onRejected: (error, afterPersistence) => {
+          if (lastWriteErrorAfterPersistence && !afterPersistence) return;
           lastWriteError = sanitizeAgentOutputWriterError(error);
+          lastWriteErrorAfterPersistence = afterPersistence;
         },
         onSaved: () => {
           saved = true;
@@ -447,11 +450,15 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
       runtimeContext: Record<string, unknown>;
       createTasks: boolean;
       onAttempt: () => void;
-      onRejected: (error: unknown) => void;
+      onRejected: (error: unknown, afterPersistence: boolean) => void;
       onSaved: () => void;
     },
   ): AgentOutputWriter {
     return {
+      recordRejectedAttempt: (error) => {
+        params.onAttempt();
+        params.onRejected(error, false);
+      },
       write: async (payload: {
         outputDate: string;
         timezone: string;
@@ -460,6 +467,7 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         items: AgentOutputItemInput[];
       }) => {
         params.onAttempt();
+        let outputPersisted = false;
         try {
           if (payload.outputDate !== params.expectedOutputDate) {
             throw new Error(`Output date mismatch: expected ${params.expectedOutputDate}, got ${payload.outputDate}`);
@@ -502,6 +510,7 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
             rawPayload,
             items: visibleItems,
           });
+          outputPersisted = true;
           const persistedItems = pairPersistedVisibleItems(visibleItems, persistedRefs);
           if (def.onOutputSaved) {
             await def.onOutputSaved({
@@ -518,7 +527,7 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
           }
           params.onSaved();
         } catch (error) {
-          params.onRejected(error);
+          params.onRejected(error, outputPersisted);
           throw error;
         }
       },

--- a/packages/server/src/agents/run/generation.ts
+++ b/packages/server/src/agents/run/generation.ts
@@ -31,6 +31,15 @@ import type { ScheduledRunAdmission } from "./queue";
 import { enabledSectionsForScope, maxItemsPerSectionForScope, sourceAsDelivery } from "./routing";
 
 const INTERNAL_OUTPUT_SECTION_ITEM_LIMIT = 25;
+const AGENT_OUTPUT_WRITER_ERROR_LIMIT = 500;
+
+function sanitizeAgentOutputWriterError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const collapsed = message.replace(/\s+/g, " ").trim() || "WriteAgentOutput failed.";
+  return collapsed.length > AGENT_OUTPUT_WRITER_ERROR_LIMIT
+    ? `${collapsed.slice(0, AGENT_OUTPUT_WRITER_ERROR_LIMIT - 1)}…`
+    : collapsed;
+}
 
 export function pairPersistedVisibleItems(
   items: AgentOutputItemInput[],
@@ -90,6 +99,8 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
     const user = await this.deps.users.findById(userId);
     if (!output || !user) return;
 
+    let writeAttempted = false;
+    let lastWriteError: string | null = null;
     let saved = false;
     const config = await this.resolveConfig(def, user.id);
     const scope = await this.resolveScopeForOutput(def, user, config, output);
@@ -177,6 +188,12 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         expectedTimezone: output.timezone,
         runtimeContext,
         createTasks: config.createTasks,
+        onAttempt: () => {
+          writeAttempted = true;
+        },
+        onRejected: (error) => {
+          lastWriteError = sanitizeAgentOutputWriterError(error);
+        },
         onSaved: () => {
           saved = true;
         },
@@ -234,7 +251,11 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         result = await this.deps.runAgent(agentParams);
       }
       if (!saved) {
-        await this.repo.markFailed(outputId, "Agent did not call WriteAgentOutput.");
+        if (writeAttempted) {
+          await this.repo.markWriteFailed(outputId, lastWriteError ?? "WriteAgentOutput failed.");
+        } else {
+          await this.repo.markFailed(outputId, "Agent did not call WriteAgentOutput.");
+        }
       } else {
         await this.deps.db
           .updateTable("agent_outputs")
@@ -245,8 +266,13 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
       }
     } catch (err) {
       if (err instanceof AgentRunAdmissionCancelledError) return;
-      const message = err instanceof Error ? err.message : String(err);
-      await this.repo.markFailed(outputId, message);
+      const message =
+        !saved && writeAttempted && lastWriteError ? lastWriteError : err instanceof Error ? err.message : String(err);
+      if (!saved && writeAttempted) {
+        await this.repo.markWriteFailed(outputId, message);
+      } else {
+        await this.repo.markFailed(outputId, message);
+      }
       this.deps.logger.error({ err, agentKey, outputId, userId }, "Agent: generation failed");
     }
   }
@@ -420,6 +446,8 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
       expectedTimezone: string;
       runtimeContext: Record<string, unknown>;
       createTasks: boolean;
+      onAttempt: () => void;
+      onRejected: (error: unknown) => void;
       onSaved: () => void;
     },
   ): AgentOutputWriter {
@@ -431,62 +459,68 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
         rawPayload: WriteAgentOutputPayload;
         items: AgentOutputItemInput[];
       }) => {
-        if (payload.outputDate !== params.expectedOutputDate) {
-          throw new Error(`Output date mismatch: expected ${params.expectedOutputDate}, got ${payload.outputDate}`);
-        }
-        if (payload.timezone !== params.expectedTimezone) {
-          throw new Error(`Timezone mismatch: expected ${params.expectedTimezone}, got ${payload.timezone}`);
-        }
-        const visibleSectionKeys = new Set(def.sections.map((s) => s.key));
-        const internalSectionKeys = new Set(def.internalOutputSections ?? []);
-        const filtered = payload.items.filter(
-          (item) =>
-            (visibleSectionKeys.has(item.sectionKey) && params.enabledSections.has(item.sectionKey)) ||
-            internalSectionKeys.has(item.sectionKey),
-        );
-        validateAgentOutputLimits({
-          items: filtered,
-          visibleSectionKeys,
-          internalSectionKeys,
-          maxItemsPerSection: params.maxItemsPerSection,
-        });
-        const reconciled = def.reconcileItems
-          ? await def.reconcileItems({ db: this.deps.db, items: filtered, runtimeContext: params.runtimeContext })
-          : filtered;
-        const itemsForHooks = await def.enrichItems(this.deps.db, reconciled);
-        validateAgentOutputLimits({
-          items: itemsForHooks,
-          visibleSectionKeys,
-          internalSectionKeys,
-          maxItemsPerSection: params.maxItemsPerSection,
-        });
-        const visibleItems = itemsForHooks.filter(
-          (item) => visibleSectionKeys.has(item.sectionKey) && params.enabledSections.has(item.sectionKey),
-        );
-        await this.validateItemRefs(def, itemsForHooks);
-        const rawPayload = rawPayloadWithRunMetadata(payload.rawPayload, params.runtimeContext);
-        assertAgentOutputPayloadSize(rawPayload);
-        const persistedRefs = await this.repo.completeOutput({
-          outputId: params.outputId,
-          masthead: payload.masthead,
-          rawPayload,
-          items: visibleItems,
-        });
-        const persistedItems = pairPersistedVisibleItems(visibleItems, persistedRefs);
-        if (def.onOutputSaved) {
-          await def.onOutputSaved({
-            db: this.deps.db,
-            config: this.deps.config,
-            logger: this.deps.logger,
-            userId: params.userId,
-            outputId: params.outputId,
-            items: itemsForHooks,
-            persistedItems,
-            createTasks: params.createTasks,
-            runtimeContext: params.runtimeContext,
+        params.onAttempt();
+        try {
+          if (payload.outputDate !== params.expectedOutputDate) {
+            throw new Error(`Output date mismatch: expected ${params.expectedOutputDate}, got ${payload.outputDate}`);
+          }
+          if (payload.timezone !== params.expectedTimezone) {
+            throw new Error(`Timezone mismatch: expected ${params.expectedTimezone}, got ${payload.timezone}`);
+          }
+          const visibleSectionKeys = new Set(def.sections.map((s) => s.key));
+          const internalSectionKeys = new Set(def.internalOutputSections ?? []);
+          const filtered = payload.items.filter(
+            (item) =>
+              (visibleSectionKeys.has(item.sectionKey) && params.enabledSections.has(item.sectionKey)) ||
+              internalSectionKeys.has(item.sectionKey),
+          );
+          validateAgentOutputLimits({
+            items: filtered,
+            visibleSectionKeys,
+            internalSectionKeys,
+            maxItemsPerSection: params.maxItemsPerSection,
           });
+          const reconciled = def.reconcileItems
+            ? await def.reconcileItems({ db: this.deps.db, items: filtered, runtimeContext: params.runtimeContext })
+            : filtered;
+          const itemsForHooks = await def.enrichItems(this.deps.db, reconciled);
+          validateAgentOutputLimits({
+            items: itemsForHooks,
+            visibleSectionKeys,
+            internalSectionKeys,
+            maxItemsPerSection: params.maxItemsPerSection,
+          });
+          const visibleItems = itemsForHooks.filter(
+            (item) => visibleSectionKeys.has(item.sectionKey) && params.enabledSections.has(item.sectionKey),
+          );
+          await this.validateItemRefs(def, itemsForHooks);
+          const rawPayload = rawPayloadWithRunMetadata(payload.rawPayload, params.runtimeContext);
+          assertAgentOutputPayloadSize(rawPayload);
+          const persistedRefs = await this.repo.completeOutput({
+            outputId: params.outputId,
+            masthead: payload.masthead,
+            rawPayload,
+            items: visibleItems,
+          });
+          const persistedItems = pairPersistedVisibleItems(visibleItems, persistedRefs);
+          if (def.onOutputSaved) {
+            await def.onOutputSaved({
+              db: this.deps.db,
+              config: this.deps.config,
+              logger: this.deps.logger,
+              userId: params.userId,
+              outputId: params.outputId,
+              items: itemsForHooks,
+              persistedItems,
+              createTasks: params.createTasks,
+              runtimeContext: params.runtimeContext,
+            });
+          }
+          params.onSaved();
+        } catch (error) {
+          params.onRejected(error);
+          throw error;
         }
-        params.onSaved();
       },
     };
   }

--- a/packages/server/src/agents/service.test.ts
+++ b/packages/server/src/agents/service.test.ts
@@ -9,8 +9,8 @@ import type { DB } from "../db/schema";
 import type { QueueManager } from "../queue";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 import { CONVERSATION_SUMMARY_AGENT_KEY, CONVERSATION_SUMMARY_AGENT_VERSION } from "./definitions/conversation-summary";
-import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION } from "./definitions/daily-brief";
-import { AgentRunService } from "./service";
+import { DAILY_BRIEF_AGENT_KEY, DAILY_BRIEF_AGENT_VERSION, dailyBriefDefinition } from "./definitions/daily-brief";
+import { AgentRunService, type AgentRunServiceDeps } from "./service";
 
 const OUTPUT_DATE = "2026-06-15";
 const PREVIOUS_DATE = "2026-06-14";
@@ -182,6 +182,224 @@ describe("Daily Brief durable-task hooks", () => {
     expect(afterEnabled).toBe(1);
   });
 });
+
+describe("Agent output writer failures", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("persists the writer rejection when WriteAgentOutput was called but rejected", async () => {
+    const output = await runOutputWriterScenario(db, async (params) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      try {
+        await params.agentOutputWriter.write({
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Daily Brief", summary: "Summary" },
+          rawPayload: dailyBriefRawPayload(),
+          items: [briefItem({ knowledgeRefs: { entityIds: ["unknown-entity"], fileIds: [] } })],
+        });
+      } catch {}
+      return runResult();
+    });
+    expect(output).toMatchObject({
+      status: "failed",
+      error_message: "Agent output validation failed: todos:Brief todo references unknown entityIds",
+    });
+  });
+
+  it("keeps the generic failure when WriteAgentOutput was never called", async () => {
+    const output = await runOutputWriterScenario(db, async () => runResult());
+    expect(output).toMatchObject({
+      status: "failed",
+      error_message: "Agent did not call WriteAgentOutput.",
+    });
+  });
+
+  it("persists the final rejection when WriteAgentOutput fails repeatedly", async () => {
+    const output = await runOutputWriterScenario(db, async (params) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      try {
+        await params.agentOutputWriter.write({
+          outputDate: PREVIOUS_DATE,
+          timezone: "UTC",
+          masthead: { title: "Daily Brief", summary: "Summary" },
+          rawPayload: dailyBriefRawPayload(PREVIOUS_DATE),
+          items: [],
+        });
+      } catch {}
+      try {
+        await params.agentOutputWriter.write({
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Daily Brief", summary: "Summary" },
+          rawPayload: dailyBriefRawPayload(),
+          items: [
+            briefItem({
+              title: "Final rejected item",
+              knowledgeRefs: { entityIds: ["unknown-entity"], fileIds: [] },
+            }),
+          ],
+        });
+      } catch {}
+      return runResult();
+    });
+    expect(output).toMatchObject({
+      status: "failed",
+      error_message: expect.stringContaining("todos:Final rejected item references unknown entityIds"),
+    });
+    expect(output?.error_message).not.toContain("Output date mismatch");
+  });
+
+  it("preserves the writer rejection when the agent run later throws", async () => {
+    const output = await runOutputWriterScenario(db, async (params) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      try {
+        await params.agentOutputWriter.write({
+          outputDate: OUTPUT_DATE,
+          timezone: "UTC",
+          masthead: { title: "Daily Brief", summary: "Summary" },
+          rawPayload: dailyBriefRawPayload(),
+          items: [briefItem({ knowledgeRefs: { entityIds: ["unknown-entity"], fileIds: [] } })],
+        });
+      } catch {}
+      throw new Error("Agent runtime failed after writer rejection");
+    });
+    expect(output).toMatchObject({
+      status: "failed",
+      error_message: "Agent output validation failed: todos:Brief todo references unknown entityIds",
+    });
+  });
+
+  it("persists a writer rejection after output persistence has completed", async () => {
+    const originalOnOutputSaved = dailyBriefDefinition.onOutputSaved;
+    dailyBriefDefinition.onOutputSaved = async () => {
+      throw new Error("Post-save hook failed\nwith details");
+    };
+
+    try {
+      const output = await runOutputWriterScenario(db, async (params) => {
+        if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+        try {
+          await params.agentOutputWriter.write({
+            outputDate: OUTPUT_DATE,
+            timezone: "UTC",
+            masthead: { title: "Daily Brief", summary: "Summary" },
+            rawPayload: dailyBriefRawPayload(),
+            items: [],
+          });
+        } catch {}
+        return runResult();
+      });
+      expect(output).toMatchObject({
+        status: "failed",
+        error_message: "Post-save hook failed with details",
+      });
+    } finally {
+      dailyBriefDefinition.onOutputSaved = originalOnOutputSaved;
+    }
+  });
+
+  it("completes the output when a rejected write is followed by a successful retry", async () => {
+    const output = await runOutputWriterScenario(db, async (params) => {
+      if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+      try {
+        await params.agentOutputWriter.write({
+          outputDate: PREVIOUS_DATE,
+          timezone: "UTC",
+          masthead: { title: "Daily Brief", summary: "Summary" },
+          rawPayload: dailyBriefRawPayload(PREVIOUS_DATE),
+          items: [],
+        });
+      } catch {}
+      await params.agentOutputWriter.write({
+        outputDate: OUTPUT_DATE,
+        timezone: "UTC",
+        masthead: { title: "Daily Brief", summary: "Summary" },
+        rawPayload: dailyBriefRawPayload(),
+        items: [],
+      });
+      return runResult();
+    });
+    expect(output).toMatchObject({
+      status: "completed",
+      error_message: null,
+    });
+  });
+
+  it("caps sanitized writer errors at five hundred characters", async () => {
+    const originalOnOutputSaved = dailyBriefDefinition.onOutputSaved;
+    dailyBriefDefinition.onOutputSaved = async () => {
+      throw new Error("x".repeat(600));
+    };
+
+    try {
+      const output = await runOutputWriterScenario(db, async (params) => {
+        if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+        try {
+          await params.agentOutputWriter.write({
+            outputDate: OUTPUT_DATE,
+            timezone: "UTC",
+            masthead: { title: "Daily Brief", summary: "Summary" },
+            rawPayload: dailyBriefRawPayload(),
+            items: [],
+          });
+        } catch {}
+        return runResult();
+      });
+      expect(output?.error_message).toHaveLength(500);
+      expect(output?.error_message).toMatch(/…$/);
+    } finally {
+      dailyBriefDefinition.onOutputSaved = originalOnOutputSaved;
+    }
+  });
+});
+
+async function runOutputWriterScenario(db: Kysely<DB>, runAgent: AgentRunServiceDeps["runAgent"]) {
+  const users = createUserRepository(db);
+  const user = await users.create({
+    name: "Daily Brief User",
+    email: "brief-owner@example.com",
+    emailVerified: true,
+  });
+  const queued: Array<() => Promise<void>> = [];
+  const service = new AgentRunService({
+    db,
+    config: createTestConfig(),
+    logger: createTestLogger(),
+    users,
+    settings: createSettingsRepository(db),
+    runAgent,
+    runScheduledAgent: async () => {
+      throw new Error("runScheduledAgent should not be called");
+    },
+    queueManager: createPausedQueueManager(queued),
+  });
+  const [row] = await service.requestGenerationForUser({
+    agentKey: DAILY_BRIEF_AGENT_KEY,
+    userId: user.id,
+    outputDate: OUTPUT_DATE,
+    triggerType: "manual",
+  });
+  if (!row) throw new Error("Expected a running output");
+  await queued[0]?.();
+  return createAgentOutputRepository(db).findById(DAILY_BRIEF_AGENT_KEY, row.id);
+}
+
+function dailyBriefRawPayload(outputDate = OUTPUT_DATE) {
+  return {
+    outputDate,
+    timezone: "UTC",
+    masthead: { title: "Daily Brief", summary: "Summary" },
+    items: [],
+  };
+}
 
 async function runAndCapture(
   db: Kysely<DB>,

--- a/packages/server/src/agents/service.test.ts
+++ b/packages/server/src/agents/service.test.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { RunAgentParams, RunAgentResult } from "../agent/runner";
+import { createWriteAgentOutputTool } from "../agent/tools/agent-output";
 import { type AgentOutputItemInput, createAgentOutputRepository } from "../db/repositories/agent-outputs";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createTaskRepository } from "../db/repositories/tasks";
@@ -222,6 +223,29 @@ describe("Agent output writer failures", () => {
     });
   });
 
+  it("persists schema validation failures before the writer receives a payload", async () => {
+    const output = await runOutputWriterScenario(db, async (params) => {
+      const writeTool = createWriteAgentOutputTool(params.agentOutputWriter);
+      try {
+        await writeTool.handler(
+          {
+            outputDate: OUTPUT_DATE,
+            timezone: "UTC",
+            masthead: { title: "", summary: "Summary" },
+            items: [],
+          },
+          {},
+        );
+      } catch {}
+      return runResult();
+    });
+    expect(output).toMatchObject({
+      status: "failed",
+      error_message: expect.stringContaining("masthead"),
+    });
+    expect(output?.error_message).not.toBe("Agent did not call WriteAgentOutput.");
+  });
+
   it("persists the final rejection when WriteAgentOutput fails repeatedly", async () => {
     const output = await runOutputWriterScenario(db, async (params) => {
       if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
@@ -300,6 +324,37 @@ describe("Agent output writer failures", () => {
       expect(output).toMatchObject({
         status: "failed",
         error_message: "Post-save hook failed with details",
+      });
+    } finally {
+      dailyBriefDefinition.onOutputSaved = originalOnOutputSaved;
+    }
+  });
+
+  it("preserves a post-save hook rejection when the model retries the writer", async () => {
+    const originalOnOutputSaved = dailyBriefDefinition.onOutputSaved;
+    dailyBriefDefinition.onOutputSaved = async () => {
+      throw new Error("Post-save hook failed before retry");
+    };
+
+    try {
+      const output = await runOutputWriterScenario(db, async (params) => {
+        if (!params.agentOutputWriter) throw new Error("agentOutputWriter missing");
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          try {
+            await params.agentOutputWriter.write({
+              outputDate: OUTPUT_DATE,
+              timezone: "UTC",
+              masthead: { title: "Daily Brief", summary: "Summary" },
+              rawPayload: dailyBriefRawPayload(),
+              items: [],
+            });
+          } catch {}
+        }
+        return runResult();
+      });
+      expect(output).toMatchObject({
+        status: "failed",
+        error_message: "Post-save hook failed before retry",
       });
     } finally {
       dailyBriefDefinition.onOutputSaved = originalOnOutputSaved;

--- a/packages/server/src/db/repositories/agent-outputs.ts
+++ b/packages/server/src/db/repositories/agent-outputs.ts
@@ -1165,6 +1165,15 @@ export function createAgentOutputRepository(db: Kysely<DB>) {
         .execute();
     },
 
+    async markWriteFailed(outputId: string, message: string): Promise<void> {
+      await db
+        .updateTable("agent_outputs")
+        .set({ status: "failed", error_message: message, updated_at: new Date().toISOString() })
+        .where("id", "=", outputId)
+        .where("status", "in", ["running", "completed"])
+        .execute();
+    },
+
     async markDeliveryFailed(outputId: string, message: string): Promise<void> {
       await db
         .updateTable("agent_outputs")


### PR DESCRIPTION
## Summary

- distinguish `WriteAgentOutput` attempts from successful persistence
- persist sanitized writer and schema rejections instead of the false never-called fallback
- preserve actionable post-persistence failures across model retries
- preserve the generic message only when no write was attempted

## Linear Scope

- Implements SKE-284: Preserve failed WriteAgentOutput errors
- Keeps telemetry expansion and terminal retry limits out of scope
- Backend-only change with no user-visible UI work

## Implementation Details

- Track `writeAttempted`, `lastWriteError`, persistence phase, and `saved` independently at the writer boundary.
- Observe Claude SDK tool-use payloads before MCP schema validation so malformed calls are recorded without weakening or transforming the advertised schema.
- Keep the AI SDK advertised schema strict while passing raw tool input to the existing handler validation and rejection tracking.
- Preserve post-persistence hook errors against later pre-persistence retry artifacts.
- Collapse writer errors to one line and cap persisted messages at 500 characters.
- Support successful retries after earlier rejected writes.
- Add service and runtime-boundary regressions for no call, schema rejection, repeated rejection, post-save retry, runtime failure, successful retry, sanitization, and length limits.

## Verification

- `pnpm biome check .` - passed; 1,245 files checked
- `pnpm typecheck` - passed
- `pnpm test` - passed; 4,916 tests passed, 20 live-provider tests skipped
- `pnpm build` - passed
- focused affected suites - passed; 25 tests
- independent Standards review - no documented-standard violations
- independent Spec review - no findings

## Risk / Rollout

- No API, database migration, configuration, provider, background-job, feature-flag, or UI changes.
- The runtime-specific handling preserves the strict model-facing tool schema and only changes how rejected attempts are retained for final failure reporting.
- A post-persistence hook failure leaves persisted item rows in storage, but marks the parent output failed so it is not exposed as a completed result.
