### PR TITLE
fix: include caller in team directory

### DIFF
--- a/packages/server/src/agent/sketch-tools.test.ts
+++ b/packages/server/src/agent/sketch-tools.test.ts
@@ -451,8 +451,8 @@ describe("createSketchMcpServer", () => {
 });
 
 describe("handleGetTeamDirectory", () => {
-  it("returns all users except current user", async () => {
-    const alice = makeUser({ id: "user-alice", name: "Alice" });
+  it("includes the current user and distinguishes workspace access from org role", async () => {
+    const alice = makeUser({ id: "user-alice", name: "Alice", auth_role: "admin", role: "Engineering Lead" });
     const bob = makeUser({ id: "user-bob", name: "Bob" });
     const result = await handleGetTeamDirectory({
       userRepo: makeUserRepoMock({
@@ -463,8 +463,24 @@ describe("handleGetTeamDirectory", () => {
     });
 
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed).toHaveLength(1);
-    expect(parsed[0]).toMatchObject({ id: "user-bob", name: "Bob" });
+    expect(parsed).toHaveLength(2);
+    expect(parsed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "user-alice",
+          name: "Alice",
+          role: "Engineering Lead",
+          workspaceRole: "admin",
+          isCurrentUser: true,
+        }),
+        expect.objectContaining({
+          id: "user-bob",
+          name: "Bob",
+          workspaceRole: "member",
+          isCurrentUser: false,
+        }),
+      ]),
+    );
   });
 
   it("returns channels from the recipient's connected accounts", async () => {

--- a/packages/server/src/agent/tools/team.ts
+++ b/packages/server/src/agent/tools/team.ts
@@ -41,16 +41,16 @@ export async function handleGetTeamDirectory(
 ): Promise<ToolResult> {
   if (!deps.userRepo) return { content: [{ type: "text" as const, text: "Team directory not available." }] };
   const users = await deps.userRepo.list();
-  const directory = users
-    .filter((u) => u.id !== deps.currentUserId)
-    .map((u) => ({
-      id: u.id,
-      name: u.name,
-      role: u.role ?? null,
-      type: u.type,
-      description: u.description ?? "No description",
-      channels: [...(u.slack_user_id ? ["slack"] : []), ...(u.whatsapp_number ? ["whatsapp"] : [])],
-    }));
+  const directory = users.map((u) => ({
+    id: u.id,
+    name: u.name,
+    role: u.role ?? null,
+    workspaceRole: u.auth_role,
+    isCurrentUser: u.id === deps.currentUserId,
+    type: u.type,
+    description: u.description ?? "No description",
+    channels: [...(u.slack_user_id ? ["slack"] : []), ...(u.whatsapp_number ? ["whatsapp"] : [])],
+  }));
   return { content: [{ type: "text" as const, text: JSON.stringify(directory, null, 2) }] };
 }
 
@@ -58,7 +58,7 @@ export function createTeamTools(deps: SketchMcpDeps) {
   return [
     tool(
       "GetTeamDirectory",
-      "Discover team members and their roles. Returns all team members except yourself.",
+      "Discover team members and their roles, including yourself. `role` is the org or job role, `workspaceRole` is workspace access (`admin` or `member`), and `isCurrentUser` identifies the caller.",
       {},
       async () => handleGetTeamDirectory(deps),
     ),

--- a/packages/server/src/scripts/inline-followup-review-fixture.isolated.test.ts
+++ b/packages/server/src/scripts/inline-followup-review-fixture.isolated.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dailyBriefRoutes, followupReviewRoutes } from "../agents/routes";
 import { AgentRunService, type AgentRunServiceDeps } from "../agents/service";
 import { createSettingsRepository } from "../db/repositories/settings";
@@ -21,6 +21,8 @@ describe("inline follow-up review fixture", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
     db = await createTestDb();
     await db
       .insertInto("users")
@@ -36,6 +38,7 @@ describe("inline follow-up review fixture", () => {
 
   afterEach(async () => {
     await db.destroy();
+    vi.useRealTimers();
   });
 
   it("seeds a brief that can complete and track follow-ups through the public review routes", async () => {


### PR DESCRIPTION
## Summary

- include the caller in `GetTeamDirectory` results
- mark the caller with `isCurrentUser` so the agent can identify them reliably
- expose `workspaceRole` from `users.auth_role` while retaining `role` for the org/job role
- update the tool description and regression coverage
- freeze the inline follow-up fixture clock so its expiry assertions remain deterministic

## Root cause

`GetTeamDirectory` explicitly filtered out `currentUserId`, so the agent could not find the person invoking the tool. It also returned only `users.role`, which is the org/job role, rather than `users.auth_role`, which determines workspace admin access.

The initial CI run also exposed an unrelated stale-clock test on `main`: the fixture seeded recommendations from a fixed July 20 timestamp while its route evaluated expiry using the real current date. The suite now runs as an isolated fake-timer test fixed at its declared fixture time.

## Impact

The agent can now answer questions about the caller's team identity and workspace-admin status without inferring identity from names or channel IDs. Existing outreach and user-search self-exclusion remains unchanged.

## Validation

- focused team-directory suite: 34 passed
- focused inline follow-up fixture suite: 3 passed
- test isolation guard: passed
- `pnpm biome check .` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm test` — 4,629 server tests passed, 20 skipped; 428 web tests passed