### PR TITLE
SKE-307: Add managed Slack connection from Channels

### DIFF
--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -180,6 +180,24 @@ describe("managed login redirect", () => {
     );
   });
 
+  it("preserves Slack connection results when redirecting to managed login", async () => {
+    const app = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://app.getsketch.ai/platform/",
+        MANAGED_AUTH_SECRET: "managed-secret-at-least-32chars-long",
+      }),
+    );
+
+    const res = await app.request("/channels?slack=error&reason=workspace_in_use");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `https://app.getsketch.ai/platform/login?return_to=${encodeURIComponent(
+        "/channels?slack=error&reason=workspace_in_use",
+      )}`,
+    );
+  });
+
   it("does not affect API routes", async () => {
     const app = createApp(
       db,

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -186,6 +186,7 @@ describe("managed login redirect", () => {
       createTestConfig({
         MANAGED_URL: "https://app.getsketch.ai/platform/",
         MANAGED_AUTH_SECRET: "managed-secret-at-least-32chars-long",
+        BASE_URL: "https://tenant.getsketch.ai",
       }),
     );
 
@@ -193,7 +194,7 @@ describe("managed login redirect", () => {
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
       `https://app.getsketch.ai/platform/login?return_to=${encodeURIComponent(
-        "/channels?slack=error&reason=workspace_in_use",
+        "https://tenant.getsketch.ai/channels?slack=error&reason=workspace_in_use",
       )}`,
     );
   });

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -36,7 +36,7 @@ import { skillsRoutes } from "./api/skills";
 import { verifyJwt } from "./auth/jwt";
 import { entityReviewRoutes } from "./entities/review";
 
-import { oauthRoutes } from "./api/oauth";
+import { oauthRoutes, resolveOrigin } from "./api/oauth";
 import { systemRoutes } from "./api/system";
 import { taskRoutes } from "./api/tasks";
 import { usageRoutes } from "./api/usage";
@@ -697,14 +697,15 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       if (!isValidPlatformSession) {
         const loginUrl = createManagedLoginUrl(managedUrl);
         const requestUrl = new URL(c.req.url);
+        const isSlackResult = path === "/channels" && requestUrl.searchParams.has("slack");
         const returnTo =
           path === "/login"
             ? requestUrl.searchParams.get("return_to")
-            : path === "/integrations" ||
-                path.startsWith("/integrations/") ||
-                (path === "/channels" && requestUrl.searchParams.has("slack"))
-              ? `${requestUrl.pathname}${requestUrl.search}`
-              : null;
+            : isSlackResult
+              ? new URL(`${requestUrl.pathname}${requestUrl.search}`, resolveOrigin(c, config.BASE_URL)).toString()
+              : path === "/integrations" || path.startsWith("/integrations/")
+                ? `${requestUrl.pathname}${requestUrl.search}`
+                : null;
         if (returnTo) {
           loginUrl.searchParams.set("return_to", returnTo);
         }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -700,7 +700,9 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
         const returnTo =
           path === "/login"
             ? requestUrl.searchParams.get("return_to")
-            : path === "/integrations" || path.startsWith("/integrations/")
+            : path === "/integrations" ||
+                path.startsWith("/integrations/") ||
+                (path === "/channels" && requestUrl.searchParams.has("slack"))
               ? `${requestUrl.pathname}${requestUrl.search}`
               : null;
         if (returnTo) {

--- a/packages/web/src/routes/channels.isolated.test.tsx
+++ b/packages/web/src/routes/channels.isolated.test.tsx
@@ -13,6 +13,11 @@ const mockAuth = vi.hoisted(() => ({
     managedUrl: undefined as string | undefined,
   },
 }));
+const mockToast = vi.hoisted(() => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+}));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@tanstack/react-router")>();
@@ -22,6 +27,10 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
       auth: mockAuth.value,
     }),
   };
+});
+vi.mock("sonner", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("sonner")>();
+  return { ...mod, toast: mockToast };
 });
 
 import { ChannelsPage } from "./channels";
@@ -52,6 +61,8 @@ function channelsHandler(
 
 describe("ChannelsPage", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(null, "", "/channels");
     mockAuth.value = {
       role: "admin",
       displayName: "User",
@@ -111,6 +122,54 @@ describe("ChannelsPage", () => {
       expect(url.pathname).toBe("/api/slack/connections/authorization");
       expect(url.searchParams.get("return_to")).toBe(`${window.location.origin}/channels`);
       expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+    });
+
+    it("shows a successful managed callback and removes its query parameters", async () => {
+      mockAuth.value = {
+        role: "admin",
+        displayName: "User",
+        displayIdentifier: "user@test.com",
+        managedUrl: "https://app.getsketch.ai/",
+      };
+      window.history.replaceState(null, "", "/channels?slack=connected");
+      channelsHandler({ configured: true, connected: true }, { configured: false, connected: null });
+
+      renderWithProviders(<ChannelsPage />);
+
+      await waitFor(() => expect(mockToast.success).toHaveBeenCalledWith("Slack connected."));
+      expect(window.location.search).toBe("");
+    });
+
+    it("resumes Slack authorization after managed login", async () => {
+      const assignSpy = vi.spyOn(window.location, "assign").mockImplementation(() => undefined);
+      mockAuth.value = {
+        role: "admin",
+        displayName: "User",
+        displayIdentifier: "user@test.com",
+        managedUrl: "https://app.getsketch.ai/",
+      };
+      window.history.replaceState(null, "", "/channels?connect=slack");
+      channelsHandler({ configured: false, connected: null }, { configured: false, connected: null });
+
+      renderWithProviders(<ChannelsPage />);
+
+      await waitFor(() => expect(assignSpy).toHaveBeenCalledOnce());
+      const authorizationUrl = new URL(String(assignSpy.mock.calls[0]?.[0]));
+      expect(authorizationUrl.origin).toBe("https://app.getsketch.ai");
+      expect(authorizationUrl.pathname).toBe("/api/slack/connections/authorization");
+      expect(authorizationUrl.searchParams.get("return_to")).toBe(`${window.location.origin}/channels`);
+      expect(window.location.search).toBe("");
+    });
+
+    it("ignores managed callback parameters in a self-hosted deployment", async () => {
+      window.history.replaceState(null, "", "/channels?slack=connected");
+      channelsHandler({ configured: false, connected: null }, { configured: false, connected: null });
+
+      renderWithProviders(<ChannelsPage />);
+
+      await screen.findByText("Slack");
+      expect(mockToast.success).not.toHaveBeenCalled();
+      expect(window.location.search).toBe("?slack=connected");
     });
   });
 

--- a/packages/web/src/routes/channels.isolated.test.tsx
+++ b/packages/web/src/routes/channels.isolated.test.tsx
@@ -6,7 +6,12 @@ import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockAuth = vi.hoisted(() => ({
-  value: { role: "admin" as "admin" | "member", displayName: "User", displayIdentifier: "user@test.com" },
+  value: {
+    role: "admin" as "admin" | "member",
+    displayName: "User",
+    displayIdentifier: "user@test.com",
+    managedUrl: undefined as string | undefined,
+  },
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -47,7 +52,12 @@ function channelsHandler(
 
 describe("ChannelsPage", () => {
   beforeEach(() => {
-    mockAuth.value = { role: "admin", displayName: "User", displayIdentifier: "user@test.com" };
+    mockAuth.value = {
+      role: "admin",
+      displayName: "User",
+      displayIdentifier: "user@test.com",
+      managedUrl: undefined,
+    };
   });
 
   it("renders both platform cards", async () => {
@@ -83,11 +93,35 @@ describe("ChannelsPage", () => {
       expect(screen.getByText("Connected")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
     });
+
+    it("shows Add to Slack for a disconnected managed tenant", async () => {
+      mockAuth.value = {
+        role: "admin",
+        displayName: "User",
+        displayIdentifier: "user@test.com",
+        managedUrl: "https://app.getsketch.ai/",
+      };
+      channelsHandler({ configured: false, connected: null }, { configured: false, connected: null });
+      renderWithProviders(<ChannelsPage />);
+
+      const link = await screen.findByRole("link", { name: "Add to Slack" });
+      const url = new URL(link.getAttribute("href") ?? "");
+
+      expect(url.origin).toBe("https://app.getsketch.ai");
+      expect(url.pathname).toBe("/api/slack/connections/authorization");
+      expect(url.searchParams.get("return_to")).toBe(`${window.location.origin}/channels`);
+      expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+    });
   });
 
   describe("member access", () => {
     it("renders disconnected channels without mutation controls for members", async () => {
-      mockAuth.value = { role: "member", displayName: "Member", displayIdentifier: "member@test.com" };
+      mockAuth.value = {
+        role: "member",
+        displayName: "Member",
+        displayIdentifier: "member@test.com",
+        managedUrl: undefined,
+      };
       channelsHandler(
         { configured: false, connected: null },
         { configured: false, connected: null },
@@ -106,7 +140,12 @@ describe("ChannelsPage", () => {
     });
 
     it("renders connected channels without action menus for members", async () => {
-      mockAuth.value = { role: "member", displayName: "Member", displayIdentifier: "member@test.com" };
+      mockAuth.value = {
+        role: "member",
+        displayName: "Member",
+        displayIdentifier: "member@test.com",
+        managedUrl: undefined,
+      };
       channelsHandler(
         { configured: true, connected: true },
         { configured: true, connected: true, phoneNumber: "+1234567890" },

--- a/packages/web/src/routes/channels.tsx
+++ b/packages/web/src/routes/channels.tsx
@@ -52,9 +52,10 @@ import { Label } from "@sketch/ui/components/label";
 import { Skeleton } from "@sketch/ui/components/skeleton";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { dashboardRoute, useDashboardAuth } from "./dashboard";
+import { managedSlackAuthorizationUrl } from "./managed-redirect";
 
 export const channelsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
@@ -64,6 +65,7 @@ export const channelsRoute = createRoute({
 
 export function ChannelsPage() {
   const auth = useDashboardAuth();
+  const queryClient = useQueryClient();
   const canManageChannels = auth.role === "admin";
   const { data, isLoading } = useQuery({
     queryKey: ["channels", "status"],
@@ -72,6 +74,34 @@ export function ChannelsPage() {
   });
 
   const allDisconnected = data?.channels?.every((ch) => ch.connected !== true);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const result = url.searchParams.get("slack");
+    if (!result) return;
+
+    const reason = url.searchParams.get("reason");
+    url.searchParams.delete("slack");
+    url.searchParams.delete("reason");
+    window.history.replaceState(null, "", url);
+
+    if (result === "connected") {
+      toast.success("Slack connected.");
+      queryClient.invalidateQueries({ queryKey: ["channels", "status"] });
+      return;
+    }
+    if (result === "cancelled") {
+      toast.info("Slack connection cancelled.");
+      return;
+    }
+
+    const messages: Record<string, string> = {
+      workspace_in_use: "That Slack workspace is already connected to another tenant.",
+      different_workspace_connected: "This tenant is already connected to a different Slack workspace.",
+      oauth_exchange_failed: "Slack could not be connected. Please try again.",
+    };
+    toast.error(messages[reason ?? ""] ?? "Slack could not be connected. Please try again.");
+  }, [queryClient]);
 
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
@@ -100,7 +130,12 @@ export function ChannelsPage() {
           </>
         ) : (
           data?.channels.map((channel) => (
-            <PlatformCard key={channel.platform} channel={channel} canManage={canManageChannels} />
+            <PlatformCard
+              key={channel.platform}
+              channel={channel}
+              canManage={canManageChannels}
+              managedUrl={auth.managedUrl}
+            />
           ))
         )}
       </div>
@@ -108,9 +143,17 @@ export function ChannelsPage() {
   );
 }
 
-function PlatformCard({ channel, canManage }: { channel: ChannelStatus; canManage: boolean }) {
+function PlatformCard({
+  channel,
+  canManage,
+  managedUrl,
+}: {
+  channel: ChannelStatus;
+  canManage: boolean;
+  managedUrl?: string;
+}) {
   if (channel.platform === "slack") {
-    return <SlackCard channel={channel} canManage={canManage} />;
+    return <SlackCard channel={channel} canManage={canManage} managedUrl={managedUrl} />;
   }
   if (channel.platform === "email") {
     return <EmailCard channel={channel} canManage={canManage} />;
@@ -118,7 +161,15 @@ function PlatformCard({ channel, canManage }: { channel: ChannelStatus; canManag
   return <WhatsAppCard channel={channel} canManage={canManage} />;
 }
 
-function SlackCard({ channel, canManage }: { channel: ChannelStatus; canManage: boolean }) {
+function SlackCard({
+  channel,
+  canManage,
+  managedUrl,
+}: {
+  channel: ChannelStatus;
+  canManage: boolean;
+  managedUrl?: string;
+}) {
   const queryClient = useQueryClient();
   const [showConnectDialog, setShowConnectDialog] = useState(false);
   const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
@@ -160,7 +211,20 @@ function SlackCard({ channel, canManage }: { channel: ChannelStatus; canManage: 
             <span className="text-sm font-medium">Slack</span>
           </div>
           <div className="flex items-center gap-2">
-            {canManage && !isConfigured && (
+            {canManage && !isConfigured && managedUrl && (
+              <Button variant="ghost" size="sm" className="gap-1.5 hover:bg-brand-accent/8" asChild>
+                <a
+                  href={managedSlackAuthorizationUrl(
+                    managedUrl,
+                    new URL("/channels", window.location.origin).toString(),
+                  )}
+                >
+                  <SlackLogoIcon size={14} weight="bold" />
+                  Add to Slack
+                </a>
+              </Button>
+            )}
+            {canManage && !isConfigured && !managedUrl && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -203,7 +267,13 @@ function SlackCard({ channel, canManage }: { channel: ChannelStatus; canManage: 
         </div>
       </div>
 
-      <SlackConnectDialog open={showConnectDialog} onOpenChange={setShowConnectDialog} onConnected={handleConnected} />
+      {!managedUrl && (
+        <SlackConnectDialog
+          open={showConnectDialog}
+          onOpenChange={setShowConnectDialog}
+          onConnected={handleConnected}
+        />
+      )}
 
       <AlertDialog open={showDisconnectDialog} onOpenChange={setShowDisconnectDialog}>
         <AlertDialogContent>

--- a/packages/web/src/routes/channels.tsx
+++ b/packages/web/src/routes/channels.tsx
@@ -76,7 +76,20 @@ export function ChannelsPage() {
   const allDisconnected = data?.channels?.every((ch) => ch.connected !== true);
 
   useEffect(() => {
+    if (!auth.managedUrl) return;
+
     const url = new URL(window.location.href);
+    if (url.searchParams.get("connect") === "slack") {
+      url.searchParams.delete("connect");
+      window.history.replaceState(null, "", url);
+      if (canManageChannels) {
+        window.location.assign(
+          managedSlackAuthorizationUrl(auth.managedUrl, new URL("/channels", window.location.origin).toString()),
+        );
+      }
+      return;
+    }
+
     const result = url.searchParams.get("slack");
     if (!result) return;
 
@@ -101,7 +114,7 @@ export function ChannelsPage() {
       oauth_exchange_failed: "Slack could not be connected. Please try again.",
     };
     toast.error(messages[reason ?? ""] ?? "Slack could not be connected. Please try again.");
-  }, [queryClient]);
+  }, [auth.managedUrl, canManageChannels, queryClient]);
 
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -11,6 +11,7 @@ export interface AuthContext {
   email?: string;
   userId?: string;
   name?: string;
+  managedUrl?: string;
   displayName: string;
   displayIdentifier: string;
 }
@@ -53,6 +54,7 @@ async function checkAuth(returnTo?: string): Promise<{ auth: AuthContext }> {
       email: session.email,
       userId: session.userId,
       name: session.name,
+      managedUrl: status.managedUrl,
       displayName: session.name ?? "User",
       displayIdentifier: session.email ?? session.name ?? "User",
     },

--- a/packages/web/src/routes/managed-redirect.isolated.test.ts
+++ b/packages/web/src/routes/managed-redirect.isolated.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { managedLoginUrl, redirectToManagedLogin } from "./managed-redirect";
+import { managedLoginUrl, managedSlackAuthorizationUrl, redirectToManagedLogin } from "./managed-redirect";
 
 const redirect = vi.hoisted(() => vi.fn((options: unknown) => ({ options })));
 
@@ -15,6 +15,12 @@ describe("managed redirect helpers", () => {
   it("preserves a return target when provided", () => {
     expect(managedLoginUrl("https://app.getsketch.ai", "/integrations?connect=github")).toBe(
       "https://app.getsketch.ai/login?return_to=%2Fintegrations%3Fconnect%3Dgithub",
+    );
+  });
+
+  it("builds a managed Slack authorization URL with an absolute tenant return target", () => {
+    expect(managedSlackAuthorizationUrl("https://app.getsketch.ai/", "https://acme.getsketch.ai/channels")).toBe(
+      "https://app.getsketch.ai/api/slack/connections/authorization?return_to=https%3A%2F%2Facme.getsketch.ai%2Fchannels",
     );
   });
 

--- a/packages/web/src/routes/managed-redirect.ts
+++ b/packages/web/src/routes/managed-redirect.ts
@@ -6,6 +6,12 @@ export function managedLoginUrl(managedUrl: string, returnTo?: string | null): s
   return url.toString();
 }
 
+export function managedSlackAuthorizationUrl(managedUrl: string, returnTo: string): string {
+  const url = new URL(`${managedUrl.replace(/\/+$/, "")}/api/slack/connections/authorization`);
+  url.searchParams.set("return_to", returnTo);
+  return url.toString();
+}
+
 export function redirectToManagedLogin(managedUrl: string, returnTo?: string | null): never {
   throw redirect({ href: managedLoginUrl(managedUrl, returnTo) });
 }


### PR DESCRIPTION
## Summary

- show managed tenant admins an **Add to Slack** action on the Channels page when Slack is not connected
- send the tenant through the platform-managed OAuth recovery flow and preserve the `/channels` return path
- surface successful, cancelled, and failed connection results on return
- keep the existing app-manifest setup path unchanged for self-hosted deployments

## Why

A managed tenant that skipped Slack during onboarding was left with the self-hosted app-manifest instructions and had no way to connect the managed Slack app later.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (4,629 server tests and 430 web tests passed; live-provider tests skipped as configured)
- `pnpm build`
- `pnpm --filter @sketch/web exec vitest run src/routes/channels.isolated.test.tsx` (14 tests passed)
- local end-to-end OAuth smoke test through ngrok

Linear: [SKE-307](https://linear.app/sketch-ai/issue/SKE-307/managed-tenants-cannot-connect-slack-after-skipping-onboarding)