### PR TITLE
SKE-298: PR 1: Compatibility, schema, and mutation policy

### DIFF
--- a/packages/server/src/agents/followup-review-routes.test.ts
+++ b/packages/server/src/agents/followup-review-routes.test.ts
@@ -98,7 +98,7 @@ describe("follow-up review routes", () => {
     expect(first.status).toBe(200);
     await expect(first.json()).resolves.toMatchObject({
       review: { kind: "completion", id: "recommendation-1", state: "accepted", canReview: false },
-      task: { id: created.taskId, status: "done" },
+      task: { id: created.taskId, status: "done", revision: 1, protectedFields: ["status"] },
     });
 
     const retry = await request("confirm_done");
@@ -132,6 +132,24 @@ describe("follow-up review routes", () => {
         actor_user_id: "user-1",
         surface: "web",
         changes_json: JSON.stringify({ status: { before: "open", after: "done" } }),
+      },
+    ]);
+    await expect(
+      db
+        .selectFrom("task_field_protections")
+        .innerJoin("task_activity_events", "task_activity_events.id", "task_field_protections.activity_event_id")
+        .select([
+          "task_field_protections.field",
+          "task_field_protections.protected_by_user_id",
+          "task_activity_events.event_kind",
+        ])
+        .where("task_field_protections.task_id", "=", created.taskId)
+        .execute(),
+    ).resolves.toEqual([
+      {
+        field: "status",
+        protected_by_user_id: "user-1",
+        event_kind: "status_changed",
       },
     ]);
   });

--- a/packages/server/src/agents/routes-task-hydration.test.ts
+++ b/packages/server/src/agents/routes-task-hydration.test.ts
@@ -48,6 +48,7 @@ function task(overrides: Partial<Selectable<TasksTable>> = {}): Selectable<Tasks
     source_provider_thread_id: "thread-1",
     source_anchor_key: "slack:42:thread-1",
     origin_agent_output_id: "summary-output-1",
+    revision: 0,
     created_at: "2026-07-17T08:00:00.000Z",
     updated_at: "2026-07-17T09:00:00.000Z",
     ...overrides,

--- a/packages/server/src/agents/routes.ts
+++ b/packages/server/src/agents/routes.ts
@@ -1,6 +1,13 @@
 import { Hono } from "hono";
 import type { Kysely, Selectable } from "kysely";
-import { type TaskAccessContext, canEditTaskStatus, resolveTaskAccessContext, toTaskDto } from "../api/task-access";
+import {
+  type TaskAccessContext,
+  type TaskEditableField,
+  canEditTaskStatus,
+  loadTaskProtectedFields,
+  resolveTaskAccessContext,
+  toTaskDto,
+} from "../api/task-access";
 import type {
   AgentDeliveryConfig,
   AgentDeliveryMention,
@@ -40,9 +47,13 @@ export interface DailyBriefTaskState {
   statusRaw: string | null;
   statusAuthority: string;
   priority: string | null;
+  dueAt: string | null;
   completedAt: string | null;
   updatedAt: string;
+  revision: number;
   canEditStatus: boolean;
+  canEditFields: Record<TaskEditableField, boolean>;
+  protectedFields: TaskEditableField[];
   readonlyReason: "not_owner" | "external_authority" | null;
 }
 
@@ -105,8 +116,12 @@ function legacyTaskLinkCandidate(
   return { taskId };
 }
 
-function toDailyBriefTaskState(task: Selectable<TasksTable>, access: TaskAccessContext): DailyBriefTaskState {
-  const dto = toTaskDto(task, access);
+function toDailyBriefTaskState(
+  task: Selectable<TasksTable>,
+  access: TaskAccessContext,
+  protectedFields: TaskEditableField[] = [],
+): DailyBriefTaskState {
+  const dto = toTaskDto(task, access, new Map(), protectedFields);
   return {
     id: dto.id,
     title: dto.title,
@@ -114,9 +129,13 @@ function toDailyBriefTaskState(task: Selectable<TasksTable>, access: TaskAccessC
     statusRaw: dto.statusRaw,
     statusAuthority: dto.statusAuthority,
     priority: dto.priority,
+    dueAt: dto.dueAt,
     completedAt: dto.completedAt,
     updatedAt: dto.updatedAt,
+    revision: dto.revision,
     canEditStatus: dto.canEditStatus,
+    canEditFields: dto.canEditFields,
+    protectedFields: dto.protectedFields,
     readonlyReason: dto.readonlyReason,
   };
 }
@@ -126,6 +145,7 @@ export async function hydrateDailyBriefTaskState(params: {
   userId: string;
   access: TaskAccessContext;
   loadVisibleTasks: (taskIds: string[], access: TaskAccessContext) => Promise<Selectable<TasksTable>[]>;
+  loadProtectedFields?: (tasks: Selectable<TasksTable>[]) => Promise<Map<string, TaskEditableField[]>>;
   logger: Pick<Logger, "debug">;
 }): Promise<Omit<AgentOutputApi, "sections"> & { sections: Record<string, HydratedDailyBriefItem[]> }> {
   const candidateByItem = new Map<AgentApiItem, TaskLinkCandidate>();
@@ -178,6 +198,7 @@ export async function hydrateDailyBriefTaskState(params: {
 
   const visibleTasks = idsToLoad.length === 0 ? [] : await params.loadVisibleTasks(idsToLoad, params.access);
   const visibleById = new Map(visibleTasks.map((task) => [task.id, task]));
+  const protectedFieldsByTask = params.loadProtectedFields ? await params.loadProtectedFields(visibleTasks) : new Map();
   let canonicalHydrated = 0;
   let legacyHydrated = 0;
   const sections: Record<string, HydratedDailyBriefItem[]> = {};
@@ -200,7 +221,7 @@ export async function hydrateDailyBriefTaskState(params: {
       return {
         ...item,
         taskId: task.id,
-        task: toDailyBriefTaskState(task, params.access),
+        task: toDailyBriefTaskState(task, params.access, protectedFieldsByTask.get(task.id)),
       };
     });
   }
@@ -384,6 +405,7 @@ export async function hydrateDailyBriefState(params: {
     userId: params.userId,
     access: params.access,
     loadVisibleTasks: params.loadVisibleTasks,
+    loadProtectedFields: (tasks) => loadTaskProtectedFields(params.db, tasks),
     logger: params.logger,
   });
   const sections: Record<string, HydratedDailyBriefItem[]> = Object.fromEntries(
@@ -534,7 +556,9 @@ export function followupReviewRoutes(service: AgentRunService, db: Kysely<DB>) {
   const taskState = async (taskId: string | undefined, access: TaskAccessContext) => {
     if (!taskId) return null;
     const task = (await tasks.listVisibleTasksByIds([taskId], access))[0];
-    return task ? toDailyBriefTaskState(task, access) : null;
+    if (!task) return null;
+    const protectedFields = await loadTaskProtectedFields(db, [task]);
+    return toDailyBriefTaskState(task, access, protectedFields.get(task.id));
   };
 
   routes.patch("/task-completion-recommendations/:recommendationId", async (c) => {

--- a/packages/server/src/api/entities.test.ts
+++ b/packages/server/src/api/entities.test.ts
@@ -982,6 +982,71 @@ describe("GET/PATCH /api/entities/:id/tasks", () => {
     ]);
   });
 
+  it("uses the same revision and field-protection policy for entity-scoped metadata edits", async () => {
+    const local = await createTaskRepository(db).upsertTask({
+      parentEntityId: "task-project",
+      parentSourceRef: null,
+      parentName: "Task Project",
+      source: "summary",
+      externalRef: null,
+      title: "Prepare launch copy",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "entity-metadata-edit",
+      createdByUserId: adminId,
+    });
+
+    const edited = await app.request(`/api/entities/task-project/tasks/${local.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        expectedRevision: 0,
+        title: "Publish launch copy",
+        priority: null,
+        dueAt: "2026-08-20",
+      }),
+    });
+    const stale = await app.request(`/api/entities/task-project/tasks/${local.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ expectedRevision: 0, dueAt: null }),
+    });
+
+    expect(edited.status).toBe(200);
+    await expect(edited.json()).resolves.toMatchObject({
+      task: {
+        id: local.taskId,
+        title: "Publish launch copy",
+        priority: null,
+        dueAt: "2026-08-20",
+        revision: 1,
+        protectedFields: ["dueAt", "priority", "title"],
+      },
+    });
+    expect(stale.status).toBe(409);
+    await expect(
+      db
+        .selectFrom("task_activity_events")
+        .select(["event_kind", "changes_json"])
+        .where("task_id", "=", local.taskId)
+        .execute(),
+    ).resolves.toEqual([
+      {
+        event_kind: "fields_changed",
+        changes_json: JSON.stringify({
+          dueAt: { before: null, after: "2026-08-20" },
+          priority: { before: "medium", after: null },
+          title: { before: "Prepare launch copy", after: "Publish launch copy" },
+        }),
+      },
+    ]);
+  });
+
   it("lets admins read and patch project-local summary tasks from other users", async () => {
     const member = await seedMember(db);
     const repo = createTaskRepository(db);
@@ -1200,7 +1265,10 @@ describe("GET/PATCH /api/entities/:id/tasks", () => {
     });
     expect(memberListRes.status).toBe(200);
     expect(memberListBody.tasks.some((task) => task.id === proposed.taskId)).toBe(false);
-    expect(patchRes.status).toBe(403);
+    expect(patchRes.status).toBe(404);
+    await expect(patchRes.json()).resolves.toEqual({
+      error: { code: "NOT_FOUND", message: "Task not found" },
+    });
   });
 
   it("returns summary tasks for a private declared project that is visible in the drawer profile", async () => {
@@ -1277,7 +1345,7 @@ describe("GET/PATCH /api/entities/:id/tasks", () => {
     });
 
     expect(invalid.status).toBe(400);
-    expect(forbidden.status).toBe(403);
+    expect(forbidden.status).toBe(404);
   });
 });
 

--- a/packages/server/src/api/entities/task-routes.ts
+++ b/packages/server/src/api/entities/task-routes.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
 import { createEntityRepository } from "../../db/repositories/entities";
+import { createLocalTaskMutationPolicy } from "../../db/repositories/local-task-mutations";
 import { type TaskStatus, createTaskRepository } from "../../db/repositories/tasks";
 import type { DB } from "../../db/schema";
 import { getFileViewer } from "../auth-helpers";
@@ -8,15 +9,18 @@ import {
   TASK_STATUSES,
   canEditTaskStatus,
   loadTaskCreators,
+  loadTaskProtectedFields,
   parseTaskLimit,
   resolveTaskAccessContext,
   toTaskDto,
 } from "../task-access";
+import { readTaskEditRequest } from "../task-edit-request";
 
 export function createTaskRoutes(db: Kysely<DB>) {
   const routes = new Hono();
   const entityRepo = createEntityRepository(db);
   const taskRepo = createTaskRepository(db);
+  const mutationPolicy = createLocalTaskMutationPolicy(db);
 
   routes.get("/:id/tasks", async (c) => {
     const parentViewer = getFileViewer(c);
@@ -37,8 +41,9 @@ export function createTaskRoutes(db: Kysely<DB>) {
       limit,
     });
     const creators = await loadTaskCreators(db, tasks);
+    const protectedFields = await loadTaskProtectedFields(db, tasks);
     return c.json({
-      tasks: tasks.map((task) => toTaskDto(task, access, creators)),
+      tasks: tasks.map((task) => toTaskDto(task, access, creators, protectedFields.get(task.id))),
     });
   });
 
@@ -48,34 +53,38 @@ export function createTaskRoutes(db: Kysely<DB>) {
     const parentViewer = getFileViewer(c);
     const entity = await entityRepo.getEntity(c.req.param("id"), parentViewer);
     if (!entity) return c.json({ error: { code: "NOT_FOUND", message: "Entity not found" } }, 404);
-    const body = (await c.req.json().catch(() => ({}))) as { status?: unknown };
-    if (typeof body.status !== "string" || !TASK_STATUSES.has(body.status)) {
-      return c.json({ error: { code: "BAD_REQUEST", message: "Invalid status" } }, 400);
+    const request = await readTaskEditRequest(c);
+    if (!request.ok) {
+      return c.json({ error: { code: request.code, message: request.message } }, request.status);
     }
-    const task = await db
-      .selectFrom("tasks")
-      .selectAll()
-      .where("id", "=", c.req.param("taskId"))
-      .where("valid_to", "is", null)
-      .executeTakeFirst();
+    const access = await resolveTaskAccessContext(db, c);
+    const tasks = await taskRepo.listVisibleTasksByIds([c.req.param("taskId")], access);
+    const task = tasks[0];
     if (!task || task.parent_entity_id !== entity.id) {
       return c.json({ error: { code: "NOT_FOUND", message: "Task not found" } }, 404);
     }
-    const access = await resolveTaskAccessContext(db, c);
     if (!canEditTaskStatus(task, access)) {
       return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
     }
-    const updated = await taskRepo.updateLocalTaskStatus({
+    const result = await mutationPolicy.mutateHumanTask({
       taskId: task.id,
       userId,
       assigneeEntityIds: access.assigneeEntityIds,
       canEditAllLocalTasks: access.canEditAllLocalTasks,
-      status: body.status as TaskStatus,
+      expectedRevision: request.value.expectedRevision,
+      changes: request.value.changes,
       surface: "web",
     });
-    if (!updated) return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
+    if (result.status === "not_editable") {
+      return c.json({ error: { code: "FORBIDDEN", message: "Task is read-only" } }, 403);
+    }
+    if (result.status === "conflict") {
+      return c.json({ error: { code: "TASK_CHANGED", message: "Task changed since it was loaded" } }, 409);
+    }
+    const updated = result.task;
     const creators = await loadTaskCreators(db, [updated]);
-    return c.json({ task: toTaskDto(updated, access, creators) });
+    const protectedFields = await loadTaskProtectedFields(db, [updated]);
+    return c.json({ task: toTaskDto(updated, access, creators, protectedFields.get(updated.id)) });
   });
 
   return routes;

--- a/packages/server/src/api/task-access.ts
+++ b/packages/server/src/api/task-access.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono";
 import type { Kysely, Selectable } from "kysely";
 import { createEntityRepository } from "../db/repositories/entities";
 import { createUserRepository } from "../db/repositories/users";
-import type { DB, TasksTable } from "../db/schema";
+import type { DB, TaskProtectedField, TasksTable } from "../db/schema";
 import { type FileViewer, getContentViewer, isAdmin } from "./auth-helpers";
 
 export const TASK_STATUSES = new Set(["open", "in_progress", "done", "dropped"]);
@@ -49,6 +49,7 @@ export function readonlyReason(
 }
 
 type TaskCreator = { name: string; email: string | null };
+export type TaskEditableField = "status" | "title" | "priority" | "dueAt";
 
 export async function loadTaskCreators(
   db: Kysely<DB>,
@@ -65,12 +66,36 @@ export async function loadTaskCreators(
   return new Map(rows.map((row) => [row.id, { name: row.name, email: row.email }]));
 }
 
+export async function loadTaskProtectedFields(
+  db: Kysely<DB>,
+  tasks: Selectable<TasksTable>[],
+): Promise<Map<string, TaskEditableField[]>> {
+  const ids = [...new Set(tasks.map((task) => task.id))];
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .selectFrom("task_field_protections")
+    .select(["task_id", "field"])
+    .where("task_id", "in", ids)
+    .orderBy("field")
+    .limit(ids.length * 4)
+    .execute();
+  const byTask = new Map<string, TaskEditableField[]>();
+  for (const row of rows) {
+    const fields = byTask.get(row.task_id) ?? [];
+    fields.push(protectedFieldToEditableField(row.field));
+    byTask.set(row.task_id, fields);
+  }
+  return byTask;
+}
+
 export function toTaskDto(
   task: Selectable<TasksTable>,
   access: Pick<TaskAccessContext, "userId" | "assigneeEntityIds" | "canEditAllLocalTasks">,
   creators: Map<string, TaskCreator> = new Map(),
+  protectedFields: TaskEditableField[] = [],
 ) {
   const creator = task.created_by_user_id ? (creators.get(task.created_by_user_id) ?? null) : null;
+  const canEdit = canEditTaskStatus(task, access);
   return {
     id: task.id,
     parentEntityId: task.parent_entity_id,
@@ -96,8 +121,20 @@ export function toTaskDto(
     readonlyReason: readonlyReason(task, access),
     completedAt: task.completed_at,
     updatedAt: task.updated_at,
-    canEditStatus: canEditTaskStatus(task, access),
+    revision: task.revision,
+    canEditStatus: canEdit,
+    canEditFields: {
+      title: canEdit,
+      priority: canEdit,
+      dueAt: canEdit,
+      status: canEdit,
+    },
+    protectedFields,
   };
+}
+
+function protectedFieldToEditableField(field: TaskProtectedField): TaskEditableField {
+  return field === "due_at" ? "dueAt" : field;
 }
 
 export async function loadViewerPersonEntityIds(

--- a/packages/server/src/api/task-edit-request.ts
+++ b/packages/server/src/api/task-edit-request.ts
@@ -1,0 +1,89 @@
+import type { Context } from "hono";
+import type { HumanTaskChanges } from "../db/repositories/local-task-mutations";
+
+const TASK_EDIT_REQUEST_LIMIT = 8 * 1024;
+const TASK_EDIT_KEYS = new Set(["expectedRevision", "title", "priority", "dueAt", "status"]);
+const TASK_EDIT_STATUSES = new Set(["open", "in_progress", "done", "dropped"]);
+const TASK_EDIT_PRIORITIES = new Set(["high", "medium", "low"]);
+
+export type TaskEditRequest = {
+  expectedRevision?: number;
+  changes: HumanTaskChanges;
+};
+
+export type TaskEditRequestResult =
+  | { ok: true; value: TaskEditRequest }
+  | { ok: false; status: 400 | 413; code: "BAD_REQUEST" | "PAYLOAD_TOO_LARGE"; message: string };
+
+export async function readTaskEditRequest(c: Context): Promise<TaskEditRequestResult> {
+  const text = await c.req.text();
+  if (new TextEncoder().encode(text).byteLength > TASK_EDIT_REQUEST_LIMIT) {
+    return { ok: false, status: 413, code: "PAYLOAD_TOO_LARGE", message: "Task edit request exceeds 8 KiB" };
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return badRequest("Invalid JSON");
+  }
+  if (!isRecord(body)) return badRequest("Task edit request must be an object");
+  if (Object.keys(body).some((key) => !TASK_EDIT_KEYS.has(key))) return badRequest("Unknown task edit field");
+
+  const expectedRevision = body.expectedRevision;
+  if (expectedRevision !== undefined && (!Number.isInteger(expectedRevision) || (expectedRevision as number) < 0)) {
+    return badRequest("Invalid expectedRevision");
+  }
+
+  const changes: HumanTaskChanges = {};
+  if (Object.hasOwn(body, "title")) {
+    if (typeof body.title !== "string") return badRequest("Invalid title");
+    const title = body.title.trim();
+    if (!title || [...title].length > 240) return badRequest("Invalid title");
+    changes.title = title;
+  }
+  if (Object.hasOwn(body, "priority")) {
+    if (body.priority !== null && (typeof body.priority !== "string" || !TASK_EDIT_PRIORITIES.has(body.priority))) {
+      return badRequest("Invalid priority");
+    }
+    changes.priority = body.priority as HumanTaskChanges["priority"];
+  }
+  if (Object.hasOwn(body, "dueAt")) {
+    if (body.dueAt !== null && (typeof body.dueAt !== "string" || !isCalendarDate(body.dueAt))) {
+      return badRequest("Invalid dueAt");
+    }
+    changes.dueAt = body.dueAt as string | null;
+  }
+  if (Object.hasOwn(body, "status")) {
+    if (typeof body.status !== "string" || !TASK_EDIT_STATUSES.has(body.status)) {
+      return badRequest("Invalid status");
+    }
+    changes.status = body.status as HumanTaskChanges["status"];
+  }
+  if (Object.keys(changes).length === 0) return badRequest("At least one task field is required");
+
+  const changesMetadata =
+    Object.hasOwn(changes, "title") || Object.hasOwn(changes, "priority") || Object.hasOwn(changes, "dueAt");
+  if (changesMetadata && expectedRevision === undefined) {
+    return badRequest("expectedRevision is required for metadata edits");
+  }
+  return { ok: true, value: { expectedRevision: expectedRevision as number | undefined, changes } };
+}
+
+function badRequest(message: string): TaskEditRequestResult {
+  return { ok: false, status: 400, code: "BAD_REQUEST", message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}

--- a/packages/server/src/api/tasks.test.ts
+++ b/packages/server/src/api/tasks.test.ts
@@ -129,6 +129,162 @@ describe("GET/PATCH /api/tasks/:taskId", () => {
     ]);
   });
 
+  it("edits task metadata against the observed revision and protects each human-authored field", async () => {
+    const task = await createTaskRepository(db).upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Draft launch notes",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "editable-metadata",
+      createdByUserId: memberId,
+    });
+
+    const edited = await app.request(`/api/tasks/${task.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        expectedRevision: 0,
+        title: "  Publish launch notes  ",
+        priority: "high",
+        dueAt: "2026-08-15",
+        status: "in_progress",
+      }),
+    });
+    const stale = await app.request(`/api/tasks/${task.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ expectedRevision: 0, priority: "low" }),
+    });
+    const staleIdempotent = await app.request(`/api/tasks/${task.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ expectedRevision: 0, priority: "high" }),
+    });
+
+    expect(edited.status).toBe(200);
+    await expect(edited.json()).resolves.toMatchObject({
+      task: {
+        id: task.taskId,
+        title: "Publish launch notes",
+        priority: "high",
+        dueAt: "2026-08-15",
+        status: "in_progress",
+        revision: 1,
+        canEditFields: {
+          title: true,
+          priority: true,
+          dueAt: true,
+          status: true,
+        },
+        protectedFields: ["dueAt", "priority", "status", "title"],
+      },
+    });
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toEqual({
+      error: { code: "TASK_CHANGED", message: "Task changed since it was loaded" },
+    });
+    expect(staleIdempotent.status).toBe(200);
+    await expect(staleIdempotent.json()).resolves.toMatchObject({ task: { revision: 1, priority: "high" } });
+    await expect(
+      db
+        .selectFrom("tasks")
+        .select(["title", "normalized_title"])
+        .where("id", "=", task.taskId)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ title: "Publish launch notes", normalized_title: "publish launch notes" });
+
+    await expect(
+      db
+        .selectFrom("task_field_protections")
+        .select(["field", "protected_by_user_id", "activity_event_id"])
+        .where("task_id", "=", task.taskId)
+        .orderBy("field")
+        .execute(),
+    ).resolves.toEqual([
+      { field: "due_at", protected_by_user_id: memberId, activity_event_id: expect.any(String) },
+      { field: "priority", protected_by_user_id: memberId, activity_event_id: expect.any(String) },
+      { field: "status", protected_by_user_id: memberId, activity_event_id: expect.any(String) },
+      { field: "title", protected_by_user_id: memberId, activity_event_id: expect.any(String) },
+    ]);
+    await expect(
+      db
+        .selectFrom("task_activity_events")
+        .select(["event_kind", "changes_json"])
+        .where("task_id", "=", task.taskId)
+        .execute(),
+    ).resolves.toEqual([
+      {
+        event_kind: "fields_changed",
+        changes_json: JSON.stringify({
+          dueAt: { before: null, after: "2026-08-15" },
+          priority: { before: "medium", after: "high" },
+          status: { before: "open", after: "in_progress" },
+          title: { before: "Draft launch notes", after: "Publish launch notes" },
+        }),
+      },
+    ]);
+  });
+
+  it("rejects malformed, unknown, and oversized task edits through the public API", async () => {
+    const task = await createTaskRepository(db).upsertTask({
+      parentEntityId: null,
+      parentSourceRef: null,
+      parentName: null,
+      source: "summary",
+      externalRef: null,
+      title: "Validate edits",
+      status: "open",
+      statusRaw: "action_item",
+      statusAuthority: "local",
+      assigneeEntityId: null,
+      assigneeName: null,
+      priority: "medium",
+      dueAt: null,
+      provenance: "summary",
+      sourceTaskId: "validate-edits",
+      createdByUserId: memberId,
+    });
+    const cases: Array<{ body: unknown; status: number }> = [
+      { body: {}, status: 400 },
+      { body: { expectedRevision: 0, parentEntityId: "project-x" }, status: 400 },
+      { body: { title: "Missing revision" }, status: 400 },
+      { body: { expectedRevision: -1, title: "Bad revision" }, status: 400 },
+      { body: { expectedRevision: 0, title: "   " }, status: 400 },
+      { body: { expectedRevision: 0, title: "🧭".repeat(241) }, status: 400 },
+      { body: { expectedRevision: 0, priority: "urgent" }, status: 400 },
+      { body: { expectedRevision: 0, dueAt: "2026-02-30" }, status: 400 },
+      { body: { expectedRevision: 0, dueAt: "2026-8-1" }, status: 400 },
+    ];
+    for (const testCase of cases) {
+      const response = await app.request(`/api/tasks/${task.taskId}`, {
+        method: "PATCH",
+        headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+        body: JSON.stringify(testCase.body),
+      });
+      expect(response.status).toBe(testCase.status);
+    }
+
+    const oversized = await app.request(`/api/tasks/${task.taskId}`, {
+      method: "PATCH",
+      headers: { Cookie: memberCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ expectedRevision: 0, title: "a".repeat(9 * 1024) }),
+    });
+    expect(oversized.status).toBe(413);
+    await expect(
+      db.selectFrom("tasks").select("revision").where("id", "=", task.taskId).executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ revision: 0 });
+  });
+
   it("lets an assignee and admin update local tasks while hiding them from unrelated members", async () => {
     const repo = createTaskRepository(db);
     const assigned = await repo.upsertTask({

--- a/packages/server/src/api/tasks.ts
+++ b/packages/server/src/api/tasks.ts
@@ -1,12 +1,21 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
-import { type TaskStatus, createTaskRepository } from "../db/repositories/tasks";
+import { createLocalTaskMutationPolicy } from "../db/repositories/local-task-mutations";
+import { createTaskRepository } from "../db/repositories/tasks";
 import type { DB } from "../db/schema";
-import { TASK_STATUSES, canEditTaskStatus, loadTaskCreators, resolveTaskAccessContext, toTaskDto } from "./task-access";
+import {
+  canEditTaskStatus,
+  loadTaskCreators,
+  loadTaskProtectedFields,
+  resolveTaskAccessContext,
+  toTaskDto,
+} from "./task-access";
+import { readTaskEditRequest } from "./task-edit-request";
 
 export function taskRoutes(db: Kysely<DB>) {
   const routes = new Hono();
   const taskRepo = createTaskRepository(db);
+  const mutationPolicy = createLocalTaskMutationPolicy(db);
 
   routes.get("/:taskId", async (c) => {
     const access = await resolveTaskAccessContext(db, c);
@@ -14,13 +23,14 @@ export function taskRoutes(db: Kysely<DB>) {
     const task = tasks[0];
     if (!task) return c.json({ error: { code: "NOT_FOUND", message: "Task not found" } }, 404);
     const creators = await loadTaskCreators(db, [task]);
-    return c.json({ task: toTaskDto(task, access, creators) });
+    const protectedFields = await loadTaskProtectedFields(db, [task]);
+    return c.json({ task: toTaskDto(task, access, creators, protectedFields.get(task.id)) });
   });
 
   routes.patch("/:taskId", async (c) => {
-    const body = (await c.req.json().catch(() => ({}))) as { status?: unknown };
-    if (typeof body.status !== "string" || !TASK_STATUSES.has(body.status)) {
-      return c.json({ error: { code: "BAD_REQUEST", message: "Invalid status" } }, 400);
+    const request = await readTaskEditRequest(c);
+    if (!request.ok) {
+      return c.json({ error: { code: request.code, message: request.message } }, request.status);
     }
     const access = await resolveTaskAccessContext(db, c);
     const tasks = await taskRepo.listVisibleTasksByIds([c.req.param("taskId")], access);
@@ -29,17 +39,25 @@ export function taskRoutes(db: Kysely<DB>) {
     if (!canEditTaskStatus(task, access)) {
       return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
     }
-    const updated = await taskRepo.updateLocalTaskStatus({
+    const result = await mutationPolicy.mutateHumanTask({
       taskId: task.id,
       userId: access.userId,
       assigneeEntityIds: access.assigneeEntityIds,
       canEditAllLocalTasks: access.canEditAllLocalTasks,
-      status: body.status as TaskStatus,
+      expectedRevision: request.value.expectedRevision,
+      changes: request.value.changes,
       surface: "web",
     });
-    if (!updated) return c.json({ error: { code: "FORBIDDEN", message: "Task status is read-only" } }, 403);
+    if (result.status === "not_editable") {
+      return c.json({ error: { code: "FORBIDDEN", message: "Task is read-only" } }, 403);
+    }
+    if (result.status === "conflict") {
+      return c.json({ error: { code: "TASK_CHANGED", message: "Task changed since it was loaded" } }, 409);
+    }
+    const updated = result.task;
     const creators = await loadTaskCreators(db, [updated]);
-    return c.json({ task: toTaskDto(updated, access, creators) });
+    const protectedFields = await loadTaskProtectedFields(db, [updated]);
+    return c.json({ task: toTaskDto(updated, access, creators, protectedFields.get(updated.id)) });
   });
 
   return routes;

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -157,6 +157,7 @@ import * as m154 from "./migrations/154-reclassify-mpim-conversations";
 import * as m155 from "./migrations/155-requeue-kept-slice-reemission";
 import * as m156 from "./migrations/156-operational-alerts";
 import * as m157 from "./migrations/157-task-activity-events";
+import * as m158 from "./migrations/158-task-human-authority";
 import type { DB } from "./schema";
 
 /**
@@ -323,6 +324,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "155-requeue-kept-slice-reemission": m155,
           "156-operational-alerts": m156,
           "157-task-activity-events": m157,
+          "158-task-human-authority": m158,
         };
       },
     },

--- a/packages/server/src/db/migrations/158-task-human-authority.ts
+++ b/packages/server/src/db/migrations/158-task-human-authority.ts
@@ -1,0 +1,164 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("tasks")
+    .addColumn("revision", "integer", (col) => col.notNull().defaultTo(0))
+    .execute();
+
+  await db.schema
+    .createTable("task_field_protections")
+    .addColumn("task_id", "text", (col) => col.notNull().references("tasks.id").onDelete("cascade"))
+    .addColumn("field", "text", (col) => col.notNull())
+    .addColumn("protected_by_user_id", "text", (col) => col.references("users.id").onDelete("set null"))
+    .addColumn("activity_event_id", "text", (col) => col.references("task_activity_events.id").onDelete("set null"))
+    .addColumn("protected_at", "text", (col) => col.notNull())
+    .addPrimaryKeyConstraint("task_field_protections_pkey", ["task_id", "field"])
+    .addCheckConstraint("task_field_protections_field_check", sql`field in ('status', 'title', 'priority', 'due_at')`)
+    .execute();
+  await db.schema
+    .createIndex("idx_task_field_protections_field_time")
+    .on("task_field_protections")
+    .columns(["field", "protected_at", "task_id"])
+    .execute();
+
+  await sql`
+    insert into task_field_protections (
+      task_id,
+      field,
+      protected_by_user_id,
+      activity_event_id,
+      protected_at
+    )
+    select
+      event.task_id,
+      'status',
+      event.actor_user_id,
+      event.id,
+      event.occurred_at
+    from task_activity_events as event
+    inner join tasks on tasks.id = event.task_id
+    where event.actor_type = 'user'
+      and event.event_kind = 'status_changed'
+      and not exists (
+        select 1
+        from task_activity_events as newer
+        where newer.task_id = event.task_id
+          and newer.actor_type = 'user'
+          and newer.event_kind = 'status_changed'
+          and (
+            newer.occurred_at > event.occurred_at
+            or (newer.occurred_at = event.occurred_at and newer.id > event.id)
+          )
+      )
+    on conflict (task_id, field) do nothing
+  `.execute(db);
+
+  await db.schema
+    .createTable("task_change_proposals")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("task_id", "text", (col) => col.notNull().references("tasks.id").onDelete("cascade"))
+    .addColumn("state", "text", (col) => col.notNull())
+    .addColumn("logical_fingerprint", "text", (col) => col.notNull())
+    .addColumn("dedupe_key", "text", (col) => col.notNull().unique())
+    .addColumn("supersedes_proposal_id", "text", (col) =>
+      col.references("task_change_proposals.id").onDelete("set null"),
+    )
+    .addColumn("reviewed_at", "text")
+    .addColumn("reviewed_by_user_id", "text", (col) => col.references("users.id").onDelete("set null"))
+    .addColumn("review_surface", "text")
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addCheckConstraint(
+      "task_change_proposals_state_check",
+      sql`state in ('pending', 'accepted', 'rejected', 'superseded')`,
+    )
+    .execute();
+  await db.schema
+    .createIndex("idx_task_change_proposals_state_time")
+    .on("task_change_proposals")
+    .columns(["state", "created_at", "task_id"])
+    .execute();
+  await db.schema
+    .createIndex("idx_task_change_proposals_fingerprint")
+    .on("task_change_proposals")
+    .columns(["task_id", "logical_fingerprint", "state"])
+    .execute();
+  await db.schema
+    .createIndex("idx_task_change_proposals_supersedes")
+    .unique()
+    .on("task_change_proposals")
+    .column("supersedes_proposal_id")
+    .execute();
+  await sql`
+    create unique index idx_task_change_proposals_one_pending
+    on task_change_proposals(task_id)
+    where state = 'pending'
+  `.execute(db);
+
+  await db.schema
+    .createTable("task_change_proposal_fields")
+    .addColumn("proposal_id", "text", (col) => col.notNull().references("task_change_proposals.id").onDelete("cascade"))
+    .addColumn("field", "text", (col) => col.notNull())
+    .addColumn("observed_revision", "integer", (col) => col.notNull())
+    .addColumn("base_value_json", "text", (col) => col.notNull())
+    .addColumn("proposed_value_json", "text", (col) => col.notNull())
+    .addColumn("rationale", "text", (col) => col.notNull())
+    .addColumn("source_occurred_at", "text", (col) => col.notNull())
+    .addColumn("origin_agent_output_id", "text", (col) => col.references("agent_outputs.id").onDelete("set null"))
+    .addPrimaryKeyConstraint("task_change_proposal_fields_pkey", ["proposal_id", "field"])
+    .addCheckConstraint("task_change_proposal_fields_field_check", sql`field in ('title', 'priority', 'due_at')`)
+    .execute();
+
+  await db.schema
+    .createTable("task_change_proposal_evidence")
+    .addColumn("proposal_id", "text", (col) => col.notNull())
+    .addColumn("field", "text", (col) => col.notNull())
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("ref_id", "text", (col) => col.notNull())
+    .addPrimaryKeyConstraint("task_change_proposal_evidence_pkey", ["proposal_id", "field", "kind", "ref_id"])
+    .addForeignKeyConstraint(
+      "task_change_proposal_evidence_field_fkey",
+      ["proposal_id", "field"],
+      "task_change_proposal_fields",
+      ["proposal_id", "field"],
+      (constraint) => constraint.onDelete("cascade"),
+    )
+    .addCheckConstraint(
+      "task_change_proposal_evidence_kind_check",
+      sql`kind in ('conversation_message', 'file', 'entity', 'fact', 'mention')`,
+    )
+    .execute();
+  await db.schema
+    .createIndex("idx_task_change_proposal_evidence_ref")
+    .on("task_change_proposal_evidence")
+    .columns(["kind", "ref_id", "proposal_id"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const state = await sql<{
+    protection_count: number | string;
+    proposal_count: number | string;
+    revision_count: number | string;
+  }>`
+    select
+      (select count(*) from task_field_protections) as protection_count,
+      (select count(*) from task_change_proposals) as proposal_count,
+      (select count(*) from tasks where revision <> 0) as revision_count
+  `.execute(db);
+  const counts = state.rows[0];
+  if (
+    Number(counts?.protection_count ?? 0) > 0 ||
+    Number(counts?.proposal_count ?? 0) > 0 ||
+    Number(counts?.revision_count ?? 0) > 0
+  ) {
+    throw new Error("Cannot remove task human-authority schema after authority or proposal state exists.");
+  }
+
+  await db.schema.dropTable("task_change_proposal_evidence").execute();
+  await db.schema.dropTable("task_change_proposal_fields").execute();
+  await db.schema.dropTable("task_change_proposals").execute();
+  await db.schema.dropTable("task_field_protections").execute();
+  await db.schema.alterTable("tasks").dropColumn("revision").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -20,7 +20,7 @@ import type { DB } from "../schema";
 import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
 
-const EXPECTED_MIGRATION_COUNT = 153;
+const EXPECTED_MIGRATION_COUNT = 154;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -188,6 +188,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[150]).toBe("155-requeue-kept-slice-reemission");
     expect(names[151]).toBe("156-operational-alerts");
     expect(names[152]).toBe("157-task-activity-events");
+    expect(names[153]).toBe("158-task-human-authority");
   });
 
   it("creates the bounded open-materializable partial index", async () => {
@@ -403,6 +404,101 @@ describe("runMigrations on Postgres — full sequence", () => {
           ('invalid-activity-surface', 'activity-contract-task', 'created', 'provider', 'teams', 'invalid-surface', '2026-07-23T00:00:00.000Z')
       `.execute(freshDb),
       ).rejects.toThrow();
+    } finally {
+      await freshDb.destroy();
+    }
+  }, 30000);
+
+  it("creates task authority revision, protection, and proposal schema", async () => {
+    const revision = await sql<{ column_name: string; data_type: string; is_nullable: string }>`
+      SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'tasks'
+        AND column_name = 'revision'
+    `.execute(db);
+    const tables = await sql<{ table_name: string }>`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name IN (
+          'task_field_protections',
+          'task_change_proposals',
+          'task_change_proposal_fields',
+          'task_change_proposal_evidence'
+        )
+      ORDER BY table_name
+    `.execute(db);
+
+    expect(revision.rows).toEqual([{ column_name: "revision", data_type: "integer", is_nullable: "NO" }]);
+    expect(tables.rows.map((row) => row.table_name)).toEqual([
+      "task_change_proposal_evidence",
+      "task_change_proposal_fields",
+      "task_change_proposals",
+      "task_field_protections",
+    ]);
+  });
+
+  it("enforces one pending proposal per task and preserves explicit null proposal values", async () => {
+    const freshDb = await createTestPgDb();
+    try {
+      await sql`
+        INSERT INTO tasks
+          (id, source, title, normalized_title, status, status_authority, provenance, source_task_id, updated_at)
+        VALUES
+          ('proposal-contract-task', 'summary', 'Contract task', 'contract task', 'open', 'local', 'summary', 'proposal-contract-task', '2026-07-27T00:00:00.000Z')
+      `.execute(freshDb);
+      await freshDb
+        .insertInto("task_change_proposals")
+        .values({
+          id: "proposal-1",
+          task_id: "proposal-contract-task",
+          state: "pending",
+          logical_fingerprint: "fingerprint-1",
+          dedupe_key: "dedupe-1",
+          supersedes_proposal_id: null,
+          reviewed_at: null,
+          reviewed_by_user_id: null,
+          review_surface: null,
+        })
+        .execute();
+      await freshDb
+        .insertInto("task_change_proposal_fields")
+        .values({
+          proposal_id: "proposal-1",
+          field: "due_at",
+          observed_revision: 0,
+          base_value_json: JSON.stringify("2026-08-01"),
+          proposed_value_json: JSON.stringify(null),
+          rationale: "The due date was explicitly removed.",
+          source_occurred_at: "2026-07-27T00:00:00.000Z",
+          origin_agent_output_id: null,
+        })
+        .execute();
+      await expect(
+        freshDb
+          .insertInto("task_change_proposals")
+          .values({
+            id: "proposal-2",
+            task_id: "proposal-contract-task",
+            state: "pending",
+            logical_fingerprint: "fingerprint-2",
+            dedupe_key: "dedupe-2",
+            supersedes_proposal_id: null,
+            reviewed_at: null,
+            reviewed_by_user_id: null,
+            review_surface: null,
+          })
+          .execute(),
+      ).rejects.toThrow();
+      const field = await freshDb
+        .selectFrom("task_change_proposal_fields")
+        .select(["base_value_json", "proposed_value_json"])
+        .where("proposal_id", "=", "proposal-1")
+        .executeTakeFirstOrThrow();
+
+      expect(JSON.parse(field.base_value_json)).toBe("2026-08-01");
+      expect(JSON.parse(field.proposed_value_json)).toBeNull();
     } finally {
       await freshDb.destroy();
     }

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -25,7 +25,7 @@ import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
 import * as combinedDurabilityReseedMigration from "./152-reseed-combined-durability-routes";
 
-const EXPECTED_MIGRATION_COUNT = 153;
+const EXPECTED_MIGRATION_COUNT = 154;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -222,6 +222,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[150]).toBe("155-requeue-kept-slice-reemission");
     expect(names[151]).toBe("156-operational-alerts");
     expect(names[152]).toBe("157-task-activity-events");
+    expect(names[153]).toBe("158-task-human-authority");
   });
 
   it("resets reviewed combined durability routes for member-source reseeding", async () => {
@@ -585,6 +586,133 @@ describe("runMigrations — full sequence", () => {
         ('invalid-activity-surface', 'activity-contract-task', 'created', 'provider', 'teams', 'invalid-surface', '2026-07-23T00:00:00.000Z')
     `.execute(db),
     ).rejects.toThrow();
+  });
+
+  it("creates task authority schema and backfills the latest human status decision", async () => {
+    const migrator = createMigrator(db);
+    const beforeAuthority = await migrator.migrateTo("157-task-activity-events");
+    expect(beforeAuthority.error).toBeUndefined();
+    await sql`INSERT INTO users (id, name) VALUES ('authority-user', 'Authority User')`.execute(db);
+    await sql`
+      INSERT INTO tasks
+        (id, source, title, normalized_title, status, status_authority, provenance, source_task_id, updated_at)
+      VALUES
+        ('authority-task', 'summary', 'Authority task', 'authority task', 'done', 'local', 'summary', 'authority-task', '2026-07-27T00:00:00.000Z')
+    `.execute(db);
+    await sql`
+      INSERT INTO task_activity_events
+        (id, task_id, event_kind, actor_type, actor_user_id, surface, dedupe_key, occurred_at)
+      VALUES
+        ('authority-event-a', 'authority-task', 'status_changed', 'user', 'authority-user', 'web', 'authority-a', '2026-07-27T01:00:00.000Z'),
+        ('authority-event-b', 'authority-task', 'status_changed', 'user', 'authority-user', 'slack', 'authority-b', '2026-07-27T01:00:00.000Z'),
+        ('authority-event-c', 'authority-task', 'status_changed', 'agent', null, 'summarizer', 'authority-c', '2026-07-27T02:00:00.000Z')
+    `.execute(db);
+
+    const latest = await migrator.migrateToLatest();
+    expect(latest.error).toBeUndefined();
+
+    const columns = await sql<{ name: string }>`
+      SELECT name FROM pragma_table_info('tasks') WHERE name = 'revision'
+    `.execute(db);
+    expect(columns.rows).toEqual([{ name: "revision" }]);
+    await expect(
+      db.selectFrom("tasks").select("revision").where("id", "=", "authority-task").executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ revision: 0 });
+    await expect(
+      db
+        .selectFrom("task_field_protections")
+        .select(["task_id", "field", "protected_by_user_id", "activity_event_id", "protected_at"])
+        .execute(),
+    ).resolves.toEqual([
+      {
+        task_id: "authority-task",
+        field: "status",
+        protected_by_user_id: "authority-user",
+        activity_event_id: "authority-event-b",
+        protected_at: "2026-07-27T01:00:00.000Z",
+      },
+    ]);
+
+    await db
+      .insertInto("task_change_proposals")
+      .values({
+        id: "proposal-a",
+        task_id: "authority-task",
+        state: "pending",
+        logical_fingerprint: "fingerprint-a",
+        dedupe_key: "dedupe-a",
+        supersedes_proposal_id: null,
+        reviewed_at: null,
+        reviewed_by_user_id: null,
+        review_surface: null,
+      })
+      .execute();
+    await db
+      .insertInto("task_change_proposal_fields")
+      .values({
+        proposal_id: "proposal-a",
+        field: "due_at",
+        observed_revision: 0,
+        base_value_json: "null",
+        proposed_value_json: JSON.stringify("2026-08-15"),
+        rationale: "A due date was stated.",
+        source_occurred_at: "2026-07-27T02:00:00.000Z",
+        origin_agent_output_id: null,
+      })
+      .execute();
+    await expect(
+      db
+        .insertInto("task_change_proposals")
+        .values({
+          id: "proposal-b",
+          task_id: "authority-task",
+          state: "pending",
+          logical_fingerprint: "fingerprint-b",
+          dedupe_key: "dedupe-b",
+          supersedes_proposal_id: null,
+          reviewed_at: null,
+          reviewed_by_user_id: null,
+          review_surface: null,
+        })
+        .execute(),
+    ).rejects.toThrow();
+    await expect(
+      db
+        .selectFrom("task_change_proposal_fields")
+        .select(["base_value_json", "proposed_value_json"])
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ base_value_json: "null", proposed_value_json: JSON.stringify("2026-08-15") });
+
+    const down = await migrator.migrateDown();
+    expect(down.error).toBeInstanceOf(Error);
+    const protectionColumns = await sql<{ name: string }>`
+      SELECT name FROM pragma_table_info('task_field_protections')
+    `.execute(db);
+    expect(protectionColumns.rows.length).toBeGreaterThan(0);
+  });
+
+  it("removes empty task authority schema during a guarded migration rollback", async () => {
+    await runMigrations(db, { quiet: true });
+    const migrator = createMigrator(db);
+    const down = await migrator.migrateDown();
+    expect(down.error).toBeUndefined();
+
+    const taskColumns = await sql<{ name: string }>`
+      SELECT name FROM pragma_table_info('tasks') WHERE name = 'revision'
+    `.execute(db);
+    const authorityTables = await sql<{ name: string }>`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table'
+        AND name IN (
+          'task_field_protections',
+          'task_change_proposals',
+          'task_change_proposal_fields',
+          'task_change_proposal_evidence'
+        )
+    `.execute(db);
+    expect(taskColumns.rows).toEqual([]);
+    expect(authorityTables.rows).toEqual([]);
   });
 
   it("migration 140 retires unassigned local agent tasks without touching structural tasks", async () => {

--- a/packages/server/src/db/repositories/conversation-followups.ts
+++ b/packages/server/src/db/repositories/conversation-followups.ts
@@ -3,8 +3,9 @@ import { type Kysely, type Selectable, type Transaction, sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
 import type { DB, TasksTable } from "../schema";
 import type { AgentOutputItemInput } from "./agent-outputs";
+import { mutateHumanTaskInTransaction } from "./local-task-mutations";
 import { type TaskActivitySurface, createTaskActivityRepository } from "./task-activity";
-import { type ConversationTaskSourceAnchor, type TaskStatus, createTaskRepository } from "./tasks";
+import { type ConversationTaskSourceAnchor, createTaskRepository } from "./tasks";
 
 const RECOMMENDATION_EXPIRY_MS = 48 * 60 * 60 * 1000;
 const RECOMMENDATION_DELIVERY_LIMIT = 3;
@@ -602,12 +603,17 @@ export function createConversationFollowupsRepository(db: Kysely<DB>) {
             return { status: "stale" as const };
           }
           if (input.action === "confirm_done") {
-            const taskUpdated = await updateActionableTaskStatus(trx, recommendation.task_id, "done", input.now, {
+            const taskMutation = await mutateHumanTaskInTransaction(trx, {
+              taskId: recommendation.task_id,
               userId: input.userId,
               assigneeEntityIds: input.assigneeEntityIds,
               canEditAllLocalTasks: input.canEditAllLocalTasks,
+              changes: { status: "done" },
+              surface: toTaskActivitySurface(input.surface),
+              mutationId: recommendation.recommendation_id,
+              now: input.now,
             });
-            if (!taskUpdated) {
+            if (taskMutation.status !== "applied") {
               const failure = await classifyReviewFailure(trx, recommendation.task_id, input);
               if (failure === "unauthorized") throw new ReviewAuthorizationChangedError(failure);
               await trx
@@ -630,8 +636,6 @@ export function createConversationFollowupsRepository(db: Kysely<DB>) {
               decisionState: state,
               userId: input.userId,
               surface: input.surface,
-              previousTaskStatus: recommendation.status,
-              nextTaskStatus: "done",
               now: input.now,
             });
             return { status: "confirmed" as const, taskId: recommendation.task_id };
@@ -664,8 +668,6 @@ export function createConversationFollowupsRepository(db: Kysely<DB>) {
             decisionState: state,
             userId: input.userId,
             surface: input.surface,
-            previousTaskStatus: recommendation.status,
-            nextTaskStatus: null,
             now: input.now,
           });
           return { status: "kept_open" as const, taskId: recommendation.task_id };
@@ -719,8 +721,6 @@ async function appendReviewDecisionActivity(
     decisionState: "accepted" | "rejected";
     userId: string;
     surface: string;
-    previousTaskStatus: string;
-    nextTaskStatus: string | null;
     now: string;
   },
 ): Promise<void> {
@@ -736,18 +736,6 @@ async function appendReviewDecisionActivity(
     identityParts: [input.recommendationId, input.decisionState],
     occurredAt: input.now,
   });
-  if (input.nextTaskStatus && input.previousTaskStatus !== input.nextTaskStatus) {
-    await activity.append({
-      taskId: input.taskId,
-      eventKind: "status_changed",
-      actorType: "user",
-      actorUserId: input.userId,
-      surface,
-      changes: { status: { before: input.previousTaskStatus, after: input.nextTaskStatus } },
-      identityParts: [input.recommendationId, input.previousTaskStatus, input.nextTaskStatus],
-      occurredAt: input.now,
-    });
-  }
 }
 
 function toTaskActivitySurface(surface: string): TaskActivitySurface {
@@ -1766,45 +1754,6 @@ async function classifyReviewFailure(
     task.created_by_user_id === authorization.userId ||
     Boolean(task.assignee_entity_id && authorization.assigneeEntityIds.includes(task.assignee_entity_id));
   return authorized ? "stale" : "unauthorized";
-}
-
-async function updateActionableTaskStatus(
-  db: Kysely<DB> | Transaction<DB>,
-  taskId: string,
-  status: TaskStatus,
-  now: string,
-  authorization: {
-    userId: string;
-    assigneeEntityIds: string[];
-    canEditAllLocalTasks?: boolean;
-  },
-): Promise<boolean> {
-  let query = db
-    .updateTable("tasks")
-    .set({
-      status,
-      status_raw: status,
-      status_authority: "local",
-      status_changed_at: now,
-      completed_at: status === "done" ? now : null,
-      updated_at: now,
-    })
-    .where("id", "=", taskId)
-    .where("valid_to", "is", null)
-    .where("status", "in", ["open", "in_progress"])
-    .where("status_authority", "=", "local")
-    .where("provenance", "in", ["summary", "brief"]);
-  if (authorization.canEditAllLocalTasks !== true) {
-    const assigneeIds = [...new Set(authorization.assigneeEntityIds)].filter(Boolean);
-    query = query.where((eb) =>
-      eb.or([
-        eb("created_by_user_id", "=", authorization.userId),
-        ...(assigneeIds.length > 0 ? [eb("assignee_entity_id", "in", assigneeIds)] : []),
-      ]),
-    );
-  }
-  const updated = await query.executeTakeFirst();
-  return Number(updated.numUpdatedRows ?? 0) > 0;
 }
 
 async function touchActionableTaskForReview(

--- a/packages/server/src/db/repositories/local-task-mutations.integration.test.ts
+++ b/packages/server/src/db/repositories/local-task-mutations.integration.test.ts
@@ -1,0 +1,82 @@
+import type { Kysely } from "kysely";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createLocalTaskMutationPolicy } from "./local-task-mutations";
+
+describe("createLocalTaskMutationPolicy postgres", () => {
+  let db: Kysely<DB>;
+
+  beforeAll(async () => {
+    db = await createTestPgDb();
+    await db.insertInto("users").values({ id: "pg-owner", name: "PG Owner", email: "pg-owner@example.com" }).execute();
+    await db
+      .insertInto("tasks")
+      .values({
+        id: "pg-task",
+        parent_entity_id: null,
+        parent_source_ref: null,
+        parent_name: null,
+        source: "daily-brief",
+        external_ref: null,
+        title: "Ship notes",
+        normalized_title: "ship notes",
+        status: "open",
+        status_raw: "open",
+        status_authority: "local",
+        assignee_entity_id: null,
+        priority: null,
+        due_at: null,
+        provenance: "brief",
+        source_task_id: "pg-task",
+        status_changed_at: null,
+        completed_at: null,
+        valid_from: null,
+        valid_to: null,
+        created_by_user_id: "pg-owner",
+      })
+      .execute();
+  }, 30000);
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  it("applies one revision with durable protections and rejects a stale overwrite", async () => {
+    const policy = createLocalTaskMutationPolicy(db);
+    const applied = await policy.mutateHumanTask({
+      taskId: "pg-task",
+      userId: "pg-owner",
+      expectedRevision: 0,
+      changes: { title: "Publish launch notes", priority: "high", dueAt: "2026-08-01" },
+      surface: "web",
+      mutationId: "pg-edit",
+    });
+    const conflict = await policy.mutateHumanTask({
+      taskId: "pg-task",
+      userId: "pg-owner",
+      expectedRevision: 0,
+      changes: { title: "Overwrite stale title" },
+      surface: "web",
+      mutationId: "pg-stale-edit",
+    });
+    const protections = await db
+      .selectFrom("task_field_protections")
+      .select(["field", "activity_event_id"])
+      .where("task_id", "=", "pg-task")
+      .orderBy("field")
+      .execute();
+
+    expect(applied).toMatchObject({
+      status: "applied",
+      task: { title: "Publish launch notes", priority: "high", due_at: "2026-08-01", revision: 1 },
+    });
+    expect(conflict).toMatchObject({ status: "conflict", task: { revision: 1 } });
+    expect(protections).toEqual([
+      { field: "due_at", activity_event_id: expect.any(String) },
+      { field: "priority", activity_event_id: expect.any(String) },
+      { field: "title", activity_event_id: expect.any(String) },
+    ]);
+    expect(new Set(protections.map((protection) => protection.activity_event_id))).toHaveProperty("size", 1);
+  });
+});

--- a/packages/server/src/db/repositories/local-task-mutations.test.ts
+++ b/packages/server/src/db/repositories/local-task-mutations.test.ts
@@ -1,0 +1,95 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createLocalTaskMutationPolicy } from "./local-task-mutations";
+import { createTaskActivityRepository } from "./task-activity";
+
+describe("createLocalTaskMutationPolicy sqlite", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await db.insertInto("users").values({ id: "owner", name: "Owner", email: "owner@example.com" }).execute();
+    await db
+      .insertInto("tasks")
+      .values({
+        id: "task-1",
+        parent_entity_id: null,
+        parent_source_ref: null,
+        parent_name: null,
+        source: "daily-brief",
+        external_ref: null,
+        title: "Ship notes",
+        normalized_title: "ship notes",
+        status: "open",
+        status_raw: "open",
+        status_authority: "local",
+        assignee_entity_id: null,
+        priority: null,
+        due_at: null,
+        provenance: "brief",
+        source_task_id: "task-1",
+        status_changed_at: null,
+        completed_at: null,
+        valid_from: null,
+        valid_to: null,
+        created_by_user_id: "owner",
+      })
+      .execute();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("rolls back the task, activity, and protections when an atomic side effect fails", async () => {
+    const policy = createLocalTaskMutationPolicy(db);
+
+    await expect(
+      policy.mutateHumanTask({
+        taskId: "task-1",
+        userId: "missing-user",
+        canEditAllLocalTasks: true,
+        expectedRevision: 0,
+        changes: { status: "done" },
+        surface: "web",
+        mutationId: "rollback-proof",
+      }),
+    ).rejects.toThrow();
+
+    const task = await db.selectFrom("tasks").selectAll().where("id", "=", "task-1").executeTakeFirstOrThrow();
+    const activity = await db.selectFrom("task_activity_events").selectAll().where("task_id", "=", "task-1").execute();
+    const protections = await db
+      .selectFrom("task_field_protections")
+      .selectAll()
+      .where("task_id", "=", "task-1")
+      .execute();
+
+    expect(task).toMatchObject({ status: "open", revision: 0 });
+    expect(activity).toEqual([]);
+    expect(protections).toEqual([]);
+  });
+
+  it("returns the canonical activity identifier when an append is replayed", async () => {
+    const activity = createTaskActivityRepository(db);
+    const input = {
+      taskId: "task-1",
+      eventKind: "fields_changed" as const,
+      actorType: "user" as const,
+      actorUserId: "owner",
+      surface: "web" as const,
+      changes: { title: { before: "Ship notes", after: "Publish notes" } },
+      identityParts: ["task-1", "same-edit"],
+      occurredAt: "2026-07-27T00:00:00.000Z",
+    };
+
+    const first = await activity.append(input);
+    const replay = await activity.append(input);
+    const rows = await db.selectFrom("task_activity_events").select("id").where("task_id", "=", "task-1").execute();
+
+    expect(first).toEqual({ id: expect.any(String), created: true });
+    expect(replay).toEqual({ id: first.id, created: false });
+    expect(rows).toEqual([{ id: first.id }]);
+  });
+});

--- a/packages/server/src/db/repositories/local-task-mutations.ts
+++ b/packages/server/src/db/repositories/local-task-mutations.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely, Selectable, Transaction } from "kysely";
+import { sql } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
+import type { DB, TaskActivitySurface, TaskProtectedField, TasksTable } from "../schema";
+import { createTaskActivityRepository } from "./task-activity";
+import type { TaskStatus } from "./tasks";
+
+export interface HumanTaskChanges {
+  title?: string;
+  priority?: "high" | "medium" | "low" | null;
+  dueAt?: string | null;
+  status?: TaskStatus;
+}
+
+export interface HumanTaskMutationInput {
+  taskId: string;
+  userId: string;
+  assigneeEntityIds?: string[];
+  canEditAllLocalTasks?: boolean;
+  expectedRevision?: number;
+  changes: HumanTaskChanges;
+  surface: TaskActivitySurface;
+  mutationId?: string;
+  now?: string;
+}
+
+export type HumanTaskMutationResult =
+  | { status: "unchanged"; task: Selectable<TasksTable> }
+  | { status: "applied"; task: Selectable<TasksTable> }
+  | { status: "conflict"; task: Selectable<TasksTable> }
+  | { status: "not_editable" };
+
+export function createLocalTaskMutationPolicy(db: Kysely<DB>) {
+  return {
+    mutateHumanTask(input: HumanTaskMutationInput): Promise<HumanTaskMutationResult> {
+      return db.transaction().execute((trx) => mutateHumanTaskInTransaction(trx, input));
+    },
+  };
+}
+
+export async function mutateHumanTaskInTransaction(
+  trx: Transaction<DB>,
+  input: HumanTaskMutationInput,
+): Promise<HumanTaskMutationResult> {
+  const existing = await trx
+    .selectFrom("tasks")
+    .selectAll()
+    .where("id", "=", input.taskId)
+    .where("valid_to", "is", null)
+    .executeTakeFirst();
+  if (!existing || !canHumanEditLocalTask(existing, input)) return { status: "not_editable" };
+
+  const changes = logicalChanges(existing, input.changes);
+  if (Object.keys(changes).length === 0) return { status: "unchanged", task: existing };
+  if (input.expectedRevision !== undefined && existing.revision !== input.expectedRevision) {
+    return { status: "conflict", task: existing };
+  }
+
+  const now = mutationTime(existing, input.now);
+  const values = taskUpdateValues(existing, input.changes, now);
+  let update = trx
+    .updateTable("tasks")
+    .set({
+      ...values,
+      revision: sql<number>`revision + 1`,
+      updated_at: now,
+    })
+    .where("id", "=", input.taskId)
+    .where("valid_to", "is", null)
+    .where("revision", "=", existing.revision)
+    .where("status_authority", "=", "local")
+    .where("provenance", "in", ["brief", "summary"]);
+  if (input.canEditAllLocalTasks !== true) {
+    const assigneeEntityIds = [...new Set(input.assigneeEntityIds ?? [])].filter(Boolean);
+    update = update.where((eb) =>
+      eb.or([
+        eb("created_by_user_id", "=", input.userId),
+        ...(assigneeEntityIds.length > 0 ? [eb("assignee_entity_id", "in", assigneeEntityIds)] : []),
+      ]),
+    );
+  }
+  const updated = await update.executeTakeFirst();
+  if (Number(updated.numUpdatedRows ?? 0) === 0) {
+    const current = await trx
+      .selectFrom("tasks")
+      .selectAll()
+      .where("id", "=", input.taskId)
+      .where("valid_to", "is", null)
+      .executeTakeFirst();
+    if (!current || !canHumanEditLocalTask(current, input)) return { status: "not_editable" };
+    if (Object.keys(logicalChanges(current, input.changes)).length === 0) {
+      return { status: "unchanged", task: current };
+    }
+    return { status: "conflict", task: current };
+  }
+
+  const eventKind = Object.keys(changes).length === 1 && changes.status ? "status_changed" : "fields_changed";
+  const activity = await createTaskActivityRepository(trx).append({
+    taskId: existing.id,
+    eventKind,
+    actorType: "user",
+    actorUserId: input.userId,
+    surface: input.surface,
+    changes,
+    identityParts: [existing.id, input.mutationId ?? randomUUID()],
+    occurredAt: now,
+  });
+  const protectedFields = Object.keys(changes).map(logicalFieldToProtectedField);
+  for (const field of protectedFields) {
+    await trx
+      .insertInto("task_field_protections")
+      .values({
+        task_id: existing.id,
+        field,
+        protected_by_user_id: input.userId,
+        activity_event_id: activity.id,
+        protected_at: now,
+      })
+      .onConflict((oc) =>
+        oc.columns(["task_id", "field"]).doUpdateSet({
+          protected_by_user_id: input.userId,
+          activity_event_id: activity.id,
+          protected_at: now,
+        }),
+      )
+      .execute();
+  }
+
+  const task = await trx.selectFrom("tasks").selectAll().where("id", "=", existing.id).executeTakeFirstOrThrow();
+  return { status: "applied", task };
+}
+
+function canHumanEditLocalTask(
+  task: Selectable<TasksTable>,
+  input: Pick<HumanTaskMutationInput, "userId" | "assigneeEntityIds" | "canEditAllLocalTasks">,
+): boolean {
+  if (task.status_authority !== "local" || (task.provenance !== "brief" && task.provenance !== "summary")) {
+    return false;
+  }
+  if (input.canEditAllLocalTasks === true) return true;
+  if (task.created_by_user_id === input.userId) return true;
+  return Boolean(task.assignee_entity_id && input.assigneeEntityIds?.includes(task.assignee_entity_id));
+}
+
+function logicalChanges(task: Selectable<TasksTable>, requested: HumanTaskChanges) {
+  const entries: Array<[string, { before: unknown; after: unknown }]> = [];
+  if (requested.title !== undefined && requested.title !== task.title) {
+    entries.push(["title", { before: task.title, after: requested.title }]);
+  }
+  if (Object.hasOwn(requested, "priority") && requested.priority !== task.priority) {
+    entries.push(["priority", { before: task.priority, after: requested.priority }]);
+  }
+  if (Object.hasOwn(requested, "dueAt") && requested.dueAt !== task.due_at) {
+    entries.push(["dueAt", { before: task.due_at, after: requested.dueAt }]);
+  }
+  if (requested.status !== undefined && requested.status !== task.status) {
+    entries.push(["status", { before: task.status, after: requested.status }]);
+  }
+  return Object.fromEntries(entries);
+}
+
+function taskUpdateValues(task: Selectable<TasksTable>, changes: HumanTaskChanges, now: string) {
+  const values: Partial<{
+    title: string;
+    normalized_title: string;
+    priority: string | null;
+    due_at: string | null;
+    status: TaskStatus;
+    status_raw: TaskStatus;
+    status_authority: "local";
+    status_changed_at: string;
+    completed_at: string | null;
+  }> = {};
+  if (changes.title !== undefined) {
+    values.title = changes.title;
+    values.normalized_title = normalizeName(changes.title);
+  }
+  if (Object.hasOwn(changes, "priority")) values.priority = changes.priority ?? null;
+  if (Object.hasOwn(changes, "dueAt")) values.due_at = changes.dueAt ?? null;
+  if (changes.status !== undefined && changes.status !== task.status) {
+    values.status = changes.status;
+    values.status_raw = changes.status;
+    values.status_authority = "local";
+    values.status_changed_at = now;
+    values.completed_at = changes.status === "done" ? now : null;
+  }
+  return values;
+}
+
+function mutationTime(task: Selectable<TasksTable>, requested: string | undefined): string {
+  if (requested) return requested;
+  const previousStatusChangedAt = Date.parse(task.status_changed_at ?? "");
+  return new Date(
+    Number.isFinite(previousStatusChangedAt) ? Math.max(Date.now(), previousStatusChangedAt + 1) : Date.now(),
+  ).toISOString();
+}
+
+function logicalFieldToProtectedField(field: string): TaskProtectedField {
+  if (field === "dueAt") return "due_at";
+  if (field === "title" || field === "priority" || field === "status") return field;
+  throw new Error(`Unsupported task field: ${field}`);
+}

--- a/packages/server/src/db/repositories/task-activity.ts
+++ b/packages/server/src/db/repositories/task-activity.ts
@@ -27,14 +27,15 @@ const EVIDENCE_IDENTIFIER_LIMIT = 5;
 
 export function createTaskActivityRepository(db: Kysely<DB> | Transaction<DB>) {
   return {
-    async append(input: AppendTaskActivityInput): Promise<{ created: boolean }> {
+    async append(input: AppendTaskActivityInput): Promise<{ id: string; created: boolean }> {
       const changes = normalizeChanges(input.changes);
       const evidence = normalizeEvidence(input.evidence);
       const dedupeKey = activityDedupeKey(input.eventKind, input.identityParts);
+      const id = randomUUID();
       const result = await db
         .insertInto("task_activity_events")
         .values({
-          id: randomUUID(),
+          id,
           task_id: input.taskId,
           event_kind: input.eventKind,
           actor_type: input.actorType,
@@ -49,7 +50,14 @@ export function createTaskActivityRepository(db: Kysely<DB> | Transaction<DB>) {
         })
         .onConflict((oc) => oc.column("dedupe_key").doNothing())
         .executeTakeFirst();
-      return { created: Number(result.numInsertedOrUpdatedRows ?? 0) > 0 };
+      const created = Number(result.numInsertedOrUpdatedRows ?? 0) > 0;
+      if (created) return { id, created: true };
+      const existing = await db
+        .selectFrom("task_activity_events")
+        .select("id")
+        .where("dedupe_key", "=", dedupeKey)
+        .executeTakeFirstOrThrow();
+      return { id: existing.id, created: false };
     },
   };
 }

--- a/packages/server/src/db/repositories/tasks.ts
+++ b/packages/server/src/db/repositories/tasks.ts
@@ -7,7 +7,8 @@ import type { AgentKnowledgeRefs, AgentOutputItemInput } from "./agent-outputs";
 import type { FileViewer } from "./connectors";
 import { fileVisibilityPredicate } from "./connectors";
 import { normalizeContactPointValue, whereLiveEntity } from "./entities";
-import { type TaskActivityChanges, type TaskActivitySurface, createTaskActivityRepository } from "./task-activity";
+import { createLocalTaskMutationPolicy } from "./local-task-mutations";
+import type { TaskActivityChanges, TaskActivitySurface } from "./task-activity";
 
 export const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
 const BRIEF_TASK_ID_SEPARATOR = "\u001f";
@@ -477,77 +478,15 @@ export function createTaskRepository(db: Kysely<DB>) {
     },
 
     async updateLocalTaskStatus(input: UpdateLocalTaskStatusInput): Promise<Selectable<TasksTable> | null> {
-      const mutationId = randomUUID();
-      return db.transaction().execute(async (trx) => {
-        for (let attempt = 0; attempt < 3; attempt += 1) {
-          const existing = await trx
-            .selectFrom("tasks")
-            .selectAll()
-            .where("id", "=", input.taskId)
-            .where("valid_to", "is", null)
-            .executeTakeFirst();
-          if (
-            !existing ||
-            !canEditLocalTask(
-              existing,
-              input.userId,
-              input.assigneeEntityIds ?? [],
-              input.canEditAllLocalTasks === true,
-            ) ||
-            existing.status_authority !== "local" ||
-            (existing.provenance !== "brief" && existing.provenance !== "summary")
-          ) {
-            return null;
-          }
-          if (existing.status === input.status) return existing;
-
-          const previousStatusChangedAt = Date.parse(existing.status_changed_at ?? "");
-          const now = new Date(
-            Number.isFinite(previousStatusChangedAt) ? Math.max(Date.now(), previousStatusChangedAt + 1) : Date.now(),
-          ).toISOString();
-          let update = trx
-            .updateTable("tasks")
-            .set({
-              status: input.status,
-              status_raw: input.status,
-              status_authority: "local",
-              status_changed_at: now,
-              completed_at: input.status === "done" ? now : null,
-              updated_at: now,
-            })
-            .where("id", "=", input.taskId)
-            .where("valid_to", "is", null)
-            .where("status", "=", existing.status)
-            .where("status_authority", "=", "local")
-            .where("provenance", "in", ["brief", "summary"]);
-          if (input.canEditAllLocalTasks !== true) {
-            update = update.where((eb) =>
-              eb.or([
-                eb("created_by_user_id", "=", input.userId),
-                ...((input.assigneeEntityIds?.length ?? 0) > 0
-                  ? [eb("assignee_entity_id", "in", input.assigneeEntityIds ?? [])]
-                  : []),
-              ]),
-            );
-          }
-          const result = await update.executeTakeFirst();
-          if (Number(result.numUpdatedRows ?? 0) === 0) continue;
-
-          await createTaskActivityRepository(trx).append({
-            taskId: existing.id,
-            eventKind: "status_changed",
-            actorType: "user",
-            actorUserId: input.userId,
-            surface: input.surface ?? "web",
-            changes: { status: { before: existing.status, after: input.status } },
-            identityParts: [existing.id, mutationId],
-            occurredAt: now,
-          });
-          return trx.selectFrom("tasks").selectAll().where("id", "=", input.taskId).executeTakeFirstOrThrow();
-        }
-
-        return null;
+      const result = await createLocalTaskMutationPolicy(db).mutateHumanTask({
+        taskId: input.taskId,
+        userId: input.userId,
+        assigneeEntityIds: input.assigneeEntityIds,
+        canEditAllLocalTasks: input.canEditAllLocalTasks,
+        changes: { status: input.status },
+        surface: input.surface ?? "web",
       });
+      return result.status === "applied" || result.status === "unchanged" ? result.task : null;
     },
   };
 }
@@ -1363,17 +1302,6 @@ function visibleTaskQuery(
           : []),
       ]),
     );
-}
-
-function canEditLocalTask(
-  task: Selectable<TasksTable>,
-  userId: string,
-  assigneeEntityIds: string[],
-  canEditAllLocalTasks = false,
-): boolean {
-  if (canEditAllLocalTasks) return true;
-  if (task.created_by_user_id === userId) return true;
-  return Boolean(task.assignee_entity_id && assigneeEntityIds.includes(task.assignee_entity_id));
 }
 
 async function findLiveProjectForTask(db: Kysely<DB>, parentSourceRef: string | null, parentName: string | null) {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1203,6 +1203,7 @@ export interface TasksTable {
   source_provider_thread_id: string | null;
   source_anchor_key: string | null;
   origin_agent_output_id: string | null;
+  revision: Generated<number>;
   created_at: Generated<string>;
   updated_at: Generated<string>;
 }
@@ -1279,6 +1280,52 @@ export interface TaskActivityEventsTable {
   dedupe_key: string;
   occurred_at: string;
   created_at: Generated<string>;
+}
+
+export type TaskProtectedField = "status" | "title" | "priority" | "due_at";
+
+export interface TaskFieldProtectionsTable {
+  task_id: string;
+  field: TaskProtectedField;
+  protected_by_user_id: string | null;
+  activity_event_id: string | null;
+  protected_at: string;
+}
+
+export type TaskChangeProposalState = "pending" | "accepted" | "rejected" | "superseded";
+export type TaskChangeProposalField = "title" | "priority" | "due_at";
+export type TaskChangeProposalEvidenceKind = "conversation_message" | "file" | "entity" | "fact" | "mention";
+
+export interface TaskChangeProposalsTable {
+  id: string;
+  task_id: string;
+  state: TaskChangeProposalState;
+  logical_fingerprint: string;
+  dedupe_key: string;
+  supersedes_proposal_id: string | null;
+  reviewed_at: string | null;
+  reviewed_by_user_id: string | null;
+  review_surface: string | null;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
+export interface TaskChangeProposalFieldsTable {
+  proposal_id: string;
+  field: TaskChangeProposalField;
+  observed_revision: number;
+  base_value_json: string;
+  proposed_value_json: string;
+  rationale: string;
+  source_occurred_at: string;
+  origin_agent_output_id: string | null;
+}
+
+export interface TaskChangeProposalEvidenceTable {
+  proposal_id: string;
+  field: TaskChangeProposalField;
+  kind: TaskChangeProposalEvidenceKind;
+  ref_id: string;
 }
 
 export interface TaskDurabilityRouteStateTable {
@@ -1465,6 +1512,10 @@ export interface DB {
   task_completion_recommendation_evidence: TaskCompletionRecommendationEvidenceTable;
   task_completion_recommendation_deliveries: TaskCompletionRecommendationDeliveriesTable;
   task_activity_events: TaskActivityEventsTable;
+  task_field_protections: TaskFieldProtectionsTable;
+  task_change_proposals: TaskChangeProposalsTable;
+  task_change_proposal_fields: TaskChangeProposalFieldsTable;
+  task_change_proposal_evidence: TaskChangeProposalEvidenceTable;
   task_durability_route_state: TaskDurabilityRouteStateTable;
   task_seed_candidates: TaskSeedCandidatesTable;
   work_cycles: WorkCyclesTable;


### PR DESCRIPTION
## Summary

Establishes the compatibility and persistence floor for human-authoritative durable task changes.

- adds monotonic task revisions, per-field human protections, and additive Task Change Proposal schema
- backfills status protection from the latest canonical human status activity
- routes direct and entity-scoped task edits through one transaction-aware mutation policy
- preserves legacy `{ status }` requests while requiring `expectedRevision` for metadata edits
- adopts the shared policy for Completion Review acceptance
- returns revision, editable fields, and protected fields in task DTOs and Daily Brief hydration
- keeps hidden local and external task identities non-disclosing

There is no experimental flag gating in this implementation.

## API and concurrency

- `PATCH /api/tasks/:taskId`
- `PATCH /api/entities/:id/tasks/:taskId`

Both routes accept `expectedRevision` plus any subset of `title`, `priority`, `dueAt`, and `status`. Metadata edits require the observed revision. Meaningful multi-field edits increment revision once, while stale already-current retries remain idempotent. Task changes, activity, revision, and protection markers commit in one transaction.

## Compatibility and rollout

- legacy status-only clients continue to work
- external, structural, expired, and unauthorized tasks remain read-only or non-disclosing
- Completion Review and existing Slack/WhatsApp coded review commands keep their current persistence and API contracts
- migration down is allowed only while no authority, proposal, or nonzero revision state exists

This PR is the blocking predecessor for SKE-299.

## Verification

- `pnpm biome check .`
- `pnpm typecheck`
- `pnpm test` — 4,639 server tests passed; 20 expected live-provider skips
- `pnpm build`
- changed unit tier — 2,837 tests passed
- SQLite and PGlite migration, constraint, rollback, replay, stale-write, and atomicity coverage
- Standards review: no findings
- Spec review: hidden entity-scoped task disclosure fixed and verified

## Linear

[SKE-298 — PR 1: Compatibility, schema, and mutation policy](https://linear.app/sketch-ai/issue/SKE-298/pr-1-compatibility-schema-and-mutation-policy)

Parent: [SKE-297 — Task Durability — Human-Authoritative Task Changes](https://linear.app/sketch-ai/issue/SKE-297/task-durability-human-authoritative-task-changes)
