### PR TITLE
SKE-294: Prevent magic-link prefetch from consuming sign-in tokens

### DIFF
--- a/packages/server/src/api/auth.ts
+++ b/packages/server/src/api/auth.ts
@@ -70,31 +70,261 @@ function escapeHtml(value: string): string {
   return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
-function magicLinkConfirmationPage(token: string, confirmation: string, returnTo: string | null): string {
+function magicLinkConfirmationPage(
+  token: string,
+  confirmation: string,
+  returnTo: string | null,
+  styleNonce: string,
+): string {
   const returnToInput = returnTo ? `<input type="hidden" name="return_to" value="${escapeHtml(returnTo)}">` : "";
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
   <title>Confirm sign in</title>
+  <style nonce="${escapeHtml(styleNonce)}">
+    :root {
+      color-scheme: dark;
+      font-family:
+        Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
+        sans-serif;
+      font-synthesis: none;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      min-width: 320px;
+      min-height: 100vh;
+      margin: 0;
+      color: #f5f5f6;
+      background: #000000;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .shell {
+      display: grid;
+      min-height: 100vh;
+      place-items: center;
+      padding: 48px 20px;
+    }
+
+    .auth {
+      width: min(100%, 400px);
+      transform: translateY(-3vh);
+    }
+
+    .brand {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 9px;
+      margin-bottom: 34px;
+      color: #fafafa;
+      font-size: 17px;
+      font-weight: 600;
+      letter-spacing: -0.025em;
+    }
+
+    .brand-mark {
+      display: block;
+      width: 28px;
+      height: 28px;
+      object-fit: contain;
+    }
+
+    .card {
+      padding: 26px 36px 28px;
+      overflow: hidden;
+      border: 1px solid #292927;
+      border-radius: 14px;
+      background: #1b1b1a;
+      box-shadow: inset 0 1px rgba(255, 255, 255, 0.025);
+      text-align: center;
+    }
+
+    .status {
+      display: grid;
+      width: 48px;
+      height: 48px;
+      margin: 0 auto 18px;
+      place-items: center;
+      border-radius: 999px;
+      color: #eeeeec;
+      background: #383836;
+    }
+
+    .status svg {
+      width: 22px;
+      height: 22px;
+    }
+
+    h1 {
+      margin: 0;
+      color: #fafafa;
+      font-size: 21px;
+      font-weight: 600;
+      line-height: 1.3;
+      letter-spacing: -0.025em;
+    }
+
+    .description {
+      max-width: 310px;
+      margin: 9px auto 24px;
+      color: #8d8d89;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    form {
+      margin: 0;
+    }
+
+    button {
+      display: flex;
+      width: 100%;
+      min-height: 44px;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 0 18px;
+      border: 1px solid #f2f2f0;
+      border-radius: 8px;
+      color: #111113;
+      background: #f2f2f0;
+      box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.3),
+        inset 0 -1px rgba(0, 0, 0, 0.08);
+      font: inherit;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition:
+        background-color 140ms ease,
+        transform 140ms ease,
+        box-shadow 140ms ease;
+    }
+
+    button:hover {
+      background: #ffffff;
+    }
+
+    button:active {
+      transform: translateY(1px);
+      box-shadow: inset 0 1px rgba(0, 0, 0, 0.12);
+    }
+
+    button:focus-visible {
+      outline: 2px solid #09090b;
+      outline-offset: 2px;
+      box-shadow: 0 0 0 4px #a1a1aa;
+    }
+
+    .arrow {
+      font-size: 17px;
+      line-height: 1;
+      transition: transform 140ms ease;
+    }
+
+    button:hover .arrow {
+      transform: translateX(2px);
+    }
+
+    .security-note {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 7px;
+      margin: 17px 0 0;
+      color: #858581;
+      font-size: 12px;
+      line-height: 1.4;
+    }
+
+    .lock {
+      position: relative;
+      width: 9px;
+      height: 7px;
+      border-radius: 2px;
+      background: #71717a;
+    }
+
+    .lock::before {
+      position: absolute;
+      top: -5px;
+      left: 2px;
+      width: 5px;
+      height: 6px;
+      border: 1.5px solid #71717a;
+      border-bottom: 0;
+      border-radius: 5px 5px 0 0;
+      content: "";
+    }
+
+    @media (max-width: 480px) {
+      .shell {
+        align-items: start;
+        padding: 56px 16px 24px;
+      }
+
+      .auth {
+        transform: none;
+      }
+
+      .brand {
+        margin-bottom: 28px;
+      }
+
+      .card {
+        padding: 26px 24px 28px;
+        border-radius: 14px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      button,
+      .arrow {
+        transition: none;
+      }
+    }
+  </style>
 </head>
 <body>
-  <main>
-    <h1>Confirm sign in</h1>
-    <p>Continue to securely sign in to Sketch.</p>
-    <form method="post" action="/api/auth/magic-link/confirmation" autocomplete="off">
-      <input type="hidden" name="token" value="${escapeHtml(token)}">
-      <input type="hidden" name="confirmation" value="${escapeHtml(confirmation)}">
-      ${returnToInput}
-      <button type="submit">Sign in</button>
-    </form>
+  <main class="shell">
+    <div class="auth">
+      <div class="brand">
+        <img class="brand-mark" src="/logos/sketch-icon-dark.png" alt="">
+        <span>Sketch</span>
+      </div>
+      <section class="card" aria-labelledby="confirmation-title">
+        <div class="status" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 3 19 6v5c0 4.5-2.7 8.3-7 10-4.3-1.7-7-5.5-7-10V6l7-3Z"/>
+            <path d="m9 12 2 2 4-4"/>
+          </svg>
+        </div>
+        <h1 id="confirmation-title">Confirm sign in</h1>
+        <p class="description">Continue to securely sign in to your Sketch workspace.</p>
+        <form method="post" action="/api/auth/magic-link/confirmation" autocomplete="off">
+          <input type="hidden" name="token" value="${escapeHtml(token)}">
+          <input type="hidden" name="confirmation" value="${escapeHtml(confirmation)}">
+          ${returnToInput}
+          <button type="submit">Sign in <span class="arrow" aria-hidden="true">→</span></button>
+        </form>
+        <p class="security-note"><span class="lock" aria-hidden="true"></span>This secure link can only be used once.</p>
+      </section>
+    </div>
   </main>
 </body>
 </html>`;
 }
 
-function setMagicLinkConfirmationHeaders(c: Context): void {
+function setMagicLinkConfirmationHeaders(c: Context, styleNonce: string): void {
   c.header("Cache-Control", "no-store");
   c.header("Pragma", "no-cache");
   c.header("Referrer-Policy", "no-referrer");
@@ -102,7 +332,7 @@ function setMagicLinkConfirmationHeaders(c: Context): void {
   c.header("X-Frame-Options", "DENY");
   c.header(
     "Content-Security-Policy",
-    "default-src 'none'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'",
+    `default-src 'none'; style-src 'nonce-${styleNonce}'; img-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'`,
   );
 }
 
@@ -310,6 +540,7 @@ export function authRoutes(
     }
 
     const confirmation = randomBytes(32).toString("hex");
+    const styleNonce = randomBytes(16).toString("base64");
     setCookie(c, MAGIC_LINK_CONFIRMATION_COOKIE, confirmation, {
       httpOnly: true,
       secure: isSecure(c),
@@ -317,8 +548,8 @@ export function authRoutes(
       path: "/api/auth/magic-link/confirmation",
       maxAge: MAGIC_LINK_CONFIRMATION_MAX_AGE,
     });
-    setMagicLinkConfirmationHeaders(c);
-    return c.html(magicLinkConfirmationPage(token, confirmation, returnTo));
+    setMagicLinkConfirmationHeaders(c, styleNonce);
+    return c.html(magicLinkConfirmationPage(token, confirmation, returnTo, styleNonce));
   });
 
   routes.post("/magic-link/confirmation", async (c) => {

--- a/packages/server/src/api/auth.ts
+++ b/packages/server/src/api/auth.ts
@@ -3,7 +3,7 @@
  * JWTs are signed with a per-deployment secret stored in the settings table,
  * so sessions survive server restarts. Cookie-based with httpOnly, sameSite=lax.
  */
-import { randomBytes } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { type Context, Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import type { Kysely } from "kysely";
@@ -13,6 +13,7 @@ import { signJwt, verifyJwt } from "../auth/jwt";
 import {
   type VerifiedUser,
   createRateLimitedMagicLinkToken,
+  findValidMagicLinkUserId,
   findVerifiedUserByEmail,
   verifyMagicLinkToken,
 } from "../auth/magic-link";
@@ -31,7 +32,9 @@ export type MagicLinkSender = (opts: {
 
 export const SESSION_COOKIE = "sketch_session";
 const PLATFORM_COOKIE = "sketch_platform_session";
+const MAGIC_LINK_CONFIRMATION_COOKIE = "sketch_magic_link_confirmation";
 const SESSION_MAX_AGE = 7 * 24 * 60 * 60; // 7 days in seconds
+const MAGIC_LINK_CONFIRMATION_MAX_AGE = 5 * 60;
 
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 type AuthRole = "admin" | "member";
@@ -61,6 +64,53 @@ function safeReturnTo(value: unknown): string | null {
   if (trimmed.startsWith("//")) return null;
   if (trimmed.startsWith("/login")) return null;
   return trimmed;
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function magicLinkConfirmationPage(token: string, confirmation: string, returnTo: string | null): string {
+  const returnToInput = returnTo ? `<input type="hidden" name="return_to" value="${escapeHtml(returnTo)}">` : "";
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Confirm sign in</title>
+</head>
+<body>
+  <main>
+    <h1>Confirm sign in</h1>
+    <p>Continue to securely sign in to Sketch.</p>
+    <form method="post" action="/api/auth/magic-link/confirmation" autocomplete="off">
+      <input type="hidden" name="token" value="${escapeHtml(token)}">
+      <input type="hidden" name="confirmation" value="${escapeHtml(confirmation)}">
+      ${returnToInput}
+      <button type="submit">Sign in</button>
+    </form>
+  </main>
+</body>
+</html>`;
+}
+
+function setMagicLinkConfirmationHeaders(c: Context): void {
+  c.header("Cache-Control", "no-store");
+  c.header("Pragma", "no-cache");
+  c.header("Referrer-Policy", "no-referrer");
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("X-Frame-Options", "DENY");
+  c.header(
+    "Content-Security-Policy",
+    "default-src 'none'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'",
+  );
+}
+
+function matchesConfirmationCookie(cookie: string | undefined, confirmation: unknown): confirmation is string {
+  if (!cookie || typeof confirmation !== "string") return false;
+  const cookieBytes = Buffer.from(cookie);
+  const confirmationBytes = Buffer.from(confirmation);
+  return cookieBytes.length === confirmationBytes.length && timingSafeEqual(cookieBytes, confirmationBytes);
 }
 
 export async function createSession(c: Context, sub: string, role: AuthRole, jwtSecret: string): Promise<void> {
@@ -246,7 +296,41 @@ export function authRoutes(
       return c.redirect("/login?error=invalid_link");
     }
 
-    const userId = await verifyMagicLinkToken(db, token);
+    const userId = await findValidMagicLinkUserId(db, token);
+    if (!userId) {
+      return c.redirect("/login?error=expired_link");
+    }
+
+    const user = await deps.userRepo.findById(userId);
+    if (!user) {
+      return c.redirect("/login?error=expired_link");
+    }
+    if (user.type === "agent" || user.type === "external") {
+      return c.redirect("/login?error=invalid_link");
+    }
+
+    const confirmation = randomBytes(32).toString("hex");
+    setCookie(c, MAGIC_LINK_CONFIRMATION_COOKIE, confirmation, {
+      httpOnly: true,
+      secure: isSecure(c),
+      sameSite: "Strict",
+      path: "/api/auth/magic-link/confirmation",
+      maxAge: MAGIC_LINK_CONFIRMATION_MAX_AGE,
+    });
+    setMagicLinkConfirmationHeaders(c);
+    return c.html(magicLinkConfirmationPage(token, confirmation, returnTo));
+  });
+
+  routes.post("/magic-link/confirmation", async (c) => {
+    const body = (await c.req.parseBody().catch(() => ({}))) as Record<string, string | File>;
+    const token = body.token;
+    const returnTo = safeReturnTo(body.return_to);
+    const confirmationCookie = getCookie(c, MAGIC_LINK_CONFIRMATION_COOKIE);
+    if (typeof token !== "string" || !matchesConfirmationCookie(confirmationCookie, body.confirmation)) {
+      return c.redirect("/login?error=invalid_link");
+    }
+
+    const userId = await findValidMagicLinkUserId(db, token);
     if (!userId) {
       return c.redirect("/login?error=expired_link");
     }
@@ -264,6 +348,12 @@ export function authRoutes(
       return c.redirect("/login?error=invalid_link");
     }
 
+    const consumedUserId = await verifyMagicLinkToken(db, token);
+    if (consumedUserId !== user.id) {
+      return c.redirect("/login?error=expired_link");
+    }
+
+    deleteCookie(c, MAGIC_LINK_CONFIRMATION_COOKIE, { path: "/api/auth/magic-link/confirmation" });
     await createSession(c, user.id, toAuthRole(user.auth_role), settingsRow.jwt_secret);
     return c.redirect(returnTo ?? "/");
   });

--- a/packages/server/src/api/middleware.ts
+++ b/packages/server/src/api/middleware.ts
@@ -33,6 +33,7 @@ const PUBLIC_PATHS = new Set([
   "/api/auth/session",
   "/api/auth/verify-email",
   "/api/auth/magic-link",
+  "/api/auth/magic-link/confirmation",
   "/api/auth/magic-link/verify",
   "/api/health",
   "/api/oauth/google/callback",

--- a/packages/server/src/auth/magic-link.ts
+++ b/packages/server/src/auth/magic-link.ts
@@ -78,6 +78,22 @@ export async function createRateLimitedMagicLinkToken(db: Kysely<DB>, userId: st
 }
 
 /**
+ * Validate a magic link token without consuming it. The confirmation GET uses
+ * this read-only check so link previews cannot spend a single-use token.
+ */
+export async function findValidMagicLinkUserId(db: Kysely<DB>, token: string): Promise<string | null> {
+  const row = await db
+    .selectFrom("magic_link_tokens")
+    .select("user_id")
+    .where("token", "=", token)
+    .where("used_at", "is", null)
+    .where("expires_at", ">", new Date().toISOString())
+    .executeTakeFirst();
+
+  return row?.user_id ?? null;
+}
+
+/**
  * Verify a magic link token. Uses an atomic UPDATE … RETURNING to prevent double-use
  * race conditions and read the user_id in a single query. The WHERE clause ensures only
  * an unused, non-expired token is matched.

--- a/packages/server/src/connectors/slack-indexing.integration.test.ts
+++ b/packages/server/src/connectors/slack-indexing.integration.test.ts
@@ -754,6 +754,7 @@ function runSuite(label: string, createDb: () => Promise<Kysely<DB>>) {
         db,
         logger,
         facade,
+        now: new Date("2026-07-18T10:00:00.000Z"),
         onSkippedNoScope: () => {
           skipped += 1;
         },

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -306,6 +306,14 @@ describe("magic link confirmation", () => {
     expect(prefetchedRes.status).toBe(200);
     expect(prefetchedRes.headers.get("cache-control")).toBe("no-store");
     expect(prefetchedRes.headers.get("referrer-policy")).toBe("no-referrer");
+    const html = await prefetchedRes.text();
+    const styleNonce = html.match(/<style nonce="([^"]+)">/)?.[1];
+    expect(styleNonce).toBeDefined();
+    expect(prefetchedRes.headers.get("content-security-policy")).toContain(`style-src 'nonce-${styleNonce}'`);
+    expect(prefetchedRes.headers.get("content-security-policy")).toContain("img-src 'self'");
+    expect(html).toContain('src="/logos/sketch-icon-dark.png"');
+    expect(html).toContain('class="card"');
+    expect(html).toContain("This secure link can only be used once.");
 
     const humanRes = await app.request(`${url.pathname}${url.search}`);
     expect(humanRes.status).toBe(200);

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -220,7 +220,7 @@ describe("managed login redirect", () => {
   });
 });
 
-describe("magic link return_to", () => {
+describe("magic link confirmation", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
@@ -234,7 +234,7 @@ describe("magic link return_to", () => {
     } catch {}
   });
 
-  it("preserves a safe integrations return path through verification", async () => {
+  function createMagicLinkApp() {
     const logger = {
       info: vi.fn(),
       warn: vi.fn(),
@@ -244,8 +244,14 @@ describe("magic link return_to", () => {
     const app = createApp(db, createTestConfig({ BASE_URL: "https://sketch.test" }), {
       logger: logger as never,
     });
-    const returnTo = "/integrations?connect=github";
+    return { app, logger };
+  }
 
+  async function requestMagicLink(
+    app: ReturnType<typeof createApp>,
+    logger: ReturnType<typeof createMagicLinkApp>["logger"],
+    returnTo?: string,
+  ) {
     const requestRes = await app.request("/api/auth/magic-link", {
       method: "POST",
       body: JSON.stringify({ email: "admin@test.com", returnTo }),
@@ -256,13 +262,121 @@ describe("magic link return_to", () => {
       .map(([data]) => (data as { magicLinkUrl?: string }).magicLinkUrl)
       .find(Boolean);
     expect(magicLinkUrl).toBeDefined();
+    return new URL(magicLinkUrl as string);
+  }
 
-    const url = new URL(magicLinkUrl as string);
+  async function openConfirmation(app: ReturnType<typeof createApp>, url: URL) {
+    const response = await app.request(`${url.pathname}${url.search}`);
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    const confirmation = html.match(/name="confirmation" value="([^"]+)"/)?.[1];
+    const cookie = response.headers.get("set-cookie")?.split(";", 1)[0];
+    expect(confirmation).toBeDefined();
+    expect(cookie).toContain("sketch_magic_link_confirmation=");
+    return { confirmation: confirmation as string, cookie: cookie as string, response };
+  }
+
+  function confirmMagicLink(
+    app: ReturnType<typeof createApp>,
+    url: URL,
+    confirmation: string,
+    cookie?: string,
+    returnTo?: string,
+  ) {
+    const body = new URLSearchParams({
+      token: url.searchParams.get("token") as string,
+      confirmation,
+    });
+    if (returnTo) body.set("return_to", returnTo);
+    return app.request("/api/auth/magic-link/confirmation", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+      body: body.toString(),
+    });
+  }
+
+  it("does not consume a magic link when GET is prefetched", async () => {
+    const { app, logger } = createMagicLinkApp();
+    const url = await requestMagicLink(app, logger);
+
+    const prefetchedRes = await app.request(`${url.pathname}${url.search}`);
+    expect(prefetchedRes.status).toBe(200);
+    expect(prefetchedRes.headers.get("cache-control")).toBe("no-store");
+    expect(prefetchedRes.headers.get("referrer-policy")).toBe("no-referrer");
+
+    const humanRes = await app.request(`${url.pathname}${url.search}`);
+    expect(humanRes.status).toBe(200);
+  });
+
+  it("creates a session after explicit confirmation and preserves a safe return path", async () => {
+    const { app, logger } = createMagicLinkApp();
+    const returnTo = "/integrations?connect=github";
+    const url = await requestMagicLink(app, logger, returnTo);
     expect(url.searchParams.get("return_to")).toBe(returnTo);
 
-    const verifyRes = await app.request(`${url.pathname}${url.search}`);
+    const { confirmation, cookie } = await openConfirmation(app, url);
+    const verifyRes = await confirmMagicLink(app, url, confirmation, cookie, returnTo);
     expect(verifyRes.status).toBe(302);
     expect(verifyRes.headers.get("location")).toBe(returnTo);
+    expect(verifyRes.headers.get("set-cookie")).toContain("sketch_session=");
+  });
+
+  it("rejects replay after a successful confirmation", async () => {
+    const { app, logger } = createMagicLinkApp();
+    const url = await requestMagicLink(app, logger);
+    const { confirmation, cookie } = await openConfirmation(app, url);
+
+    const firstRes = await confirmMagicLink(app, url, confirmation, cookie);
+    expect(firstRes.status).toBe(302);
+    expect(firstRes.headers.get("location")).toBe("/");
+
+    const replayRes = await confirmMagicLink(app, url, confirmation, cookie);
+    expect(replayRes.status).toBe(302);
+    expect(replayRes.headers.get("location")).toBe("/login?error=expired_link");
+    expect(replayRes.headers.get("set-cookie") ?? "").not.toContain("sketch_session=");
+  });
+
+  it("rejects an expired token before confirmation", async () => {
+    const { app, logger } = createMagicLinkApp();
+    const url = await requestMagicLink(app, logger);
+    await db
+      .updateTable("magic_link_tokens")
+      .set({ expires_at: new Date(Date.now() - 1_000).toISOString() })
+      .where("token", "=", url.searchParams.get("token") as string)
+      .execute();
+
+    const response = await app.request(`${url.pathname}${url.search}`);
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/login?error=expired_link");
+  });
+
+  it("drops an unsafe return path during confirmation", async () => {
+    const { app, logger } = createMagicLinkApp();
+    const url = await requestMagicLink(app, logger);
+    const { confirmation, cookie } = await openConfirmation(app, url);
+
+    const response = await confirmMagicLink(app, url, confirmation, cookie, "https://attacker.test/steal");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/");
+    expect(response.headers.get("set-cookie")).toContain("sketch_session=");
+  });
+
+  it("requires the same-site confirmation cookie without consuming the token", async () => {
+    const { app, logger } = createMagicLinkApp();
+    const url = await requestMagicLink(app, logger);
+    const { confirmation, cookie } = await openConfirmation(app, url);
+
+    const missingCookieRes = await confirmMagicLink(app, url, confirmation);
+    expect(missingCookieRes.status).toBe(302);
+    expect(missingCookieRes.headers.get("location")).toBe("/login?error=invalid_link");
+
+    const confirmedRes = await confirmMagicLink(app, url, confirmation, cookie);
+    expect(confirmedRes.status).toBe(302);
+    expect(confirmedRes.headers.get("location")).toBe("/");
+    expect(confirmedRes.headers.get("set-cookie")).toContain("sketch_session=");
   });
 });
 

--- a/packages/server/src/magic-link-confirmation.integration.test.ts
+++ b/packages/server/src/magic-link-confirmation.integration.test.ts
@@ -1,0 +1,81 @@
+import type { Kysely } from "kysely";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { hashPassword } from "./auth/password";
+import { createSettingsRepository } from "./db/repositories/settings";
+import { createUserRepository } from "./db/repositories/users";
+import type { DB } from "./db/schema";
+import { createApp } from "./http";
+import { createTestConfig, createTestPgDb } from "./test-utils";
+
+describe("magic link confirmation on Postgres", () => {
+  let db: Kysely<DB>;
+
+  /**
+   * Magic link issuance opens its own Kysely transaction, so this integration
+   * suite uses a fresh Postgres database instead of an outer rollback transaction.
+   */
+  beforeAll(async () => {
+    db = await createTestPgDb();
+    await createSettingsRepository(db).create();
+    await createUserRepository(db).create({
+      name: "Postgres Admin",
+      email: "postgres-admin@test.com",
+      emailVerified: true,
+      passwordHash: await hashPassword("testpassword123"),
+      authRole: "admin",
+    });
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  it("keeps GET non-consuming and consumes only an explicit POST", async () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const app = createApp(db, createTestConfig({ BASE_URL: "https://sketch.test", DB_TYPE: "postgres" }), {
+      logger: logger as never,
+    });
+
+    const requestRes = await app.request("/api/auth/magic-link", {
+      method: "POST",
+      body: JSON.stringify({ email: "postgres-admin@test.com" }),
+    });
+    expect(requestRes.status).toBe(200);
+
+    const magicLinkUrl = logger.info.mock.calls
+      .map(([data]) => (data as { magicLinkUrl?: string }).magicLinkUrl)
+      .find(Boolean);
+    expect(magicLinkUrl).toBeDefined();
+    const url = new URL(magicLinkUrl as string);
+
+    const prefetchRes = await app.request(`${url.pathname}${url.search}`);
+    expect(prefetchRes.status).toBe(200);
+
+    const confirmationRes = await app.request(`${url.pathname}${url.search}`);
+    expect(confirmationRes.status).toBe(200);
+    const confirmation = (await confirmationRes.text()).match(/name="confirmation" value="([^"]+)"/)?.[1];
+    const confirmationCookie = confirmationRes.headers.get("set-cookie")?.split(";", 1)[0];
+    expect(confirmation).toBeDefined();
+    expect(confirmationCookie).toContain("sketch_magic_link_confirmation=");
+
+    const verifyRes = await app.request("/api/auth/magic-link/confirmation", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: confirmationCookie as string,
+      },
+      body: new URLSearchParams({
+        token: url.searchParams.get("token") as string,
+        confirmation: confirmation as string,
+      }).toString(),
+    });
+    expect(verifyRes.status).toBe(302);
+    expect(verifyRes.headers.get("location")).toBe("/");
+    expect(verifyRes.headers.get("set-cookie")).toContain("sketch_session=");
+  });
+});


### PR DESCRIPTION
## Summary
- prevent WhatsApp link previews and security prefetches from consuming single-use magic-link tokens
- change the existing GET verification route into a non-mutating confirmation page
- consume the token and create the session only after an explicit, cookie-bound POST confirmation

## Linear Scope
- [SKE-294: Prevent magic-link prefetch from consuming sign-in tokens](https://linear.app/sketch-ai/issue/SKE-294/prevent-magic-link-prefetch-from-consuming-sign-in-tokens)

## Root Cause
The magic-link URL used `GET /api/auth/magic-link/verify`, and that GET called the atomic token-consumption query. Automated WhatsApp preview or security requests could therefore set `used_at` before the recipient opened the link, leaving the human request with `expired_link`.

## Implementation Details
- add a portable read-only Kysely lookup for unused, unexpired tokens
- serve a no-store confirmation form from the existing GET route with CSP, frame, referrer, and content-type protections
- bind confirmation to a short-lived `HttpOnly`, `Secure`-when-HTTPS, `SameSite=Strict` cookie and constant-time nonce comparison
- add public `POST /api/auth/magic-link/confirmation` for atomic single-use consumption and session creation
- preserve safe internal `return_to` redirects while dropping external values
- keep the final consume operation as `UPDATE ... RETURNING` so concurrent or replayed confirmations cannot both succeed

## Verification
- regression test first reproduced the bug: the original GET returned `302` and consumed the token instead of serving a reusable confirmation step
- `pnpm biome check .` - passed
- `pnpm typecheck` - passed
- `pnpm test` - passed (4,562 server tests and 407 web tests; 20 documented live-test skips)
- `pnpm build` - passed
- SQLite public HTTP coverage: prefetch non-consumption, confirmation success, replay rejection, expiry, safe and unsafe `return_to`, and missing confirmation cookie
- Postgres/PGlite public HTTP coverage: repeated GET validation followed by successful atomic POST consumption
- two-axis review: Standards and Spec passed after moving the consuming POST to a noun resource route

## Risk / Rollout
- no migration, configuration, feature-flag, or deployment change
- existing delivered magic-link URLs remain compatible
- recipients now make one explicit confirmation click before the session is created
- production was not modified or deployed
