### PR TITLE
SKE-301: Split automation authoring from execution model selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,9 @@ LOG_LEVEL=info          # debug | info | warn | error
 # VISION_ENABLED=false
 # VISION_MODEL=xiaomi/mimo-v2.5
 # OPENROUTER_API_KEY=sk-or-v1-...
+# Optional complete OpenRouter model ID for natural-language automation creation and editing.
+# Reuses the configured OpenRouter credentials; leave unset to preserve normal authoring behavior.
+# AUTOMATION_AUTHORING_MODEL=anthropic/claude-sonnet-4.6
 # Entity graph heuristics
 # LLM_PROMOTION_THRESHOLD=2
 # LLM_TASK_CORROBORATION_THRESHOLD=2

--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -187,6 +187,24 @@ describe("buildSystemContext", () => {
       expect(result).toContain("must call ListFollowups first");
       expect(result).toContain("durable follow-up state is authoritative");
     });
+
+    it("routes semantic authoring through natural-language ManageScheduledTasks requests when configured", () => {
+      const result = buildSystemContext({ platform: "slack", automationAuthoringEnabled: true });
+
+      expect(result).toContain("pass the user's requested change as a natural-language request");
+      expect(result).toContain("Do not construct or pass automation definition fields");
+      expect(result).toContain("Never use updateStepContent");
+      expect(result).toContain("list, pause, resume, run, delete, and inspect run history");
+      expect(result).toContain("include the resolved target ID and label in the natural-language");
+    });
+
+    it("preserves legacy structured authoring guidance when authoring is not configured", () => {
+      const result = buildSystemContext({ platform: "slack" });
+
+      expect(result).not.toContain("Do not construct or pass automation definition fields");
+      expect(result).not.toContain("Never use updateStepContent");
+      expect(result).toContain("pass the resolved target ID in ManageScheduledTasks delivery");
+    });
   });
 
   describe("file attachments section", () => {

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -330,6 +330,7 @@ export function buildSystemContext(params: {
   indexedSources?: Array<{ source: string; fileCount: number }>;
   agentInstructions?: string | null;
   visionAnalysisEnabled?: boolean;
+  automationAuthoringEnabled?: boolean;
 }): string {
   const sections: string[] = [];
 
@@ -378,12 +379,23 @@ export function buildSystemContext(params: {
     "## Scheduled Tasks",
     "",
     "Use the ManageScheduledTasks tool when a user asks to do something periodically, on a schedule, or as a reminder. The creation context is filled in automatically, but final delivery is editable through the delivery fields.",
-    "When the user names a delivery destination, use SearchDeliveryTargets first, then pass the resolved target ID in ManageScheduledTasks delivery.",
+    params.automationAuthoringEnabled
+      ? "When the user names a delivery destination, use SearchDeliveryTargets first, then include the resolved target ID and label in the natural-language ManageScheduledTasks request."
+      : "When the user names a delivery destination, use SearchDeliveryTargets first, then pass the resolved target ID in ManageScheduledTasks delivery.",
     "If a workflow is created from a Slack thread, default future workflow output to the parent channel top-level. Only set delivery.threadTs when the user explicitly asks to post workflow updates in that thread.",
     "When running a scheduled task, return the final message only; Sketch will automatically deliver your returned text to the task's configured Slack/WhatsApp destination, so do not try to find or use a chat-sending tool unless the task explicitly asks you to DM another person.",
     "When a scheduled task asks for reminders, follow-ups, outstanding commitments, or completed work, you must call ListFollowups first. Its durable follow-up state is authoritative: pending items stay pending, looks-resolved items require user review, confirmed or rejected work must not be reconstructed from chat history, and untracked items must remain labelled as untracked.",
     "For external app events, prefer a Canvas-managed trigger only when a Canvas skill/MCP is available: use Canvas search_components to find the trigger, then create a workflow with triggerConfig.type='canvas'. If Canvas is not available, use a normal scheduled cron/interval/once trigger instead.",
   );
+
+  if (params.automationAuthoringEnabled) {
+    sections.push(
+      "When creating or semantically editing an automation, pass the user's requested change as a natural-language request to ManageScheduledTasks. For edits, include the task ID.",
+      "Do not construct or pass automation definition fields such as schedules, timezones, delivery, titles, descriptions, steps, edges, prompts, scripts, apps, modes, skills, MCP servers, or models. The automation authoring model owns the complete definition.",
+      "Never use updateStepContent. Prompt, script, app, mode, skill, MCP, schedule, delivery, and structural changes must use a full ManageScheduledTasks update with the user's natural-language request.",
+      "Operational actions remain deterministic: use ManageScheduledTasks directly to list, pause, resume, run, delete, and inspect run history without an authoring request.",
+    );
+  }
 
   if (params.platform === "web") {
     sections.push(

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -12,6 +12,7 @@ import { type SDKUserMessage, query } from "@anthropic-ai/claude-agent-sdk";
 import { AGENT_BUILT_IN_TOOL_NAMES, VISUAL_ANALYSIS_AGENT_TOOL_NAME } from "@sketch/shared";
 import type { AutomationArtifact, WebChatIntegrationConnectionData } from "@sketch/shared";
 import type { Kysely, Selectable } from "kysely";
+import type { ChatAutomationAuthoring } from "../automation/chat-authoring";
 import { listIndexedSourcesForPrompt } from "../connectors/search";
 import type { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import type { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
@@ -313,6 +314,8 @@ export interface RunAgentParams {
   taskContext?: TaskContext;
   getSlack?: () => SlackBot | null;
   scheduler?: TaskScheduler;
+  chatAutomationAuthoring?: ChatAutomationAuthoring;
+  automationAuthoringEnabled?: boolean;
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };
@@ -788,6 +791,7 @@ async function runAgentWithAiSdk(params: RunAgentParams): Promise<RunAgentResult
     indexedSources,
     agentInstructions: params.agentInstructions,
     visionAnalysisEnabled: visualAnalysisAllowed,
+    automationAuthoringEnabled: params.automationAuthoringEnabled,
   });
   const claudeMdContext = await loadAgentRuntimeClaudeMdContext({
     orgClaudeDir: params.claudeConfigDir,
@@ -1142,6 +1146,7 @@ async function runAgentWithClaudeSdk(params: RunAgentParams): Promise<RunAgentRe
     indexedSources,
     agentInstructions: params.agentInstructions,
     visionAnalysisEnabled: visualAnalysisAllowed,
+    automationAuthoringEnabled: params.automationAuthoringEnabled,
   });
 
   const sdkBuiltInTools = resolveSdkBuiltInTools(params.agentAllowedTools);
@@ -1203,6 +1208,7 @@ async function runAgentWithClaudeSdk(params: RunAgentParams): Promise<RunAgentRe
     loadIntegrationProvider: params.loadIntegrationProvider,
     taskContext: params.taskContext,
     scheduler: params.scheduler,
+    chatAuthoring: params.chatAutomationAuthoring,
     stepContentRepo: params.stepContentRepo,
     automationRunsRepo: params.automationRunsRepo,
     queueManager: params.queueManager,

--- a/packages/server/src/agent/runtime/custom-tools.ts
+++ b/packages/server/src/agent/runtime/custom-tools.ts
@@ -176,6 +176,7 @@ function buildSketchMcpDeps(params: RunAgentParams, deps: AgentRuntimeCustomTool
     loadIntegrationProvider: params.loadIntegrationProvider,
     taskContext: params.taskContext,
     scheduler: params.scheduler,
+    chatAuthoring: params.chatAutomationAuthoring,
     stepContentRepo: params.stepContentRepo,
     automationRunsRepo: params.automationRunsRepo,
     queueManager: params.queueManager,

--- a/packages/server/src/agent/runtime/provider.test.ts
+++ b/packages/server/src/agent/runtime/provider.test.ts
@@ -76,6 +76,7 @@ describe("agent runtime provider factory", () => {
 
     expect(provider.provider).toBe("openrouter");
     expect(provider.modelId).toBe("vendor/non-claude-live-model");
+    expect((provider.model as { supportsStructuredOutputs?: boolean }).supportsStructuredOutputs).toBe(true);
     expect(provider.preparePrompt({ systemPrompt: "sys", prompt: "user", cacheBreakpoints: true })).toEqual({
       instructions: "sys",
       messages: [{ role: "user", content: "user" }],

--- a/packages/server/src/agent/runtime/provider.ts
+++ b/packages/server/src/agent/runtime/provider.ts
@@ -178,6 +178,10 @@ export function createAgentRuntimeProvider(
       headers: config.headers,
       fetch: deps.fetch,
       includeUsage: true,
+      // OpenRouter advertises JSON-schema structured output for the authoring model.
+      // Without this flag the AI SDK silently downgrades Output.object to JSON-object
+      // mode, allowing prose that fails the automation schema.
+      supportsStructuredOutputs: config.provider === "openrouter",
     });
     return {
       provider: config.provider,

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -48,6 +48,7 @@ export function createSketchMcpToolDefinitions(deps: SketchMcpDeps) {
     createLocalClaudeSessionTool(deps),
     createManageScheduledTasksTool({
       scheduler: deps.scheduler,
+      chatAuthoring: deps.chatAuthoring,
       taskContext: deps.taskContext,
       stepContentRepo: deps.stepContentRepo,
       automationRunsRepo: deps.automationRunsRepo,

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -1,6 +1,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
 import { z } from "zod/v4";
+import type { ChatAutomationAuthoring, ChatAutomationAuthoringResult } from "../../automation/chat-authoring";
 import {
   AutomationValidationError,
   validateAutomationBuilderSaveRequest,
@@ -139,10 +140,33 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
   step_apps: z.array(z.string()).optional().describe("Updated MCP server slugs for updateStepContent action."),
 };
 
-type WorkflowStepInput = z.infer<typeof workflowStepSchema>;
+const authoredScheduledTasksSchema = {
+  action: z.enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun"]).describe(
+    `Action to perform.
+- 'add': create an automation from the user's natural-language request
+- 'update': edit an automation from the user's natural-language request (requires task_id)
+- 'list': list automations in this context
+- 'remove': delete an automation (requires task_id)
+- 'pause': pause an automation (requires task_id)
+- 'resume': resume a paused automation (requires task_id)
+- 'run': manually trigger an automation (requires task_id)
+- 'getRun': inspect run results (requires task_id, optional run_id for specific run)`,
+  ),
+  request: z
+    .string()
+    .optional()
+    .describe(
+      "The user's natural-language automation request. Required for add and update; preserve their intent verbatim.",
+    ),
+  task_id: z.string().optional().describe("ID of the task. Required for update/remove/pause/resume/run/getRun."),
+  run_id: z.string().optional().describe("Run ID for getRun action. Omit for latest run."),
+};
+
+export type WorkflowStepInput = z.infer<typeof workflowStepSchema>;
 
 type ManageScheduledTasksParams = {
   action: "list" | "add" | "update" | "remove" | "pause" | "resume" | "run" | "getRun" | "updateStepContent";
+  request?: string;
   prompt?: string;
   schedule_type?: "cron" | "interval" | "once" | "external";
   schedule_value?: string;
@@ -181,6 +205,7 @@ export interface ManageScheduledTasksDeps {
   activeQueueKey?: string;
   config?: { BASE_URL?: string; PORT: number };
   automationArtifactCollector?: AutomationArtifactCollector;
+  chatAuthoring?: ChatAutomationAuthoring;
 }
 
 function stripContentFromSteps(steps: WorkflowStepInput[]): WorkflowStep[] {
@@ -445,7 +470,7 @@ function buildBuilderUrl(taskId: string, config: ManageScheduledTasksDeps["confi
 }
 
 function buildArtifactTags(params: {
-  steps: WorkflowStepInput[];
+  steps: Array<WorkflowStep & { apps?: string[] }>;
   scheduleType: string;
   deliveryPlatform: string;
 }): string[] {
@@ -463,7 +488,7 @@ function buildArtifactScheduleLabel(params: {
   scheduleType: string;
   scheduleValue: string;
   timezone: string;
-  steps: WorkflowStepInput[];
+  steps: Array<WorkflowStep & { apps?: string[] }>;
 }): string {
   if (params.scheduleType === "external") {
     const trigger = params.steps.find((step) => step.type === "trigger")?.triggerConfig;
@@ -480,7 +505,7 @@ function buildArtifactScheduleLabel(params: {
 function collectAutomationArtifact(params: {
   deps: ManageScheduledTasksDeps;
   task: ScheduledTask;
-  steps: WorkflowStepInput[];
+  steps: Array<WorkflowStep & { apps?: string[] }>;
   scheduleType: string;
   scheduleValue: string;
   timezone: string;
@@ -510,6 +535,89 @@ function collectAutomationArtifact(params: {
   return builderUrl;
 }
 
+const LEGACY_AUTHORING_FIELDS = [
+  "prompt",
+  "schedule_type",
+  "schedule_value",
+  "timezone",
+  "session_mode",
+  "title",
+  "description",
+  "steps",
+  "edges",
+  "output_target",
+  "output_platform",
+  "output_thread_ts",
+  "output_mode",
+  "delivery",
+  "step_id",
+  "step_content",
+  "step_apps",
+] as const satisfies readonly (keyof ManageScheduledTasksParams)[];
+
+function hasLegacyAuthoringFields(params: ManageScheduledTasksParams): boolean {
+  return LEGACY_AUTHORING_FIELDS.some((field) => hasOwn(params, field));
+}
+
+async function handleConfiguredChatAuthoring(
+  params: ManageScheduledTasksParams,
+  deps: ManageScheduledTasksDeps,
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const text = (msg: string) => ({ content: [{ type: "text" as const, text: msg }] });
+  const chatAuthoring = deps.chatAuthoring;
+  if (!chatAuthoring) {
+    return text("Error: automation authoring is not configured.");
+  }
+  if (params.action === "updateStepContent") {
+    return text(
+      "Error: direct step-content updates are unavailable while automation authoring is configured. Use update with a natural-language request so the change is applied as a full automation edit.",
+    );
+  }
+  if (params.action !== "add" && params.action !== "update") {
+    return text("Error: this action is not an automation authoring action.");
+  }
+  if (hasLegacyAuthoringFields(params)) {
+    return text(
+      "Error: structured automation fields cannot be supplied while automation authoring is configured. Pass only the user's natural-language request.",
+    );
+  }
+  const request = params.request?.trim();
+  if (!request) {
+    return text(`Error: request is required for ${params.action} action.`);
+  }
+  if (params.action === "update" && !params.task_id) {
+    return text("Error: task_id is required for update action.");
+  }
+
+  let result: ChatAutomationAuthoringResult;
+  try {
+    result = await chatAuthoring.author({
+      action: params.action === "add" ? "create" : "edit",
+      request,
+      ...(params.task_id ? { taskId: params.task_id } : {}),
+      taskContext: deps.taskContext,
+    });
+  } catch {
+    return text("Error: automation authoring is temporarily unavailable. No changes were saved.");
+  }
+
+  if (result.kind === "clarification") return text(result.message);
+  if (result.kind === "error") return text(`Error: ${result.message}`);
+
+  if (params.action === "add") {
+    collectAutomationArtifact({
+      deps,
+      task: result.task,
+      steps: result.artifact.steps,
+      scheduleType: result.artifact.scheduleType,
+      scheduleValue: result.artifact.scheduleValue,
+      timezone: result.artifact.timezone,
+    });
+  }
+  const verb = params.action === "add" ? "created" : "updated";
+  return text(`Automation ${verb}:\n${JSON.stringify(result.task, null, 2)}`);
+}
+
 export async function handleManageScheduledTasks(
   params: ManageScheduledTasksParams,
   deps: ManageScheduledTasksDeps,
@@ -523,6 +631,10 @@ export async function handleManageScheduledTasks(
     "Error: Action steps require a broker-capable integration provider (e.g. Canvas MCP in skill mode). Configure one in Settings → Integrations, or use agent-only automations.";
   const FRESH_SESSION_ONLY_MSG =
     "Error: scheduled automations currently support only 'fresh' session_mode. Omit session_mode or set it to 'fresh'.";
+
+  if (deps.chatAuthoring && (action === "add" || action === "update" || action === "updateStepContent")) {
+    return handleConfiguredChatAuthoring(params, deps);
+  }
 
   /** Returns an error response if any action step is present but no broker-capable
    *  provider is configured. Returns null when validation passes (no action steps,
@@ -1067,7 +1179,7 @@ export function createManageScheduledTasksTool(deps: Partial<ManageScheduledTask
   return tool(
     "ManageScheduledTasks",
     "Manage scheduled tasks that run automatically. Platform, delivery target, and creator are filled in automatically from context. Do not ask the user for these.",
-    manageScheduledTasksSchema,
+    deps.chatAuthoring ? authoredScheduledTasksSchema : manageScheduledTasksSchema,
     async (params) => {
       if (!deps.scheduler || !deps.taskContext) {
         return { content: [{ type: "text" as const, text: "Scheduled tasks are not available in this context." }] };
@@ -1083,6 +1195,7 @@ export function createManageScheduledTasksTool(deps: Partial<ManageScheduledTask
         activeQueueKey: deps.activeQueueKey,
         config: deps.config,
         automationArtifactCollector: deps.automationArtifactCollector,
+        chatAuthoring: deps.chatAuthoring,
       });
     },
   );

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -1,5 +1,6 @@
 import type { AutomationArtifact, WebChatIntegrationConnectionData } from "@sketch/shared";
 import type { Kysely, Selectable } from "kysely";
+import type { ChatAutomationAuthoring } from "../../automation/chat-authoring";
 import type { createAutomationRunsRepository } from "../../db/repositories/automation-runs";
 import type { createAutomationStepContentRepository } from "../../db/repositories/automation-step-content";
 import type { createConversationRepository } from "../../db/repositories/conversations";
@@ -94,6 +95,7 @@ export interface SketchMcpDeps {
   taskContext?: TaskContext;
   getSlack?: () => SlackBot | null;
   scheduler?: TaskScheduler;
+  chatAuthoring?: ChatAutomationAuthoring;
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: { getQueue: (key: string) => { enqueue: (fn: () => Promise<void>) => void } };

--- a/packages/server/src/api/scheduled-tasks.test.ts
+++ b/packages/server/src/api/scheduled-tasks.test.ts
@@ -890,7 +890,22 @@ describe("Scheduled Tasks API", () => {
       content: "Stale prompt",
     });
 
-    const refreshTaskSchedule = vi.fn(async () => null);
+    let refreshObserved:
+      | {
+          revision: number;
+          title: string | null;
+          content: Awaited<ReturnType<typeof stepContent.getByTask>>;
+        }
+      | undefined;
+    const refreshTaskSchedule = vi.fn(async (taskId: string) => {
+      const committedRow = await tasks.getById(taskId);
+      refreshObserved = {
+        revision: committedRow?.revision ?? -1,
+        title: committedRow?.title ?? null,
+        content: await stepContent.getByTask(taskId),
+      };
+      return null;
+    });
     const app = createApp(db, config, {
       scheduler: {
         pauseTask: vi.fn(),
@@ -918,6 +933,11 @@ describe("Scheduled Tasks API", () => {
       scheduleValue: "120",
     });
     expect(refreshTaskSchedule).toHaveBeenCalledWith("task-builder");
+    expect(refreshObserved).toMatchObject({
+      revision: 1,
+      title: "Daily account brief",
+      content: [{ step_id: "agent-1", content: "Check account activity and summarize changes." }],
+    });
 
     const row = await tasks.getById("task-builder");
     expect(row).toMatchObject({

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -1,13 +1,12 @@
 import { type Context, Hono } from "hono";
-import { type Kysely, type Selectable, sql } from "kysely";
+import type { Kysely, Selectable } from "kysely";
 import type { Logger } from "pino";
 import {
   AutomationValidationError,
   buildAutomationDefinition,
   parseAutomationBuilderSaveRequest,
-  scheduledTaskFieldsFromSaveRequest,
-  validateAutomationBuilderSaveRequest,
 } from "../automation/definition";
+import { replaceAutomationDefinition } from "../automation/persistence";
 import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
 import { createChannelRepository } from "../db/repositories/channels";
@@ -479,8 +478,16 @@ export function scheduledTaskRoutes(
     const brokerCapable = request.steps.some((step) => step.type === "action")
       ? await hasBrokerCapableProvider()
       : true;
+    const userId = await resolveUserId(c.get("sub"));
+    let saveResult: Awaited<ReturnType<typeof replaceAutomationDefinition>>;
     try {
-      validateAutomationBuilderSaveRequest({ request, brokerCapable });
+      saveResult = await replaceAutomationDefinition({
+        db,
+        taskId: id,
+        request,
+        actor: { userId, canManageAnyTask: c.get("role") === "admin" },
+        brokerCapable,
+      });
     } catch (err) {
       if (err instanceof AutomationValidationError) {
         logger?.warn(
@@ -494,62 +501,6 @@ export function scheduledTaskRoutes(
       }
       throw err;
     }
-
-    const userId = await resolveUserId(c.get("sub"));
-    let updatedRow: ScheduledTaskRow | undefined;
-    const contentEntries = Object.values(request.stepContent).filter((content) =>
-      request.steps.some((step) => step.id === content.stepId && step.type !== "trigger"),
-    );
-
-    const saveResult = await db.transaction().execute(async (trx) => {
-      const current = await trx.selectFrom("scheduled_tasks").selectAll().where("id", "=", id).executeTakeFirst();
-      if (!current) return { kind: "not_found" as const };
-      if (!canAccess(current, userId, c.get("role"))) return { kind: "not_found" as const };
-      if (request.expectedRevision !== undefined && current.revision !== request.expectedRevision) {
-        return { kind: "revision_conflict" as const, currentRevision: current.revision };
-      }
-
-      const fields = scheduledTaskFieldsFromSaveRequest(request);
-      let update = trx
-        .updateTable("scheduled_tasks")
-        .set({
-          ...fields,
-          revision: sql<number>`revision + 1`,
-          updated_at: sql`CURRENT_TIMESTAMP`,
-          last_edited_by: userId,
-        })
-        .where("id", "=", id);
-      if (request.expectedRevision !== undefined) {
-        update = update.where("revision", "=", request.expectedRevision);
-      }
-      const updateResult = await update.executeTakeFirst();
-      if (Number(updateResult.numUpdatedRows ?? 0) === 0) {
-        const latest = await trx
-          .selectFrom("scheduled_tasks")
-          .select("revision")
-          .where("id", "=", id)
-          .executeTakeFirst();
-        return { kind: "revision_conflict" as const, currentRevision: latest?.revision ?? current.revision };
-      }
-
-      const txStepContentRepo = createAutomationStepContentRepository(trx);
-      await txStepContentRepo.deleteOrphanedSteps(
-        id,
-        contentEntries.map((content) => content.stepId),
-      );
-      for (const content of contentEntries) {
-        await txStepContentRepo.upsert({
-          taskId: id,
-          stepId: content.stepId,
-          contentType: content.contentType,
-          content: content.content,
-          apps: content.apps,
-        });
-      }
-
-      updatedRow = await trx.selectFrom("scheduled_tasks").selectAll().where("id", "=", id).executeTakeFirst();
-      return { kind: "saved" as const };
-    });
 
     if (saveResult.kind === "not_found") {
       return c.json({ error: { code: "NOT_FOUND", message: "Scheduled task not found" } }, 404);
@@ -568,7 +519,7 @@ export function scheduledTaskRoutes(
     }
 
     await scheduler.refreshTaskSchedule(id);
-    const refreshed = (await repo.getById(id)) ?? updatedRow ?? result.row;
+    const refreshed = (await repo.getById(id)) ?? saveResult.row;
     return c.json({ automation: await loadFullDefinition(refreshed) });
   });
 

--- a/packages/server/src/automation/authoring/evaluation.test.ts
+++ b/packages/server/src/automation/authoring/evaluation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { AutomationValidationError, validateAutomationBuilderSaveRequest } from "../definition";
+import { poorGenerationFixtures } from "./fixtures";
+import { automationAuthoringDefinitionSchema, toAutomationBuilderSaveRequest } from "./schema";
+
+describe("automation authoring deterministic evaluation fixtures", () => {
+  it.each(poorGenerationFixtures)(
+    "$name violates the $expectedIssue semantic invariant",
+    ({ draft, expectedIssue }) => {
+      const generated = automationAuthoringDefinitionSchema.parse(draft);
+      const request = toAutomationBuilderSaveRequest(generated, { taskId: "eval-task", status: "active" });
+
+      try {
+        validateAutomationBuilderSaveRequest({ request, brokerCapable: true });
+        throw new Error("expected fixture to violate an automation invariant");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AutomationValidationError);
+        expect((error as AutomationValidationError).issues.map((issue) => issue.code)).toContain(expectedIssue);
+      }
+    },
+  );
+});

--- a/packages/server/src/automation/authoring/fixtures.ts
+++ b/packages/server/src/automation/authoring/fixtures.ts
@@ -1,0 +1,116 @@
+import type { AutomationDefinition } from "@sketch/shared";
+import type { AutomationAuthoringDefinition } from "./schema";
+
+export const validAuthoringDefinition: AutomationAuthoringDefinition = {
+  title: "Weekday digest",
+  description: "Summarize updates every weekday",
+  prompt: "Summarize the completed workflow",
+  scheduleType: "cron",
+  scheduleValue: "0 9 * * 1-5",
+  timezone: "Asia/Kolkata",
+  delivery: {
+    platform: "slack",
+    targetType: "dm",
+    targetId: "U123",
+    threadTs: null,
+    mode: "deliver",
+  },
+  steps: [
+    {
+      id: "trigger",
+      type: "trigger",
+      label: "Weekday schedule",
+      icon: "clock",
+      position: { x: 0, y: 0 },
+      triggerConfig: {
+        type: "schedule",
+        scheduleType: "cron",
+        scheduleValue: "0 9 * * 1-5",
+        timezone: "Asia/Kolkata",
+      },
+    },
+    {
+      id: "digest",
+      type: "agent",
+      label: "Prepare digest",
+      icon: "sketch-ai",
+      position: { x: 260, y: 0 },
+      agentMode: "sketch",
+      agentSkills: ["daily-summary"],
+      agentMcpServers: ["linear"],
+    },
+  ],
+  edges: [{ id: "trigger-digest", from: "trigger", to: "digest" }],
+  stepContent: {
+    digest: {
+      stepId: "digest",
+      contentType: "prompt",
+      content: "Summarize updates and call out blockers.",
+      apps: ["linear"],
+    },
+  },
+};
+
+export const existingAutomationDefinition: AutomationDefinition = {
+  id: "task-123",
+  platform: "slack",
+  contextType: "dm",
+  deliveryTarget: "U123",
+  threadTs: null,
+  prompt: validAuthoringDefinition.prompt,
+  scheduleType: validAuthoringDefinition.scheduleType,
+  scheduleValue: validAuthoringDefinition.scheduleValue,
+  timezone: validAuthoringDefinition.timezone,
+  sessionMode: "fresh",
+  nextRunAt: null,
+  lastRunAt: null,
+  status: "active",
+  createdBy: "user-1",
+  createdAt: "2026-07-20T00:00:00.000Z",
+  updatedAt: "2026-07-26T00:00:00.000Z",
+  revision: 7,
+  title: validAuthoringDefinition.title,
+  description: validAuthoringDefinition.description,
+  originChat: null,
+  delivery: validAuthoringDefinition.delivery,
+  steps: validAuthoringDefinition.steps.map((step) =>
+    step.id === "digest" ? { ...step, agentModel: "xiaomi/mimo-v2.5" } : step,
+  ),
+  edges: validAuthoringDefinition.edges,
+  stepContent: {
+    digest: {
+      taskId: "task-123",
+      ...validAuthoringDefinition.stepContent.digest,
+      updatedAt: "2026-07-26T00:00:00.000Z",
+    },
+  },
+  latestRun: null,
+  recentRuns: [],
+};
+
+export const poorGenerationFixtures = [
+  {
+    name: "missing agent content",
+    draft: {
+      ...validAuthoringDefinition,
+      stepContent: {},
+    },
+    expectedIssue: "AGENT_PROMPT_REQUIRED",
+  },
+  {
+    name: "disconnected execution step",
+    draft: {
+      ...validAuthoringDefinition,
+      edges: [],
+    },
+    expectedIssue: "MISSING_EDGES",
+  },
+  {
+    name: "mismatched trigger schedule",
+    draft: {
+      ...validAuthoringDefinition,
+      scheduleValue: "0 10 * * 1-5",
+    },
+    expectedIssue: "SCHEDULE_TRIGGER_MISMATCH",
+  },
+] as const;

--- a/packages/server/src/automation/authoring/generator.test.ts
+++ b/packages/server/src/automation/authoring/generator.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { validAuthoringDefinition } from "./fixtures";
+import { createAiSdkAutomationAuthoringGenerator } from "./generator";
+import { automationAuthoringOutputSchema } from "./schema";
+import { AutomationAuthoringGeneratedOutputError, type StructuredAutomationAuthoringGenerator } from "./service";
+
+const provider = {
+  provider: "openrouter" as const,
+  modelId: "anthropic/claude-sonnet-4.6",
+  model: {} as never,
+};
+
+function request(): Parameters<StructuredAutomationAuthoringGenerator["generate"]>[0] {
+  return {
+    operation: "create",
+    provider,
+    instructions: "Return a definition",
+    prompt: "Create a digest",
+    outputSchema: automationAuthoringOutputSchema,
+    attempt: 1,
+    maxRetries: 0,
+    timeoutMs: 30_000,
+    maxOutputTokens: 4096,
+  };
+}
+
+describe("AI SDK automation authoring generator", () => {
+  it("uses structured output with hard retry, timeout, output, and retained-body bounds", async () => {
+    const generateText = vi.fn().mockResolvedValue({
+      output: { kind: "definition", definition: validAuthoringDefinition },
+      response: { modelId: "anthropic/claude-sonnet-4.6" },
+      usage: {
+        inputTokens: 120,
+        inputTokenDetails: { noCacheTokens: 100, cacheReadTokens: 20, cacheWriteTokens: 0 },
+        outputTokens: 50,
+      },
+    });
+    const generator = createAiSdkAutomationAuthoringGenerator({ generateText });
+
+    await expect(generator.generate(request())).resolves.toMatchObject({
+      output: { kind: "definition" },
+      model: "anthropic/claude-sonnet-4.6",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 20,
+        cacheWriteTokens: 0,
+      },
+    });
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: provider.model,
+        instructions: "Return a definition",
+        prompt: "Create a digest",
+        maxRetries: 0,
+        timeout: { totalMs: 30_000 },
+        maxOutputTokens: 4096,
+        include: { requestBody: false, requestMessages: false, responseBody: false },
+        output: expect.anything(),
+      }),
+    );
+  });
+
+  it("classifies structured-output parse failures as validation failures with usage but no response text", async () => {
+    const generateText = vi.fn().mockRejectedValue({
+      name: "AI_NoObjectGeneratedError",
+      text: "sensitive invalid draft",
+      response: { modelId: "anthropic/claude-sonnet-4.6" },
+      usage: {
+        inputTokens: 80,
+        inputTokenDetails: { noCacheTokens: 80, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        outputTokens: 10,
+      },
+    });
+    const generator = createAiSdkAutomationAuthoringGenerator({
+      generateText,
+      isNoObjectGeneratedError: (error) =>
+        Boolean(
+          error && typeof error === "object" && (error as { name?: string }).name === "AI_NoObjectGeneratedError",
+        ),
+    });
+
+    try {
+      await generator.generate(request());
+      throw new Error("expected structured output failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AutomationAuthoringGeneratedOutputError);
+      expect(error).not.toHaveProperty("text");
+      expect((error as AutomationAuthoringGeneratedOutputError).generation).toMatchObject({
+        model: "anthropic/claude-sonnet-4.6",
+        usage: { inputTokens: 80, outputTokens: 10 },
+      });
+    }
+  });
+});

--- a/packages/server/src/automation/authoring/generator.test.ts
+++ b/packages/server/src/automation/authoring/generator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { validAuthoringDefinition } from "./fixtures";
 import { createAiSdkAutomationAuthoringGenerator } from "./generator";
-import { automationAuthoringOutputSchema } from "./schema";
+import { automationAuthoringTransportSchema } from "./schema";
 import { AutomationAuthoringGeneratedOutputError, type StructuredAutomationAuthoringGenerator } from "./service";
 
 const provider = {
@@ -16,7 +16,7 @@ function request(): Parameters<StructuredAutomationAuthoringGenerator["generate"
     provider,
     instructions: "Return a definition",
     prompt: "Create a digest",
-    outputSchema: automationAuthoringOutputSchema,
+    outputSchema: automationAuthoringTransportSchema,
     attempt: 1,
     maxRetries: 0,
     timeoutMs: 30_000,
@@ -27,7 +27,11 @@ function request(): Parameters<StructuredAutomationAuthoringGenerator["generate"
 describe("AI SDK automation authoring generator", () => {
   it("uses structured output with hard retry, timeout, output, and retained-body bounds", async () => {
     const generateText = vi.fn().mockResolvedValue({
-      output: { kind: "definition", definition: validAuthoringDefinition },
+      output: {
+        kind: "definition",
+        definitionJson: JSON.stringify(validAuthoringDefinition),
+        question: "",
+      },
       response: { modelId: "anthropic/claude-sonnet-4.6" },
       usage: {
         inputTokens: 120,
@@ -50,7 +54,7 @@ describe("AI SDK automation authoring generator", () => {
     expect(generateText).toHaveBeenCalledWith(
       expect.objectContaining({
         model: provider.model,
-        instructions: "Return a definition",
+        instructions: expect.stringMatching(/Return a definition[\s\S]*definitionJson[\s\S]*"steps"/),
         prompt: "Create a digest",
         maxRetries: 0,
         timeout: { totalMs: 30_000 },
@@ -59,6 +63,26 @@ describe("AI SDK automation authoring generator", () => {
         output: expect.anything(),
       }),
     );
+  });
+
+  it("decodes a clarification from the provider-compatible transport", async () => {
+    const generateText = vi.fn().mockResolvedValue({
+      output: {
+        kind: "clarification",
+        definitionJson: "",
+        question: "Which Slack channel should receive the digest?",
+      },
+      response: { modelId: "anthropic/claude-sonnet-4.6" },
+      usage: {},
+    });
+    const generator = createAiSdkAutomationAuthoringGenerator({ generateText });
+
+    await expect(generator.generate(request())).resolves.toMatchObject({
+      output: {
+        kind: "clarification",
+        question: "Which Slack channel should receive the digest?",
+      },
+    });
   });
 
   it("classifies structured-output parse failures as validation failures with usage but no response text", async () => {

--- a/packages/server/src/automation/authoring/generator.ts
+++ b/packages/server/src/automation/authoring/generator.ts
@@ -1,5 +1,7 @@
 import { NoObjectGeneratedError, Output, generateText } from "ai";
+import { z } from "zod";
 import { extractRuntimeModelUsage } from "../../agent/runtime/usage";
+import { automationAuthoringOutputSchema } from "./schema";
 import {
   AutomationAuthoringGeneratedOutputError,
   type StructuredAutomationAuthoringGeneration,
@@ -67,7 +69,14 @@ export function createAiSdkAutomationAuthoringGenerator(
       try {
         const result = await runGenerateText({
           model: params.provider.model,
-          instructions: params.instructions,
+          instructions: `${params.instructions}
+
+Return exactly one transport JSON object with the keys kind, definitionJson, and question.
+- For kind "definition", set definitionJson to the JSON-encoded definition object and question to an empty string.
+- For kind "clarification", set definitionJson to an empty string and question to the clarification question.
+
+The decoded semantic output must conform exactly to this schema:
+${JSON.stringify(z.toJSONSchema(automationAuthoringOutputSchema))}`,
           prompt: params.prompt,
           output: Output.object({ schema: params.outputSchema }),
           maxRetries: params.maxRetries,
@@ -75,11 +84,23 @@ export function createAiSdkAutomationAuthoringGenerator(
           maxOutputTokens: params.maxOutputTokens,
           include: { requestBody: false, requestMessages: false, responseBody: false },
         });
-        return generationFrom({
+        const generation = generationFrom({
           output: result.output,
           model: result.response.modelId || params.provider.modelId,
           usage: result.usage,
         });
+        try {
+          const transport = params.outputSchema.parse(result.output);
+          return {
+            ...generation,
+            output:
+              transport.kind === "definition"
+                ? { kind: "definition", definition: JSON.parse(transport.definitionJson) }
+                : { kind: "clarification", question: transport.question },
+          };
+        } catch {
+          throw new AutomationAuthoringGeneratedOutputError(undefined, generation);
+        }
       } catch (error) {
         if (!isNoObjectGeneratedError(error)) throw error;
         const structuredError = error as NoObjectGeneratedLike;

--- a/packages/server/src/automation/authoring/generator.ts
+++ b/packages/server/src/automation/authoring/generator.ts
@@ -1,0 +1,97 @@
+import { NoObjectGeneratedError, Output, generateText } from "ai";
+import { extractRuntimeModelUsage } from "../../agent/runtime/usage";
+import {
+  AutomationAuthoringGeneratedOutputError,
+  type StructuredAutomationAuthoringGeneration,
+  type StructuredAutomationAuthoringGenerator,
+} from "./service";
+
+interface GenerateTextInput {
+  model: Parameters<typeof generateText>[0]["model"];
+  instructions: string;
+  prompt: string;
+  output: ReturnType<typeof Output.object>;
+  maxRetries: 0;
+  timeout: { totalMs: number };
+  maxOutputTokens: number;
+  include: { requestBody: false; requestMessages: false; responseBody: false };
+}
+
+interface GenerateTextResultLike {
+  output: unknown;
+  response: { modelId: string };
+  usage: unknown;
+}
+
+type GenerateTextLike = (input: GenerateTextInput) => Promise<GenerateTextResultLike>;
+
+interface NoObjectGeneratedLike {
+  response?: { modelId?: string };
+  usage?: unknown;
+}
+
+function sdkCostFromUsage(usage: unknown): number {
+  if (!usage || typeof usage !== "object") return 0;
+  const raw = (usage as { raw?: unknown }).raw;
+  if (!raw || typeof raw !== "object") return 0;
+  const cost = (raw as { cost?: unknown }).cost;
+  return typeof cost === "number" && Number.isFinite(cost) ? cost : 0;
+}
+
+function generationFrom(params: {
+  output: unknown;
+  model: string;
+  usage: unknown;
+}): StructuredAutomationAuthoringGeneration {
+  return {
+    output: params.output,
+    model: params.model,
+    usage: extractRuntimeModelUsage(params.usage),
+    sdkCostUsd: sdkCostFromUsage(params.usage),
+  };
+}
+
+export function createAiSdkAutomationAuthoringGenerator(
+  deps: {
+    generateText?: GenerateTextLike;
+    isNoObjectGeneratedError?: (error: unknown) => boolean;
+  } = {},
+): StructuredAutomationAuthoringGenerator {
+  const runGenerateText: GenerateTextLike =
+    deps.generateText ??
+    ((input) => generateText(input as Parameters<typeof generateText>[0]) as Promise<GenerateTextResultLike>);
+  const isNoObjectGeneratedError = deps.isNoObjectGeneratedError ?? NoObjectGeneratedError.isInstance;
+
+  return {
+    async generate(params) {
+      try {
+        const result = await runGenerateText({
+          model: params.provider.model,
+          instructions: params.instructions,
+          prompt: params.prompt,
+          output: Output.object({ schema: params.outputSchema }),
+          maxRetries: params.maxRetries,
+          timeout: { totalMs: params.timeoutMs },
+          maxOutputTokens: params.maxOutputTokens,
+          include: { requestBody: false, requestMessages: false, responseBody: false },
+        });
+        return generationFrom({
+          output: result.output,
+          model: result.response.modelId || params.provider.modelId,
+          usage: result.usage,
+        });
+      } catch (error) {
+        if (!isNoObjectGeneratedError(error)) throw error;
+        const structuredError = error as NoObjectGeneratedLike;
+        throw new AutomationAuthoringGeneratedOutputError(
+          undefined,
+          generationFrom({
+            output: null,
+            model: structuredError.response?.modelId || params.provider.modelId,
+            usage: structuredError.usage,
+          }),
+        );
+      }
+    },
+  };
+}

--- a/packages/server/src/automation/authoring/provider.test.ts
+++ b/packages/server/src/automation/authoring/provider.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_AGENT_RUNTIME_COST_TABLE } from "../../agent/runtime/pricing";
+import { AutomationAuthoringProviderError, createAutomationAuthoringProviderLoader } from "./provider";
+
+const openRouterConfig = {
+  provider: "openrouter" as const,
+  modelId: "xiaomi/mimo-v2.5",
+  apiKey: "sk-or-existing",
+  baseUrl: "https://openrouter.ai/api/v1",
+  headers: { "X-Title": "Sketch" },
+  costTable: DEFAULT_AGENT_RUNTIME_COST_TABLE,
+};
+
+describe("automation authoring provider", () => {
+  it("reuses the configured OpenRouter connection and overrides only its model", async () => {
+    const createProvider = vi.fn((config) => config);
+    const load = createAutomationAuthoringProviderLoader(
+      {
+        modelId: "anthropic/claude-sonnet-4.6",
+        loadProviderConfig: async () => openRouterConfig,
+      },
+      { createProvider },
+    );
+
+    await expect(load()).resolves.toMatchObject({
+      provider: "openrouter",
+      modelId: "anthropic/claude-sonnet-4.6",
+      apiKey: "sk-or-existing",
+      baseUrl: "https://openrouter.ai/api/v1",
+      headers: { "X-Title": "Sketch" },
+    });
+    expect(createProvider).toHaveBeenCalledWith({
+      ...openRouterConfig,
+      modelId: "anthropic/claude-sonnet-4.6",
+    });
+  });
+
+  it.each(["anthropic", "bedrock", "vertex", "openai-compatible"] as const)(
+    "rejects the %s provider instead of silently using it",
+    async (provider) => {
+      const load = createAutomationAuthoringProviderLoader(
+        {
+          modelId: "anthropic/claude-sonnet-4.6",
+          loadProviderConfig: async () => ({ ...openRouterConfig, provider }),
+        },
+        { createProvider: vi.fn() },
+      );
+
+      await expect(load()).rejects.toMatchObject({
+        name: "AutomationAuthoringProviderError",
+        code: "OPENROUTER_REQUIRED",
+      });
+    },
+  );
+
+  it("fails closed when the configured provider cannot be resolved", async () => {
+    const load = createAutomationAuthoringProviderLoader(
+      {
+        modelId: "anthropic/claude-sonnet-4.6",
+        loadProviderConfig: async () => null,
+      },
+      { createProvider: vi.fn() },
+    );
+
+    await expect(load()).rejects.toEqual(
+      new AutomationAuthoringProviderError(
+        "PROVIDER_UNAVAILABLE",
+        "Automation authoring requires a complete OpenRouter provider configuration",
+      ),
+    );
+  });
+
+  it("does not mutate process-wide provider environment variables", async () => {
+    const before = {
+      ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+      CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+    };
+    const load = createAutomationAuthoringProviderLoader(
+      {
+        modelId: "anthropic/claude-sonnet-4.6",
+        loadProviderConfig: async () => openRouterConfig,
+      },
+      { createProvider: (config) => config },
+    );
+
+    await load();
+
+    expect({
+      ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+      CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+    }).toEqual(before);
+  });
+});

--- a/packages/server/src/automation/authoring/provider.ts
+++ b/packages/server/src/automation/authoring/provider.ts
@@ -1,0 +1,59 @@
+import type { AgentRuntimeProviderFactoryConfig } from "../../agent/runtime/contracts";
+import { type AgentRuntimeProvider, createAgentRuntimeProvider } from "../../agent/runtime/provider";
+
+export type AutomationAuthoringProviderErrorCode = "PROVIDER_UNAVAILABLE" | "OPENROUTER_REQUIRED";
+
+export class AutomationAuthoringProviderError extends Error {
+  readonly code: AutomationAuthoringProviderErrorCode;
+
+  constructor(code: AutomationAuthoringProviderErrorCode, message: string) {
+    super(message);
+    this.name = "AutomationAuthoringProviderError";
+    this.code = code;
+  }
+}
+
+export interface AutomationAuthoringProviderLoaderConfig {
+  modelId: string;
+  loadProviderConfig: () => Promise<AgentRuntimeProviderFactoryConfig | null>;
+}
+
+export type OpenRouterAutomationAuthoringProvider = AgentRuntimeProvider & { provider: "openrouter" };
+
+export function createAutomationAuthoringProviderLoader(
+  config: AutomationAuthoringProviderLoaderConfig,
+): () => Promise<OpenRouterAutomationAuthoringProvider>;
+export function createAutomationAuthoringProviderLoader<T>(
+  config: AutomationAuthoringProviderLoaderConfig,
+  deps: {
+    createProvider: (providerConfig: AgentRuntimeProviderFactoryConfig) => T;
+  },
+): () => Promise<T>;
+export function createAutomationAuthoringProviderLoader<T>(
+  config: AutomationAuthoringProviderLoaderConfig,
+  deps: {
+    createProvider: (providerConfig: AgentRuntimeProviderFactoryConfig) => T;
+  } = {
+    createProvider: createAgentRuntimeProvider as (providerConfig: AgentRuntimeProviderFactoryConfig) => T,
+  },
+): () => Promise<T> {
+  return async () => {
+    const providerConfig = await config.loadProviderConfig();
+    if (!providerConfig) {
+      throw new AutomationAuthoringProviderError(
+        "PROVIDER_UNAVAILABLE",
+        "Automation authoring requires a complete OpenRouter provider configuration",
+      );
+    }
+    if (providerConfig.provider !== "openrouter") {
+      throw new AutomationAuthoringProviderError(
+        "OPENROUTER_REQUIRED",
+        "Automation authoring is configured but the active LLM provider is not OpenRouter",
+      );
+    }
+    return deps.createProvider({
+      ...providerConfig,
+      modelId: config.modelId,
+    });
+  };
+}

--- a/packages/server/src/automation/authoring/schema.test.ts
+++ b/packages/server/src/automation/authoring/schema.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import {
   automationAuthoringDefinitionSchema,
   automationAuthoringOutputSchema,
+  automationAuthoringTransportSchema,
   toAutomationBuilderSaveRequest,
 } from "./schema";
 
@@ -105,6 +107,16 @@ describe("automation authoring schema", () => {
 
     expect(automationAuthoringDefinitionSchema.safeParse(mismatched).success).toBe(false);
     expect(automationAuthoringDefinitionSchema.safeParse(orphaned).success).toBe(false);
+  });
+
+  it("uses a Claude-compatible native structured-output transport schema", () => {
+    const schema = JSON.stringify(z.toJSONSchema(automationAuthoringTransportSchema));
+
+    expect(schema).not.toContain('"oneOf"');
+    expect(schema).not.toContain('"minItems"');
+    expect(schema).toContain('"definitionJson"');
+    expect(schema).toContain('"question"');
+    expect(schema).toContain('"additionalProperties":false');
   });
 
   it("allows one concise clarification instead of a definition", () => {

--- a/packages/server/src/automation/authoring/schema.test.ts
+++ b/packages/server/src/automation/authoring/schema.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  automationAuthoringDefinitionSchema,
+  automationAuthoringOutputSchema,
+  toAutomationBuilderSaveRequest,
+} from "./schema";
+
+const completeDraft = {
+  title: "Weekday digest",
+  description: "Summarize updates every weekday",
+  prompt: "Summarize the completed workflow",
+  scheduleType: "cron" as const,
+  scheduleValue: "0 9 * * 1-5",
+  timezone: "Asia/Kolkata",
+  delivery: {
+    platform: "slack" as const,
+    targetType: "dm" as const,
+    targetId: "U123",
+    threadTs: null,
+    mode: "deliver" as const,
+  },
+  steps: [
+    {
+      id: "trigger",
+      type: "trigger" as const,
+      label: "Weekday schedule",
+      icon: "clock",
+      position: { x: 0, y: 0 },
+      triggerConfig: {
+        type: "schedule" as const,
+        scheduleType: "cron" as const,
+        scheduleValue: "0 9 * * 1-5",
+        timezone: "Asia/Kolkata",
+      },
+    },
+    {
+      id: "digest",
+      type: "agent" as const,
+      label: "Prepare digest",
+      icon: "sketch-ai",
+      position: { x: 260, y: 0 },
+      agentMode: "sketch" as const,
+    },
+  ],
+  edges: [{ id: "trigger-digest", from: "trigger", to: "digest" }],
+  stepContent: {
+    digest: {
+      stepId: "digest",
+      contentType: "prompt" as const,
+      content: "Summarize updates and call out blockers.",
+      apps: ["linear"],
+    },
+  },
+};
+
+describe("automation authoring schema", () => {
+  it("accepts a complete replacement definition and injects server-owned fields", () => {
+    const draft = automationAuthoringDefinitionSchema.parse(completeDraft);
+
+    expect(
+      toAutomationBuilderSaveRequest(draft, { taskId: "task-123", status: "paused", expectedRevision: 7 }),
+    ).toMatchObject({
+      expectedRevision: 7,
+      status: "paused",
+      title: "Weekday digest",
+      stepContent: {
+        digest: {
+          taskId: "task-123",
+          stepId: "digest",
+          contentType: "prompt",
+          apps: ["linear"],
+        },
+      },
+    });
+  });
+
+  it("rejects agentModel anywhere in generated steps", () => {
+    const withPinnedExecutionModel = structuredClone(completeDraft);
+    Object.assign(withPinnedExecutionModel.steps[1], { agentModel: "anthropic/claude-sonnet-4.6" });
+
+    expect(automationAuthoringDefinitionSchema.safeParse(withPinnedExecutionModel).success).toBe(false);
+  });
+
+  it("rejects model-authored operational status", () => {
+    expect(
+      automationAuthoringDefinitionSchema.safeParse({
+        ...completeDraft,
+        status: "completed",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects mismatched and orphaned generated step content", () => {
+    const mismatched = structuredClone(completeDraft);
+    mismatched.stepContent.digest.stepId = "other";
+    const orphaned = structuredClone(completeDraft);
+    Object.assign(orphaned.stepContent, {
+      removed: {
+        stepId: "removed",
+        contentType: "prompt",
+        content: "Do something",
+        apps: null,
+      },
+    });
+
+    expect(automationAuthoringDefinitionSchema.safeParse(mismatched).success).toBe(false);
+    expect(automationAuthoringDefinitionSchema.safeParse(orphaned).success).toBe(false);
+  });
+
+  it("allows one concise clarification instead of a definition", () => {
+    expect(
+      automationAuthoringOutputSchema.parse({
+        kind: "clarification",
+        question: "Which Slack channel should receive the digest?",
+      }),
+    ).toEqual({
+      kind: "clarification",
+      question: "Which Slack channel should receive the digest?",
+    });
+    expect(
+      automationAuthoringOutputSchema.safeParse({
+        kind: "clarification",
+        question: "x".repeat(241),
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/server/src/automation/authoring/schema.ts
+++ b/packages/server/src/automation/authoring/schema.ts
@@ -44,6 +44,19 @@ export const automationAuthoringDefinitionSchema = automationBuilderSaveRequestS
     }
   });
 
+/**
+ * Claude's native structured-output subset rejects constraints in the complete
+ * authoring schema. Carry definitions as JSON text inside a strict flat object,
+ * then validate the decoded value against the complete application schema.
+ */
+export const automationAuthoringTransportSchema = z
+  .object({
+    kind: z.enum(["definition", "clarification"]),
+    definitionJson: z.string(),
+    question: z.string(),
+  })
+  .strict();
+
 export const automationAuthoringOutputSchema = z.discriminatedUnion("kind", [
   z
     .object({

--- a/packages/server/src/automation/authoring/schema.ts
+++ b/packages/server/src/automation/authoring/schema.ts
@@ -1,0 +1,87 @@
+import {
+  type AutomationBuilderSaveRequest,
+  automationBuilderSaveRequestSchema,
+  automationStepContentSchema,
+  workflowStepSchema,
+} from "@sketch/shared";
+import { z } from "zod";
+
+export const automationAuthoringStepSchema = workflowStepSchema.omit({ agentModel: true }).strict();
+
+export const automationAuthoringStepContentSchema = automationStepContentSchema
+  .omit({ taskId: true, updatedAt: true })
+  .strict();
+
+export const automationAuthoringDefinitionSchema = automationBuilderSaveRequestSchema
+  .omit({
+    expectedRevision: true,
+    status: true,
+    steps: true,
+    stepContent: true,
+  })
+  .extend({
+    steps: z.array(automationAuthoringStepSchema).min(2),
+    stepContent: z.record(z.string(), automationAuthoringStepContentSchema),
+  })
+  .strict()
+  .superRefine((definition, context) => {
+    const stepIds = new Set(definition.steps.map((step) => step.id));
+    for (const [key, content] of Object.entries(definition.stepContent)) {
+      if (key !== content.stepId) {
+        context.addIssue({
+          code: "custom",
+          path: ["stepContent", key, "stepId"],
+          message: "Step content key must match stepId",
+        });
+      }
+      if (!stepIds.has(key)) {
+        context.addIssue({
+          code: "custom",
+          path: ["stepContent", key],
+          message: "Step content must belong to a generated step",
+        });
+      }
+    }
+  });
+
+export const automationAuthoringOutputSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("definition"),
+      definition: automationAuthoringDefinitionSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("clarification"),
+      question: z.string().trim().min(1).max(240),
+    })
+    .strict(),
+]);
+
+export type AutomationAuthoringDefinition = z.infer<typeof automationAuthoringDefinitionSchema>;
+export type AutomationAuthoringOutput = z.infer<typeof automationAuthoringOutputSchema>;
+
+export function toAutomationBuilderSaveRequest(
+  definition: AutomationAuthoringDefinition,
+  server: {
+    taskId: string;
+    status: AutomationBuilderSaveRequest["status"];
+    expectedRevision?: number;
+  },
+): AutomationBuilderSaveRequest {
+  return {
+    ...definition,
+    status: server.status,
+    expectedRevision: server.expectedRevision,
+    stepContent: Object.fromEntries(
+      Object.entries(definition.stepContent).map(([key, content]) => [
+        key,
+        {
+          ...content,
+          taskId: server.taskId,
+        },
+      ]),
+    ),
+  };
+}

--- a/packages/server/src/automation/authoring/service.test.ts
+++ b/packages/server/src/automation/authoring/service.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it, vi } from "vitest";
+import { AutomationValidationError } from "../definition";
+import { existingAutomationDefinition, poorGenerationFixtures, validAuthoringDefinition } from "./fixtures";
+import {
+  AutomationAuthoringTimeoutError,
+  AutomationAuthoringValidationError,
+  type StructuredAutomationAuthoringGenerator,
+  createAutomationAuthoringService,
+} from "./service";
+
+function generation(output: unknown) {
+  return {
+    output,
+    model: "anthropic/claude-sonnet-4.6",
+    usage: {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+    sdkCostUsd: 0,
+  };
+}
+
+function createHarness(outputs: unknown[]) {
+  const generate = vi.fn<StructuredAutomationAuthoringGenerator["generate"]>();
+  for (const output of outputs) generate.mockResolvedValueOnce(generation(output));
+  const telemetry = { recordAttempt: vi.fn().mockResolvedValue(undefined) };
+  const service = createAutomationAuthoringService({
+    loadProvider: async () => ({
+      provider: "openrouter",
+      modelId: "anthropic/claude-sonnet-4.6",
+      model: {} as never,
+    }),
+    generator: { generate },
+    telemetry,
+    configuredModelId: "anthropic/claude-sonnet-4.6",
+  });
+  return { service, generate, telemetry };
+}
+
+describe("automation authoring service", () => {
+  it("creates a complete definition using bounded structured generation", async () => {
+    const { service, generate } = createHarness([{ kind: "definition", definition: validAuthoringDefinition }]);
+
+    const result = await service.create({
+      request: "Every weekday at 9, send me a Linear digest",
+      serverContext: {
+        taskId: "task-new",
+        platform: "slack",
+        contextType: "dm",
+        deliveryDefaults: {
+          platform: "slack",
+          targetType: "dm",
+          targetId: "U123",
+          threadTs: null,
+          mode: "deliver",
+        },
+        timezone: "Asia/Kolkata",
+        currentTime: "2026-07-27T12:00:00.000Z",
+      },
+      brokerCapable: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "definition",
+      definition: {
+        title: "Weekday digest",
+        stepContent: { digest: { taskId: "task-new" } },
+      },
+    });
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "create",
+        attempt: 1,
+        maxRetries: 0,
+        timeoutMs: expect.any(Number),
+        maxOutputTokens: 4096,
+      }),
+    );
+    expect(generate.mock.calls[0]?.[0].timeoutMs).toBeGreaterThan(0);
+    expect(generate.mock.calls[0]?.[0].timeoutMs).toBeLessThanOrEqual(30_000);
+    expect(generate.mock.calls[0]?.[0].prompt).toContain('"brokerCapable":true');
+  });
+
+  it("returns one concise clarification without validating or drafting", async () => {
+    const { service, generate } = createHarness([
+      { kind: "clarification", question: "Which Slack channel should receive it?" },
+    ]);
+
+    await expect(
+      service.create({
+        request: "Send a digest",
+        serverContext: {
+          taskId: "task-new",
+          platform: "slack",
+          contextType: "dm",
+          deliveryDefaults: {
+            platform: "slack",
+            targetType: "dm",
+            targetId: "U123",
+            threadTs: null,
+            mode: "deliver",
+          },
+          timezone: "Asia/Kolkata",
+          currentTime: "2026-07-27T12:00:00.000Z",
+        },
+        brokerCapable: true,
+      }),
+    ).resolves.toEqual({
+      kind: "clarification",
+      question: "Which Slack channel should receive it?",
+    });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("edits from the complete existing definition and carries its execution model by stable step id", async () => {
+    const edited = {
+      ...validAuthoringDefinition,
+      title: "Weekday leadership digest",
+    };
+    const { service, generate } = createHarness([{ kind: "definition", definition: edited }]);
+
+    const result = await service.edit({
+      request: "Rename it to Weekday leadership digest",
+      existing: existingAutomationDefinition,
+      brokerCapable: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "definition",
+      definition: {
+        expectedRevision: 7,
+        status: "active",
+        title: "Weekday leadership digest",
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            id: "digest",
+            agentModel: "xiaomi/mimo-v2.5",
+            agentSkills: ["daily-summary"],
+            agentMcpServers: ["linear"],
+          }),
+        ]),
+        stepContent: {
+          digest: expect.objectContaining({
+            content: "Summarize updates and call out blockers.",
+            apps: ["linear"],
+          }),
+        },
+      },
+    });
+    const call = generate.mock.calls[0]?.[0];
+    expect(call?.prompt).toContain('"revision":7');
+    expect(call?.prompt).toContain('"agentModel":"xiaomi/mimo-v2.5"');
+    expect(call?.prompt).toContain('"brokerCapable":true');
+  });
+
+  it("preserves the server-owned operational status during edits", async () => {
+    const { service } = createHarness([{ kind: "definition", definition: validAuthoringDefinition }]);
+
+    const result = await service.edit({
+      request: "Shorten the description",
+      existing: { ...existingAutomationDefinition, status: "paused" },
+      brokerCapable: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "definition",
+      definition: { status: "paused" },
+    });
+  });
+
+  it("fails closed when a generated edit drops the stable ID of a model-pinned step", async () => {
+    const renamedStep = {
+      ...validAuthoringDefinition,
+      steps: validAuthoringDefinition.steps.map((step) =>
+        step.id === "digest" ? { ...step, id: "leadership-digest" } : step,
+      ),
+      edges: [{ id: "trigger-leadership-digest", from: "trigger", to: "leadership-digest" }],
+      stepContent: {
+        "leadership-digest": {
+          ...validAuthoringDefinition.stepContent.digest,
+          stepId: "leadership-digest",
+        },
+      },
+    };
+    const { service, generate } = createHarness([
+      { kind: "definition", definition: renamedStep },
+      { kind: "definition", definition: renamedStep },
+    ]);
+
+    await expect(
+      service.edit({
+        request: "Rename the digest label without changing its execution model",
+        existing: existingAutomationDefinition,
+        brokerCapable: true,
+      }),
+    ).rejects.toBeInstanceOf(AutomationAuthoringValidationError);
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(generate.mock.calls[1]?.[0].prompt).toContain("PINNED_STEP_ID_REQUIRED");
+  });
+
+  it.each(poorGenerationFixtures)(
+    "retries once when generated output has $expectedIssue",
+    async ({ draft, expectedIssue }) => {
+      const { service, generate, telemetry } = createHarness([
+        { kind: "definition", definition: draft },
+        { kind: "definition", definition: validAuthoringDefinition },
+      ]);
+
+      const result = await service.create({
+        request: "Every weekday at 9, send me a digest",
+        serverContext: {
+          taskId: "task-new",
+          platform: "slack",
+          contextType: "dm",
+          deliveryDefaults: {
+            platform: "slack",
+            targetType: "dm",
+            targetId: "U123",
+            threadTs: null,
+            mode: "deliver",
+          },
+          timezone: "Asia/Kolkata",
+          currentTime: "2026-07-27T12:00:00.000Z",
+        },
+        brokerCapable: true,
+      });
+
+      expect(result.kind).toBe("definition");
+      expect(generate).toHaveBeenCalledTimes(2);
+      expect(generate.mock.calls[1]?.[0]).toMatchObject({ attempt: 2, maxRetries: 0 });
+      expect(generate.mock.calls[1]?.[0].prompt).toContain(expectedIssue);
+      expect(generate.mock.calls[1]?.[0].prompt).toContain('"priorDraft"');
+      expect(telemetry.recordAttempt).toHaveBeenCalledWith(
+        expect.objectContaining({ attempt: 1, validationOutcome: "invalid" }),
+      );
+    },
+  );
+
+  it("fails after one validation retry without returning an invalid definition", async () => {
+    const invalid = poorGenerationFixtures[0].draft;
+    const { service, generate } = createHarness([
+      { kind: "definition", definition: invalid },
+      { kind: "definition", definition: invalid },
+    ]);
+
+    await expect(
+      service.create({
+        request: "Every weekday at 9, send me a digest",
+        serverContext: {
+          taskId: "task-new",
+          platform: "slack",
+          contextType: "dm",
+          deliveryDefaults: {
+            platform: "slack",
+            targetType: "dm",
+            targetId: "U123",
+            threadTs: null,
+            mode: "deliver",
+          },
+          timezone: "Asia/Kolkata",
+          currentTime: "2026-07-27T12:00:00.000Z",
+        },
+        brokerCapable: true,
+      }),
+    ).rejects.toBeInstanceOf(AutomationAuthoringValidationError);
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry provider failures", async () => {
+    const generate = vi
+      .fn<StructuredAutomationAuthoringGenerator["generate"]>()
+      .mockRejectedValue(new Error("OpenRouter unavailable"));
+    const service = createAutomationAuthoringService({
+      loadProvider: async () => ({
+        provider: "openrouter",
+        modelId: "anthropic/claude-sonnet-4.6",
+        model: {} as never,
+      }),
+      generator: { generate },
+      telemetry: { recordAttempt: vi.fn().mockResolvedValue(undefined) },
+      configuredModelId: "anthropic/claude-sonnet-4.6",
+    });
+
+    await expect(
+      service.create({
+        request: "Create a digest",
+        serverContext: {
+          taskId: "task-new",
+          platform: "slack",
+          contextType: "dm",
+          deliveryDefaults: {
+            platform: "slack",
+            targetType: "dm",
+            targetId: "U123",
+            threadTs: null,
+            mode: "deliver",
+          },
+          timezone: "Asia/Kolkata",
+          currentTime: "2026-07-27T12:00:00.000Z",
+        },
+        brokerCapable: true,
+      }),
+    ).rejects.toThrow("OpenRouter unavailable");
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one thirty-second deadline across the validation retry", async () => {
+    let clock = 0;
+    const generate = vi
+      .fn<StructuredAutomationAuthoringGenerator["generate"]>()
+      .mockImplementationOnce(async () => {
+        clock = 25_000;
+        return generation({ kind: "definition", definition: poorGenerationFixtures[0].draft });
+      })
+      .mockImplementationOnce(async () => generation({ kind: "definition", definition: validAuthoringDefinition }));
+    const service = createAutomationAuthoringService({
+      loadProvider: async () => ({
+        provider: "openrouter",
+        modelId: "anthropic/claude-sonnet-4.6",
+        model: {} as never,
+      }),
+      generator: { generate },
+      telemetry: { recordAttempt: vi.fn().mockResolvedValue(undefined) },
+      configuredModelId: "anthropic/claude-sonnet-4.6",
+      now: () => clock,
+    });
+
+    await service.create({
+      request: "Create a digest",
+      serverContext: {
+        taskId: "task-new",
+        platform: "slack",
+        contextType: "dm",
+        deliveryDefaults: {
+          platform: "slack",
+          targetType: "dm",
+          targetId: "U123",
+          threadTs: null,
+          mode: "deliver",
+        },
+        timezone: "Asia/Kolkata",
+        currentTime: "2026-07-27T12:00:00.000Z",
+      },
+      brokerCapable: true,
+    });
+
+    expect(generate.mock.calls[0]?.[0].timeoutMs).toBe(30_000);
+    expect(generate.mock.calls[1]?.[0].timeoutMs).toBe(5_000);
+  });
+
+  it("classifies provider aborts as a fail-closed timeout without retrying", async () => {
+    const timeout = new Error("request aborted");
+    timeout.name = "AbortError";
+    const generate = vi.fn<StructuredAutomationAuthoringGenerator["generate"]>().mockRejectedValue(timeout);
+    const telemetry = { recordAttempt: vi.fn().mockResolvedValue(undefined) };
+    const service = createAutomationAuthoringService({
+      loadProvider: async () => ({
+        provider: "openrouter",
+        modelId: "anthropic/claude-sonnet-4.6",
+        model: {} as never,
+      }),
+      generator: { generate },
+      telemetry,
+      configuredModelId: "anthropic/claude-sonnet-4.6",
+    });
+
+    await expect(
+      service.create({
+        request: "Create a digest",
+        serverContext: {
+          taskId: "task-new",
+          platform: "slack",
+          contextType: "dm",
+          deliveryDefaults: {
+            platform: "slack",
+            targetType: "dm",
+            targetId: "U123",
+            threadTs: null,
+            mode: "deliver",
+          },
+          timezone: "Asia/Kolkata",
+          currentTime: "2026-07-27T12:00:00.000Z",
+        },
+        brokerCapable: true,
+      }),
+    ).rejects.toBeInstanceOf(AutomationAuthoringTimeoutError);
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(telemetry.recordAttempt).toHaveBeenCalledWith(expect.objectContaining({ validationOutcome: "timeout" }));
+  });
+
+  it("uses existing graph validation before returning a generated definition", async () => {
+    const { service } = createHarness([
+      { kind: "definition", definition: poorGenerationFixtures[1].draft },
+      { kind: "definition", definition: poorGenerationFixtures[1].draft },
+    ]);
+
+    try {
+      await service.create({
+        request: "Create a digest",
+        serverContext: {
+          taskId: "task-new",
+          platform: "slack",
+          contextType: "dm",
+          deliveryDefaults: {
+            platform: "slack",
+            targetType: "dm",
+            targetId: "U123",
+            threadTs: null,
+            mode: "deliver",
+          },
+          timezone: "Asia/Kolkata",
+          currentTime: "2026-07-27T12:00:00.000Z",
+        },
+        brokerCapable: true,
+      });
+      throw new Error("expected validation error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AutomationAuthoringValidationError);
+      expect((error as AutomationAuthoringValidationError).cause).toBeInstanceOf(AutomationValidationError);
+    }
+  });
+});

--- a/packages/server/src/automation/authoring/service.ts
+++ b/packages/server/src/automation/authoring/service.ts
@@ -5,6 +5,7 @@ import { AutomationValidationError, validateAutomationBuilderSaveRequest } from 
 import {
   type AutomationAuthoringOutput,
   automationAuthoringOutputSchema,
+  automationAuthoringTransportSchema,
   toAutomationBuilderSaveRequest,
 } from "./schema";
 import type {
@@ -37,7 +38,7 @@ export interface StructuredAutomationAuthoringGenerator {
     provider: AutomationAuthoringProvider;
     instructions: string;
     prompt: string;
-    outputSchema: typeof automationAuthoringOutputSchema;
+    outputSchema: typeof automationAuthoringTransportSchema;
     attempt: number;
     maxRetries: 0;
     timeoutMs: number;
@@ -295,7 +296,7 @@ export function createAutomationAuthoringService(deps: {
                   repair,
                   priorDraft,
                 }),
-          outputSchema: automationAuthoringOutputSchema,
+          outputSchema: automationAuthoringTransportSchema,
           attempt,
           maxRetries: 0,
           timeoutMs: remainingMs,

--- a/packages/server/src/automation/authoring/service.ts
+++ b/packages/server/src/automation/authoring/service.ts
@@ -1,0 +1,385 @@
+import type { AutomationBuilderSaveRequest, AutomationDefinition, WorkflowStep } from "@sketch/shared";
+import type { LanguageModel } from "ai";
+import { z } from "zod";
+import { AutomationValidationError, validateAutomationBuilderSaveRequest } from "../definition";
+import {
+  type AutomationAuthoringOutput,
+  automationAuthoringOutputSchema,
+  toAutomationBuilderSaveRequest,
+} from "./schema";
+import type {
+  AutomationAuthoringOperation,
+  AutomationAuthoringTelemetry,
+  AutomationAuthoringUsage,
+  AutomationAuthoringValidationOutcome,
+} from "./telemetry";
+
+const MAX_GENERATION_ATTEMPTS = 2;
+const GENERATION_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_TOKENS = 4096;
+
+export interface AutomationAuthoringProvider {
+  provider: "openrouter";
+  modelId: string;
+  model: LanguageModel;
+}
+
+export interface StructuredAutomationAuthoringGeneration {
+  output: unknown;
+  model: string;
+  usage: AutomationAuthoringUsage;
+  sdkCostUsd: number;
+}
+
+export interface StructuredAutomationAuthoringGenerator {
+  generate(params: {
+    operation: AutomationAuthoringOperation;
+    provider: AutomationAuthoringProvider;
+    instructions: string;
+    prompt: string;
+    outputSchema: typeof automationAuthoringOutputSchema;
+    attempt: number;
+    maxRetries: 0;
+    timeoutMs: number;
+    maxOutputTokens: number;
+  }): Promise<StructuredAutomationAuthoringGeneration>;
+}
+
+export class AutomationAuthoringGeneratedOutputError extends Error {
+  readonly generation?: StructuredAutomationAuthoringGeneration;
+
+  constructor(
+    message = "The authoring model did not return schema-valid structured output",
+    generation?: StructuredAutomationAuthoringGeneration,
+  ) {
+    super(message);
+    this.name = "AutomationAuthoringGeneratedOutputError";
+    this.generation = generation;
+  }
+}
+
+export class AutomationAuthoringValidationError extends Error {
+  constructor(cause: z.ZodError | AutomationValidationError | AutomationAuthoringGeneratedOutputError) {
+    super("Automation authoring did not produce a valid definition", { cause });
+    this.name = "AutomationAuthoringValidationError";
+  }
+}
+
+export class AutomationAuthoringTimeoutError extends Error {
+  constructor() {
+    super("Automation authoring exceeded its time limit");
+    this.name = "AutomationAuthoringTimeoutError";
+  }
+}
+
+export interface AutomationAuthoringServerContext {
+  taskId: string;
+  platform: "slack" | "whatsapp";
+  contextType: "dm" | "channel" | "group";
+  deliveryDefaults: {
+    platform: "slack" | "whatsapp";
+    targetType: "dm" | "channel" | "group";
+    targetId: string;
+    threadTs: null;
+    mode: "deliver";
+  };
+  timezone: string;
+  currentTime: string;
+}
+
+export type AutomationAuthoringResult =
+  | { kind: "clarification"; question: string }
+  | { kind: "definition"; definition: AutomationBuilderSaveRequest };
+
+export interface AutomationAuthoringService {
+  create(input: {
+    request: string;
+    serverContext: AutomationAuthoringServerContext;
+    brokerCapable: boolean;
+  }): Promise<AutomationAuthoringResult>;
+  edit(input: {
+    request: string;
+    existing: AutomationDefinition;
+    brokerCapable: boolean;
+  }): Promise<AutomationAuthoringResult>;
+}
+
+function validationSummary(error: z.ZodError | AutomationValidationError | AutomationAuthoringGeneratedOutputError) {
+  if (error instanceof AutomationValidationError) {
+    return error.issues.map((issue) => `${issue.code}: ${issue.message}`).join("; ");
+  }
+  if (error instanceof z.ZodError) {
+    return error.issues.map((issue) => `${issue.path.join(".") || "output"}: ${issue.message}`).join("; ");
+  }
+  return error.message;
+}
+
+function isValidationFailure(
+  error: unknown,
+): error is z.ZodError | AutomationValidationError | AutomationAuthoringGeneratedOutputError {
+  return (
+    error instanceof z.ZodError ||
+    error instanceof AutomationValidationError ||
+    error instanceof AutomationAuthoringGeneratedOutputError
+  );
+}
+
+function isTimeoutFailure(error: unknown): boolean {
+  return (
+    error instanceof AutomationAuthoringTimeoutError ||
+    (error instanceof Error &&
+      (error.name.toLowerCase().includes("timeout") ||
+        error.name.toLowerCase().includes("abort") ||
+        error.message.toLowerCase().includes("timed out")))
+  );
+}
+
+function authoringInstructions(operation: AutomationAuthoringOperation): string {
+  return `You design Sketch automations. Return a complete ${operation === "create" ? "new" : "replacement"} definition or one concise clarification question only when essential information is missing. Preserve every unspecified property and every stable step ID during edits. Never choose or emit an execution model or operational status. Keep the returned top-level schedule fields identical to the returned trigger step configuration. Every non-trigger step needs matching step content, and the graph must be connected and acyclic.`;
+}
+
+function createPrompt(input: {
+  request: string;
+  serverContext: AutomationAuthoringServerContext;
+  brokerCapable: boolean;
+  repair?: string;
+  priorDraft?: unknown;
+}): string {
+  return JSON.stringify({
+    operation: "create",
+    request: input.request,
+    serverContext: input.serverContext,
+    brokerCapable: input.brokerCapable,
+    ...(input.priorDraft !== undefined ? { priorDraft: input.priorDraft } : {}),
+    ...(input.repair ? { priorValidationFailure: input.repair } : {}),
+  });
+}
+
+function editPrompt(input: {
+  request: string;
+  existing: AutomationDefinition;
+  brokerCapable: boolean;
+  repair?: string;
+  priorDraft?: unknown;
+}): string {
+  return JSON.stringify({
+    operation: "edit",
+    requestedChange: input.request,
+    existingDefinition: input.existing,
+    brokerCapable: input.brokerCapable,
+    ...(input.priorDraft !== undefined ? { priorDraft: input.priorDraft } : {}),
+    ...(input.repair ? { priorValidationFailure: input.repair } : {}),
+  });
+}
+
+function preserveExistingAgentModels(
+  steps: AutomationBuilderSaveRequest["steps"],
+  existing: AutomationDefinition | undefined,
+): WorkflowStep[] {
+  if (!existing) return steps;
+  const models = new Map(
+    existing.steps.flatMap((step) => (step.agentModel ? [[step.id, step.agentModel] as const] : [])),
+  );
+  const generatedStepIds = new Set(steps.map((step) => step.id));
+  const missingPinnedStepIds = [...models.keys()].filter((stepId) => !generatedStepIds.has(stepId));
+  if (missingPinnedStepIds.length > 0) {
+    throw new AutomationValidationError(
+      missingPinnedStepIds.map((stepId) => ({
+        code: "PINNED_STEP_ID_REQUIRED",
+        path: `steps.${stepId}`,
+        message: `Step ${stepId} has an explicit execution model and must retain its stable ID during chat editing`,
+      })),
+    );
+  }
+  return steps.map((step) => {
+    const agentModel = models.get(step.id);
+    return agentModel ? { ...step, agentModel } : step;
+  });
+}
+
+function emptyUsage(): AutomationAuthoringUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+  };
+}
+
+export function createAutomationAuthoringService(deps: {
+  loadProvider: () => Promise<AutomationAuthoringProvider>;
+  generator: StructuredAutomationAuthoringGenerator;
+  telemetry: AutomationAuthoringTelemetry;
+  configuredModelId: string;
+  now?: () => number;
+}): AutomationAuthoringService {
+  const now = deps.now ?? Date.now;
+
+  async function author(params: {
+    operation: AutomationAuthoringOperation;
+    request: string;
+    taskId: string;
+    expectedRevision?: number;
+    existing?: AutomationDefinition;
+    serverContext?: AutomationAuthoringServerContext;
+    brokerCapable: boolean;
+  }): Promise<AutomationAuthoringResult> {
+    const operationStartedAt = now();
+    let provider: AutomationAuthoringProvider;
+    try {
+      provider = await deps.loadProvider();
+    } catch (error) {
+      await deps.telemetry.recordAttempt({
+        operation: params.operation,
+        provider: "openrouter",
+        configuredModel: deps.configuredModelId,
+        responseModel: null,
+        attempt: 1,
+        latencyMs: Math.max(0, now() - operationStartedAt),
+        totalLatencyMs: Math.max(0, now() - operationStartedAt),
+        usage: emptyUsage(),
+        sdkCostUsd: 0,
+        validationOutcome: "provider_error",
+        validationIssueCodes: [],
+      });
+      throw error;
+    }
+    let repair: string | undefined;
+    let priorDraft: unknown;
+    let finalValidationError:
+      | z.ZodError
+      | AutomationValidationError
+      | AutomationAuthoringGeneratedOutputError
+      | undefined;
+
+    for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt += 1) {
+      const startedAt = now();
+      const remainingMs = GENERATION_TIMEOUT_MS - Math.max(0, startedAt - operationStartedAt);
+      if (remainingMs <= 0) {
+        await deps.telemetry.recordAttempt({
+          operation: params.operation,
+          provider: "openrouter",
+          configuredModel: provider.modelId,
+          responseModel: null,
+          attempt,
+          latencyMs: 0,
+          totalLatencyMs: Math.max(0, startedAt - operationStartedAt),
+          usage: emptyUsage(),
+          sdkCostUsd: 0,
+          validationOutcome: "timeout",
+          validationIssueCodes: [],
+        });
+        throw new AutomationAuthoringTimeoutError();
+      }
+      let generation: StructuredAutomationAuthoringGeneration | undefined;
+      let validationOutcome: AutomationAuthoringValidationOutcome = "provider_error";
+      let validationIssueCodes: string[] = [];
+      try {
+        generation = await deps.generator.generate({
+          operation: params.operation,
+          provider,
+          instructions: authoringInstructions(params.operation),
+          prompt:
+            params.operation === "create"
+              ? createPrompt({
+                  request: params.request,
+                  serverContext: params.serverContext as AutomationAuthoringServerContext,
+                  brokerCapable: params.brokerCapable,
+                  repair,
+                  priorDraft,
+                })
+              : editPrompt({
+                  request: params.request,
+                  existing: params.existing as AutomationDefinition,
+                  brokerCapable: params.brokerCapable,
+                  repair,
+                  priorDraft,
+                }),
+          outputSchema: automationAuthoringOutputSchema,
+          attempt,
+          maxRetries: 0,
+          timeoutMs: remainingMs,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+        });
+        const output: AutomationAuthoringOutput = automationAuthoringOutputSchema.parse(generation.output);
+        if (output.kind === "clarification") {
+          validationOutcome = "clarification";
+          return { kind: "clarification", question: output.question };
+        }
+
+        const definition = toAutomationBuilderSaveRequest(output.definition, {
+          taskId: params.taskId,
+          status: params.existing?.status ?? "active",
+          expectedRevision: params.expectedRevision,
+        });
+        definition.steps = preserveExistingAgentModels(definition.steps, params.existing);
+        validateAutomationBuilderSaveRequest({
+          request: definition,
+          brokerCapable: params.brokerCapable,
+        });
+        validationOutcome = "valid";
+        return { kind: "definition", definition };
+      } catch (error) {
+        if (error instanceof AutomationAuthoringGeneratedOutputError && error.generation) {
+          generation = error.generation;
+        }
+        if (isTimeoutFailure(error)) {
+          validationOutcome = "timeout";
+          throw new AutomationAuthoringTimeoutError();
+        }
+        if (!isValidationFailure(error)) throw error;
+        validationOutcome = "invalid";
+        validationIssueCodes =
+          error instanceof AutomationValidationError
+            ? error.issues.map((issue) => issue.code)
+            : error instanceof z.ZodError
+              ? ["STRUCTURED_OUTPUT_SCHEMA"]
+              : ["STRUCTURED_OUTPUT_PARSE"];
+        finalValidationError = error;
+        repair = validationSummary(error);
+        priorDraft = generation?.output;
+        if (attempt === MAX_GENERATION_ATTEMPTS) {
+          throw new AutomationAuthoringValidationError(error);
+        }
+      } finally {
+        await deps.telemetry.recordAttempt({
+          operation: params.operation,
+          provider: "openrouter",
+          configuredModel: provider.modelId,
+          responseModel: generation?.model ?? null,
+          attempt,
+          latencyMs: Math.max(0, now() - startedAt),
+          totalLatencyMs: Math.max(0, now() - operationStartedAt),
+          usage: generation?.usage ?? emptyUsage(),
+          sdkCostUsd: generation?.sdkCostUsd ?? 0,
+          validationOutcome,
+          validationIssueCodes,
+        });
+      }
+    }
+
+    throw new AutomationAuthoringValidationError(finalValidationError ?? new AutomationAuthoringGeneratedOutputError());
+  }
+
+  return {
+    create(input) {
+      return author({
+        operation: "create",
+        request: input.request,
+        taskId: input.serverContext.taskId,
+        serverContext: input.serverContext,
+        brokerCapable: input.brokerCapable,
+      });
+    },
+    edit(input) {
+      return author({
+        operation: "edit",
+        request: input.request,
+        taskId: input.existing.id,
+        expectedRevision: input.existing.revision,
+        existing: input.existing,
+        brokerCapable: input.brokerCapable,
+      });
+    },
+  };
+}

--- a/packages/server/src/automation/authoring/telemetry.test.ts
+++ b/packages/server/src/automation/authoring/telemetry.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAutomationAuthoringTelemetry } from "./telemetry";
+
+describe("automation authoring telemetry", () => {
+  it("records provider, model, attempt, latency, usage, cost, and validation without content", async () => {
+    const entries: Record<string, unknown>[] = [];
+    const logger = {
+      info: vi.fn((fields: Record<string, unknown>) => entries.push(fields)),
+      warn: vi.fn(),
+    };
+    const pricing = {
+      resolve: vi.fn().mockResolvedValue({ costUsd: 0.0123, costSource: "openrouter" }),
+    };
+    const telemetry = createAutomationAuthoringTelemetry({ logger: logger as never, pricing });
+
+    await telemetry.recordAttempt({
+      operation: "edit",
+      provider: "openrouter",
+      configuredModel: "anthropic/claude-sonnet-4.6",
+      responseModel: "anthropic/claude-sonnet-4.6",
+      attempt: 2,
+      latencyMs: 1234,
+      totalLatencyMs: 2345,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 20,
+        cacheWriteTokens: 0,
+      },
+      sdkCostUsd: 0,
+      validationOutcome: "valid",
+      validationIssueCodes: [],
+    });
+
+    expect(entries).toEqual([
+      {
+        operation: "edit",
+        provider: "openrouter",
+        configuredModel: "anthropic/claude-sonnet-4.6",
+        responseModel: "anthropic/claude-sonnet-4.6",
+        attempt: 2,
+        latencyMs: 1234,
+        totalLatencyMs: 2345,
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 20,
+        cacheWriteTokens: 0,
+        costUsd: 0.0123,
+        costSource: "openrouter",
+        validationOutcome: "valid",
+        validationIssueCodes: [],
+      },
+    ]);
+    expect(Object.keys(entries[0] ?? {})).not.toEqual(
+      expect.arrayContaining(["prompt", "request", "content", "script", "delivery", "credentials"]),
+    );
+    expect(pricing.resolve).toHaveBeenCalledWith({
+      provider: "openrouter",
+      model: "anthropic/claude-sonnet-4.6",
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 20,
+      cacheCreationTokens: 0,
+      sdkCostUsd: 0,
+    });
+  });
+
+  it("does not fail authoring when cost telemetry cannot be resolved", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const telemetry = createAutomationAuthoringTelemetry({
+      logger: logger as never,
+      pricing: { resolve: vi.fn().mockRejectedValue(new Error("pricing unavailable")) },
+    });
+
+    await expect(
+      telemetry.recordAttempt({
+        operation: "create",
+        provider: "openrouter",
+        configuredModel: "anthropic/claude-sonnet-4.6",
+        responseModel: null,
+        attempt: 1,
+        latencyMs: 10,
+        totalLatencyMs: 10,
+        usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        sdkCostUsd: 0,
+        validationOutcome: "provider_error",
+        validationIssueCodes: [],
+      }),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/server/src/automation/authoring/telemetry.ts
+++ b/packages/server/src/automation/authoring/telemetry.ts
@@ -1,0 +1,87 @@
+import type { PricingService } from "../../cost/cost-pricing";
+import type { Logger } from "../../logger";
+
+export type AutomationAuthoringOperation = "create" | "edit";
+export type AutomationAuthoringValidationOutcome = "valid" | "invalid" | "clarification" | "provider_error" | "timeout";
+
+export interface AutomationAuthoringUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export interface AutomationAuthoringAttemptTelemetry {
+  operation: AutomationAuthoringOperation;
+  provider: "openrouter";
+  configuredModel: string;
+  responseModel: string | null;
+  attempt: number;
+  latencyMs: number;
+  totalLatencyMs: number;
+  usage: AutomationAuthoringUsage;
+  sdkCostUsd: number;
+  validationOutcome: AutomationAuthoringValidationOutcome;
+  validationIssueCodes: string[];
+}
+
+export interface AutomationAuthoringTelemetry {
+  recordAttempt(event: AutomationAuthoringAttemptTelemetry): Promise<void>;
+}
+
+export function createAutomationAuthoringTelemetry(params: {
+  logger: Pick<Logger, "info" | "warn">;
+  pricing: PricingService;
+}): AutomationAuthoringTelemetry {
+  return {
+    async recordAttempt(event) {
+      try {
+        const { costUsd, costSource } = await params.pricing.resolve({
+          provider: event.provider,
+          model: event.responseModel ?? event.configuredModel,
+          inputTokens: event.usage.inputTokens,
+          outputTokens: event.usage.outputTokens,
+          cacheReadTokens: event.usage.cacheReadTokens,
+          cacheCreationTokens: event.usage.cacheWriteTokens,
+          sdkCostUsd: event.sdkCostUsd,
+        });
+        params.logger.info(
+          {
+            operation: event.operation,
+            provider: event.provider,
+            configuredModel: event.configuredModel,
+            responseModel: event.responseModel,
+            attempt: event.attempt,
+            latencyMs: event.latencyMs,
+            totalLatencyMs: event.totalLatencyMs,
+            inputTokens: event.usage.inputTokens,
+            outputTokens: event.usage.outputTokens,
+            cacheReadTokens: event.usage.cacheReadTokens,
+            cacheWriteTokens: event.usage.cacheWriteTokens,
+            costUsd,
+            costSource,
+            validationOutcome: event.validationOutcome,
+            validationIssueCodes: event.validationIssueCodes,
+          },
+          "Automation authoring generation completed",
+        );
+      } catch (error) {
+        params.logger.warn(
+          {
+            err: error,
+            operation: event.operation,
+            provider: event.provider,
+            configuredModel: event.configuredModel,
+            responseModel: event.responseModel,
+            attempt: event.attempt,
+            latencyMs: event.latencyMs,
+            totalLatencyMs: event.totalLatencyMs,
+            validationOutcome: event.validationOutcome,
+            validationIssueCodes: event.validationIssueCodes,
+          },
+          "Failed to record automation authoring cost telemetry",
+        );
+      }
+    },
+  };
+}

--- a/packages/server/src/automation/chat-authoring.test.ts
+++ b/packages/server/src/automation/chat-authoring.test.ts
@@ -1,0 +1,288 @@
+import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import { createTestDb } from "../test-utils";
+import { createChatAutomationAuthoring } from "./chat-authoring";
+import type { buildAutomationDefinition } from "./definition";
+import { createAutomationDefinition } from "./persistence";
+
+function definition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
+  return {
+    title: "Daily brief",
+    description: "Summarize updates",
+    prompt: "Summarize updates",
+    scheduleType: "interval",
+    scheduleValue: "120",
+    timezone: "Asia/Kolkata",
+    status: "active",
+    delivery: {
+      platform: "slack",
+      targetType: "dm",
+      targetId: "D123",
+      threadTs: null,
+      mode: "deliver",
+    },
+    steps: [
+      {
+        id: "trigger",
+        type: "trigger",
+        label: "Every two minutes",
+        icon: "clock",
+        position: { x: 0, y: 0 },
+        triggerConfig: {
+          type: "schedule",
+          scheduleType: "interval",
+          scheduleValue: "120",
+          timezone: "Asia/Kolkata",
+        },
+      },
+      {
+        id: "brief",
+        type: "agent",
+        label: "Prepare brief",
+        icon: "sketch-ai",
+        position: { x: 260, y: 0 },
+        agentMode: "sketch",
+      },
+    ],
+    edges: [{ id: "trigger-brief", from: "trigger", to: "brief" }],
+    stepContent: {
+      brief: {
+        taskId: "server-owned",
+        stepId: "brief",
+        contentType: "prompt",
+        content: "Summarize updates and blockers.",
+        apps: ["linear"],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function taskContext() {
+  return {
+    platform: "slack" as const,
+    contextType: "dm" as const,
+    deliveryTarget: "D123",
+    createdBy: "user-1",
+    creatorTimezone: "Asia/Kolkata",
+    canManageAnyTask: false,
+    origin: {
+      platform: "web" as const,
+      conversationId: "conversation-1",
+      providerThreadId: null,
+      currentMessageId: 42,
+    },
+  };
+}
+
+describe("chat automation authoring orchestration", () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("persists a complete create before refreshing and emits artifact inputs", async () => {
+    const authoredDefinition = definition();
+    const authoring = {
+      create: vi.fn(async () => ({ kind: "definition" as const, definition: authoredDefinition })),
+      edit: vi.fn(),
+    };
+    const refreshTaskSchedule = vi.fn(async (taskId: string) => {
+      const row = await createScheduledTaskRepository(db).getById(taskId);
+      const content = await createAutomationStepContentRepository(db).getByTask(taskId);
+      expect(row).toMatchObject({ title: "Daily brief", created_by: "user-1" });
+      expect(content).toEqual([
+        expect.objectContaining({ step_id: "brief", content: "Summarize updates and blockers." }),
+      ]);
+      return row
+        ? {
+            id: row.id,
+            platform: "slack" as const,
+            contextType: "dm" as const,
+            deliveryTarget: row.delivery_target,
+            threadTs: row.thread_ts,
+            prompt: row.prompt,
+            scheduleType: "interval" as const,
+            scheduleValue: row.schedule_value,
+            timezone: row.timezone,
+            sessionMode: "fresh" as const,
+            nextRunAt: row.next_run_at,
+            lastRunAt: row.last_run_at,
+            status: "active" as const,
+            createdBy: row.created_by,
+            createdAt: row.created_at,
+            title: row.title,
+            description: row.description,
+            originChat: null,
+            steps: row.steps,
+            edges: row.edges,
+            outputTarget: row.output_target,
+            outputPlatform: row.output_platform,
+            outputThreadTs: row.output_thread_ts,
+            outputMode: "deliver" as const,
+            delivery: authoredDefinition.delivery,
+          }
+        : null;
+    });
+    const service = createChatAutomationAuthoring({
+      db,
+      authoring,
+      scheduler: { refreshTaskSchedule, getTaskById: vi.fn() },
+      loadIntegrationProvider: async () => null,
+      createId: () => "automation-created",
+      now: () => new Date("2026-07-27T12:00:00.000Z"),
+    });
+
+    const result = await service.author({
+      action: "create",
+      request: "Send me a daily brief",
+      taskContext: taskContext(),
+    });
+
+    expect(authoring.create).toHaveBeenCalledWith({
+      request: "Send me a daily brief",
+      brokerCapable: false,
+      serverContext: {
+        taskId: "automation-created",
+        platform: "slack",
+        contextType: "dm",
+        deliveryDefaults: {
+          platform: "slack",
+          targetType: "dm",
+          targetId: "D123",
+          threadTs: null,
+          mode: "deliver",
+        },
+        timezone: "Asia/Kolkata",
+        currentTime: "2026-07-27T12:00:00.000Z",
+      },
+    });
+    expect(refreshTaskSchedule).toHaveBeenCalledWith("automation-created");
+    expect(result).toMatchObject({
+      kind: "saved",
+      task: { id: "automation-created" },
+      artifact: { scheduleType: "interval", steps: [expect.anything(), expect.objectContaining({ apps: ["linear"] })] },
+    });
+  });
+
+  it("returns a clarification without persisting or refreshing", async () => {
+    const refreshTaskSchedule = vi.fn();
+    const service = createChatAutomationAuthoring({
+      db,
+      authoring: {
+        create: vi.fn(async () => ({ kind: "clarification" as const, question: "Which channel should receive it?" })),
+        edit: vi.fn(),
+      },
+      scheduler: { refreshTaskSchedule, getTaskById: vi.fn() },
+      loadIntegrationProvider: async () => null,
+      createId: () => "clarification-task",
+    });
+
+    await expect(
+      service.author({ action: "create", request: "Create a digest", taskContext: taskContext() }),
+    ).resolves.toEqual({ kind: "clarification", message: "Which channel should receive it?" });
+    await expect(createScheduledTaskRepository(db).getById("clarification-task")).resolves.toBeUndefined();
+    expect(refreshTaskSchedule).not.toHaveBeenCalled();
+  });
+
+  it("loads the complete owned definition for edit and reports revision conflicts without refreshing", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: {
+        id: "automation-edit",
+        platform: "slack",
+        contextType: "dm",
+        deliveryTarget: "D123",
+        threadTs: null,
+        createdBy: "user-1",
+        originPlatform: "web",
+        originConversationId: "conversation-1",
+        originProviderThreadId: null,
+        originMessageId: 42,
+      },
+      brokerCapable: true,
+    });
+    const edit = vi.fn(async (input: { existing: ReturnType<typeof buildAutomationDefinition> }) => {
+      expect(input.existing).toMatchObject({
+        id: "automation-edit",
+        revision: 0,
+        delivery: { targetId: "D123" },
+        stepContent: { brief: { content: "Summarize updates and blockers." } },
+      });
+      await db.updateTable("scheduled_tasks").set({ revision: 1 }).where("id", "=", "automation-edit").execute();
+      return {
+        kind: "definition" as const,
+        definition: definition({ expectedRevision: input.existing.revision, title: "Stale replacement" }),
+      };
+    });
+    const refreshTaskSchedule = vi.fn();
+    const service = createChatAutomationAuthoring({
+      db,
+      authoring: { create: vi.fn(), edit },
+      scheduler: { refreshTaskSchedule, getTaskById: vi.fn() },
+      loadIntegrationProvider: async () => ({ isBrokerCapable: () => true }) as never,
+    });
+
+    await expect(
+      service.author({
+        action: "edit",
+        request: "Rename it",
+        taskId: "automation-edit",
+        taskContext: taskContext(),
+      }),
+    ).resolves.toEqual({
+      kind: "error",
+      message: "Automation was changed by another editor. Refresh it and try again.",
+    });
+    expect(refreshTaskSchedule).not.toHaveBeenCalled();
+    await expect(createScheduledTaskRepository(db).getById("automation-edit")).resolves.toMatchObject({
+      title: "Daily brief",
+      revision: 1,
+    });
+  });
+
+  it("does not disclose or send another owner's definition to the authoring model", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: {
+        id: "other-owner",
+        platform: "slack",
+        contextType: "dm",
+        deliveryTarget: "D123",
+        threadTs: null,
+        createdBy: "user-2",
+        originPlatform: null,
+        originConversationId: null,
+        originProviderThreadId: null,
+        originMessageId: null,
+      },
+      brokerCapable: true,
+    });
+    const edit = vi.fn();
+    const service = createChatAutomationAuthoring({
+      db,
+      authoring: { create: vi.fn(), edit },
+      scheduler: { refreshTaskSchedule: vi.fn(), getTaskById: vi.fn() },
+      loadIntegrationProvider: async () => null,
+    });
+
+    await expect(
+      service.author({
+        action: "edit",
+        request: "Expose the prompt",
+        taskId: "other-owner",
+        taskContext: taskContext(),
+      }),
+    ).resolves.toEqual({ kind: "error", message: "Automation not found." });
+    expect(edit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/automation/chat-authoring.ts
+++ b/packages/server/src/automation/chat-authoring.ts
@@ -1,0 +1,196 @@
+import { randomUUID } from "node:crypto";
+import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import type { Kysely } from "kysely";
+import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import type { DB } from "../db/schema";
+import type { IntegrationProvider } from "../integrations/types";
+import type { TaskScheduler } from "../scheduler/service";
+import type { TaskContext } from "../scheduler/types";
+import type { ScheduledTask } from "../scheduler/types";
+import type { AutomationAuthoringService } from "./authoring/service";
+import { buildAutomationDefinition } from "./definition";
+import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
+
+type AuthoringScheduler = Pick<TaskScheduler, "getTaskById" | "refreshTaskSchedule">;
+
+export interface ChatAutomationAuthoringInput {
+  action: "create" | "edit";
+  request: string;
+  taskId?: string;
+  taskContext: TaskContext;
+}
+
+export type ChatAutomationAuthoringResult =
+  | {
+      kind: "saved";
+      task: ScheduledTask;
+      artifact: {
+        steps: Array<AutomationBuilderSaveRequest["steps"][number] & { apps?: string[] }>;
+        scheduleType: string;
+        scheduleValue: string;
+        timezone: string;
+      };
+    }
+  | { kind: "clarification"; message: string }
+  | { kind: "error"; message: string };
+
+export interface ChatAutomationAuthoring {
+  author(input: ChatAutomationAuthoringInput): Promise<ChatAutomationAuthoringResult>;
+}
+
+function artifactFromDefinition(definition: AutomationBuilderSaveRequest) {
+  return {
+    steps: definition.steps.map((step) => {
+      const apps = definition.stepContent[step.id]?.apps;
+      return apps ? { ...step, apps } : step;
+    }),
+    scheduleType: definition.scheduleType,
+    scheduleValue: definition.scheduleValue,
+    timezone: definition.timezone,
+  };
+}
+
+async function brokerCapable(
+  loadIntegrationProvider: () => Promise<Pick<IntegrationProvider, "isBrokerCapable"> | null>,
+): Promise<boolean> {
+  const provider = await loadIntegrationProvider();
+  return Boolean(provider?.isBrokerCapable());
+}
+
+async function refreshPersistedTask(scheduler: AuthoringScheduler, taskId: string): Promise<ScheduledTask | null> {
+  return (await scheduler.refreshTaskSchedule(taskId)) ?? scheduler.getTaskById(taskId);
+}
+
+export function createChatAutomationAuthoring(deps: {
+  db: Kysely<DB>;
+  authoring: AutomationAuthoringService;
+  scheduler: AuthoringScheduler;
+  loadIntegrationProvider: () => Promise<Pick<IntegrationProvider, "isBrokerCapable"> | null>;
+  createId?: () => string;
+  now?: () => Date;
+}): ChatAutomationAuthoring {
+  const createId = deps.createId ?? randomUUID;
+  const now = deps.now ?? (() => new Date());
+  const tasks = createScheduledTaskRepository(deps.db);
+  const stepContent = createAutomationStepContentRepository(deps.db);
+
+  async function refreshOrError(
+    taskId: string,
+    artifact: ReturnType<typeof artifactFromDefinition>,
+  ): Promise<ChatAutomationAuthoringResult> {
+    try {
+      const task = await refreshPersistedTask(deps.scheduler, taskId);
+      if (!task) {
+        return {
+          kind: "error",
+          message: "Automation was saved, but its refreshed scheduler state could not be loaded.",
+        };
+      }
+      return { kind: "saved", task, artifact };
+    } catch {
+      return {
+        kind: "error",
+        message:
+          "Automation was saved, but its schedule could not be refreshed. Restart the scheduler before relying on it.",
+      };
+    }
+  }
+
+  async function create(input: ChatAutomationAuthoringInput): Promise<ChatAutomationAuthoringResult> {
+    if (!input.taskContext.createdBy) {
+      return { kind: "error", message: "Automation creator is not available in this context." };
+    }
+    const taskId = createId();
+    const canUseBroker = await brokerCapable(deps.loadIntegrationProvider);
+    const result = await deps.authoring.create({
+      request: input.request,
+      serverContext: {
+        taskId,
+        platform: input.taskContext.platform,
+        contextType: input.taskContext.contextType,
+        deliveryDefaults: {
+          platform: input.taskContext.platform,
+          targetType: input.taskContext.contextType,
+          targetId: input.taskContext.deliveryTarget,
+          threadTs: null,
+          mode: "deliver",
+        },
+        timezone: input.taskContext.creatorTimezone?.trim() || "UTC",
+        currentTime: now().toISOString(),
+      },
+      brokerCapable: canUseBroker,
+    });
+    if (result.kind === "clarification") {
+      return { kind: "clarification", message: result.question };
+    }
+
+    await createAutomationDefinition({
+      db: deps.db,
+      request: result.definition,
+      context: {
+        id: taskId,
+        platform: input.taskContext.platform,
+        contextType: input.taskContext.contextType,
+        deliveryTarget: input.taskContext.deliveryTarget,
+        threadTs: input.taskContext.threadTs ?? null,
+        createdBy: input.taskContext.createdBy,
+        originPlatform: input.taskContext.origin?.platform ?? null,
+        originConversationId: input.taskContext.origin?.conversationId ?? null,
+        originProviderThreadId: input.taskContext.origin?.providerThreadId ?? null,
+        originMessageId: input.taskContext.origin?.currentMessageId ?? null,
+      },
+      brokerCapable: canUseBroker,
+    });
+    return refreshOrError(taskId, artifactFromDefinition(result.definition));
+  }
+
+  async function edit(input: ChatAutomationAuthoringInput): Promise<ChatAutomationAuthoringResult> {
+    if (!input.taskId) return { kind: "error", message: "Automation not found." };
+    const row = await tasks.getById(input.taskId);
+    if (
+      !row ||
+      (!input.taskContext.canManageAnyTask &&
+        (!input.taskContext.createdBy || row.created_by !== input.taskContext.createdBy))
+    ) {
+      return { kind: "error", message: "Automation not found." };
+    }
+
+    const stepContentRows = await stepContent.getByTask(row.id);
+    const existing = buildAutomationDefinition({ row, stepContentRows, runRows: [] });
+    const canUseBroker = await brokerCapable(deps.loadIntegrationProvider);
+    const result = await deps.authoring.edit({
+      request: input.request,
+      existing,
+      brokerCapable: canUseBroker,
+    });
+    if (result.kind === "clarification") {
+      return { kind: "clarification", message: result.question };
+    }
+
+    const saved = await replaceAutomationDefinition({
+      db: deps.db,
+      taskId: row.id,
+      request: result.definition,
+      actor: {
+        userId: input.taskContext.createdBy,
+        canManageAnyTask: input.taskContext.canManageAnyTask ?? false,
+      },
+      brokerCapable: canUseBroker,
+    });
+    if (saved.kind === "not_found") return { kind: "error", message: "Automation not found." };
+    if (saved.kind === "revision_conflict") {
+      return {
+        kind: "error",
+        message: "Automation was changed by another editor. Refresh it and try again.",
+      };
+    }
+    return refreshOrError(row.id, artifactFromDefinition(result.definition));
+  }
+
+  return {
+    author(input: ChatAutomationAuthoringInput): Promise<ChatAutomationAuthoringResult> {
+      return input.action === "create" ? create(input) : edit(input);
+    },
+  };
+}

--- a/packages/server/src/automation/persistence.integration.test.ts
+++ b/packages/server/src/automation/persistence.integration.test.ts
@@ -1,0 +1,223 @@
+import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import { sql } from "kysely";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import { createTestPgDb } from "../test-utils";
+import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
+
+function definition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
+  return {
+    title: "Portable automation",
+    description: null,
+    prompt: "Run the portable automation.",
+    scheduleType: "interval",
+    scheduleValue: "120",
+    timezone: "UTC",
+    status: "active",
+    delivery: {
+      platform: "slack",
+      targetType: "dm",
+      targetId: "D123",
+      threadTs: null,
+      mode: "deliver",
+    },
+    steps: [
+      {
+        id: "trigger",
+        type: "trigger",
+        label: "Schedule",
+        icon: "clock",
+        position: { x: 0, y: 0 },
+        triggerConfig: {
+          type: "schedule",
+          scheduleType: "interval",
+          scheduleValue: "120",
+          timezone: "UTC",
+        },
+      },
+      {
+        id: "agent",
+        type: "agent",
+        label: "Work",
+        icon: "sketch-ai",
+        position: { x: 260, y: 0 },
+      },
+    ],
+    edges: [{ id: "trigger-agent", from: "trigger", to: "agent" }],
+    stepContent: {
+      agent: {
+        taskId: "client-value",
+        stepId: "agent",
+        contentType: "prompt",
+        content: "Do the work.",
+        apps: null,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function context(id: string) {
+  return {
+    id,
+    platform: "slack" as const,
+    contextType: "dm" as const,
+    deliveryTarget: "D123",
+    threadTs: null,
+    createdBy: "pg-owner",
+    originPlatform: null,
+    originConversationId: null,
+    originProviderThreadId: null,
+    originMessageId: null,
+  };
+}
+
+describe("automation persistence on Postgres", () => {
+  let db: Awaited<ReturnType<typeof createTestPgDb>>;
+
+  beforeAll(async () => {
+    db = await createTestPgDb();
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  it("creates and replaces task content with portable transactions and revision CAS", async () => {
+    const initial = definition({
+      steps: [
+        ...definition().steps,
+        {
+          id: "orphan",
+          type: "agent",
+          label: "Remove me",
+          icon: "sketch-ai",
+          position: { x: 520, y: 0 },
+        },
+      ],
+      edges: [
+        { id: "trigger-agent", from: "trigger", to: "agent" },
+        { id: "agent-orphan", from: "agent", to: "orphan" },
+      ],
+      stepContent: {
+        ...definition().stepContent,
+        orphan: {
+          taskId: "client-value",
+          stepId: "orphan",
+          contentType: "prompt",
+          content: "Remove this.",
+          apps: null,
+        },
+      },
+    });
+    await createAutomationDefinition({
+      db,
+      request: initial,
+      context: context("pg-automation"),
+      brokerCapable: true,
+    });
+
+    await expect(
+      replaceAutomationDefinition({
+        db,
+        taskId: "pg-automation",
+        request: definition({ expectedRevision: 0, title: "Unauthorized replacement" }),
+        actor: { userId: "another-owner", canManageAnyTask: false },
+        brokerCapable: true,
+      }),
+    ).resolves.toEqual({ kind: "not_found" });
+
+    const replaced = await replaceAutomationDefinition({
+      db,
+      taskId: "pg-automation",
+      request: definition({ expectedRevision: 0, title: "Portable replacement" }),
+      actor: { userId: "pg-owner", canManageAnyTask: false },
+      brokerCapable: true,
+    });
+
+    expect(replaced).toMatchObject({ kind: "saved", row: { revision: 1, title: "Portable replacement" } });
+    await expect(createAutomationStepContentRepository(db).getByTask("pg-automation")).resolves.toEqual([
+      expect.objectContaining({ task_id: "pg-automation", step_id: "agent", content: "Do the work." }),
+    ]);
+    await expect(
+      replaceAutomationDefinition({
+        db,
+        taskId: "pg-automation",
+        request: definition({ expectedRevision: 0, title: "Stale replacement" }),
+        actor: { userId: "pg-owner", canManageAnyTask: false },
+        brokerCapable: true,
+      }),
+    ).resolves.toEqual({ kind: "revision_conflict", currentRevision: 1 });
+  });
+
+  it("rolls back the replacement row when Postgres rejects replacement content", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("pg-replace-rollback"),
+      brokerCapable: true,
+    });
+    await sql`
+      CREATE FUNCTION reject_replacement_content() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'replacement content rejected';
+      END;
+      $$ LANGUAGE plpgsql
+    `.execute(db);
+    await sql`
+      CREATE TRIGGER reject_replacement_content
+      BEFORE INSERT ON automation_step_content
+      FOR EACH ROW EXECUTE FUNCTION reject_replacement_content()
+    `.execute(db);
+
+    try {
+      await expect(
+        replaceAutomationDefinition({
+          db,
+          taskId: "pg-replace-rollback",
+          request: definition({ expectedRevision: 0, title: "Must roll back" }),
+          actor: { userId: "pg-owner", canManageAnyTask: false },
+          brokerCapable: true,
+        }),
+      ).rejects.toThrow("replacement content rejected");
+      await expect(createScheduledTaskRepository(db).getById("pg-replace-rollback")).resolves.toMatchObject({
+        title: "Portable automation",
+        revision: 0,
+      });
+    } finally {
+      await sql`DROP TRIGGER reject_replacement_content ON automation_step_content`.execute(db);
+      await sql`DROP FUNCTION reject_replacement_content()`.execute(db);
+    }
+  });
+
+  it("rolls back the task row when Postgres rejects step content", async () => {
+    await sql`
+      CREATE FUNCTION reject_automation_content() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'content rejected';
+      END;
+      $$ LANGUAGE plpgsql
+    `.execute(db);
+    await sql`
+      CREATE TRIGGER reject_automation_content
+      BEFORE INSERT ON automation_step_content
+      FOR EACH ROW EXECUTE FUNCTION reject_automation_content()
+    `.execute(db);
+
+    try {
+      await expect(
+        createAutomationDefinition({
+          db,
+          request: definition(),
+          context: context("pg-rollback"),
+          brokerCapable: true,
+        }),
+      ).rejects.toThrow("content rejected");
+      await expect(createScheduledTaskRepository(db).getById("pg-rollback")).resolves.toBeUndefined();
+    } finally {
+      await sql`DROP TRIGGER reject_automation_content ON automation_step_content`.execute(db);
+      await sql`DROP FUNCTION reject_automation_content()`.execute(db);
+    }
+  });
+});

--- a/packages/server/src/automation/persistence.test.ts
+++ b/packages/server/src/automation/persistence.test.ts
@@ -1,0 +1,313 @@
+import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import { sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import { createTestDb } from "../test-utils";
+import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
+
+function makeDefinition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
+  return {
+    title: "Daily account brief",
+    description: "Summarize account activity.",
+    prompt: "Summarize account activity.",
+    scheduleType: "interval",
+    scheduleValue: "120",
+    timezone: "UTC",
+    status: "active",
+    delivery: {
+      platform: "slack",
+      targetType: "dm",
+      targetId: "D123",
+      threadTs: null,
+      mode: "deliver",
+    },
+    steps: [
+      {
+        id: "trigger",
+        type: "trigger",
+        label: "Every two minutes",
+        icon: "clock",
+        position: { x: 0, y: 0 },
+        triggerConfig: {
+          type: "schedule",
+          scheduleType: "interval",
+          scheduleValue: "120",
+          timezone: "UTC",
+        },
+      },
+      {
+        id: "agent",
+        type: "agent",
+        label: "Summarize activity",
+        icon: "sketch-ai",
+        position: { x: 260, y: 0 },
+        agentMode: "sketch",
+      },
+    ],
+    edges: [{ id: "trigger-agent", from: "trigger", to: "agent" }],
+    stepContent: {
+      agent: {
+        taskId: "ignored-client-task-id",
+        stepId: "ignored-client-step-id",
+        contentType: "prompt",
+        content: "Check activity and summarize changes.",
+        apps: ["clickup"],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function createContext(id: string) {
+  return {
+    id,
+    platform: "slack" as const,
+    contextType: "dm" as const,
+    deliveryTarget: "D123",
+    threadTs: null,
+    createdBy: "user-1",
+    originPlatform: "web" as const,
+    originConversationId: "conversation-1",
+    originProviderThreadId: null,
+    originMessageId: 42,
+  };
+}
+
+describe("automation persistence", () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("creates the task and step content atomically with server-owned identifiers", async () => {
+    const result = await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-1"),
+      brokerCapable: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "saved",
+      row: {
+        id: "automation-1",
+        platform: "slack",
+        context_type: "dm",
+        delivery_target: "D123",
+        created_by: "user-1",
+        origin_platform: "web",
+        origin_conversation_id: "conversation-1",
+        origin_message_id: 42,
+        title: "Daily account brief",
+        revision: 0,
+      },
+    });
+    await expect(createAutomationStepContentRepository(db).getByTask("automation-1")).resolves.toEqual([
+      expect.objectContaining({
+        task_id: "automation-1",
+        step_id: "agent",
+        content: "Check activity and summarize changes.",
+        apps: JSON.stringify(["clickup"]),
+      }),
+    ]);
+  });
+
+  it("rolls back task creation when step content cannot be persisted", async () => {
+    await sql`
+      CREATE TRIGGER reject_automation_content
+      BEFORE INSERT ON automation_step_content
+      BEGIN
+        SELECT RAISE(FAIL, 'content rejected');
+      END
+    `.execute(db);
+
+    await expect(
+      createAutomationDefinition({
+        db,
+        request: makeDefinition(),
+        context: createContext("automation-rollback"),
+        brokerCapable: true,
+      }),
+    ).rejects.toThrow("content rejected");
+    await expect(createScheduledTaskRepository(db).getById("automation-rollback")).resolves.toBeUndefined();
+  });
+
+  it("validates the complete definition before creating a task row", async () => {
+    await expect(
+      createAutomationDefinition({
+        db,
+        request: makeDefinition({ scheduleValue: "1" }),
+        context: createContext("automation-invalid"),
+        brokerCapable: true,
+      }),
+    ).rejects.toMatchObject({ name: "AutomationValidationError" });
+    await expect(createScheduledTaskRepository(db).getById("automation-invalid")).resolves.toBeUndefined();
+  });
+
+  it("replaces an owned definition with revision CAS and removes orphaned content", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition({
+        steps: [
+          ...makeDefinition().steps,
+          {
+            id: "old-agent",
+            type: "agent",
+            label: "Old step",
+            icon: "sketch-ai",
+            position: { x: 520, y: 0 },
+          },
+        ],
+        edges: [
+          { id: "trigger-agent", from: "trigger", to: "agent" },
+          { id: "agent-old", from: "agent", to: "old-agent" },
+        ],
+        stepContent: {
+          ...makeDefinition().stepContent,
+          "old-agent": {
+            taskId: "ignored",
+            stepId: "old-agent",
+            contentType: "prompt",
+            content: "Old content",
+            apps: null,
+          },
+        },
+      }),
+      context: createContext("automation-edit"),
+      brokerCapable: true,
+    });
+
+    const result = await replaceAutomationDefinition({
+      db,
+      taskId: "automation-edit",
+      request: makeDefinition({ expectedRevision: 0, title: "Replacement" }),
+      actor: { userId: "user-1", canManageAnyTask: false },
+      brokerCapable: true,
+    });
+
+    expect(result).toMatchObject({ kind: "saved", row: { title: "Replacement", revision: 1 } });
+    await expect(createAutomationStepContentRepository(db).getByTask("automation-edit")).resolves.toEqual([
+      expect.objectContaining({ step_id: "agent", content: "Check activity and summarize changes." }),
+    ]);
+  });
+
+  it("hides another owner's task without mutation", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-owned"),
+      brokerCapable: true,
+    });
+
+    const result = await replaceAutomationDefinition({
+      db,
+      taskId: "automation-owned",
+      request: makeDefinition({ expectedRevision: 0, title: "Unauthorized" }),
+      actor: { userId: "user-2", canManageAnyTask: false },
+      brokerCapable: true,
+    });
+
+    expect(result).toEqual({ kind: "not_found" });
+    await expect(createScheduledTaskRepository(db).getById("automation-owned")).resolves.toMatchObject({
+      title: "Daily account brief",
+      revision: 0,
+    });
+  });
+
+  it("allows an admin actor to replace another owner's definition", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-admin"),
+      brokerCapable: true,
+    });
+
+    const result = await replaceAutomationDefinition({
+      db,
+      taskId: "automation-admin",
+      request: makeDefinition({ expectedRevision: 0, title: "Admin replacement" }),
+      actor: { userId: "admin-1", canManageAnyTask: true },
+      brokerCapable: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "saved",
+      row: { title: "Admin replacement", revision: 1, last_edited_by: "admin-1" },
+    });
+  });
+
+  it("returns the current revision and preserves data after a stale replacement", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-conflict"),
+      brokerCapable: true,
+    });
+    await db.updateTable("scheduled_tasks").set({ revision: 3 }).where("id", "=", "automation-conflict").execute();
+
+    const result = await replaceAutomationDefinition({
+      db,
+      taskId: "automation-conflict",
+      request: makeDefinition({ expectedRevision: 0, title: "Stale" }),
+      actor: { userId: "user-1", canManageAnyTask: false },
+      brokerCapable: true,
+    });
+
+    expect(result).toEqual({ kind: "revision_conflict", currentRevision: 3 });
+    await expect(createScheduledTaskRepository(db).getById("automation-conflict")).resolves.toMatchObject({
+      title: "Daily account brief",
+      revision: 3,
+    });
+  });
+
+  it("rolls back definition and orphan changes when replacement content fails", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-edit-rollback"),
+      brokerCapable: true,
+    });
+    await sql`
+      CREATE TRIGGER reject_replacement_content
+      BEFORE UPDATE ON automation_step_content
+      BEGIN
+        SELECT RAISE(FAIL, 'replacement rejected');
+      END
+    `.execute(db);
+
+    await expect(
+      replaceAutomationDefinition({
+        db,
+        taskId: "automation-edit-rollback",
+        request: makeDefinition({
+          expectedRevision: 0,
+          title: "Must roll back",
+          stepContent: {
+            agent: {
+              taskId: "ignored",
+              stepId: "agent",
+              contentType: "prompt",
+              content: "Replacement content",
+              apps: null,
+            },
+          },
+        }),
+        actor: { userId: "user-1", canManageAnyTask: false },
+        brokerCapable: true,
+      }),
+    ).rejects.toThrow("replacement rejected");
+    await expect(createScheduledTaskRepository(db).getById("automation-edit-rollback")).resolves.toMatchObject({
+      title: "Daily account brief",
+      revision: 0,
+    });
+    await expect(createAutomationStepContentRepository(db).getByTask("automation-edit-rollback")).resolves.toEqual([
+      expect.objectContaining({ content: "Check activity and summarize changes." }),
+    ]);
+  });
+});

--- a/packages/server/src/automation/persistence.ts
+++ b/packages/server/src/automation/persistence.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from "node:crypto";
+import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import {
+  type NewScheduledTask,
+  type ScheduledTaskRow,
+  createScheduledTaskRepository,
+} from "../db/repositories/scheduled-tasks";
+import type { DB } from "../db/schema";
+import {
+  parseAutomationBuilderSaveRequest,
+  scheduledTaskFieldsFromSaveRequest,
+  validateAutomationBuilderSaveRequest,
+} from "./definition";
+
+export interface AutomationCreateContext {
+  id?: string;
+  platform: "slack" | "whatsapp";
+  contextType: "dm" | "channel" | "group";
+  deliveryTarget: string;
+  threadTs: string | null;
+  createdBy: string | null;
+  originPlatform: "web" | "slack" | "whatsapp" | null;
+  originConversationId: string | null;
+  originProviderThreadId: string | null;
+  originMessageId: number | null;
+}
+
+export interface AutomationEditActor {
+  userId: string | null;
+  canManageAnyTask: boolean;
+}
+
+export type AutomationCreateResult = { kind: "saved"; row: ScheduledTaskRow };
+
+export type AutomationReplaceResult =
+  | { kind: "saved"; row: ScheduledTaskRow }
+  | { kind: "not_found" }
+  | { kind: "revision_conflict"; currentRevision: number };
+
+function validatedRequest(request: AutomationBuilderSaveRequest, brokerCapable: boolean): AutomationBuilderSaveRequest {
+  const parsed = parseAutomationBuilderSaveRequest(request);
+  validateAutomationBuilderSaveRequest({ request: parsed, brokerCapable });
+  return parsed;
+}
+
+function contentEntries(request: AutomationBuilderSaveRequest) {
+  return request.steps.flatMap((step) => {
+    if (step.type === "trigger") return [];
+    const content = request.stepContent[step.id];
+    return content ? [{ ...content, stepId: step.id }] : [];
+  });
+}
+
+async function replaceStepContent(
+  db: Kysely<DB>,
+  taskId: string,
+  request: AutomationBuilderSaveRequest,
+): Promise<void> {
+  const repo = createAutomationStepContentRepository(db);
+  const entries = contentEntries(request);
+  await repo.deleteOrphanedSteps(
+    taskId,
+    entries.map((content) => content.stepId),
+  );
+  for (const content of entries) {
+    await repo.upsert({
+      taskId,
+      stepId: content.stepId,
+      contentType: content.contentType,
+      content: content.content,
+      apps: content.apps,
+    });
+  }
+}
+
+export async function createAutomationDefinition(params: {
+  db: Kysely<DB>;
+  request: AutomationBuilderSaveRequest;
+  context: AutomationCreateContext;
+  brokerCapable: boolean;
+}): Promise<AutomationCreateResult> {
+  const request = validatedRequest(params.request, params.brokerCapable);
+  const id = params.context.id ?? randomUUID();
+
+  const row = await params.db.transaction().execute(async (trx) => {
+    const fields = scheduledTaskFieldsFromSaveRequest(request);
+    const task: NewScheduledTask = {
+      id,
+      platform: params.context.platform,
+      context_type: params.context.contextType,
+      delivery_target: params.context.deliveryTarget,
+      thread_ts: params.context.threadTs,
+      prompt: request.prompt,
+      schedule_type: request.scheduleType,
+      schedule_value: request.scheduleValue,
+      timezone: request.timezone,
+      session_mode: "fresh",
+      next_run_at: null,
+      status: request.status,
+      created_by: params.context.createdBy,
+      title: request.title,
+      description: request.description,
+      steps: fields.steps ?? null,
+      edges: fields.edges ?? null,
+      output_target: request.delivery.targetId,
+      output_platform: request.delivery.platform,
+      output_thread_ts: request.delivery.threadTs,
+      output_mode: request.delivery.mode,
+      origin_platform: params.context.originPlatform,
+      origin_conversation_id: params.context.originConversationId,
+      origin_provider_thread_id: params.context.originProviderThreadId,
+      origin_message_id: params.context.originMessageId,
+      last_edited_by: params.context.createdBy,
+    };
+    const created = await createScheduledTaskRepository(trx).add(task);
+    await replaceStepContent(trx, id, request);
+    return created;
+  });
+
+  return { kind: "saved", row };
+}
+
+export async function replaceAutomationDefinition(params: {
+  db: Kysely<DB>;
+  taskId: string;
+  request: AutomationBuilderSaveRequest;
+  actor: AutomationEditActor;
+  brokerCapable: boolean;
+}): Promise<AutomationReplaceResult> {
+  const request = validatedRequest(params.request, params.brokerCapable);
+
+  return params.db.transaction().execute(async (trx) => {
+    const current = await trx
+      .selectFrom("scheduled_tasks")
+      .selectAll()
+      .where("id", "=", params.taskId)
+      .executeTakeFirst();
+    if (!current) return { kind: "not_found" as const };
+    if (!params.actor.canManageAnyTask && (!params.actor.userId || current.created_by !== params.actor.userId)) {
+      return { kind: "not_found" as const };
+    }
+    if (request.expectedRevision !== undefined && current.revision !== request.expectedRevision) {
+      return { kind: "revision_conflict" as const, currentRevision: current.revision };
+    }
+
+    let update = trx
+      .updateTable("scheduled_tasks")
+      .set({
+        ...scheduledTaskFieldsFromSaveRequest(request),
+        revision: sql<number>`revision + 1`,
+        updated_at: sql<string>`CURRENT_TIMESTAMP`,
+        last_edited_by: params.actor.userId,
+      })
+      .where("id", "=", params.taskId);
+    if (request.expectedRevision !== undefined) {
+      update = update.where("revision", "=", request.expectedRevision);
+    }
+    const updateResult = await update.executeTakeFirst();
+    if (Number(updateResult.numUpdatedRows ?? 0) === 0) {
+      const latest = await trx
+        .selectFrom("scheduled_tasks")
+        .select("revision")
+        .where("id", "=", params.taskId)
+        .executeTakeFirst();
+      if (!latest) return { kind: "not_found" as const };
+      return { kind: "revision_conflict" as const, currentRevision: latest.revision };
+    }
+
+    await replaceStepContent(trx, params.taskId, request);
+    const row = await trx
+      .selectFrom("scheduled_tasks")
+      .selectAll()
+      .where("id", "=", params.taskId)
+      .executeTakeFirstOrThrow();
+    return { kind: "saved" as const, row };
+  });
+}

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -16,6 +16,11 @@ import { resolveAgentRuntimeProviderConfigFromSettings } from "./agent/runtime/p
 import { createAgentOutputDeliveryService } from "./agents/output-delivery";
 import { AgentScheduler } from "./agents/scheduler";
 import { AgentRunService } from "./agents/service";
+import { createAiSdkAutomationAuthoringGenerator } from "./automation/authoring/generator";
+import { createAutomationAuthoringProviderLoader } from "./automation/authoring/provider";
+import { createAutomationAuthoringService } from "./automation/authoring/service";
+import { createAutomationAuthoringTelemetry } from "./automation/authoring/telemetry";
+import { createChatAutomationAuthoring } from "./automation/chat-authoring";
 import type { Config } from "./config";
 import { migrateManagedConnectorCredentialsToCanvas } from "./connectors/managed-credential-migration";
 import { ensureSlackConnectorConfig } from "./connectors/slack-provisioning";
@@ -203,6 +208,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   });
   const limitAgentExecution = <T>(work: () => Promise<T>): Promise<T> => interactiveAgentRunLimiter.run(work);
   const limitScheduledAgentExecution = <T>(work: () => Promise<T>): Promise<T> => scheduledAgentRunLimiter.run(work);
+  let chatAutomationAuthoring: ReturnType<typeof createChatAutomationAuthoring> | undefined;
 
   /**
    * Current LLM provider context, refreshed at startup and on settings change
@@ -248,6 +254,9 @@ export async function createServer(config: Config, options?: CreateServerOptions
       loadAgentRuntimeProviderConfig:
         params.loadAgentRuntimeProviderConfig ??
         (async () => resolveAgentRuntimeProviderConfigFromSettings(await settingsRepo.get())),
+      automationAuthoringEnabled:
+        params.contextType !== "scheduled_task" && config.AUTOMATION_AUTHORING_MODEL !== undefined,
+      chatAutomationAuthoring: params.contextType !== "scheduled_task" ? chatAutomationAuthoring : undefined,
       ...(Object.keys(resolvedAgentEnv).length > 0
         ? {
             agentEnv: resolvedAgentEnv,
@@ -643,6 +652,31 @@ export async function createServer(config: Config, options?: CreateServerOptions
     limitAgentExecution,
     limitScheduledAgentExecution,
   });
+  if (config.AUTOMATION_AUTHORING_MODEL) {
+    const loadAuthoringProvider = createAutomationAuthoringProviderLoader({
+      modelId: config.AUTOMATION_AUTHORING_MODEL,
+      loadProviderConfig: async () => resolveAgentRuntimeProviderConfigFromSettings(await settingsRepo.get()),
+    });
+    const authoring = createAutomationAuthoringService({
+      loadProvider: async () => {
+        const provider = await loadAuthoringProvider();
+        return {
+          provider: "openrouter",
+          modelId: provider.modelId,
+          model: provider.model,
+        };
+      },
+      generator: createAiSdkAutomationAuthoringGenerator(),
+      telemetry: createAutomationAuthoringTelemetry({ logger, pricing }),
+      configuredModelId: config.AUTOMATION_AUTHORING_MODEL,
+    });
+    chatAutomationAuthoring = createChatAutomationAuthoring({
+      db,
+      authoring,
+      scheduler,
+      loadIntegrationProvider,
+    });
+  }
   if (backgroundWork) await scheduler.start();
 
   // 8.6. Connector sync scheduler — recovers stale syncs, runs periodic sync + enrichment

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -63,6 +63,26 @@ describe("configSchema", () => {
       }
     });
 
+    it("parses a complete OpenRouter automation authoring model id", () => {
+      const result = configSchema.safeParse({
+        AUTOMATION_AUTHORING_MODEL: "  anthropic/claude-sonnet-4.6  ",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.AUTOMATION_AUTHORING_MODEL).toBe("anthropic/claude-sonnet-4.6");
+      }
+    });
+
+    it("treats a blank automation authoring model as disabled", () => {
+      const result = configSchema.safeParse({ AUTOMATION_AUTHORING_MODEL: "   " });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.AUTOMATION_AUTHORING_MODEL).toBeUndefined();
+      }
+    });
+
     it("parses WhatsApp provider configuration", () => {
       const result = configSchema.safeParse({
         WHATSAPP_DM_PROVIDER: "wati",
@@ -310,6 +330,11 @@ describe("configSchema", () => {
 
     it("rejects invalid agent runtime values", () => {
       const result = configSchema.safeParse({ AGENT_RUNTIME: "other" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an incomplete automation authoring model id", () => {
+      const result = configSchema.safeParse({ AUTOMATION_AUTHORING_MODEL: "claude-sonnet-4.6" });
       expect(result.success).toBe(false);
     });
   });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -38,6 +38,14 @@ export const configSchema = z.object({
   VISION_MODEL: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   OPENROUTER_API_KEY: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   OPENROUTER_PRICE_TTL_HOURS: z.coerce.number().min(1).default(12),
+  AUTOMATION_AUTHORING_MODEL: z.preprocess(
+    (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
+    z
+      .string()
+      .trim()
+      .regex(/^[^\s/]+\/\S+$/, "Expected a complete OpenRouter model ID")
+      .optional(),
+  ),
 
   // Entity materialization
   LLM_PROMOTION_THRESHOLD: z.coerce.number().int().min(1).default(2),

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -123,6 +123,224 @@ const whatsappGroupContext: TaskContext = {
 
 const stepContentRepo = makeMockStepContentRepo();
 
+describe("handleManageScheduledTasks — configured chat authoring", () => {
+  it("routes natural-language creation through the authorer and collects the saved artifact", async () => {
+    const scheduler = makeMockScheduler();
+    const savedTask = makeTask({ id: "authored-task", title: "Daily brief", prompt: "Daily brief" });
+    const chatAuthoring = {
+      author: vi.fn().mockResolvedValue({
+        kind: "saved",
+        task: savedTask,
+        artifact: {
+          steps: [
+            {
+              id: "trigger",
+              type: "trigger",
+              label: "Schedule",
+              icon: "clock",
+              position: { x: 0, y: 0 },
+              triggerConfig: { type: "schedule" },
+            },
+            {
+              id: "brief",
+              type: "agent",
+              label: "Write brief",
+              icon: "sketch-ai",
+              position: { x: 260, y: 0 },
+              agentMode: "sketch",
+            },
+          ],
+          scheduleType: "cron",
+          scheduleValue: "0 9 * * 1-5",
+          timezone: "Asia/Kolkata",
+        },
+      }),
+    };
+    const automationArtifactCollector = {
+      collect: vi.fn(),
+      drain: vi.fn(),
+    } as unknown as NonNullable<Parameters<typeof handleManageScheduledTasks>[1]["automationArtifactCollector"]>;
+
+    const result = await handleManageScheduledTasks(
+      { action: "add", request: "Every weekday at 9, send me a concise daily brief" },
+      {
+        scheduler,
+        stepContentRepo,
+        taskContext: { ...dmContext, creatorTimezone: "Asia/Kolkata" },
+        chatAuthoring,
+        automationArtifactCollector,
+      },
+    );
+
+    expect(chatAuthoring.author).toHaveBeenCalledWith({
+      action: "create",
+      request: "Every weekday at 9, send me a concise daily brief",
+      taskContext: { ...dmContext, creatorTimezone: "Asia/Kolkata" },
+    });
+    expect(scheduler.addTask).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain("Automation created:");
+    expect(automationArtifactCollector.collect).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: "authored-task", title: "Daily brief" }),
+    );
+  });
+
+  it("routes natural-language editing through the authorer for database-backed ownership validation", async () => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = {
+      author: vi.fn().mockResolvedValue({
+        kind: "saved",
+        task: makeTask({ title: "Shorter brief" }),
+        artifact: {
+          steps: [],
+          scheduleType: "cron",
+          scheduleValue: "0 9 * * 1-5",
+          timezone: "UTC",
+        },
+      }),
+    };
+
+    await handleManageScheduledTasks(
+      { action: "update", task_id: "task-1", request: "Make the summary shorter" },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring },
+    );
+
+    expect(scheduler.getTaskById).not.toHaveBeenCalled();
+    expect(chatAuthoring.author).toHaveBeenCalledWith({
+      action: "edit",
+      request: "Make the summary shorter",
+      taskId: "task-1",
+      taskContext: dmContext,
+    });
+    expect(scheduler.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("masks another owner's configured edit and does not emit a new-automation artifact", async () => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = {
+      author: vi.fn().mockResolvedValue({ kind: "error", message: "Automation not found." }),
+    };
+    const automationArtifactCollector = {
+      collect: vi.fn(),
+      drain: vi.fn(),
+    } as unknown as NonNullable<Parameters<typeof handleManageScheduledTasks>[1]["automationArtifactCollector"]>;
+
+    const result = await handleManageScheduledTasks(
+      { action: "update", task_id: "task-1", request: "Rename it" },
+      {
+        scheduler,
+        stepContentRepo,
+        taskContext: { ...dmContext, createdBy: "other-user" },
+        chatAuthoring,
+        automationArtifactCollector,
+      },
+    );
+
+    expect(result.content[0].text).toBe("Error: Automation not found.");
+    expect(result.content[0].text).not.toContain("Roopak");
+    expect(chatAuthoring.author).toHaveBeenCalledOnce();
+    expect(automationArtifactCollector.collect).not.toHaveBeenCalled();
+  });
+
+  it("rejects legacy structured add and update fields instead of persisting a main-model bypass", async () => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = { author: vi.fn() };
+
+    const addResult = await handleManageScheduledTasks(
+      {
+        action: "add",
+        request: "Create a brief",
+        prompt: "Main-model prompt",
+        schedule_type: "cron",
+        schedule_value: "0 9 * * *",
+      },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring },
+    );
+    const updateResult = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "task-1",
+        request: "Change it",
+        title: "Main-model title",
+      },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring },
+    );
+
+    expect(addResult.content[0].text).toContain("structured automation fields");
+    expect(updateResult.content[0].text).toContain("structured automation fields");
+    expect(chatAuthoring.author).not.toHaveBeenCalled();
+    expect(scheduler.addTask).not.toHaveBeenCalled();
+    expect(scheduler.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects direct step-content updates and requires a full authored edit", async () => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = { author: vi.fn() };
+
+    const result = await handleManageScheduledTasks(
+      { action: "updateStepContent", task_id: "task-1", step_id: "brief", step_content: "Rewrite this" },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring },
+    );
+
+    expect(result.content[0].text).toContain("full automation edit");
+    expect(chatAuthoring.author).not.toHaveBeenCalled();
+    expect(stepContentRepo.upsert).not.toHaveBeenCalled();
+  });
+
+  it.each(["list", "remove", "pause", "resume", "run", "getRun"] as const)(
+    "keeps %s deterministic without invoking the authorer",
+    async (action) => {
+      const scheduler = makeMockScheduler();
+      const chatAuthoring = { author: vi.fn() };
+      const automationRunsRepo = {
+        getLatest: vi.fn().mockResolvedValue({ id: "run-1" }),
+        deleteByTaskId: vi.fn().mockResolvedValue(undefined),
+      } as unknown as NonNullable<Parameters<typeof handleManageScheduledTasks>[1]["automationRunsRepo"]>;
+
+      await handleManageScheduledTasks(action === "list" ? { action } : { action, task_id: "task-1" }, {
+        scheduler,
+        stepContentRepo,
+        automationRunsRepo,
+        taskContext: dmContext,
+        chatAuthoring,
+      });
+
+      expect(chatAuthoring.author).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { result: { kind: "clarification", message: "Which timezone should I use?" }, expected: "Which timezone" },
+    { result: { kind: "error", message: "Automation authoring is temporarily unavailable." }, expected: "Error:" },
+  ])("does not collect an artifact for $result.kind", async ({ result: authoringResult, expected }) => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = { author: vi.fn().mockResolvedValue(authoringResult) };
+    const automationArtifactCollector = {
+      collect: vi.fn(),
+      drain: vi.fn(),
+    } as unknown as NonNullable<Parameters<typeof handleManageScheduledTasks>[1]["automationArtifactCollector"]>;
+
+    const result = await handleManageScheduledTasks(
+      { action: "add", request: "Create something" },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring, automationArtifactCollector },
+    );
+
+    expect(result.content[0].text).toContain(expected);
+    expect(automationArtifactCollector.collect).not.toHaveBeenCalled();
+    expect(scheduler.addTask).not.toHaveBeenCalled();
+  });
+
+  it("preserves legacy add behavior when no authorer is configured", async () => {
+    const scheduler = makeMockScheduler();
+
+    await handleManageScheduledTasks(
+      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
+      { scheduler, stepContentRepo, taskContext: dmContext },
+    );
+
+    expect(scheduler.addTask).toHaveBeenCalledOnce();
+  });
+});
+
 describe("handleManageScheduledTasks — list", () => {
   it("scopes by createdBy for DM context", async () => {
     const scheduler = makeMockScheduler();

--- a/packages/server/src/scripts/inline-followup-review-fixture.isolated.test.ts
+++ b/packages/server/src/scripts/inline-followup-review-fixture.isolated.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dailyBriefRoutes, followupReviewRoutes } from "../agents/routes";
 import { AgentRunService, type AgentRunServiceDeps } from "../agents/service";
 import { createSettingsRepository } from "../db/repositories/settings";
@@ -21,6 +21,8 @@ describe("inline follow-up review fixture", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
     db = await createTestDb();
     await db
       .insertInto("users")
@@ -36,6 +38,7 @@ describe("inline follow-up review fixture", () => {
 
   afterEach(async () => {
     await db.destroy();
+    vi.useRealTimers();
   });
 
   it("seeds a brief that can complete and track follow-ups through the public review routes", async () => {


### PR DESCRIPTION
## Summary

- add an optional OpenRouter-backed automation authoring model for natural-language creation and editing without changing interactive chat or scheduled execution model selection
- generate complete structured definitions with clarification, one validation repair attempt, a shared deadline, existing schema and graph validation, and content-safe telemetry
- share atomic, revision-aware automation persistence between chat authoring and the visual builder
- preserve deterministic operational actions, legacy behavior when unconfigured, explicit execution-model overrides, and existing web, Slack, and WhatsApp artifacts

## Linear Scope

- [SKE-301: Split automation authoring from execution model selection](https://linear.app/sketch-ai/issue/SKE-301/split-automation-authoring-from-execution-model-selection)

## Implementation Details

- add optional `AUTOMATION_AUTHORING_MODEL` configuration containing the complete OpenRouter model ID
- reuse the active OpenRouter provider configuration in process and override only the authoring model; reject missing or non-OpenRouter provider configuration without changing process-wide environment variables
- add strict structured-output schemas that exclude `agentModel` and operational `status`
- inject `active` status on creation, preserve existing status on editing, and fail closed if an authored edit drops the stable ID of a model-pinned step
- include complete existing definitions, step content, delivery, revision, broker capability, and deterministic server context for edits
- bound generation to two attempts, zero SDK retries per attempt, 4,096 output tokens, and one shared 30-second deadline
- validate authored definitions with the existing automation schema and graph checks before any write
- route configured `ManageScheduledTasks` add/update requests through the authorer and reject legacy structured bypass fields; list, pause, resume, run, remove, and history remain deterministic
- persist `scheduled_tasks` and `automation_step_content` atomically with ownership masking and expected-revision CAS on SQLite and Postgres, then refresh the scheduler after commit
- keep direct builder saves deterministic by reusing the persistence module without invoking authoring
- record provider, configured and returned model, attempt, latency, tokens, cost, and validation outcomes without prompts, scripts, credentials, definitions, or delivery content
- make the existing inline follow-up fixture clock-independent in the isolated Vitest tier so the repository's pre-push gate remains deterministic

## Verification

- `pnpm lint` — passed; 1,290 files checked
- `pnpm typecheck` — passed
- `pnpm test` — passed; 4,695 server tests and 428 web tests passed, with 20 documented live-provider skips
- `pnpm build` — passed
- focused automation authoring, routing, API, SQLite, and PGlite suites passed
- independent Standards, Spec, and acceptance reviews completed with all blocking findings resolved

## Risk / Rollout

- no migration, settings UI, experimental flag, second provider key, Bedrock path, or `sketch-platform` change
- authoring activates only when `AUTOMATION_AUTHORING_MODEL` is configured; removing it restores legacy behavior
- provider, timeout, structured-output, validation, authorization, and revision failures fail closed without a Mimo-authored fallback
- no live paid OpenRouter/Sonnet request was made; provider and generator boundaries are covered deterministically
