### PR TITLE
SKE-308: Trigger automations from Slack channel messages

### DIFF
--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -196,6 +196,8 @@ describe("buildSystemContext", () => {
       expect(result).toContain("Never use updateStepContent");
       expect(result).toContain("list, pause, resume, run, delete, and inspect run history");
       expect(result).toContain("include the resolved target ID and label in the natural-language");
+      expect(result).toContain("call SearchDeliveryTargets with platform='slack' and targetType='channel' first");
+      expect(result).toContain("never invent a channel ID");
     });
 
     it("preserves legacy structured authoring guidance when authoring is not configured", () => {

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -391,6 +391,7 @@ export function buildSystemContext(params: {
   if (params.automationAuthoringEnabled) {
     sections.push(
       "When creating or semantically editing an automation, pass the user's requested change as a natural-language request to ManageScheduledTasks. For edits, include the task ID.",
+      "When the user names a Slack channel as the source for a native Slack channel-message trigger, call SearchDeliveryTargets with platform='slack' and targetType='channel' first. Pass the matched channel's targetId and label in the natural-language authoring request; never invent a channel ID. If there is no unique match, ask the user to clarify.",
       "Do not construct or pass automation definition fields such as schedules, timezones, delivery, titles, descriptions, steps, edges, prompts, scripts, apps, modes, skills, MCP servers, or models. The automation authoring model owns the complete definition.",
       "Never use updateStepContent. Prompt, script, app, mode, skill, MCP, schedule, delivery, and structural changes must use a full ManageScheduledTasks update with the user's natural-language request.",
       "Operational actions remain deterministic: use ManageScheduledTasks directly to list, pause, resume, run, delete, and inspect run history without an authoring request.",

--- a/packages/server/src/agent/tools/scheduled-tasks-slack-trigger.test.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks-slack-trigger.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleManageScheduledTasks } from "./scheduled-tasks";
+
+const trigger = (channelId: string) => ({
+  id: "trigger",
+  type: "trigger" as const,
+  label: "Slack channel message",
+  icon: "slack",
+  position: { x: 0, y: 0 },
+  triggerConfig: { type: "slack_channel_message" as const, channelId },
+});
+
+const agent = {
+  id: "agent",
+  type: "agent" as const,
+  label: "Create task",
+  icon: "sketch-ai",
+  position: { x: 240, y: 0 },
+  agentPrompt: "Create a task from the Slack message.",
+};
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  const scheduler = {
+    addTask: vi.fn().mockResolvedValue({ id: "task-1", status: "active", delivery: { mode: "silent" } }),
+    getTaskById: vi.fn().mockResolvedValue({
+      id: "task-1",
+      platform: "slack",
+      contextType: "channel",
+      deliveryTarget: "C1",
+      threadTs: null,
+      prompt: "Create task",
+      scheduleType: "external",
+      scheduleValue: "slack_channel_message",
+      timezone: "UTC",
+      status: "active",
+      createdBy: "u1",
+      title: "Create task",
+      description: null,
+      steps: JSON.stringify([trigger("C1"), agent]),
+      edges: JSON.stringify([{ id: "trigger-agent", from: "trigger", to: "agent" }]),
+      outputTarget: "C1",
+      outputPlatform: "slack",
+      outputThreadTs: null,
+      outputMode: "silent",
+      revision: 0,
+    }),
+    updateTask: vi.fn(),
+  };
+  return {
+    scheduler,
+    taskContext: { platform: "slack" as const, contextType: "channel" as const, deliveryTarget: "C1", createdBy: "u1" },
+    stepContentRepo: { upsert: vi.fn().mockResolvedValue(undefined), getByTask: vi.fn().mockResolvedValue([]) },
+    ...overrides,
+  };
+}
+
+describe("manage_scheduled_tasks Slack channel trigger", () => {
+  it("infers the external Slack trigger schedule when adding a channel-message workflow", async () => {
+    const deps = makeDeps();
+
+    await handleManageScheduledTasks(
+      { action: "add", title: "Slack bug report", steps: [trigger("C1"), agent], output_mode: "silent" },
+      deps as never,
+    );
+
+    expect(deps.scheduler.addTask).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduleType: "external", scheduleValue: "slack_channel_message" }),
+    );
+  });
+
+  it("rejects a blank Slack channel ID", async () => {
+    const deps = makeDeps();
+
+    const result = await handleManageScheduledTasks(
+      { action: "add", title: "Slack bug report", steps: [trigger(" "), agent], output_mode: "silent" },
+      deps as never,
+    );
+
+    expect(result.content[0]?.text).toContain("Slack channel message trigger requires channelId");
+    expect(deps.scheduler.addTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects a schedule-only update to an existing Slack channel trigger", async () => {
+    const deps = makeDeps();
+
+    const result = await handleManageScheduledTasks(
+      { action: "update", task_id: "task-1", schedule_value: "canvas" },
+      deps as never,
+    );
+
+    expect(result.content[0]?.text).toContain("update the Slack channel message trigger steps");
+    expect(deps.scheduler.updateTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -44,7 +44,8 @@ const workflowStepSchema = z.object({
   timeout: z.number().optional().describe("Step timeout in seconds. Default: 1800 (30 min)."),
   triggerConfig: z
     .object({
-      type: z.enum(["webhook", "schedule", "canvas"]),
+      type: z.enum(["webhook", "schedule", "canvas", "slack_channel_message"]),
+      channelId: z.string().trim().min(1).optional(),
       scheduleType: z.enum(["cron", "interval", "once"]).optional(),
       scheduleValue: z.string().optional(),
       timezone: z.string().optional(),
@@ -687,7 +688,15 @@ export async function handleManageScheduledTasks(
         }
         const triggerStep = params.steps.find((step) => step.type === "trigger");
         const isCanvasManagedTrigger = triggerStep?.triggerConfig?.type === "canvas";
-        if (!isCanvasManagedTrigger && (!params.schedule_type || !params.schedule_value)) {
+        const isSlackChannelMessageTrigger = triggerStep?.triggerConfig?.type === "slack_channel_message";
+        if (isSlackChannelMessageTrigger && !triggerStep.triggerConfig?.channelId?.trim()) {
+          return text("Error: Slack channel message trigger requires channelId.");
+        }
+        if (
+          !isCanvasManagedTrigger &&
+          !isSlackChannelMessageTrigger &&
+          (!params.schedule_type || !params.schedule_value)
+        ) {
           return text("Error: schedule_type and schedule_value are required for add action.");
         }
         if (triggerStep?.triggerConfig?.type === "canvas") {
@@ -697,6 +706,10 @@ export async function handleManageScheduledTasks(
             ...triggerStep.triggerConfig,
             status: triggerStep.triggerConfig.status ?? "pending_canvas_setup",
           };
+        }
+        if (triggerStep?.triggerConfig?.type === "slack_channel_message") {
+          params.schedule_type = "external";
+          params.schedule_value = "slack_channel_message";
         }
 
         const brokerError = await ensureBrokerForActionSteps(params.steps);
@@ -960,6 +973,10 @@ export async function handleManageScheduledTasks(
             status: triggerStep.triggerConfig.status ?? "pending_canvas_setup",
           };
         }
+        if (triggerStep?.triggerConfig?.type === "slack_channel_message") {
+          updateFields.scheduleType = "external";
+          updateFields.scheduleValue = "slack_channel_message";
+        }
         let stepsForDb = stripContentFromSteps(params.steps);
         if (triggerStep?.triggerConfig?.type !== "canvas") {
           const scheduleType = updateFields.scheduleType ?? guardedTask?.scheduleType;
@@ -1047,6 +1064,12 @@ export async function handleManageScheduledTasks(
 
       const scheduleChanged =
         params.schedule_type !== undefined || params.schedule_value !== undefined || params.timezone !== undefined;
+      const existingTrigger = parseWorkflowStepsJson(guardedTask?.steps)?.find(
+        (step) => step.type === "trigger",
+      )?.triggerConfig;
+      if (!params.steps && scheduleChanged && existingTrigger?.type === "slack_channel_message") {
+        return text("Error: update the Slack channel message trigger steps to change its trigger metadata.");
+      }
       if (!params.steps && scheduleChanged && guardedTask?.steps) {
         const scheduleType = updateFields.scheduleType ?? guardedTask.scheduleType;
         const scheduleValue = updateFields.scheduleValue ?? guardedTask.scheduleValue;

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -1,6 +1,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
 import { z } from "zod/v4";
+import { AutomationAuthoringValidationError } from "../../automation/authoring/service";
 import type { ChatAutomationAuthoring, ChatAutomationAuthoringResult } from "../../automation/chat-authoring";
 import {
   AutomationValidationError,
@@ -598,7 +599,10 @@ async function handleConfiguredChatAuthoring(
       ...(params.task_id ? { taskId: params.task_id } : {}),
       taskContext: deps.taskContext,
     });
-  } catch {
+  } catch (error) {
+    if (error instanceof AutomationAuthoringValidationError) {
+      return text("Error: automation authoring could not produce a valid definition. No changes were saved.");
+    }
     return text("Error: automation authoring is temporarily unavailable. No changes were saved.");
   }
 

--- a/packages/server/src/api/web-chat.test.ts
+++ b/packages/server/src/api/web-chat.test.ts
@@ -857,6 +857,29 @@ describe("web chat API", () => {
     await expect(users.findById(admin.id)).resolves.toMatchObject({ tool_progress: "off" });
   });
 
+  it("passes the live Slack resolver into web chat agent runs", async () => {
+    await seedAdmin(db);
+    const runAgent = vi.fn().mockResolvedValue(makeAgentResult());
+    const getSlack = vi.fn(() => null);
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      runAgent,
+      buildMcpServers: vi.fn().mockResolvedValue({}),
+      getSlack,
+    });
+    const cookie = await login(app);
+
+    const res = await app.request("/api/web-chat", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Find my Slack channels" }),
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(runAgent).toHaveBeenCalledWith(expect.objectContaining({ getSlack }));
+  });
+
   it("rejects invalid web chat progress settings", async () => {
     await seedAdmin(db);
     const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {

--- a/packages/server/src/api/web-chat.ts
+++ b/packages/server/src/api/web-chat.ts
@@ -46,16 +46,13 @@ import {
 import type { QueueManager } from "../queue";
 import type { TaskScheduler } from "../scheduler/service";
 import type { ScheduledTask } from "../scheduler/types";
+import type { SlackBot } from "../slack/bot";
 import { transcribeAudioFile } from "../transcription/service";
 import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 
 type UserRepo = ReturnType<typeof createUserRepository>;
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 type InboxMessagesRepo = ReturnType<typeof createInboxMessagesRepository>;
-type SlackDmResolver = {
-  openDmChannel(slackUserId: string, botToken?: string): Promise<string | null>;
-};
-
 interface WebChatRouteDeps {
   db: Kysely<DB>;
   config: Config;
@@ -70,7 +67,7 @@ interface WebChatRouteDeps {
   stepContentRepo?: ReturnType<typeof createAutomationStepContentRepository>;
   automationRunsRepo?: ReturnType<typeof createAutomationRunsRepository>;
   queueManager?: QueueManager;
-  getSlack?: () => SlackDmResolver | null;
+  getSlack?: () => SlackBot | null;
   sendDm?: (params: {
     userId: string;
     platform: string;
@@ -1679,6 +1676,7 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
               userEmail: currentUser.email,
               userPhone: currentUser.whatsapp_number,
               logger: deps.logger,
+              getSlack: deps.getSlack,
               platform: deliveryPlatform,
               responseSurface: "web",
               contextType: "dm",

--- a/packages/server/src/automation/authoring/generator.test.ts
+++ b/packages/server/src/automation/authoring/generator.test.ts
@@ -85,6 +85,19 @@ describe("AI SDK automation authoring generator", () => {
     });
   });
 
+  it("classifies missing structured output as a validation failure", async () => {
+    const generateText = vi.fn().mockRejectedValue({ name: "AI_NoOutputGeneratedError" });
+    const generator = createAiSdkAutomationAuthoringGenerator({
+      generateText,
+      isNoOutputGeneratedError: (error) =>
+        Boolean(
+          error && typeof error === "object" && (error as { name?: string }).name === "AI_NoOutputGeneratedError",
+        ),
+    });
+
+    await expect(generator.generate(request())).rejects.toBeInstanceOf(AutomationAuthoringGeneratedOutputError);
+  });
+
   it("classifies structured-output parse failures as validation failures with usage but no response text", async () => {
     const generateText = vi.fn().mockRejectedValue({
       name: "AI_NoObjectGeneratedError",

--- a/packages/server/src/automation/authoring/generator.ts
+++ b/packages/server/src/automation/authoring/generator.ts
@@ -1,4 +1,4 @@
-import { NoObjectGeneratedError, Output, generateText } from "ai";
+import { NoObjectGeneratedError, NoOutputGeneratedError, Output, generateText } from "ai";
 import { z } from "zod";
 import { extractRuntimeModelUsage } from "../../agent/runtime/usage";
 import { automationAuthoringOutputSchema } from "./schema";
@@ -57,12 +57,14 @@ export function createAiSdkAutomationAuthoringGenerator(
   deps: {
     generateText?: GenerateTextLike;
     isNoObjectGeneratedError?: (error: unknown) => boolean;
+    isNoOutputGeneratedError?: (error: unknown) => boolean;
   } = {},
 ): StructuredAutomationAuthoringGenerator {
   const runGenerateText: GenerateTextLike =
     deps.generateText ??
     ((input) => generateText(input as Parameters<typeof generateText>[0]) as Promise<GenerateTextResultLike>);
   const isNoObjectGeneratedError = deps.isNoObjectGeneratedError ?? NoObjectGeneratedError.isInstance;
+  const isNoOutputGeneratedError = deps.isNoOutputGeneratedError ?? NoOutputGeneratedError.isInstance;
 
   return {
     async generate(params) {
@@ -102,7 +104,7 @@ ${JSON.stringify(z.toJSONSchema(automationAuthoringOutputSchema))}`,
           throw new AutomationAuthoringGeneratedOutputError(undefined, generation);
         }
       } catch (error) {
-        if (!isNoObjectGeneratedError(error)) throw error;
+        if (!isNoObjectGeneratedError(error) && !isNoOutputGeneratedError(error)) throw error;
         const structuredError = error as NoObjectGeneratedLike;
         throw new AutomationAuthoringGeneratedOutputError(
           undefined,

--- a/packages/server/src/automation/authoring/service.test.ts
+++ b/packages/server/src/automation/authoring/service.test.ts
@@ -75,12 +75,17 @@ describe("automation authoring service", () => {
         attempt: 1,
         maxRetries: 0,
         timeoutMs: expect.any(Number),
-        maxOutputTokens: 4096,
+        maxOutputTokens: 8192,
       }),
     );
     expect(generate.mock.calls[0]?.[0].timeoutMs).toBeGreaterThan(0);
-    expect(generate.mock.calls[0]?.[0].timeoutMs).toBeLessThanOrEqual(30_000);
+    expect(generate.mock.calls[0]?.[0].timeoutMs).toBeLessThanOrEqual(60_000);
     expect(generate.mock.calls[0]?.[0].prompt).toContain('"brokerCapable":true');
+    expect(generate.mock.calls[0]?.[0].instructions).toContain("native Slack channel message trigger");
+    expect(generate.mock.calls[0]?.[0].instructions).toContain("server-authenticated localPath");
+    expect(generate.mock.calls[0]?.[0].instructions).toContain("ctx.integrations.executeAction");
+    expect(generate.mock.calls[0]?.[0].instructions).toContain("fetch Slack urlPrivate without authentication");
+    expect(generate.mock.calls[0]?.[0].instructions).toContain("Do not implement this as polling");
   });
 
   it("returns one concise clarification without validating or drafting", async () => {
@@ -112,6 +117,25 @@ describe("automation authoring service", () => {
       question: "Which Slack channel should receive it?",
     });
     expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives code-heavy replacement edits enough output budget", async () => {
+    const { service, generate } = createHarness([{ kind: "definition", definition: validAuthoringDefinition }]);
+    const codeHeavyRequest = `Rewrite the action script using this runtime contract:\n${"return structuredResult;\n".repeat(300)}`;
+
+    await service.edit({
+      request: codeHeavyRequest,
+      existing: existingAutomationDefinition,
+      brokerCapable: true,
+    });
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "edit",
+        maxOutputTokens: 8192,
+        prompt: expect.stringContaining(JSON.stringify(codeHeavyRequest).slice(1, -1)),
+      }),
+    );
   });
 
   it("edits from the complete existing definition and carries its execution model by stable step id", async () => {
@@ -306,7 +330,7 @@ describe("automation authoring service", () => {
     expect(generate).toHaveBeenCalledTimes(1);
   });
 
-  it("shares one thirty-second deadline across the validation retry", async () => {
+  it("shares one sixty-second deadline across the validation retry", async () => {
     let clock = 0;
     const generate = vi
       .fn<StructuredAutomationAuthoringGenerator["generate"]>()
@@ -346,8 +370,8 @@ describe("automation authoring service", () => {
       brokerCapable: true,
     });
 
-    expect(generate.mock.calls[0]?.[0].timeoutMs).toBe(30_000);
-    expect(generate.mock.calls[1]?.[0].timeoutMs).toBe(5_000);
+    expect(generate.mock.calls[0]?.[0].timeoutMs).toBe(60_000);
+    expect(generate.mock.calls[1]?.[0].timeoutMs).toBe(35_000);
   });
 
   it("classifies provider aborts as a fail-closed timeout without retrying", async () => {
@@ -388,6 +412,47 @@ describe("automation authoring service", () => {
     ).rejects.toBeInstanceOf(AutomationAuthoringTimeoutError);
     expect(generate).toHaveBeenCalledTimes(1);
     expect(telemetry.recordAttempt).toHaveBeenCalledWith(expect.objectContaining({ validationOutcome: "timeout" }));
+  });
+
+  it("retries transient provider failures before giving up", async () => {
+    const { service, generate, telemetry } = createHarness([]);
+    const providerError = Object.assign(new Error("upstream unavailable"), {
+      name: "APICallError",
+      statusCode: 503,
+    });
+    generate
+      .mockRejectedValueOnce(providerError)
+      .mockResolvedValueOnce(generation({ kind: "definition", definition: validAuthoringDefinition }));
+
+    const result = await service.create({
+      request: "Create a digest",
+      serverContext: {
+        taskId: "task-new",
+        platform: "slack",
+        contextType: "dm",
+        deliveryDefaults: {
+          platform: "slack",
+          targetType: "dm",
+          targetId: "U123",
+          threadTs: null,
+          mode: "deliver",
+        },
+        timezone: "Asia/Kolkata",
+        currentTime: "2026-07-27T12:00:00.000Z",
+      },
+      brokerCapable: true,
+    });
+
+    expect(result.kind).toBe("definition");
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(telemetry.recordAttempt).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ attempt: 1, validationOutcome: "provider_error" }),
+    );
+    expect(telemetry.recordAttempt).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ attempt: 2, validationOutcome: "valid" }),
+    );
   });
 
   it("uses existing graph validation before returning a generated definition", async () => {

--- a/packages/server/src/automation/authoring/service.ts
+++ b/packages/server/src/automation/authoring/service.ts
@@ -16,8 +16,8 @@ import type {
 } from "./telemetry";
 
 const MAX_GENERATION_ATTEMPTS = 2;
-const GENERATION_TIMEOUT_MS = 30_000;
-const MAX_OUTPUT_TOKENS = 4096;
+const GENERATION_TIMEOUT_MS = 60_000;
+const MAX_OUTPUT_TOKENS = 8192;
 
 export interface AutomationAuthoringProvider {
   provider: "openrouter";
@@ -135,8 +135,17 @@ function isTimeoutFailure(error: unknown): boolean {
   );
 }
 
+function isRetryableProviderFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === "AbortError" || error.name === "AutomationAuthoringTimeoutError") return false;
+  const statusCode = (error as Error & { statusCode?: unknown }).statusCode;
+  if (typeof statusCode === "number") return statusCode === 408 || statusCode === 429 || statusCode >= 500;
+  if (error.name === "APICallError") return true;
+  return /(?:fetch|network|socket|connection|reset|temporarily unavailable)/i.test(error.message);
+}
+
 function authoringInstructions(operation: AutomationAuthoringOperation): string {
-  return `You design Sketch automations. Return a complete ${operation === "create" ? "new" : "replacement"} definition or one concise clarification question only when essential information is missing. Preserve every unspecified property and every stable step ID during edits. Never choose or emit an execution model or operational status. Keep the returned top-level schedule fields identical to the returned trigger step configuration. Every non-trigger step needs matching step content, and the graph must be connected and acyclic.`;
+  return `You design Sketch automations. Return a complete ${operation === "create" ? "new" : "replacement"} definition or one concise clarification question only when essential information is missing. Preserve every unspecified property and every stable step ID during edits. Never choose or emit an execution model or operational status. Keep the returned top-level schedule fields identical to the returned trigger step configuration. Every non-trigger step needs matching step content, and the graph must be connected and acyclic. For requests to run when a message is posted in a Slack channel, use the native Slack channel message trigger: set the trigger config type to "slack_channel_message", include the stable Slack channel ID in channelId, set scheduleType to "external" and scheduleValue to "slack_channel_message", and pass the message text and attachments through trigger data to the workflow. Trigger files can include a server-authenticated localPath inside the automation workspace. When an integration action needs those bytes, call ctx.integrations.executeAction with localFiles entries containing path and configuredProp; do not read or base64-encode the file in the script, put file bytes in CLI arguments, or fetch Slack urlPrivate without authentication. Do not implement this as polling or a scheduled Slack history check. Use the automation's native delivery configuration for the reply rather than adding a Slack send-message action solely for delivery.`;
 }
 
 function createPrompt(input: {
@@ -328,7 +337,11 @@ export function createAutomationAuthoringService(deps: {
           validationOutcome = "timeout";
           throw new AutomationAuthoringTimeoutError();
         }
-        if (!isValidationFailure(error)) throw error;
+        if (!isValidationFailure(error)) {
+          validationOutcome = "provider_error";
+          if (attempt < MAX_GENERATION_ATTEMPTS && isRetryableProviderFailure(error)) continue;
+          throw error;
+        }
         validationOutcome = "invalid";
         validationIssueCodes =
           error instanceof AutomationValidationError

--- a/packages/server/src/automation/definition.ts
+++ b/packages/server/src/automation/definition.ts
@@ -216,6 +216,9 @@ export function formatAutomationScheduleLabel(
 ): string {
   if (definition.scheduleType === "external") {
     const trigger = definition.steps.find((step) => step.type === "trigger")?.triggerConfig;
+    if (trigger?.type === "slack_channel_message") {
+      return `Slack channel message${trigger.channelId ? ` - ${trigger.channelId}` : ""}`;
+    }
     if (trigger?.type === "canvas") {
       const parts = ["Canvas"];
       if (trigger.app) parts.push(trigger.app);
@@ -391,13 +394,26 @@ function validateTriggerSchedule(
     return;
   }
   if (request.scheduleType === "external") {
-    if (config.type !== "webhook" && config.type !== "canvas") {
+    if (config.type !== "webhook" && config.type !== "canvas" && config.type !== "slack_channel_message") {
       addIssue(
         issues,
         "TRIGGER_CONFIG_MISMATCH",
-        "External automations require webhook or canvas trigger config",
+        "External automations require webhook, canvas, or Slack channel message trigger config",
         "steps",
       );
+    }
+    if (config.type === "slack_channel_message") {
+      if (request.scheduleValue !== "slack_channel_message") {
+        addIssue(
+          issues,
+          "TRIGGER_CONFIG_MISMATCH",
+          "Slack channel message triggers require schedule value slack_channel_message",
+          "scheduleValue",
+        );
+      }
+      if (!config.channelId) {
+        addIssue(issues, "TRIGGER_CONFIG_REQUIRED", "Slack channel message trigger requires channelId", "steps");
+      }
     }
     return;
   }
@@ -451,10 +467,12 @@ function validateScheduleValue(request: AutomationBuilderSaveRequest, issues: Bu
 export function scheduledTaskFieldsFromSaveRequest(
   request: AutomationBuilderSaveRequest,
 ): Partial<Selectable<ScheduledTasksTable>> {
+  const trigger = request.steps.find((step) => step.type === "trigger")?.triggerConfig;
+  const isSlackChannelMessage = trigger?.type === "slack_channel_message";
   return {
     prompt: request.prompt,
-    schedule_type: request.scheduleType,
-    schedule_value: request.scheduleValue,
+    schedule_type: isSlackChannelMessage ? "external" : request.scheduleType,
+    schedule_value: isSlackChannelMessage ? "slack_channel_message" : request.scheduleValue,
     timezone: request.timezone,
     status: request.status,
     title: request.title,

--- a/packages/server/src/automation/slack-channel-message-trigger.test.ts
+++ b/packages/server/src/automation/slack-channel-message-trigger.test.ts
@@ -1,0 +1,13 @@
+import { workflowTriggerConfigSchema } from "@sketch/shared";
+import { describe, expect, it } from "vitest";
+
+describe("Slack channel message trigger", () => {
+  it("requires an exact nonblank Slack channel ID", () => {
+    expect(workflowTriggerConfigSchema.safeParse({ type: "slack_channel_message", channelId: "C123" }).success).toBe(
+      true,
+    );
+    expect(workflowTriggerConfigSchema.safeParse({ type: "slack_channel_message", channelId: " " }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/server/src/db/repositories/scheduled-tasks.ts
+++ b/packages/server/src/db/repositories/scheduled-tasks.ts
@@ -83,6 +83,17 @@ export function createScheduledTaskRepository(db: Kysely<DB>) {
         .execute();
     },
 
+    async listActiveSlackChannelMessageTriggers(): Promise<ScheduledTaskRow[]> {
+      return db
+        .selectFrom("scheduled_tasks")
+        .selectAll()
+        .where("status", "=", "active")
+        .where("schedule_type", "=", "external")
+        .where("schedule_value", "=", "slack_channel_message")
+        .orderBy("created_at", "asc")
+        .execute();
+    },
+
     async countActiveForUserWithin(userId: string, startAt: string, endAt: string): Promise<number> {
       const row = await db
         .selectFrom("scheduled_tasks")

--- a/packages/server/src/integrations/canvas.test.ts
+++ b/packages/server/src/integrations/canvas.test.ts
@@ -342,6 +342,40 @@ describe("CanvasProvider", () => {
     });
   });
 
+  it("executes a Canvas action through the configured REST endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { id: "task-1" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new CanvasProvider("https://canvas.example.com", "sk-test", "provider-1");
+
+    await expect(
+      provider.executeAction({
+        userEmail: "priya@example.com",
+        componentKey: "clickup-create-task-with-attachment",
+        configuredProps: { name: "Bug report" },
+      }),
+    ).resolves.toEqual({ id: "task-1" });
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe("https://canvas.example.com/api/direct-executions/action");
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        Authorization: "Bearer sk-test",
+        "Content-Type": "application/json",
+        "X-User-Email": "priya@example.com",
+      },
+      body: JSON.stringify({
+        componentKey: "clickup-create-task-with-attachment",
+        configuredProps: { name: "Bug report" },
+      }),
+    });
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it("mints Sketch connector credentials with user and role headers", async () => {
     const envelope = {
       version: 1,

--- a/packages/server/src/integrations/canvas.test.ts
+++ b/packages/server/src/integrations/canvas.test.ts
@@ -376,6 +376,30 @@ describe("CanvasProvider", () => {
     expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
 
+  it("propagates caller cancellation to Canvas action requests", async () => {
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new CanvasProvider("https://canvas.example.com", "sk-test", "provider-1");
+    const controller = new AbortController();
+    const request = provider.executeAction(
+      {
+        userEmail: "priya@example.com",
+        componentKey: "clickup-create-task",
+        configuredProps: {},
+      },
+      controller.signal,
+    );
+
+    controller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("mints Sketch connector credentials with user and role headers", async () => {
     const envelope = {
       version: 1,

--- a/packages/server/src/integrations/canvas.ts
+++ b/packages/server/src/integrations/canvas.ts
@@ -143,8 +143,10 @@ export class CanvasProvider implements IntegrationProvider {
     return true;
   }
 
-  async executeAction(request: IntegrationActionRequest): Promise<unknown> {
+  async executeAction(request: IntegrationActionRequest, signal?: AbortSignal): Promise<unknown> {
     const url = new URL("/api/direct-executions/action", this.apiUrl);
+    const requestSignal = AbortSignal.timeout(ACTION_REQUEST_TIMEOUT_MS);
+    const combinedSignal = signal ? AbortSignal.any([signal, requestSignal]) : requestSignal;
     const res = await fetch(url, {
       method: "POST",
       headers: this.headers(request.userEmail),
@@ -152,7 +154,7 @@ export class CanvasProvider implements IntegrationProvider {
         componentKey: request.componentKey,
         configuredProps: request.configuredProps,
       }),
-      signal: AbortSignal.timeout(ACTION_REQUEST_TIMEOUT_MS),
+      signal: combinedSignal,
     });
     if (!res.ok) throw await this.parseError(res, `Canvas action execution failed: ${res.status} ${res.statusText}`);
     const body = (await res.json()) as { success?: boolean; data?: unknown; message?: string; error?: string };

--- a/packages/server/src/integrations/canvas.ts
+++ b/packages/server/src/integrations/canvas.ts
@@ -11,9 +11,10 @@ import { join } from "node:path";
 import type { IntegrationApp, IntegrationConnection, PageInfo } from "@sketch/shared";
 import { z } from "zod";
 import type { CredentialEnvelope } from "../connectors/credential-envelope";
-import type { BrokerSpec, IntegrationProvider, IntegrationUserOrgRole } from "./types";
+import type { BrokerSpec, IntegrationActionRequest, IntegrationProvider, IntegrationUserOrgRole } from "./types";
 
 const REQUEST_TIMEOUT_MS = 30_000;
+const ACTION_REQUEST_TIMEOUT_MS = 120_000;
 
 type CanvasAccountResponse = {
   id: string;
@@ -142,6 +143,29 @@ export class CanvasProvider implements IntegrationProvider {
     return true;
   }
 
+  async executeAction(request: IntegrationActionRequest): Promise<unknown> {
+    const url = new URL("/api/direct-executions/action", this.apiUrl);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: this.headers(request.userEmail),
+      body: JSON.stringify({
+        componentKey: request.componentKey,
+        configuredProps: request.configuredProps,
+      }),
+      signal: AbortSignal.timeout(ACTION_REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) throw await this.parseError(res, `Canvas action execution failed: ${res.status} ${res.statusText}`);
+    const body = (await res.json()) as { success?: boolean; data?: unknown; message?: string; error?: string };
+    if (body.success !== true) {
+      throw new CanvasProviderRequestError(
+        502,
+        body.error ?? "UPSTREAM_ERROR",
+        body.message ?? "Canvas action execution returned an invalid response",
+      );
+    }
+    return body.data;
+  }
+
   getBrokerSpec({
     userEmail,
     claudeConfigDir,
@@ -149,7 +173,9 @@ export class CanvasProvider implements IntegrationProvider {
     userEmail: string | null;
     claudeConfigDir: string;
   }): BrokerSpec {
-    const credentialEnv: Record<string, string> = {};
+    const credentialEnv: Record<string, string> = {
+      CANVAS_MCP_URL: this.apiUrl.endsWith("/mcp") ? this.apiUrl : `${this.apiUrl.replace(/\/+$/, "")}/mcp`,
+    };
     if (this.apiKey) credentialEnv.CANVAS_API_KEY_MCP = this.apiKey;
     if (userEmail) credentialEnv.CANVAS_USER_EMAIL = userEmail;
     return {

--- a/packages/server/src/integrations/types.ts
+++ b/packages/server/src/integrations/types.ts
@@ -56,7 +56,7 @@ export interface IntegrationProvider {
    * or null for HTTP-only providers (no CLI surface).
    */
   getBrokerSpec(params: { userEmail: string | null; claudeConfigDir: string }): BrokerSpec | null;
-  executeAction?(request: IntegrationActionRequest): Promise<unknown>;
+  executeAction?(request: IntegrationActionRequest, signal?: AbortSignal): Promise<unknown>;
 }
 
 /**

--- a/packages/server/src/integrations/types.ts
+++ b/packages/server/src/integrations/types.ts
@@ -20,6 +20,12 @@ export interface BrokerSpec {
   launcherEnvName: string;
 }
 
+export interface IntegrationActionRequest {
+  userEmail: string;
+  componentKey: string;
+  configuredProps: Record<string, unknown>;
+}
+
 export interface IntegrationProvider {
   /** Stable provider type identifier (e.g. "canvas"). */
   readonly type: string;
@@ -50,6 +56,7 @@ export interface IntegrationProvider {
    * or null for HTTP-only providers (no CLI surface).
    */
   getBrokerSpec(params: { userEmail: string | null; claudeConfigDir: string }): BrokerSpec | null;
+  executeAction?(request: IntegrationActionRequest): Promise<unknown>;
 }
 
 /**

--- a/packages/server/src/integrations/wrapper.integration.test.ts
+++ b/packages/server/src/integrations/wrapper.integration.test.ts
@@ -233,20 +233,33 @@ describe("CanvasProvider.getBrokerSpec", () => {
     expect(spec.launcherEnvName).toBe("CANVAS_CLI");
     expect(spec.credentialEnv).toEqual({
       CANVAS_API_KEY_MCP: "key-1",
+      CANVAS_MCP_URL: "https://canvas.example.com/mcp",
       CANVAS_USER_EMAIL: "u@example.com",
     });
+  });
+
+  it("does not duplicate an MCP path already present in the API URL", () => {
+    const provider = new CanvasProvider("https://canvas.example.com/mcp", "key-1", "p1");
+    const spec = provider.getBrokerSpec({ userEmail: null, claudeConfigDir: "/etc/claude" });
+    expect(spec.credentialEnv.CANVAS_MCP_URL).toBe("https://canvas.example.com/mcp");
   });
 
   it("omits CANVAS_USER_EMAIL when userEmail is null", () => {
     const provider = new CanvasProvider("https://canvas.example.com", "key-1", "p1");
     const spec = provider.getBrokerSpec({ userEmail: null, claudeConfigDir: "/etc/claude" });
-    expect(spec.credentialEnv).toEqual({ CANVAS_API_KEY_MCP: "key-1" });
+    expect(spec.credentialEnv).toEqual({
+      CANVAS_API_KEY_MCP: "key-1",
+      CANVAS_MCP_URL: "https://canvas.example.com/mcp",
+    });
   });
 
   it("omits CANVAS_API_KEY_MCP when apiKey is empty", () => {
     const provider = new CanvasProvider("https://canvas.example.com", "", "p1");
     const spec = provider.getBrokerSpec({ userEmail: "u@example.com", claudeConfigDir: "/etc/claude" });
-    expect(spec.credentialEnv).toEqual({ CANVAS_USER_EMAIL: "u@example.com" });
+    expect(spec.credentialEnv).toEqual({
+      CANVAS_MCP_URL: "https://canvas.example.com/mcp",
+      CANVAS_USER_EMAIL: "u@example.com",
+    });
   });
 });
 

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -483,6 +483,48 @@ export class TaskScheduler {
     });
   }
 
+  private async canDispatchSlackChannelMessage(task: ScheduledTaskRow, channelId: string): Promise<boolean> {
+    if (!task.created_by) {
+      this.deps.logger.warn({ taskId: task.id, channelId }, "TaskScheduler: skipping Slack trigger without a creator");
+      return false;
+    }
+
+    try {
+      const creator = await this.deps.userRepo.findById(task.created_by);
+      if (!creator?.slack_user_id) {
+        this.deps.logger.warn(
+          { taskId: task.id, channelId },
+          "TaskScheduler: skipping Slack trigger without a Slack creator",
+        );
+        return false;
+      }
+
+      const slack = this.deps.getSlack();
+      if (!slack) {
+        this.deps.logger.warn(
+          { taskId: task.id, channelId },
+          "TaskScheduler: skipping Slack trigger while Slack is unavailable",
+        );
+        return false;
+      }
+
+      const isMember = await slack.isUserInChannel(channelId, creator.slack_user_id);
+      if (!isMember) {
+        this.deps.logger.warn(
+          { taskId: task.id, channelId },
+          "TaskScheduler: skipping Slack trigger for a non-member creator",
+        );
+      }
+      return isMember;
+    } catch (err) {
+      this.deps.logger.warn(
+        { err, taskId: task.id, channelId },
+        "TaskScheduler: failed to verify Slack trigger membership",
+      );
+      return false;
+    }
+  }
+
   async dispatchSlackChannelMessage(channelId: string, triggerData: unknown): Promise<void> {
     const tasks = await this.repo.listActiveSlackChannelMessageTriggers();
     for (const task of tasks) {
@@ -491,7 +533,15 @@ export class TaskScheduler {
       const parsed = workflowTriggerConfigSchema.safeParse(trigger);
       if (!parsed.success || parsed.data.type !== "slack_channel_message" || parsed.data.channelId !== channelId)
         continue;
-      await this.enqueueTaskById(task.id, triggerData);
+      if (!(await this.canDispatchSlackChannelMessage(task, channelId))) continue;
+      try {
+        await this.enqueueTaskById(task.id, triggerData);
+      } catch (err) {
+        this.deps.logger.warn(
+          { err, taskId: task.id, channelId },
+          "TaskScheduler: failed to enqueue Slack channel message trigger",
+        );
+      }
     }
   }
 

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -14,6 +14,10 @@
  * camelCase ScheduledTask application type.
  */
 import { randomUUID } from "node:crypto";
+import { constants, createWriteStream } from "node:fs";
+import { mkdir, open, realpath, stat } from "node:fs/promises";
+import { basename, join, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
 import { workflowTriggerConfigSchema } from "@sketch/shared";
 import { Cron } from "croner";
 import type { Kysely } from "kysely";
@@ -39,8 +43,12 @@ import { deliverProactiveDm } from "../whatsapp/proactive-delivery";
 import { whatsappTargetFromDeliveryTarget } from "../whatsapp/provider";
 import type { WhatsAppRuntime } from "../whatsapp/runtime";
 import { isSlackDmChannelId, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
-import { type AutomationExecutionResult, executeAutomation } from "../workflows/runtime";
-import { testAutomationStep } from "../workflows/runtime";
+import {
+  type AutomationExecutionResult,
+  executeAutomation,
+  resolveAutomationWorkspaceDir,
+  testAutomationStep,
+} from "../workflows/runtime";
 import { createWorkflowDeliveryCapture } from "./delivery-capture";
 import { parseOnceSchedule } from "./parse-once";
 import { getScheduledTaskRowQueueKey } from "./queue-key";
@@ -56,6 +64,114 @@ function parseSlackTriggerSteps(value: string | null): Array<{ type?: string; tr
   } catch {
     return [];
   }
+}
+
+interface SlackTriggerFile {
+  name?: unknown;
+  urlPrivate?: unknown;
+  mimetype?: unknown;
+  size?: unknown;
+  localPath?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function copySlackTriggerFilesToTaskWorkspace(params: {
+  dataDir: string;
+  task: ScheduledTaskRow;
+  triggerData: unknown;
+  sourceWorkspaceDir: string;
+  logger: Logger;
+}): Promise<unknown> {
+  if (!isRecord(params.triggerData) || !Array.isArray(params.triggerData.files)) return params.triggerData;
+
+  const workspaceRoot = resolve(params.dataDir, "workspaces");
+  const sourceWorkspace = resolve(params.sourceWorkspaceDir);
+  const destinationWorkspace = resolve(resolveAutomationWorkspaceDir(params.dataDir, params.task));
+  const destinationDir = join(destinationWorkspace, "automation-trigger-files");
+  let destinationDirPromise: Promise<string> | null = null;
+  const prepareDestinationDir = () => {
+    destinationDirPromise ??= (async () => {
+      await mkdir(destinationDir, { recursive: true });
+      const [workspaceRootPath, destinationWorkspacePath, destinationDirPath] = await Promise.all([
+        realpath(workspaceRoot),
+        realpath(destinationWorkspace),
+        realpath(destinationDir),
+      ]);
+      const relativeDestinationWorkspace = destinationWorkspace.slice(workspaceRoot.length + 1);
+      const expectedDestinationWorkspacePath = resolve(workspaceRootPath, relativeDestinationWorkspace);
+      if (
+        !destinationWorkspace.startsWith(`${workspaceRoot}${sep}`) ||
+        destinationWorkspacePath !== expectedDestinationWorkspacePath ||
+        destinationDirPath !== join(destinationWorkspacePath, "automation-trigger-files")
+      ) {
+        throw new Error("Invalid automation trigger destination workspace");
+      }
+      return destinationDirPath;
+    })();
+    return destinationDirPromise;
+  };
+  const files = await Promise.all(
+    params.triggerData.files.map(async (value): Promise<unknown> => {
+      if (!isRecord(value)) return value;
+      const file = value as SlackTriggerFile & Record<string, unknown>;
+      if (typeof file.localPath !== "string") return file;
+
+      try {
+        const [sourcePath, sourceWorkspacePath, workspaceRootPath] = await Promise.all([
+          realpath(resolve(file.localPath)),
+          realpath(sourceWorkspace),
+          realpath(workspaceRoot),
+        ]);
+        const relativeSourceWorkspace = sourceWorkspace.slice(workspaceRoot.length + 1);
+        const expectedSourceWorkspacePath = resolve(workspaceRootPath, relativeSourceWorkspace);
+        const sourceWorkspaceContained =
+          sourceWorkspace.startsWith(`${workspaceRoot}${sep}`) && sourceWorkspacePath === expectedSourceWorkspacePath;
+        const sourceFileContained =
+          sourcePath === sourceWorkspacePath || sourcePath.startsWith(`${sourceWorkspacePath}${sep}`);
+        if (!sourceWorkspaceContained || !sourceFileContained) {
+          params.logger.warn(
+            { taskId: params.task.id, fileName: file.name },
+            "TaskScheduler: ignored Slack trigger file outside the source channel workspace",
+          );
+          const { localPath: _localPath, ...safeFile } = file;
+          return safeFile;
+        }
+
+        const destinationDirPath = await prepareDestinationDir();
+        const destinationPath = join(destinationDirPath, `${randomUUID()}-${basename(sourcePath)}`);
+        const sourceHandle = await open(sourcePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+        try {
+          const [openedStat, currentStat, currentPath] = await Promise.all([
+            sourceHandle.stat(),
+            stat(sourcePath),
+            realpath(sourcePath),
+          ]);
+          if (currentPath !== sourcePath || openedStat.dev !== currentStat.dev || openedStat.ino !== currentStat.ino) {
+            throw new Error("Slack trigger file changed during validation");
+          }
+          await pipeline(
+            sourceHandle.createReadStream({ autoClose: false }),
+            createWriteStream(destinationPath, { flags: "wx" }),
+          );
+        } finally {
+          await sourceHandle.close();
+        }
+        return { ...file, localPath: destinationPath };
+      } catch (err) {
+        params.logger.warn(
+          { err, taskId: params.task.id, fileName: file.name },
+          "TaskScheduler: failed to copy Slack trigger file into the automation workspace",
+        );
+        const { localPath: _localPath, ...safeFile } = file;
+        return safeFile;
+      }
+    }),
+  );
+
+  return { ...params.triggerData, files };
 }
 
 export interface TaskSchedulerDeps {
@@ -525,7 +641,11 @@ export class TaskScheduler {
     }
   }
 
-  async dispatchSlackChannelMessage(channelId: string, triggerData: unknown): Promise<void> {
+  async dispatchSlackChannelMessage(
+    channelId: string,
+    triggerData: unknown,
+    options?: { sourceWorkspaceDir?: string },
+  ): Promise<void> {
     const tasks = await this.repo.listActiveSlackChannelMessageTriggers();
     for (const task of tasks) {
       const steps = parseSlackTriggerSteps(task.steps);
@@ -535,7 +655,18 @@ export class TaskScheduler {
         continue;
       if (!(await this.canDispatchSlackChannelMessage(task, channelId))) continue;
       try {
-        await this.enqueueTaskById(task.id, triggerData);
+        const taskTriggerData = await copySlackTriggerFilesToTaskWorkspace({
+          dataDir: this.deps.config.DATA_DIR,
+          task,
+          triggerData,
+          sourceWorkspaceDir:
+            options?.sourceWorkspaceDir ??
+            (/^[A-Za-z0-9_-]+$/.test(channelId)
+              ? resolve(this.deps.config.DATA_DIR, "workspaces", `channel-${channelId}`)
+              : resolve(this.deps.config.DATA_DIR, "workspaces", ".invalid-slack-channel")),
+          logger: this.deps.logger,
+        });
+        await this.enqueueTaskById(task.id, taskTriggerData);
       } catch (err) {
         this.deps.logger.warn(
           { err, taskId: task.id, channelId },

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -14,6 +14,7 @@
  * camelCase ScheduledTask application type.
  */
 import { randomUUID } from "node:crypto";
+import { workflowTriggerConfigSchema } from "@sketch/shared";
 import { Cron } from "croner";
 import type { Kysely } from "kysely";
 import type { McpServerConfig, runAgent } from "../agent/runner";
@@ -46,6 +47,16 @@ import { getScheduledTaskRowQueueKey } from "./queue-key";
 import type { ScheduledTask } from "./types";
 
 type AgentExecutionQueue = "interactive" | "scheduled";
+
+function parseSlackTriggerSteps(value: string | null): Array<{ type?: string; triggerConfig?: unknown }> {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as Array<{ type?: string; triggerConfig?: unknown }>) : [];
+  } catch {
+    return [];
+  }
+}
 
 export interface TaskSchedulerDeps {
   db: Kysely<DB>;
@@ -205,6 +216,7 @@ export class TaskScheduler {
   private async executeTaskNow(
     task: ScheduledTaskRow,
     executionQueue: AgentExecutionQueue,
+    trigger?: { provided: boolean; data: unknown },
   ): Promise<AutomationExecutionResult> {
     const { config, logger, loadIntegrationProvider } = this.deps;
     const delivery = resolveWorkflowDelivery(task);
@@ -216,7 +228,7 @@ export class TaskScheduler {
 
     const result = await executeAutomation({
       task,
-      triggerData: { scheduledAt: new Date().toISOString(), taskId: task.id },
+      triggerData: trigger?.provided ? trigger.data : { scheduledAt: new Date().toISOString(), taskId: task.id },
       db: this.deps.db,
       logger,
       config,
@@ -257,6 +269,7 @@ export class TaskScheduler {
     task: ScheduledTaskRow,
     getTask: () => Promise<ScheduledTaskRow | null>,
     executionQueue: AgentExecutionQueue,
+    trigger?: { provided: boolean; data: unknown },
   ): Promise<AutomationExecutionResult | null> {
     const queueKey = this.getQueueKey(task);
     return new Promise<AutomationExecutionResult | null>((resolve, reject) => {
@@ -267,7 +280,7 @@ export class TaskScheduler {
             resolve(null);
             return;
           }
-          resolve(await this.executeTaskNow(current, executionQueue));
+          resolve(await this.executeTaskNow(current, executionQueue, trigger));
         } catch (err) {
           reject(err);
         }
@@ -458,15 +471,28 @@ export class TaskScheduler {
     return this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive");
   }
 
-  async enqueueTaskById(id: string): Promise<void> {
+  async enqueueTaskById(id: string, ...triggerData: [] | [unknown]): Promise<void> {
     const row = await this.repo.getById(id);
     if (!row) throw new Error(`Task ${id} not found`);
     if (row.status === "completed" && row.schedule_type === "once") return;
     if (row.status !== "active") throw new Error(`Task ${id} is not active`);
 
-    this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive").catch((err) => {
+    const trigger = triggerData.length === 0 ? undefined : { provided: true, data: triggerData[0] };
+    this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive", trigger).catch((err) => {
       this.deps.logger.error({ err, taskId: id }, "Automation background execution failed");
     });
+  }
+
+  async dispatchSlackChannelMessage(channelId: string, triggerData: unknown): Promise<void> {
+    const tasks = await this.repo.listActiveSlackChannelMessageTriggers();
+    for (const task of tasks) {
+      const steps = parseSlackTriggerSteps(task.steps);
+      const trigger = steps.find((step) => step?.type === "trigger")?.triggerConfig;
+      const parsed = workflowTriggerConfigSchema.safeParse(trigger);
+      if (!parsed.success || parsed.data.type !== "slack_channel_message" || parsed.data.channelId !== channelId)
+        continue;
+      await this.enqueueTaskById(task.id, triggerData);
+    }
   }
 
   async getTaskById(id: string): Promise<ScheduledTask | null> {

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -15,7 +15,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { constants, createWriteStream } from "node:fs";
-import { mkdir, open, realpath, stat } from "node:fs/promises";
+import { mkdir, open, realpath, rm, stat } from "node:fs/promises";
 import { basename, join, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { workflowTriggerConfigSchema } from "@sketch/shared";
@@ -78,36 +78,41 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-async function copySlackTriggerFilesToTaskWorkspace(params: {
+interface CopiedSlackTriggerFiles {
+  triggerData: unknown;
+  localFileRoot?: string;
+}
+
+async function copySlackTriggerFilesToIsolatedWorkspace(params: {
   dataDir: string;
   task: ScheduledTaskRow;
   triggerData: unknown;
   sourceWorkspaceDir: string;
   logger: Logger;
-}): Promise<unknown> {
-  if (!isRecord(params.triggerData) || !Array.isArray(params.triggerData.files)) return params.triggerData;
+}): Promise<CopiedSlackTriggerFiles> {
+  if (!isRecord(params.triggerData) || !Array.isArray(params.triggerData.files)) {
+    return { triggerData: params.triggerData };
+  }
 
   const workspaceRoot = resolve(params.dataDir, "workspaces");
   const sourceWorkspace = resolve(params.sourceWorkspaceDir);
-  const destinationWorkspace = resolve(resolveAutomationWorkspaceDir(params.dataDir, params.task));
-  const destinationDir = join(destinationWorkspace, "automation-trigger-files");
+  const stagingRoot = resolve(params.dataDir, "automation-trigger-files");
+  const destinationName = randomUUID();
+  const destinationDir = join(stagingRoot, destinationName);
   let destinationDirPromise: Promise<string> | null = null;
   const prepareDestinationDir = () => {
     destinationDirPromise ??= (async () => {
-      await mkdir(destinationDir, { recursive: true });
-      const [workspaceRootPath, destinationWorkspacePath, destinationDirPath] = await Promise.all([
-        realpath(workspaceRoot),
-        realpath(destinationWorkspace),
+      await mkdir(destinationDir, { recursive: true, mode: 0o700 });
+      const [dataDirPath, stagingRootPath, destinationDirPath] = await Promise.all([
+        realpath(params.dataDir),
+        realpath(stagingRoot),
         realpath(destinationDir),
       ]);
-      const relativeDestinationWorkspace = destinationWorkspace.slice(workspaceRoot.length + 1);
-      const expectedDestinationWorkspacePath = resolve(workspaceRootPath, relativeDestinationWorkspace);
       if (
-        !destinationWorkspace.startsWith(`${workspaceRoot}${sep}`) ||
-        destinationWorkspacePath !== expectedDestinationWorkspacePath ||
-        destinationDirPath !== join(destinationWorkspacePath, "automation-trigger-files")
+        stagingRootPath !== join(dataDirPath, "automation-trigger-files") ||
+        destinationDirPath !== join(stagingRootPath, destinationName)
       ) {
-        throw new Error("Invalid automation trigger destination workspace");
+        throw new Error("Invalid automation trigger staging workspace");
       }
       return destinationDirPath;
     })();
@@ -171,7 +176,10 @@ async function copySlackTriggerFilesToTaskWorkspace(params: {
     }),
   );
 
-  return { ...params.triggerData, files };
+  return {
+    triggerData: { ...params.triggerData, files },
+    ...(destinationDirPromise ? { localFileRoot: await destinationDirPromise } : {}),
+  };
 }
 
 export interface TaskSchedulerDeps {
@@ -332,7 +340,7 @@ export class TaskScheduler {
   private async executeTaskNow(
     task: ScheduledTaskRow,
     executionQueue: AgentExecutionQueue,
-    trigger?: { provided: boolean; data: unknown },
+    trigger?: { provided: boolean; data: unknown; localFileRoot?: string },
   ): Promise<AutomationExecutionResult> {
     const { config, logger, loadIntegrationProvider } = this.deps;
     const delivery = resolveWorkflowDelivery(task);
@@ -364,6 +372,7 @@ export class TaskScheduler {
         executionQueue === "scheduled" ? this.deps.limitScheduledAgentExecution : this.deps.limitAgentExecution,
       loadAgentRuntimeProviderConfig: async () =>
         resolveAgentRuntimeProviderConfigFromSettings(await this.deps.settingsRepo.get()),
+      trustedLocalFileRoot: trigger?.localFileRoot,
     });
 
     const now = new Date().toISOString();
@@ -385,7 +394,7 @@ export class TaskScheduler {
     task: ScheduledTaskRow,
     getTask: () => Promise<ScheduledTaskRow | null>,
     executionQueue: AgentExecutionQueue,
-    trigger?: { provided: boolean; data: unknown },
+    trigger?: { provided: boolean; data: unknown; localFileRoot?: string },
   ): Promise<AutomationExecutionResult | null> {
     const queueKey = this.getQueueKey(task);
     return new Promise<AutomationExecutionResult | null>((resolve, reject) => {
@@ -587,16 +596,26 @@ export class TaskScheduler {
     return this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive");
   }
 
-  async enqueueTaskById(id: string, ...triggerData: [] | [unknown]): Promise<void> {
+  async enqueueTaskById(
+    id: string,
+    ...triggerData: [] | [unknown] | [unknown, { localFileRoot: string }]
+  ): Promise<void> {
     const row = await this.repo.getById(id);
     if (!row) throw new Error(`Task ${id} not found`);
     if (row.status === "completed" && row.schedule_type === "once") return;
     if (row.status !== "active") throw new Error(`Task ${id} is not active`);
 
-    const trigger = triggerData.length === 0 ? undefined : { provided: true, data: triggerData[0] };
-    this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive", trigger).catch((err) => {
-      this.deps.logger.error({ err, taskId: id }, "Automation background execution failed");
-    });
+    const trigger =
+      triggerData.length === 0
+        ? undefined
+        : { provided: true, data: triggerData[0], localFileRoot: triggerData[1]?.localFileRoot };
+    this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive", trigger)
+      .catch((err) => {
+        this.deps.logger.error({ err, taskId: id }, "Automation background execution failed");
+      })
+      .finally(async () => {
+        if (trigger?.localFileRoot) await rm(trigger.localFileRoot, { recursive: true, force: true });
+      });
   }
 
   private async canDispatchSlackChannelMessage(task: ScheduledTaskRow, channelId: string): Promise<boolean> {
@@ -647,15 +666,23 @@ export class TaskScheduler {
     options?: { sourceWorkspaceDir?: string },
   ): Promise<void> {
     const tasks = await this.repo.listActiveSlackChannelMessageTriggers();
+    const membershipChecks = new Map<string, Promise<boolean>>();
     for (const task of tasks) {
       const steps = parseSlackTriggerSteps(task.steps);
       const trigger = steps.find((step) => step?.type === "trigger")?.triggerConfig;
       const parsed = workflowTriggerConfigSchema.safeParse(trigger);
       if (!parsed.success || parsed.data.type !== "slack_channel_message" || parsed.data.channelId !== channelId)
         continue;
-      if (!(await this.canDispatchSlackChannelMessage(task, channelId))) continue;
+      const membershipKey = task.created_by ?? `task:${task.id}`;
+      let membershipCheck = membershipChecks.get(membershipKey);
+      if (!membershipCheck) {
+        membershipCheck = this.canDispatchSlackChannelMessage(task, channelId);
+        membershipChecks.set(membershipKey, membershipCheck);
+      }
+      if (!(await membershipCheck)) continue;
+      let localFileRoot: string | undefined;
       try {
-        const taskTriggerData = await copySlackTriggerFilesToTaskWorkspace({
+        const copied = await copySlackTriggerFilesToIsolatedWorkspace({
           dataDir: this.deps.config.DATA_DIR,
           task,
           triggerData,
@@ -666,8 +693,14 @@ export class TaskScheduler {
               : resolve(this.deps.config.DATA_DIR, "workspaces", ".invalid-slack-channel")),
           logger: this.deps.logger,
         });
-        await this.enqueueTaskById(task.id, taskTriggerData);
+        localFileRoot = copied.localFileRoot;
+        if (localFileRoot) {
+          await this.enqueueTaskById(task.id, copied.triggerData, { localFileRoot });
+        } else {
+          await this.enqueueTaskById(task.id, copied.triggerData);
+        }
       } catch (err) {
+        if (localFileRoot) await rm(localFileRoot, { recursive: true, force: true });
         this.deps.logger.warn(
           { err, taskId: task.id, channelId },
           "TaskScheduler: failed to enqueue Slack channel message trigger",

--- a/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
+++ b/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
@@ -18,12 +18,17 @@ vi.mock("../workflows/runtime", () => ({
 }));
 
 function makeDeps(db: Kysely<DB>) {
+  const slack = {
+    postMessage: vi.fn(),
+    postThreadReply: vi.fn(),
+    isUserInChannel: vi.fn().mockResolvedValue(true),
+  };
   return {
     db,
     config: createTestConfig({ DATA_DIR: "/tmp/slack-trigger-test" }),
     logger: createTestLogger(),
     queueManager: new QueueManager(),
-    getSlack: () => ({ postMessage: vi.fn(), postThreadReply: vi.fn(), isConnected: true }),
+    getSlack: () => slack,
     whatsapp: { isConnected: false },
     settingsRepo: { get: vi.fn().mockResolvedValue({}) },
     runAgent: vi.fn(),
@@ -34,7 +39,7 @@ function makeDeps(db: Kysely<DB>) {
       update: vi.fn().mockResolvedValue(undefined),
     },
     stepContentRepo: { getByTask: vi.fn().mockResolvedValue([]) },
-    userRepo: { findById: vi.fn().mockResolvedValue({ id: "user-1", email: "user@example.com" }) },
+    userRepo: { findById: vi.fn().mockResolvedValue({ id: "user-1", slack_user_id: "U_CREATOR" }) },
   };
 }
 
@@ -83,13 +88,42 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
 
   it("dispatches an active exact-channel trigger once and preserves its object payload", async () => {
     await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
-    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const deps = makeDeps(db);
+    const scheduler = new TaskScheduler(deps as never);
     const triggerData = { messageTs: "1.2", nested: { exact: true } };
 
     await scheduler.dispatchSlackChannelMessage("C_MATCH", triggerData);
 
     await vi.waitFor(() => expect(executionParams).toHaveLength(1));
+    expect(deps.getSlack().isUserInChannel).toHaveBeenCalledWith("C_MATCH", "U_CREATOR");
     expect(executionParams[0]?.triggerData).toBe(triggerData);
+  });
+
+  it("fails closed when the task creator is no longer a member of the Slack channel", async () => {
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const deps = makeDeps(db);
+    deps.getSlack().isUserInChannel.mockResolvedValue(false);
+    const scheduler = new TaskScheduler(deps as never);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", { messageTs: "1.2" });
+
+    expect(executionParams).toHaveLength(0);
+    expect(deps.getSlack().isUserInChannel).toHaveBeenCalledWith("C_MATCH", "U_CREATOR");
+  });
+
+  it("continues dispatching later matching tasks when an enqueue fails", async () => {
+    const first = await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const second = await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskByIdImpl = scheduler.enqueueTaskById.bind(scheduler);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById");
+    enqueueTaskById.mockRejectedValueOnce(new Error("task no longer active")).mockImplementation(enqueueTaskByIdImpl);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", { messageTs: "1.2" });
+
+    await vi.waitFor(() => expect(executionParams).toHaveLength(1));
+    expect(enqueueTaskById).toHaveBeenNthCalledWith(1, first.id, { messageTs: "1.2" });
+    expect(enqueueTaskById).toHaveBeenNthCalledWith(2, second.id, { messageTs: "1.2" });
   });
 
   it("does not dispatch wrong-channel, paused, malformed, or non-Slack external workflows", async () => {

--- a/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
+++ b/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
@@ -132,9 +132,27 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
     expect(enqueueTaskById).toHaveBeenCalledOnce();
     const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath: string }> };
     expect(triggerData.files[0]?.localPath).toMatch(
-      /^(?:\/private)?\/tmp\/slack-trigger-test\/workspaces\/user-1\/automation-trigger-files\//,
+      /^(?:\/private)?\/tmp\/slack-trigger-test\/automation-trigger-files\/[^/]+\//,
     );
     await expect(readFile(triggerData.files[0]?.localPath ?? "", "utf8")).resolves.toBe("jpeg-bytes");
+  });
+
+  it("removes the isolated trigger file workspace after execution", async () => {
+    const sourcePath = "/tmp/slack-trigger-test/workspaces/channel-C_MATCH/attachments/source.jpeg";
+    await mkdir("/tmp/slack-trigger-test/workspaces/channel-C_MATCH/attachments", { recursive: true });
+    await writeFile(sourcePath, "jpeg-bytes");
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", {
+      files: [{ name: "source.jpeg", localPath: sourcePath }],
+    });
+
+    await vi.waitFor(() => expect(executionParams).toHaveLength(1));
+    const triggerData = executionParams[0]?.triggerData as { files: Array<{ localPath: string }> };
+    await vi.waitFor(async () => {
+      await expect(readFile(triggerData.files[0]?.localPath ?? "", "utf8")).rejects.toThrow();
+    });
   });
 
   it("rejects Slack trigger file symlinks that escape the source channel workspace", async () => {
@@ -230,15 +248,14 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
     await expect(readFile(triggerData.files[0]?.localPath ?? "", "utf8")).resolves.toBe("bound-agent-bytes");
   });
 
-  it("rejects a symlinked automation trigger destination directory", async () => {
+  it("rejects a symlinked automation trigger staging root", async () => {
     const sourceDir = "/tmp/slack-trigger-test/workspaces/channel-C_MATCH/attachments";
     const sourcePath = `${sourceDir}/source.txt`;
     const outsideDir = "/tmp/slack-trigger-test/outside-destination";
     await mkdir(sourceDir, { recursive: true });
-    await mkdir("/tmp/slack-trigger-test/workspaces/channel-C_OUT", { recursive: true });
     await mkdir(outsideDir, { recursive: true });
     await writeFile(sourcePath, "source-bytes");
-    await symlink(outsideDir, "/tmp/slack-trigger-test/workspaces/channel-C_OUT/automation-trigger-files");
+    await symlink(outsideDir, "/tmp/slack-trigger-test/automation-trigger-files");
     await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
     const scheduler = new TaskScheduler(makeDeps(db) as never);
     const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
@@ -247,8 +264,7 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
       files: [{ name: "source.txt", localPath: sourcePath }],
     });
 
-    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath?: string }> };
-    expect(triggerData.files[0]?.localPath).toBeUndefined();
+    expect(enqueueTaskById).not.toHaveBeenCalled();
   });
 
   it("fails closed when the task creator is no longer a member of the Slack channel", async () => {
@@ -266,7 +282,8 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
   it("continues dispatching later matching tasks when an enqueue fails", async () => {
     const first = await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
     const second = await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
-    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const deps = makeDeps(db);
+    const scheduler = new TaskScheduler(deps as never);
     const enqueueTaskByIdImpl = scheduler.enqueueTaskById.bind(scheduler);
     const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById");
     enqueueTaskById.mockRejectedValueOnce(new Error("task no longer active")).mockImplementation(enqueueTaskByIdImpl);
@@ -276,6 +293,7 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
     await vi.waitFor(() => expect(executionParams).toHaveLength(1));
     expect(enqueueTaskById).toHaveBeenNthCalledWith(1, first.id, { messageTs: "1.2" });
     expect(enqueueTaskById).toHaveBeenNthCalledWith(2, second.id, { messageTs: "1.2" });
+    expect(deps.getSlack().isUserInChannel).toHaveBeenCalledOnce();
   });
 
   it("does not dispatch wrong-channel, paused, malformed, or non-Slack external workflows", async () => {

--- a/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
+++ b/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
@@ -1,0 +1,142 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import type { DB } from "../db/schema";
+import { QueueManager } from "../queue";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import type { ExecuteAutomationParams } from "../workflows/runtime";
+import { TaskScheduler } from "./service";
+
+let executionParams: ExecuteAutomationParams[] = [];
+
+vi.mock("../workflows/runtime", () => ({
+  executeAutomation: vi.fn().mockImplementation(async (params: ExecuteAutomationParams) => {
+    executionParams.push(params);
+    return { runId: "run-1", status: "completed", finalOutput: null, stepOutputs: {} };
+  }),
+  testAutomationStep: vi.fn(),
+}));
+
+function makeDeps(db: Kysely<DB>) {
+  return {
+    db,
+    config: createTestConfig({ DATA_DIR: "/tmp/slack-trigger-test" }),
+    logger: createTestLogger(),
+    queueManager: new QueueManager(),
+    getSlack: () => ({ postMessage: vi.fn(), postThreadReply: vi.fn(), isConnected: true }),
+    whatsapp: { isConnected: false },
+    settingsRepo: { get: vi.fn().mockResolvedValue({}) },
+    runAgent: vi.fn(),
+    buildMcpServers: vi.fn().mockResolvedValue({}),
+    loadIntegrationProvider: vi.fn().mockResolvedValue(null),
+    automationRunsRepo: {
+      create: vi.fn().mockResolvedValue("run-1"),
+      update: vi.fn().mockResolvedValue(undefined),
+    },
+    stepContentRepo: { getByTask: vi.fn().mockResolvedValue([]) },
+    userRepo: { findById: vi.fn().mockResolvedValue({ id: "user-1", email: "user@example.com" }) },
+  };
+}
+
+const baseTask = {
+  platform: "slack" as const,
+  context_type: "channel" as const,
+  delivery_target: "C_OUT",
+  thread_ts: null,
+  prompt: "Handle Slack event",
+  schedule_type: "external",
+  schedule_value: "slack_channel_message",
+  timezone: "UTC",
+  session_mode: "fresh",
+  created_by: "user-1",
+  status: "active" as const,
+  next_run_at: null,
+  output_mode: "silent" as const,
+};
+
+function slackTrigger(channelId: string) {
+  return JSON.stringify([
+    {
+      id: "trigger",
+      type: "trigger",
+      label: "Slack channel message",
+      icon: "slack",
+      position: { x: 0, y: 0 },
+      triggerConfig: { type: "slack_channel_message", channelId },
+    },
+  ]);
+}
+
+describe("TaskScheduler.dispatchSlackChannelMessage", () => {
+  let db: Kysely<DB>;
+  let repo: ReturnType<typeof createScheduledTaskRepository>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    repo = createScheduledTaskRepository(db);
+    executionParams = [];
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("dispatches an active exact-channel trigger once and preserves its object payload", async () => {
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const triggerData = { messageTs: "1.2", nested: { exact: true } };
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", triggerData);
+
+    await vi.waitFor(() => expect(executionParams).toHaveLength(1));
+    expect(executionParams[0]?.triggerData).toBe(triggerData);
+  });
+
+  it("does not dispatch wrong-channel, paused, malformed, or non-Slack external workflows", async () => {
+    await repo.add({ ...baseTask, steps: slackTrigger("C_OTHER") });
+    await repo.add({ ...baseTask, status: "paused", steps: slackTrigger("C_MATCH") });
+    await repo.add({ ...baseTask, steps: "not-json" });
+    await repo.add({
+      ...baseTask,
+      steps: JSON.stringify([
+        {
+          id: "trigger",
+          type: "trigger",
+          label: "Slack channel message",
+          icon: "slack",
+          position: { x: 0, y: 0 },
+          triggerConfig: { type: "slack_channel_message" },
+        },
+      ]),
+    });
+    await repo.add({
+      ...baseTask,
+      schedule_value: "canvas",
+      steps: JSON.stringify([
+        {
+          id: "trigger",
+          type: "trigger",
+          label: "Canvas",
+          icon: "canvas",
+          position: { x: 0, y: 0 },
+          triggerConfig: { type: "canvas" },
+        },
+      ]),
+    });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", { messageTs: "1.2" });
+
+    expect(executionParams).toHaveLength(0);
+  });
+
+  it("preserves an explicitly supplied null trigger payload", async () => {
+    const task = await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+
+    await scheduler.enqueueTaskById(task.id, null);
+
+    await vi.waitFor(() => expect(executionParams).toHaveLength(1));
+    expect(executionParams[0]?.triggerData).toBeNull();
+  });
+});

--- a/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
+++ b/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
@@ -1,3 +1,4 @@
+import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
@@ -14,6 +15,8 @@ vi.mock("../workflows/runtime", () => ({
     executionParams.push(params);
     return { runId: "run-1", status: "completed", finalOutput: null, stepOutputs: {} };
   }),
+  resolveAutomationWorkspaceDir: (dataDir: string, task: { context_type: string; created_by: string | null }) =>
+    `${dataDir}/workspaces/${task.context_type === "dm" ? task.created_by : "channel-C_OUT"}`,
   testAutomationStep: vi.fn(),
 }));
 
@@ -84,6 +87,7 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
 
   afterEach(async () => {
     await db.destroy();
+    await rm("/tmp/slack-trigger-test", { recursive: true, force: true });
   });
 
   it("dispatches an active exact-channel trigger once and preserves its object payload", async () => {
@@ -97,6 +101,154 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
     await vi.waitFor(() => expect(executionParams).toHaveLength(1));
     expect(deps.getSlack().isUserInChannel).toHaveBeenCalledWith("C_MATCH", "U_CREATOR");
     expect(executionParams[0]?.triggerData).toBe(triggerData);
+  });
+
+  it("copies authenticated Slack files into each automation workspace before dispatch", async () => {
+    const sourcePath = "/tmp/slack-trigger-test/workspaces/channel-C_MATCH/attachments/source.jpeg";
+    await mkdir("/tmp/slack-trigger-test/workspaces/channel-C_MATCH/attachments", { recursive: true });
+    await writeFile(sourcePath, "jpeg-bytes");
+    await repo.add({
+      ...baseTask,
+      context_type: "dm",
+      delivery_target: "D_USER",
+      steps: slackTrigger("C_MATCH"),
+    });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", {
+      messageTs: "1.2",
+      files: [
+        {
+          name: "source.jpeg",
+          mimetype: "image/jpeg",
+          size: 10,
+          urlPrivate: "https://files.slack.com/source.jpeg",
+          localPath: sourcePath,
+        },
+      ],
+    });
+
+    expect(enqueueTaskById).toHaveBeenCalledOnce();
+    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath: string }> };
+    expect(triggerData.files[0]?.localPath).toMatch(
+      /^(?:\/private)?\/tmp\/slack-trigger-test\/workspaces\/user-1\/automation-trigger-files\//,
+    );
+    await expect(readFile(triggerData.files[0]?.localPath ?? "", "utf8")).resolves.toBe("jpeg-bytes");
+  });
+
+  it("rejects Slack trigger file symlinks that escape the source channel workspace", async () => {
+    const attachmentsDir = "/tmp/slack-trigger-test/workspaces/channel-C_MATCH/attachments";
+    const outsidePath = "/tmp/slack-trigger-test/outside.txt";
+    const sourcePath = `${attachmentsDir}/source.txt`;
+    await mkdir(attachmentsDir, { recursive: true });
+    await writeFile(outsidePath, "sensitive-bytes");
+    await symlink(outsidePath, sourcePath);
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", {
+      channelId: "C_MATCH",
+      files: [{ name: "source.txt", localPath: sourcePath }],
+    });
+
+    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath?: string }> };
+    expect(triggerData.files[0]?.localPath).toBeUndefined();
+  });
+
+  it("uses the dispatched channel rather than a mismatched payload channel for source containment", async () => {
+    const otherDir = "/tmp/slack-trigger-test/workspaces/channel-C_OTHER/attachments";
+    const sourcePath = `${otherDir}/source.txt`;
+    await mkdir(otherDir, { recursive: true });
+    await writeFile(sourcePath, "other-channel-bytes");
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", {
+      channelId: "C_OTHER",
+      files: [{ name: "source.txt", localPath: sourcePath }],
+    });
+
+    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath?: string }> };
+    expect(triggerData.files[0]?.localPath).toBeUndefined();
+  });
+
+  it("rejects source channel identifiers containing path traversal", async () => {
+    const sourceDir = "/tmp/slack-trigger-test/workspaces/user-1/attachments";
+    const sourcePath = `${sourceDir}/source.txt`;
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(sourcePath, "user-workspace-bytes");
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH/../user-1") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH/../user-1", {
+      files: [{ name: "source.txt", localPath: sourcePath }],
+    });
+
+    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath?: string }> };
+    expect(triggerData.files[0]?.localPath).toBeUndefined();
+  });
+
+  it("rejects a source channel workspace symlink to a sibling workspace", async () => {
+    const outsideDir = "/tmp/slack-trigger-test/workspaces/user-2";
+    const sourcePath = `${outsideDir}/source.txt`;
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(sourcePath, "outside-channel-bytes");
+    await mkdir("/tmp/slack-trigger-test/workspaces", { recursive: true });
+    await symlink(outsideDir, "/tmp/slack-trigger-test/workspaces/channel-C_MATCH");
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", {
+      files: [{ name: "source.txt", localPath: sourcePath }],
+    });
+
+    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath?: string }> };
+    expect(triggerData.files[0]?.localPath).toBeUndefined();
+  });
+
+  it("accepts the trusted nested workspace for a bound-agent channel", async () => {
+    const sourceWorkspaceDir = "/tmp/slack-trigger-test/workspaces/agent-A/channel-C_MATCH";
+    const sourcePath = `${sourceWorkspaceDir}/attachments/source.txt`;
+    await mkdir(`${sourceWorkspaceDir}/attachments`, { recursive: true });
+    await writeFile(sourcePath, "bound-agent-bytes");
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
+
+    await scheduler.dispatchSlackChannelMessage(
+      "C_MATCH",
+      { files: [{ name: "source.txt", localPath: sourcePath }] },
+      { sourceWorkspaceDir },
+    );
+
+    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath?: string }> };
+    await expect(readFile(triggerData.files[0]?.localPath ?? "", "utf8")).resolves.toBe("bound-agent-bytes");
+  });
+
+  it("rejects a symlinked automation trigger destination directory", async () => {
+    const sourceDir = "/tmp/slack-trigger-test/workspaces/channel-C_MATCH/attachments";
+    const sourcePath = `${sourceDir}/source.txt`;
+    const outsideDir = "/tmp/slack-trigger-test/outside-destination";
+    await mkdir(sourceDir, { recursive: true });
+    await mkdir("/tmp/slack-trigger-test/workspaces/channel-C_OUT", { recursive: true });
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(sourcePath, "source-bytes");
+    await symlink(outsideDir, "/tmp/slack-trigger-test/workspaces/channel-C_OUT/automation-trigger-files");
+    await repo.add({ ...baseTask, steps: slackTrigger("C_MATCH") });
+    const scheduler = new TaskScheduler(makeDeps(db) as never);
+    const enqueueTaskById = vi.spyOn(scheduler, "enqueueTaskById").mockResolvedValue(undefined);
+
+    await scheduler.dispatchSlackChannelMessage("C_MATCH", {
+      files: [{ name: "source.txt", localPath: sourcePath }],
+    });
+
+    const triggerData = enqueueTaskById.mock.calls[0]?.[1] as { files: Array<{ localPath?: string }> };
+    expect(triggerData.files[0]?.localPath).toBeUndefined();
   });
 
   it("fails closed when the task creator is no longer a member of the Slack channel", async () => {

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -7,6 +7,10 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { handleManageScheduledTasks } from "../agent/sketch-tools";
+import {
+  AutomationAuthoringGeneratedOutputError,
+  AutomationAuthoringValidationError,
+} from "../automation/authoring/service";
 import type { TaskScheduler } from "./service";
 import type { ScheduledTask } from "./types";
 import type { TaskContext } from "./types";
@@ -212,6 +216,24 @@ describe("handleManageScheduledTasks — configured chat authoring", () => {
       taskContext: dmContext,
     });
     expect(scheduler.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid generated output separately from provider unavailability", async () => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = {
+      author: vi
+        .fn()
+        .mockRejectedValue(new AutomationAuthoringValidationError(new AutomationAuthoringGeneratedOutputError())),
+    };
+
+    const result = await handleManageScheduledTasks(
+      { action: "update", task_id: "task-1", request: "Rewrite the action script" },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring },
+    );
+
+    expect(result.content[0].text).toBe(
+      "Error: automation authoring could not produce a valid definition. No changes were saved.",
+    );
   });
 
   it("masks another owner's configured edit and does not emit a new-automation artifact", async () => {

--- a/packages/server/src/slack/adapter.isolated.test.ts
+++ b/packages/server/src/slack/adapter.isolated.test.ts
@@ -79,6 +79,10 @@ function makeStoredMessage(overrides: Record<string, unknown> = {}) {
     isThreadReply: false,
     providerTimestamp: null,
     receivedAt: "2025-01-01",
+    source: "live" as const,
+    effectiveAt: "2025-01-01",
+    connectionKey: null,
+    backfillRangeId: null,
     createdAt: "2025-01-01",
     ...overrides,
   };
@@ -922,6 +926,43 @@ describe("slack/adapter", () => {
       expect(deps.runAgent).not.toHaveBeenCalled();
     });
 
+    it("dispatches a newly captured top-level message to Slack triggers", async () => {
+      const dispatchSlackChannelMessage = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({ scheduler: { dispatchSlackChannelMessage } as unknown as SlackAdapterDeps["scheduler"] });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { channel } = getHandlers();
+
+      await channel({ text: "ambient update", userId: "S1", channelId: "C1", ts: "2", type: "channel_message" });
+
+      expect(dispatchSlackChannelMessage).toHaveBeenCalledWith(
+        "C1",
+        expect.objectContaining({
+          type: "slack_channel_message",
+          channelId: "C1",
+          messageTs: "2",
+          text: "ambient update",
+          userId: "S1",
+          capturedMessageId: 1,
+          conversationId: 1,
+        }),
+      );
+    });
+
+    it("does not dispatch a duplicate passive message", async () => {
+      const dispatchSlackChannelMessage = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({ scheduler: { dispatchSlackChannelMessage } as unknown as SlackAdapterDeps["scheduler"] });
+      vi.mocked(deps.repos.conversations.insertMessage).mockResolvedValue({
+        row: makeStoredMessage(),
+        inserted: false,
+      });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { channel } = getHandlers();
+
+      await channel({ text: "duplicate", userId: "S1", channelId: "C1", ts: "2", type: "channel_message" });
+
+      expect(dispatchSlackChannelMessage).not.toHaveBeenCalled();
+    });
+
     it("captures passive top-level channel messages without running the agent", async () => {
       const deps = makeDeps();
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
@@ -971,6 +1012,17 @@ describe("slack/adapter", () => {
       );
       expect(mockBotInstance.postThreadReply).toHaveBeenCalledWith("C1", "1", "Now tracking that follow-up.");
       expect(deps.runAgent).not.toHaveBeenCalled();
+    });
+
+    it("never dispatches a passive thread message to Slack triggers", async () => {
+      const dispatchSlackChannelMessage = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({ scheduler: { dispatchSlackChannelMessage } as unknown as SlackAdapterDeps["scheduler"] });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { thread } = getHandlers();
+
+      await thread({ text: "reply", userId: "S1", channelId: "C1", ts: "2", threadTs: "1", type: "thread_message" });
+
+      expect(dispatchSlackChannelMessage).not.toHaveBeenCalled();
     });
 
     it("captures passive thread messages without running the agent", async () => {

--- a/packages/server/src/slack/adapter.isolated.test.ts
+++ b/packages/server/src/slack/adapter.isolated.test.ts
@@ -365,7 +365,8 @@ describe("slack/adapter", () => {
     });
 
     it("records group DM (mpim) captures under their own conversation kind", async () => {
-      const deps = makeDeps();
+      const dispatchSlackChannelMessage = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({ scheduler: { dispatchSlackChannelMessage } as unknown as SlackAdapterDeps["scheduler"] });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
       const { channel } = getHandlers();
 
@@ -382,6 +383,7 @@ describe("slack/adapter", () => {
         { platform: "slack", kind: "mpim", providerConversationId: "G_MPIM" },
         expect.anything(),
       );
+      expect(dispatchSlackChannelMessage).not.toHaveBeenCalled();
     });
   });
 
@@ -905,7 +907,11 @@ describe("slack/adapter", () => {
   describe("passive channel handler", () => {
     it("handles a top-level follow-up command without running the agent", async () => {
       const followupReviewHandler = vi.fn().mockResolvedValue({ handled: true, message: "Marked the follow-up done." });
-      const deps = makeDeps({ followupReviewHandler });
+      const dispatchSlackChannelMessage = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({
+        followupReviewHandler,
+        scheduler: { dispatchSlackChannelMessage } as unknown as SlackAdapterDeps["scheduler"],
+      });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
       const { channel } = getHandlers();
 
@@ -923,6 +929,7 @@ describe("slack/adapter", () => {
         surface: "slack",
       });
       expect(mockBotInstance.postThreadReply).toHaveBeenCalledWith("C1", "2", "Marked the follow-up done.");
+      expect(dispatchSlackChannelMessage).not.toHaveBeenCalled();
       expect(deps.runAgent).not.toHaveBeenCalled();
     });
 

--- a/packages/server/src/slack/adapter.isolated.test.ts
+++ b/packages/server/src/slack/adapter.isolated.test.ts
@@ -1350,6 +1350,22 @@ describe("slack/adapter", () => {
       expect(agentCall.integrationMcpServers).toEqual(mcpServers);
     });
 
+    it("dispatches newly captured top-level mentions to channel automations", async () => {
+      const dispatchSlackChannelMessage = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({ scheduler: { dispatchSlackChannelMessage } as unknown as SlackAdapterDeps["scheduler"] });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { mention } = getHandlers();
+
+      await mention({ text: "help", userId: "S1", channelId: "C1", ts: "1", type: "channel_mention" });
+      await flush();
+
+      expect(dispatchSlackChannelMessage).toHaveBeenCalledWith(
+        "C1",
+        expect.objectContaining({ channelId: "C1", messageTs: "1", text: "help", userId: "S1" }),
+        { sourceWorkspaceDir: "/tmp/test-data/workspaces/channel-C1" },
+      );
+    });
+
     it("passes teammate messaging deps to agent for channel mentions", async () => {
       const deps = makeDeps();
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);

--- a/packages/server/src/slack/adapter.isolated.test.ts
+++ b/packages/server/src/slack/adapter.isolated.test.ts
@@ -939,7 +939,21 @@ describe("slack/adapter", () => {
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
       const { channel } = getHandlers();
 
-      await channel({ text: "ambient update", userId: "S1", channelId: "C1", ts: "2", type: "channel_message" });
+      await channel({
+        text: "ambient update",
+        userId: "S1",
+        channelId: "C1",
+        ts: "2",
+        type: "channel_message",
+        files: [
+          {
+            name: "test.txt",
+            urlPrivate: "https://files.slack.com/files-pri/test.txt",
+            mimetype: "text/plain",
+            size: 100,
+          },
+        ],
+      });
 
       expect(dispatchSlackChannelMessage).toHaveBeenCalledWith(
         "C1",
@@ -949,10 +963,51 @@ describe("slack/adapter", () => {
           messageTs: "2",
           text: "ambient update",
           userId: "S1",
+          files: [
+            expect.objectContaining({
+              name: "test.txt",
+              localPath: "/tmp/test.txt",
+            }),
+          ],
           capturedMessageId: 1,
           conversationId: 1,
         }),
+        { sourceWorkspaceDir: "/tmp/test-data/workspaces/channel-C1" },
       );
+    });
+
+    it("keeps Slack file descriptors aligned when an earlier same-sized download fails", async () => {
+      const dispatchSlackChannelMessage = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({ scheduler: { dispatchSlackChannelMessage } as unknown as SlackAdapterDeps["scheduler"] });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      vi.mocked(downloadSlackFile).mockRejectedValueOnce(new Error("download failed")).mockResolvedValueOnce({
+        originalName: "second.txt",
+        mimeType: "text/plain; charset=utf-8",
+        localPath: "/tmp/second.txt",
+        sizeBytes: 100,
+      });
+      const { channel } = getHandlers();
+
+      await channel({
+        text: "two files",
+        userId: "S1",
+        channelId: "C1",
+        ts: "2",
+        type: "channel_message",
+        files: [
+          { name: "first.txt", urlPrivate: "https://files.slack.com/first.txt", mimetype: "text/plain", size: 100 },
+          { name: "second.txt", urlPrivate: "https://files.slack.com/second.txt", mimetype: "text/plain", size: 100 },
+        ],
+      });
+
+      const triggerData = dispatchSlackChannelMessage.mock.calls[0]?.[1] as {
+        files: Array<{ name: string; localPath?: string }>;
+      };
+      expect(triggerData.files).toEqual([
+        expect.objectContaining({ name: "first.txt" }),
+        expect.objectContaining({ name: "second.txt", localPath: "/tmp/second.txt" }),
+      ]);
+      expect(triggerData.files[0]?.localPath).toBeUndefined();
     });
 
     it("does not dispatch a duplicate passive message", async () => {

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -165,6 +165,10 @@ export async function validateSlackTokens(botToken: string, appToken?: string) {
   await slackApiCall(botToken, "auth.test");
 }
 
+interface DownloadedSlackAttachment extends Attachment {
+  slackFileIndex: number;
+}
+
 async function downloadSlackFiles(
   files: SlackFile[],
   botToken: string | null | undefined,
@@ -172,20 +176,29 @@ async function downloadSlackFiles(
   maxBytes: number,
   logger: Logger,
   failureLogMessage = "Failed to download file",
-): Promise<Attachment[]> {
-  const attachments: Attachment[] = [];
-  for (const file of files) {
+): Promise<DownloadedSlackAttachment[]> {
+  const attachments: DownloadedSlackAttachment[] = [];
+  for (const [slackFileIndex, file] of files.entries()) {
     try {
       if (!botToken) {
         throw new Error("Slack bot token not configured");
       }
       const downloaded = await downloadSlackFile(file.urlPrivate, botToken, attachDir, maxBytes, logger);
-      attachments.push(downloaded);
+      attachments.push({ ...downloaded, slackFileIndex });
     } catch (err) {
       logger.warn({ err, fileName: file.name }, failureLogMessage);
     }
   }
   return attachments;
+}
+
+function filesForAutomationTrigger(files: SlackFile[] | undefined, attachments: Attachment[]) {
+  return (files ?? []).map((file, slackFileIndex) => {
+    const attachment = attachments.find(
+      (candidate) => (candidate as Partial<DownloadedSlackAttachment>).slackFileIndex === slackFileIndex,
+    );
+    return attachment ? { ...file, localPath: attachment.localPath } : file;
+  });
 }
 
 async function downloadMessageAttachments(params: {
@@ -825,19 +838,23 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
         }
       }
       if (capture.inserted && !followupReviewHandled && message.channelType !== "mpim" && scheduler) {
-        await scheduler.dispatchSlackChannelMessage(message.channelId, {
-          type: "slack_channel_message",
-          channelId: message.channelId,
-          messageTs: message.ts,
-          text: message.text,
-          userId: message.userId ?? null,
-          botId: message.botId ?? null,
-          appId: message.appId ?? null,
-          subtype: message.subtype ?? null,
-          files: message.files ?? [],
-          capturedMessageId: capture.captured?.id ?? null,
-          conversationId: capture.conversation.id,
-        });
+        await scheduler.dispatchSlackChannelMessage(
+          message.channelId,
+          {
+            type: "slack_channel_message",
+            channelId: message.channelId,
+            messageTs: message.ts,
+            text: message.text,
+            userId: message.userId ?? null,
+            botId: message.botId ?? null,
+            appId: message.appId ?? null,
+            subtype: message.subtype ?? null,
+            files: filesForAutomationTrigger(message.files, attachments),
+            capturedMessageId: capture.captured?.id ?? null,
+            conversationId: capture.conversation.id,
+          },
+          { sourceWorkspaceDir: workspaceDir },
+        );
       }
     } catch (err) {
       logger.warn({ err, channelId: message.channelId }, "Failed to capture passive Slack channel message");

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -347,10 +347,13 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
     await slackBot.publishHomeView(slackUserId, view);
   };
 
-  const resolvePassiveSender = async (slackUserId: string) => {
+  const resolvePassiveSender = async (message: Parameters<SlackMessageHandler>[0]) => {
+    if (!message.userId) {
+      return { senderName: "Slack bot", senderUserId: null };
+    }
     const [user, userInfo] = await Promise.all([
-      repos.users.findBySlackId(slackUserId),
-      slackDeps.userCache.resolve(slackUserId, (id) => slackBot.getUserInfo(id)),
+      repos.users.findBySlackId(message.userId),
+      slackDeps.userCache.resolve(message.userId, (id) => slackBot.getUserInfo(id)),
     ]);
     return {
       senderName: user?.name ?? userInfo.realName,
@@ -433,7 +436,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
     const captured = await repos.conversations.insertMessage({
       conversationId: conversation.id,
       providerMessageId: message.ts,
-      senderJid: message.userId,
+      senderJid: message.userId ?? message.botId ?? "unknown",
       senderName: params.senderName,
       senderUserId: params.senderUserId ?? null,
       addressedToSketch: params.addressedToSketch,
@@ -503,6 +506,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
 
   // DM handler
   slackBot.onMessage(async (message) => {
+    if (!message.userId) return;
     const replyToUser = (text: string): Promise<unknown> =>
       message.threadTs
         ? slackBot.postThreadReply(message.channelId, message.threadTs, text)
@@ -799,8 +803,8 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
         maxBytes: maxFileBytes,
         logger,
       });
-      const sender = await resolvePassiveSender(message.userId);
-      await captureSlackMessage({
+      const sender = await resolvePassiveSender(message);
+      const capture = await captureSlackMessage({
         message,
         senderName: sender.senderName,
         senderUserId: sender.senderUserId,
@@ -817,6 +821,21 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
         if (followupReview.handled) {
           await slackBot.postThreadReply(message.channelId, message.ts, followupReview.message);
         }
+      }
+      if (capture.inserted && scheduler) {
+        await scheduler.dispatchSlackChannelMessage(message.channelId, {
+          type: "slack_channel_message",
+          channelId: message.channelId,
+          messageTs: message.ts,
+          text: message.text,
+          userId: message.userId ?? null,
+          botId: message.botId ?? null,
+          appId: message.appId ?? null,
+          subtype: message.subtype ?? null,
+          files: message.files ?? [],
+          capturedMessageId: capture.captured?.id ?? null,
+          conversationId: capture.conversation.id,
+        });
       }
     } catch (err) {
       logger.warn({ err, channelId: message.channelId }, "Failed to capture passive Slack channel message");
@@ -837,7 +856,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
         maxBytes: maxFileBytes,
         logger,
       });
-      const sender = await resolvePassiveSender(message.userId);
+      const sender = await resolvePassiveSender(message);
       await captureSlackMessage({
         message,
         senderName: sender.senderName,
@@ -872,6 +891,8 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
 
   // Channel mention handler
   slackBot.onChannelMention(async (message) => {
+    const userId = message.userId;
+    if (!userId) return;
     const threadTs = message.threadTs ?? message.ts;
     const activeQueueKey = `${message.channelId}:${threadTs}`;
     const mentionQueue = queue.getQueue(activeQueueKey);
@@ -883,7 +904,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
       let clearAssistantStatus: (() => Promise<void>) | null = null;
 
       try {
-        user = await resolveUser(message.userId);
+        user = await resolveUser(userId);
 
         let channel = await ensureChannelRow(message.channelId);
 

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -1045,6 +1045,25 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
           displayName: channel.name,
         });
         if (!capture.captured) return;
+        if (capture.inserted && !message.threadTs && channel.type !== "mpim" && scheduler) {
+          await scheduler.dispatchSlackChannelMessage(
+            message.channelId,
+            {
+              type: "slack_channel_message",
+              channelId: message.channelId,
+              messageTs: message.ts,
+              text: message.text,
+              userId: message.userId ?? null,
+              botId: message.botId ?? null,
+              appId: message.appId ?? null,
+              subtype: message.subtype ?? null,
+              files: filesForAutomationTrigger(message.files, attachments),
+              capturedMessageId: capture.captured.id,
+              conversationId: capture.conversation.id,
+            },
+            { sourceWorkspaceDir: workspaceDir },
+          );
+        }
 
         const cursor = await repos.conversations.getCursor({
           conversationId: capture.conversation.id,

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -812,6 +812,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
         attachments,
         displayName: channel.name,
       });
+      let followupReviewHandled = false;
       if (sender.senderUserId) {
         const followupReview = await handleFollowupReviewCommand({
           text: message.text,
@@ -819,10 +820,11 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
           surface: "slack",
         });
         if (followupReview.handled) {
+          followupReviewHandled = true;
           await slackBot.postThreadReply(message.channelId, message.ts, followupReview.message);
         }
       }
-      if (capture.inserted && scheduler) {
+      if (capture.inserted && !followupReviewHandled && message.channelType !== "mpim" && scheduler) {
         await scheduler.dispatchSlackChannelMessage(message.channelId, {
           type: "slack_channel_message",
           channelId: message.channelId,

--- a/packages/server/src/slack/bot-events.isolated.test.ts
+++ b/packages/server/src/slack/bot-events.isolated.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "../test-utils";
+
+const mocks = vi.hoisted(() => ({
+  messageHandler: undefined as undefined | ((event: { message: Record<string, unknown> }) => Promise<void>),
+  auth: { user_id: "U_SKETCH", bot_id: "B_SKETCH" },
+}));
+
+vi.mock("@slack/bolt", () => ({
+  App: class {
+    client = { auth: { test: vi.fn(async () => mocks.auth) } };
+    message(handler: (event: { message: Record<string, unknown> }) => Promise<void>) {
+      mocks.messageHandler = handler;
+    }
+    event() {}
+    action() {}
+    async start() {}
+    async stop() {}
+  },
+  verifySlackRequest: vi.fn(),
+}));
+
+import { SlackBot } from "./bot";
+
+function makeBot() {
+  return new SlackBot({ mode: "socket", botToken: "xoxb-test", appToken: "xapp-test", logger: createTestLogger() });
+}
+
+async function deliver(message: Record<string, unknown>) {
+  if (!mocks.messageHandler) throw new Error("Message handler was not registered");
+  await mocks.messageHandler({ message });
+}
+
+describe("SlackBot channel message normalization", () => {
+  beforeEach(() => {
+    mocks.messageHandler = undefined;
+    mocks.auth = { user_id: "U_SKETCH", bot_id: "B_SKETCH" };
+  });
+
+  it("forwards an external userless bot message to the top-level channel handler", async () => {
+    const bot = makeBot();
+    const onChannelMessage = vi.fn().mockResolvedValue(undefined);
+    bot.onChannelMessage(onChannelMessage);
+    await bot.start();
+
+    await deliver({
+      type: "message",
+      subtype: "bot_message",
+      bot_id: "B_WORKFLOW",
+      app_id: "A_WORKFLOW",
+      channel: "C1",
+      text: "Bug report",
+      ts: "1.2",
+    });
+
+    expect(onChannelMessage).toHaveBeenCalledWith({
+      type: "channel_message",
+      text: "Bug report",
+      botId: "B_WORKFLOW",
+      appId: "A_WORKFLOW",
+      subtype: "bot_message",
+      channelId: "C1",
+      ts: "1.2",
+    });
+  });
+
+  it("suppresses messages from Sketch by user ID or bot ID", async () => {
+    const bot = makeBot();
+    const onChannelMessage = vi.fn().mockResolvedValue(undefined);
+    bot.onChannelMessage(onChannelMessage);
+    await bot.start();
+
+    await deliver({ type: "message", user: "U_SKETCH", channel: "C1", text: "self", ts: "1" });
+    await deliver({ type: "message", bot_id: "B_SKETCH", channel: "C1", text: "self", ts: "2" });
+
+    expect(onChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not forward a userless bot thread reply to the passive thread handler", async () => {
+    const bot = makeBot();
+    const onThreadMessage = vi.fn().mockResolvedValue(undefined);
+    bot.onThreadMessage(onThreadMessage);
+    await bot.start();
+
+    await deliver({
+      type: "message",
+      subtype: "bot_message",
+      bot_id: "B_WORKFLOW",
+      channel: "C1",
+      text: "thread bot message",
+      ts: "2",
+      thread_ts: "1",
+    });
+
+    expect(onThreadMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/slack/bot.ts
+++ b/packages/server/src/slack/bot.ts
@@ -66,7 +66,10 @@ interface RawSlackFile {
 
 export interface SlackMessage {
   text: string;
-  userId: string;
+  userId?: string;
+  botId?: string;
+  appId?: string;
+  subtype?: string;
   channelId: string;
   ts: string;
   type: "dm" | "channel_message" | "channel_mention" | "thread_message";
@@ -130,6 +133,7 @@ export class SlackBot {
   private appHomeOpenedHandler: AppHomeOpenedHandler | null = null;
   private homeActionHandler: HomeActionHandler | null = null;
   private botUserId: string | null = null;
+  private botId: string | null = null;
   private seenEvents = new Map<string, number>();
   private seenEventsTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -205,11 +209,16 @@ export class SlackBot {
   async start(): Promise<void> {
     const auth = await this.app.client.auth.test();
     this.botUserId = auth.user_id ?? null;
-    this.logger.info({ botUserId: this.botUserId }, "Resolved bot user ID");
+    this.botId = "bot_id" in auth && typeof auth.bot_id === "string" ? auth.bot_id : null;
+    this.logger.info({ botUserId: this.botUserId, botId: this.botId }, "Resolved bot IDs");
 
     this.app.message(async ({ message }) => {
-      if (!("user" in message) || !message.user) return;
-      if (message.user === this.botUserId) return;
+      const userId = "user" in message && typeof message.user === "string" ? message.user : undefined;
+      const botId = "bot_id" in message && typeof message.bot_id === "string" ? message.bot_id : undefined;
+      const appId = "app_id" in message && typeof message.app_id === "string" ? message.app_id : undefined;
+      const subtype = "subtype" in message && typeof message.subtype === "string" ? message.subtype : undefined;
+      if (!userId && !botId) return;
+      if (userId === this.botUserId || botId === this.botId) return;
 
       const isIm = "channel_type" in message && message.channel_type === "im";
       const channelType =
@@ -219,7 +228,7 @@ export class SlackBot {
       const mentionsBot = this.botUserId ? text.includes(`<@${this.botUserId}>`) : false;
 
       if (isIm) {
-        if (!this.handler) return;
+        if (!userId || !this.handler) return;
 
         const hasText = "text" in message && message.text;
         const rawFiles = "files" in message && Array.isArray(message.files) ? message.files : [];
@@ -236,7 +245,10 @@ export class SlackBot {
         await this.handler({
           type: "dm",
           text: hasText ? (message as { text: string }).text : "",
-          userId: message.user,
+          ...(userId ? { userId } : {}),
+          ...(botId ? { botId } : {}),
+          ...(appId ? { appId } : {}),
+          ...(subtype ? { subtype } : {}),
           channelId: message.channel,
           ts: message.ts,
           ...(threadTs ? { threadTs } : {}),
@@ -264,6 +276,7 @@ export class SlackBot {
       }
 
       if (threadTs && this.threadMessageHandler) {
+        if (!userId) return;
         const hasText = text.length > 0;
         const rawFiles = "files" in message && Array.isArray(message.files) ? message.files : [];
         const hasFiles = rawFiles.length > 0;
@@ -279,7 +292,10 @@ export class SlackBot {
         await this.threadMessageHandler({
           type: "thread_message",
           text,
-          userId: message.user,
+          ...(userId ? { userId } : {}),
+          ...(botId ? { botId } : {}),
+          ...(appId ? { appId } : {}),
+          ...(subtype ? { subtype } : {}),
           channelId: message.channel,
           ts: message.ts,
           threadTs,
@@ -306,7 +322,10 @@ export class SlackBot {
           type: "channel_message",
           ...(channelType ? { channelType } : {}),
           text,
-          userId: message.user,
+          ...(userId ? { userId } : {}),
+          ...(botId ? { botId } : {}),
+          ...(appId ? { appId } : {}),
+          ...(subtype ? { subtype } : {}),
           channelId: message.channel,
           ts: message.ts,
           ...(files.length > 0 && { files }),

--- a/packages/server/src/workflows/runtime.isolated.test.ts
+++ b/packages/server/src/workflows/runtime.isolated.test.ts
@@ -638,9 +638,9 @@ describe("executeAutomation action steps", () => {
   });
 
   it("executes server-owned integration actions with bounded workspace files", async () => {
-    const workspaceDir = "/tmp/sketch-runtime-test/workspaces/user-1";
-    const filePath = `${workspaceDir}/automation-trigger-files/bug.jpeg`;
-    await mkdir(`${workspaceDir}/automation-trigger-files`, { recursive: true });
+    const trustedLocalFileRoot = "/tmp/sketch-runtime-test/automation-trigger-files/run-1";
+    const filePath = `${trustedLocalFileRoot}/bug.jpeg`;
+    await mkdir(trustedLocalFileRoot, { recursive: true });
     await writeFile(filePath, "jpeg-bytes");
     const executeAction = vi.fn().mockResolvedValue({ id: "clickup-task-1" });
     const params = makeParams({
@@ -648,6 +648,7 @@ describe("executeAutomation action steps", () => {
         { id: "act1", type: "action", label: "Create ClickUp task", icon: "code", position: { x: 0, y: 100 } },
       ]),
       triggerData: { filePath },
+      trustedLocalFileRoot,
       stepContentRepo: makeStepContent([
         {
           stepId: "act1",
@@ -703,7 +704,7 @@ describe("executeAutomation action steps", () => {
     const result = await executeAutomation(params as never);
 
     expect(result.status).toBe("failed");
-    expect(result.stepOutputs.act1.error?.message).toContain("outside the automation workspace");
+    expect(result.stepOutputs.act1.error?.message).toContain("outside the trusted automation file roots");
     expect(executeAction).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/workflows/runtime.isolated.test.ts
+++ b/packages/server/src/workflows/runtime.isolated.test.ts
@@ -470,6 +470,41 @@ describe("executeAutomation agent steps", () => {
 });
 
 describe("testAutomationStep", () => {
+  it("builds a representative Slack channel-message payload for trigger step tests", async () => {
+    const params = makeParams({
+      task: makeTask({
+        steps: JSON.stringify([
+          {
+            id: "trigger",
+            type: "trigger",
+            label: "Slack message",
+            icon: "slack",
+            position: { x: 0, y: 0 },
+            triggerConfig: { type: "slack_channel_message", channelId: "C123" },
+          },
+        ]),
+      }),
+    });
+
+    const result = await testAutomationStep({ ...params, stepId: "trigger" } as never);
+
+    expect(result.status).toBe("completed");
+    expect(result.finalOutput).toEqual({
+      type: "slack_channel_message",
+      taskId: "task-1",
+      channelId: "C123",
+      messageTs: "1710000000.000000",
+      text: "Example Slack channel message",
+      userId: "U123456",
+      botId: null,
+      appId: null,
+      subtype: null,
+      files: [],
+      capturedMessageId: null,
+      conversationId: "C123",
+    });
+  });
+
   it("uses the latest completed upstream output instead of the current step-test run", async () => {
     const runAgent = vi.fn().mockResolvedValue({
       pendingUploads: [],
@@ -667,14 +702,17 @@ describe("executeAutomation action steps", () => {
     const result = await executeAutomation(params as never);
 
     expect(result.status).toBe("completed");
-    expect(executeAction).toHaveBeenCalledWith({
-      userEmail: "roopak@canvasx.ai",
-      componentKey: "clickup-create-task-with-attachment",
-      configuredProps: {
-        name: "Bug report",
-        file_content_base64: Buffer.from("jpeg-bytes").toString("base64"),
+    expect(executeAction).toHaveBeenCalledWith(
+      {
+        userEmail: "roopak@canvasx.ai",
+        componentKey: "clickup-create-task-with-attachment",
+        configuredProps: {
+          name: "Bug report",
+          file_content_base64: Buffer.from("jpeg-bytes").toString("base64"),
+        },
       },
-    });
+      expect.any(AbortSignal),
+    );
   });
 
   it("rejects integration action files outside the automation workspace", async () => {

--- a/packages/server/src/workflows/runtime.isolated.test.ts
+++ b/packages/server/src/workflows/runtime.isolated.test.ts
@@ -1,3 +1,4 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { runAgentRuntimeCore } from "../agent/runtime/core";
@@ -634,6 +635,76 @@ describe("executeAutomation action steps", () => {
     expect(onEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "step.completed", stepId: "act1", outputSummary: expect.any(String) }),
     );
+  });
+
+  it("executes server-owned integration actions with bounded workspace files", async () => {
+    const workspaceDir = "/tmp/sketch-runtime-test/workspaces/user-1";
+    const filePath = `${workspaceDir}/automation-trigger-files/bug.jpeg`;
+    await mkdir(`${workspaceDir}/automation-trigger-files`, { recursive: true });
+    await writeFile(filePath, "jpeg-bytes");
+    const executeAction = vi.fn().mockResolvedValue({ id: "clickup-task-1" });
+    const params = makeParams({
+      task: makeActionTask([
+        { id: "act1", type: "action", label: "Create ClickUp task", icon: "code", position: { x: 0, y: 100 } },
+      ]),
+      triggerData: { filePath },
+      stepContentRepo: makeStepContent([
+        {
+          stepId: "act1",
+          content: `
+            return ctx.integrations.executeAction({
+              componentKey: "clickup-create-task-with-attachment",
+              configuredProps: { name: "Bug report" },
+              localFiles: [{ path: input.filePath, configuredProp: "file_content_base64" }]
+            });
+          `,
+        },
+      ]),
+      loadIntegrationProvider: vi.fn().mockResolvedValue(makeBrokerProvider({ executeAction })),
+    });
+
+    const result = await executeAutomation(params as never);
+
+    expect(result.status).toBe("completed");
+    expect(executeAction).toHaveBeenCalledWith({
+      userEmail: "roopak@canvasx.ai",
+      componentKey: "clickup-create-task-with-attachment",
+      configuredProps: {
+        name: "Bug report",
+        file_content_base64: Buffer.from("jpeg-bytes").toString("base64"),
+      },
+    });
+  });
+
+  it("rejects integration action files outside the automation workspace", async () => {
+    const outsidePath = "/tmp/sketch-runtime-outside.jpeg";
+    await writeFile(outsidePath, "not-allowed");
+    const executeAction = vi.fn();
+    const params = makeParams({
+      task: makeActionTask([
+        { id: "act1", type: "action", label: "Create ClickUp task", icon: "code", position: { x: 0, y: 100 } },
+      ]),
+      triggerData: { filePath: outsidePath },
+      stepContentRepo: makeStepContent([
+        {
+          stepId: "act1",
+          content: `
+            return ctx.integrations.executeAction({
+              componentKey: "clickup-create-task-with-attachment",
+              configuredProps: {},
+              localFiles: [{ path: input.filePath, configuredProp: "file_content_base64" }]
+            });
+          `,
+        },
+      ]),
+      loadIntegrationProvider: vi.fn().mockResolvedValue(makeBrokerProvider({ executeAction })),
+    });
+
+    const result = await executeAutomation(params as never);
+
+    expect(result.status).toBe("failed");
+    expect(result.stepOutputs.act1.error?.message).toContain("outside the automation workspace");
+    expect(executeAction).not.toHaveBeenCalled();
   });
 
   it("fails the action step with a clear error when the provider is not broker-capable", async () => {

--- a/packages/server/src/workflows/runtime.ts
+++ b/packages/server/src/workflows/runtime.ts
@@ -606,6 +606,22 @@ function buildTriggerSamplePayload(task: ScheduledTaskRow, step: WorkflowStep): 
       receivedAt: new Date().toISOString(),
     };
   }
+  if (config?.type === "slack_channel_message") {
+    return {
+      type: "slack_channel_message",
+      taskId: task.id,
+      channelId: config.channelId ?? null,
+      messageTs: "1710000000.000000",
+      text: "Example Slack channel message",
+      userId: "U123456",
+      botId: null,
+      appId: null,
+      subtype: null,
+      files: [],
+      capturedMessageId: null,
+      conversationId: config.channelId ?? null,
+    };
+  }
   return { type: "webhook", taskId: task.id, receivedAt: new Date().toISOString() };
 }
 
@@ -682,7 +698,7 @@ export interface ScriptContext {
   env: Readonly<Record<string, string>>;
   workspaceDir: string;
   integrations: {
-    executeAction(request: ScriptIntegrationActionRequest): Promise<unknown>;
+    executeAction(request: ScriptIntegrationActionRequest, signal?: AbortSignal): Promise<unknown>;
   };
 }
 
@@ -728,6 +744,17 @@ async function executeActionStep(params: ActionStepParams): Promise<unknown> {
       integrationEnv: integrationAccess.envVars,
     });
 
+    const timeoutMs = (step.timeout ?? 1800) * 1000;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      controller.signal.addEventListener(
+        "abort",
+        () => reject(new Error(`Action step ${step.id} timed out after ${timeoutMs}ms`)),
+        { once: true },
+      );
+    });
+
     const ctx = buildScriptContext({
       taskId: params.taskId,
       runId,
@@ -744,23 +771,13 @@ async function executeActionStep(params: ActionStepParams): Promise<unknown> {
           workspaceDir,
           trustedLocalFileRoot: params.trustedLocalFileRoot,
         });
-        return integrationProvider.executeAction({
+        const actionRequest = {
           userEmail: creatorEmail,
           componentKey: request.componentKey,
           configuredProps,
-        });
+        };
+        return integrationProvider.executeAction(actionRequest, controller.signal);
       },
-    });
-
-    const timeoutMs = (step.timeout ?? 1800) * 1000;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      controller.signal.addEventListener(
-        "abort",
-        () => reject(new Error(`Action step ${step.id} timed out after ${timeoutMs}ms`)),
-        { once: true },
-      );
     });
 
     try {
@@ -850,7 +867,7 @@ function buildScriptContext(params: {
   logger: Logger;
   env: Readonly<Record<string, string>>;
   workspaceDir: string;
-  executeIntegrationAction: (request: ScriptIntegrationActionRequest) => Promise<unknown>;
+  executeIntegrationAction: (request: ScriptIntegrationActionRequest, signal?: AbortSignal) => Promise<unknown>;
 }): ScriptContext {
   const log =
     params.logger.child?.({ taskId: params.taskId, runId: params.runId, stepId: params.stepId }) ?? params.logger;

--- a/packages/server/src/workflows/runtime.ts
+++ b/packages/server/src/workflows/runtime.ts
@@ -60,6 +60,7 @@ export interface ExecuteAutomationParams {
   recordWorkflowStep?: RecordWorkflowStep;
   limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
   loadAgentRuntimeProviderConfig?: () => Promise<AgentRuntimeProviderFactoryConfig | null>;
+  trustedLocalFileRoot?: string;
 }
 
 export type AutomationExecutionEvent =
@@ -435,6 +436,7 @@ async function executeWorkflowStep(params: {
       workspaceDir,
       loadIntegrationProvider: runtimeParams.loadIntegrationProvider,
       listAgentEnvForRuntime: runtimeParams.listAgentEnvForRuntime,
+      trustedLocalFileRoot: runtimeParams.trustedLocalFileRoot,
     });
   }
 
@@ -698,6 +700,7 @@ interface ActionStepParams {
   workspaceDir: string;
   loadIntegrationProvider: () => Promise<IntegrationProvider | null>;
   listAgentEnvForRuntime?: (context: AgentEnvironmentRuntimeContext) => Promise<Record<string, string>>;
+  trustedLocalFileRoot?: string;
 }
 
 async function executeActionStep(params: ActionStepParams): Promise<unknown> {
@@ -739,6 +742,7 @@ async function executeActionStep(params: ActionStepParams): Promise<unknown> {
         const configuredProps = await materializeIntegrationActionFiles({
           request,
           workspaceDir,
+          trustedLocalFileRoot: params.trustedLocalFileRoot,
         });
         return integrationProvider.executeAction({
           userEmail: creatorEmail,
@@ -813,18 +817,20 @@ const MAX_INTEGRATION_ACTION_FILE_BYTES = 25 * 1024 * 1024;
 async function materializeIntegrationActionFiles(params: {
   request: ScriptIntegrationActionRequest;
   workspaceDir: string;
+  trustedLocalFileRoot?: string;
 }): Promise<Record<string, unknown>> {
   const files = params.request.localFiles ?? [];
   if (files.length > MAX_INTEGRATION_ACTION_FILES) {
     throw new Error(`Integration actions support at most ${MAX_INTEGRATION_ACTION_FILES} local files`);
   }
-  const workspaceRealPath = await realpath(params.workspaceDir);
+  const allowedRoots = [await realpath(params.workspaceDir)];
+  if (params.trustedLocalFileRoot) allowedRoots.push(await realpath(params.trustedLocalFileRoot));
   const configuredProps = { ...params.request.configuredProps };
   let totalBytes = 0;
   for (const file of files) {
     const fileRealPath = await realpath(file.path);
-    if (!fileRealPath.startsWith(`${workspaceRealPath}${sep}`)) {
-      throw new Error("Integration action file is outside the automation workspace");
+    if (!allowedRoots.some((root) => fileRealPath.startsWith(`${root}${sep}`))) {
+      throw new Error("Integration action file is outside the trusted automation file roots");
     }
     if (!file.configuredProp.trim()) throw new Error("Integration action file configuredProp is required");
     const content = await readFile(fileRealPath);

--- a/packages/server/src/workflows/runtime.ts
+++ b/packages/server/src/workflows/runtime.ts
@@ -9,8 +9,8 @@
  * Credentials are resolved at execution time via loadIntegrationProvider (org-level) +
  * creator's email (user scoping).
  */
-import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { join, sep } from "node:path";
 import type { Kysely } from "kysely";
 import { removeReservedAgentEnv } from "../agent/environment";
 import { buildPlatformFormattingLines, buildSketchContext } from "../agent/prompt";
@@ -134,7 +134,7 @@ export async function executeAutomation(params: ExecuteAutomationParams): Promis
 
   // 4. Create run record
   const runId = await runsRepo.create({ taskId: task.id, triggerData });
-  const workspaceDir = resolveWorkspaceDir(params.config.DATA_DIR, task);
+  const workspaceDir = resolveAutomationWorkspaceDir(params.config.DATA_DIR, task);
   await mkdir(workspaceDir, { recursive: true });
   const emitEvent = async (event: AutomationExecutionEvent) => {
     try {
@@ -336,7 +336,7 @@ export async function testAutomationStep(
 
   const runId = await runsRepo.create({ taskId: task.id, triggerData: { type: "step_test", stepId, triggerData } });
   const stepOutputs: Record<string, StepOutput> = {};
-  const workspaceDir = resolveWorkspaceDir(params.config.DATA_DIR, task);
+  const workspaceDir = resolveAutomationWorkspaceDir(params.config.DATA_DIR, task);
   await mkdir(workspaceDir, { recursive: true });
 
   if (step.type === "trigger") {
@@ -607,7 +607,7 @@ function buildTriggerSamplePayload(task: ScheduledTaskRow, step: WorkflowStep): 
   return { type: "webhook", taskId: task.id, receivedAt: new Date().toISOString() };
 }
 
-function resolveWorkspaceDir(dataDir: string, task: ScheduledTaskRow): string {
+export function resolveAutomationWorkspaceDir(dataDir: string, task: ScheduledTaskRow): string {
   if (task.context_type === "channel") {
     return join(dataDir, "workspaces", `channel-${task.delivery_target}`);
   }
@@ -664,10 +664,24 @@ type AsyncFunctionConstructor = (
 
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor as AsyncFunctionConstructor;
 
+export interface ScriptIntegrationFile {
+  path: string;
+  configuredProp: string;
+}
+
+export interface ScriptIntegrationActionRequest {
+  componentKey: string;
+  configuredProps: Record<string, unknown>;
+  localFiles?: ScriptIntegrationFile[];
+}
+
 export interface ScriptContext {
   log: Logger;
   env: Readonly<Record<string, string>>;
   workspaceDir: string;
+  integrations: {
+    executeAction(request: ScriptIntegrationActionRequest): Promise<unknown>;
+  };
 }
 
 interface ActionStepParams {
@@ -688,16 +702,16 @@ interface ActionStepParams {
 
 async function executeActionStep(params: ActionStepParams): Promise<unknown> {
   const { script, step, input, runId, logger, creatorEmail, workspaceDir, loadIntegrationProvider } = params;
-
+  const integrationProvider = await loadIntegrationProvider();
   const integrationAccess = await startIntegrationAccess({
     userEmail: creatorEmail,
     claudeConfigDir: params.config.CLAUDE_CONFIG_DIR,
     workspaceDir,
-    loadIntegrationProvider,
+    loadIntegrationProvider: async () => integrationProvider,
     logger,
   });
 
-  if (!integrationAccess.envVars.CANVAS_CLI) {
+  if (!integrationAccess.envVars.CANVAS_CLI && !integrationProvider?.executeAction) {
     await cleanupIntegrationAccess(integrationAccess);
     throw new Error(
       `Action step ${step.id} requires a broker-capable integration provider; none is currently configured. Reconfigure the integration in Settings → Integrations.`,
@@ -718,6 +732,20 @@ async function executeActionStep(params: ActionStepParams): Promise<unknown> {
       logger,
       env,
       workspaceDir,
+      executeIntegrationAction: async (request) => {
+        if (!integrationProvider?.executeAction || !creatorEmail) {
+          throw new Error("The configured integration provider cannot execute server-owned actions");
+        }
+        const configuredProps = await materializeIntegrationActionFiles({
+          request,
+          workspaceDir,
+        });
+        return integrationProvider.executeAction({
+          userEmail: creatorEmail,
+          componentKey: request.componentKey,
+          configuredProps,
+        });
+      },
     });
 
     const timeoutMs = (step.timeout ?? 1800) * 1000;
@@ -779,6 +807,36 @@ async function buildScriptEnv(params: {
   return Object.freeze(env);
 }
 
+const MAX_INTEGRATION_ACTION_FILES = 5;
+const MAX_INTEGRATION_ACTION_FILE_BYTES = 25 * 1024 * 1024;
+
+async function materializeIntegrationActionFiles(params: {
+  request: ScriptIntegrationActionRequest;
+  workspaceDir: string;
+}): Promise<Record<string, unknown>> {
+  const files = params.request.localFiles ?? [];
+  if (files.length > MAX_INTEGRATION_ACTION_FILES) {
+    throw new Error(`Integration actions support at most ${MAX_INTEGRATION_ACTION_FILES} local files`);
+  }
+  const workspaceRealPath = await realpath(params.workspaceDir);
+  const configuredProps = { ...params.request.configuredProps };
+  let totalBytes = 0;
+  for (const file of files) {
+    const fileRealPath = await realpath(file.path);
+    if (!fileRealPath.startsWith(`${workspaceRealPath}${sep}`)) {
+      throw new Error("Integration action file is outside the automation workspace");
+    }
+    if (!file.configuredProp.trim()) throw new Error("Integration action file configuredProp is required");
+    const content = await readFile(fileRealPath);
+    totalBytes += content.byteLength;
+    if (totalBytes > MAX_INTEGRATION_ACTION_FILE_BYTES) {
+      throw new Error("Integration action files exceed the 25 MiB limit");
+    }
+    configuredProps[file.configuredProp] = content.toString("base64");
+  }
+  return configuredProps;
+}
+
 function buildScriptContext(params: {
   taskId: string;
   runId: string;
@@ -786,6 +844,7 @@ function buildScriptContext(params: {
   logger: Logger;
   env: Readonly<Record<string, string>>;
   workspaceDir: string;
+  executeIntegrationAction: (request: ScriptIntegrationActionRequest) => Promise<unknown>;
 }): ScriptContext {
   const log =
     params.logger.child?.({ taskId: params.taskId, runId: params.runId, stepId: params.stepId }) ?? params.logger;
@@ -793,6 +852,7 @@ function buildScriptContext(params: {
     log,
     env: params.env,
     workspaceDir: params.workspaceDir,
+    integrations: Object.freeze({ executeAction: params.executeIntegrationAction }),
   });
 }
 

--- a/packages/shared/src/automation.ts
+++ b/packages/shared/src/automation.ts
@@ -1,20 +1,31 @@
 import { z } from "zod";
 
-export const workflowTriggerConfigSchema = z.object({
-  type: z.enum(["webhook", "schedule", "canvas"]),
-  scheduleType: z.enum(["cron", "interval", "once"]).optional(),
-  scheduleValue: z.string().optional(),
-  timezone: z.string().optional(),
-  app: z.string().optional(),
-  eventDescription: z.string().optional(),
-  componentKey: z.string().optional(),
-  configuredProps: z.record(z.string(), z.unknown()).optional(),
-  status: z.enum(["pending_canvas_setup", "active", "error"]).optional(),
-  canvasWorkflowId: z.string().optional(),
-  canvasTriggerNodeId: z.string().optional(),
-  canvasActionNodeId: z.string().optional(),
-  errorMessage: z.string().optional(),
-});
+export const workflowTriggerConfigSchema = z
+  .object({
+    type: z.enum(["webhook", "schedule", "canvas", "slack_channel_message"]),
+    channelId: z.string().trim().min(1).optional(),
+    scheduleType: z.enum(["cron", "interval", "once"]).optional(),
+    scheduleValue: z.string().optional(),
+    timezone: z.string().optional(),
+    app: z.string().optional(),
+    eventDescription: z.string().optional(),
+    componentKey: z.string().optional(),
+    configuredProps: z.record(z.string(), z.unknown()).optional(),
+    status: z.enum(["pending_canvas_setup", "active", "error"]).optional(),
+    canvasWorkflowId: z.string().optional(),
+    canvasTriggerNodeId: z.string().optional(),
+    canvasActionNodeId: z.string().optional(),
+    errorMessage: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.type === "slack_channel_message" && !value.channelId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["channelId"],
+        message: "Slack channel message trigger requires channelId",
+      });
+    }
+  });
 
 export type WorkflowTriggerConfig = z.infer<typeof workflowTriggerConfigSchema>;
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -153,7 +153,8 @@ export interface ScheduledTaskOriginChatMessage {
 }
 
 export interface WorkflowTriggerConfig {
-  type: "webhook" | "schedule" | "canvas";
+  type: "webhook" | "schedule" | "canvas" | "slack_channel_message";
+  channelId?: string;
   scheduleType?: "cron" | "interval" | "once";
   scheduleValue?: string;
   timezone?: string;

--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -264,6 +264,31 @@ describe("AutomationBuilderPage", () => {
     mocks.chatMessages = [];
   });
 
+  it("renders a Slack channel message trigger and its channel", async () => {
+    const user = userEvent.setup();
+    mocks.getAutomation.mockResolvedValue({
+      ...automation,
+      scheduleType: "external",
+      scheduleValue: "slack_channel_message",
+      steps: [
+        {
+          ...automation.steps[0],
+          label: "Slack channel message",
+          icon: "slack",
+          triggerConfig: { type: "slack_channel_message", channelId: "C123" },
+        },
+        ...automation.steps.slice(1),
+      ],
+    });
+    renderBuilder();
+
+    await user.click(await screen.findByRole("button", { name: "Slack channel message" }));
+
+    await waitFor(() => expect(screen.getByText("Trigger type")).toBeInTheDocument());
+    expect(screen.getAllByDisplayValue("Slack channel message").length).toBeGreaterThan(0);
+    expect(screen.getAllByDisplayValue("C123").length).toBeGreaterThan(0);
+  });
+
   it("opens a fresh builder chat and sends the active automation id", async () => {
     const user = userEvent.setup();
     renderBuilder();

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -883,6 +883,7 @@ type StepVisualKind =
   | "schedule-trigger"
   | "webhook-trigger"
   | "canvas-trigger"
+  | "slack-channel-message-trigger"
   | "agent"
   | "gmail-action"
   | "sheets-action"
@@ -921,6 +922,13 @@ const stepVisuals: Record<StepVisualKind, StepVisual> = {
     shape: "notched",
     toneClass: "border-violet-200/20 bg-[#18161a]",
     glyphClass: "text-violet-100/75",
+  },
+  "slack-channel-message-trigger": {
+    kind: "slack-channel-message-trigger",
+    icon: SlackLogoIcon,
+    shape: "notched",
+    toneClass: "border-fuchsia-200/20 bg-[#181618]",
+    glyphClass: "text-fuchsia-100/75",
   },
   agent: {
     kind: "agent",
@@ -1001,6 +1009,7 @@ function resolveStepVisual(step: WorkflowStep, content: AutomationStepContent | 
   if (step.type === "trigger") {
     if (step.triggerConfig?.type === "webhook") return stepVisuals["webhook-trigger"];
     if (step.triggerConfig?.type === "canvas") return stepVisuals["canvas-trigger"];
+    if (step.triggerConfig?.type === "slack_channel_message") return stepVisuals["slack-channel-message-trigger"];
     return stepVisuals["schedule-trigger"];
   }
 
@@ -1521,11 +1530,17 @@ function NodeInputPanel({
 function TriggerFields({ draft }: { draft: DraftAutomation }) {
   const triggerStep = draft.steps.find((step) => step.type === "trigger");
   const config = triggerStep?.triggerConfig ?? { type: "schedule" as const };
+  const triggerLabel = config.type === "slack_channel_message" ? "Slack channel message" : config.type;
   return (
     <>
       <Field label="Trigger type">
-        <Input value={config.type} className={builderReadOnlyInputClass} readOnly aria-readonly="true" />
+        <Input value={triggerLabel} className={builderReadOnlyInputClass} readOnly aria-readonly="true" />
       </Field>
+      {config.type === "slack_channel_message" ? (
+        <Field label="Slack channel">
+          <Input value={config.channelId ?? ""} className={builderReadOnlyInputClass} readOnly aria-readonly="true" />
+        </Field>
+      ) : null}
       {config.type === "schedule" ? (
         <>
           <Field label="Schedule type">

--- a/packages/web/src/routes/scheduled-tasks.isolated.test.tsx
+++ b/packages/web/src/routes/scheduled-tasks.isolated.test.tsx
@@ -139,9 +139,15 @@ describe("ScheduledTasksPage", () => {
       }),
     ]);
 
+    const user = userEvent.setup();
     renderWithProviders(<ScheduledTasksPage />);
 
     expect(await screen.findByText("Trigger · Slack channel message · C123")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Show details for Post the Monday revenue summary/i }));
+    expect(await screen.findByText("Trigger-based")).toBeInTheDocument();
+    expect(screen.getByText("Slack channel message · C123")).toBeInTheDocument();
+    expect(screen.queryByText("Timezone")).not.toBeInTheDocument();
+    expect(screen.queryByText("Next run")).not.toBeInTheDocument();
   });
 
   it("shows the empty state when there are no tasks", async () => {

--- a/packages/web/src/routes/scheduled-tasks.isolated.test.tsx
+++ b/packages/web/src/routes/scheduled-tasks.isolated.test.tsx
@@ -129,6 +129,21 @@ describe("ScheduledTasksPage", () => {
     expect(screen.getByText("Mondays at 9:00 AM")).toBeInTheDocument();
   });
 
+  it("renders a Slack channel message trigger and channel in the automation list", async () => {
+    installTaskHandlers([
+      buildTask({
+        scheduleType: "external",
+        scheduleValue: "slack_channel_message",
+        scheduleLabel: "Slack channel message - C123",
+        triggerConfig: { type: "slack_channel_message", channelId: "C123" },
+      }),
+    ]);
+
+    renderWithProviders(<ScheduledTasksPage />);
+
+    expect(await screen.findByText("Trigger · Slack channel message · C123")).toBeInTheDocument();
+  });
+
   it("shows the empty state when there are no tasks", async () => {
     installTaskHandlers([]);
 

--- a/packages/web/src/routes/scheduled-tasks.tsx
+++ b/packages/web/src/routes/scheduled-tasks.tsx
@@ -162,6 +162,9 @@ function isCanvasManaged(task: ScheduledTaskListItem): boolean {
 }
 
 function getTriggerDetail(task: ScheduledTaskListItem): string {
+  if (task.triggerConfig?.type === "slack_channel_message") {
+    return `Slack channel message · ${task.triggerConfig.channelId}`;
+  }
   if (isCanvasManaged(task)) {
     const config = task.triggerConfig;
     const parts = ["Canvas"];
@@ -174,6 +177,9 @@ function getTriggerDetail(task: ScheduledTaskListItem): string {
 }
 
 function getTaskScheduleLabel(task: ScheduledTaskListItem): string {
+  if (task.triggerConfig?.type === "slack_channel_message") {
+    return `Trigger · Slack channel message · ${task.triggerConfig.channelId}`;
+  }
   if (!isCanvasManaged(task)) return task.scheduleLabel;
 
   const config = task.triggerConfig;

--- a/packages/web/src/routes/scheduled-tasks.tsx
+++ b/packages/web/src/routes/scheduled-tasks.tsx
@@ -161,6 +161,10 @@ function isCanvasManaged(task: ScheduledTaskListItem): boolean {
   return task.triggerConfig?.type === "canvas" || (task.scheduleType === "external" && task.scheduleValue === "canvas");
 }
 
+function isTriggerBased(task: ScheduledTaskListItem): boolean {
+  return isCanvasManaged(task) || task.triggerConfig?.type === "slack_channel_message";
+}
+
 function getTriggerDetail(task: ScheduledTaskListItem): string {
   if (task.triggerConfig?.type === "slack_channel_message") {
     return `Slack channel message · ${task.triggerConfig.channelId}`;
@@ -1055,7 +1059,7 @@ function TaskRow({
 
 function TaskExpandedDetail({ task, isAdmin }: { task: ScheduledTaskListItem; isAdmin: boolean }) {
   const targetLabel = task.targetLabel || task.deliveryTarget;
-  const canvasManaged = isCanvasManaged(task);
+  const triggerBased = isTriggerBased(task);
 
   return (
     <div className="border-t border-border bg-muted/20 px-4 py-4 space-y-4">
@@ -1066,11 +1070,11 @@ function TaskExpandedDetail({ task, isAdmin }: { task: ScheduledTaskListItem; is
       <dl className="grid gap-4 text-sm sm:grid-cols-2">
         <DetailItem label="Source" value={`${task.targetKindLabel} \u00b7 ${targetLabel}`} />
         <DetailItem label="Delivery" value={formatDelivery(task)} />
-        <DetailItem label="Type" value={canvasManaged ? "Trigger-based" : "Scheduled"} />
-        <DetailItem label={canvasManaged ? "Trigger" : "Schedule"} value={getTriggerDetail(task)} />
-        {canvasManaged ? null : <DetailItem label="Timezone" value={task.timezone} />}
+        <DetailItem label="Type" value={triggerBased ? "Trigger-based" : "Scheduled"} />
+        <DetailItem label={triggerBased ? "Trigger" : "Schedule"} value={getTriggerDetail(task)} />
+        {triggerBased ? null : <DetailItem label="Timezone" value={task.timezone} />}
         <DetailItem label="Session mode" value={formatSessionMode(task.sessionMode)} />
-        {canvasManaged ? null : <DetailItem label="Next run" value={formatDateTime(task.nextRunAt)} />}
+        {triggerBased ? null : <DetailItem label="Next run" value={formatDateTime(task.nextRunAt)} />}
         <DetailItem label="Last run" value={formatDateTime(task.lastRunAt)} />
         <DetailItem label="Created" value={formatDateTime(task.createdAt)} />
         {isAdmin ? <DetailItem label="Created by" value={task.creatorName ?? task.createdBy ?? "Unknown"} /> : null}


### PR DESCRIPTION
## Summary

- add a `slack_channel_message` automation trigger scoped to a Slack channel ID
- dispatch newly captured top-level channel messages to every matching active automation
- authenticate Slack file downloads and make bounded workspace-local attachments available to automation scripts
- execute Canvas-managed integration actions without exposing credentials or file bytes to generated scripts

## Linear Scope

- [SKE-308: Trigger automations from Slack channel messages](https://linear.app/sketch-ai/issue/SKE-308/trigger-automations-from-slack-channel-messages)

## Implementation Details

- persist Slack message triggers as external workflows and dispatch only after idempotent passive capture inserts a new top-level channel message
- pass channel/message identity, sender metadata, files, and captured conversation references as trigger data
- revalidate each automation creator's current Slack channel membership and isolate per-automation enqueue failures
- download Slack files with bot authentication and preserve stable Slack-file-to-download association when individual downloads fail
- copy files from the trusted channel or bound-agent workspace into each automation workspace with canonical source/destination containment, traversal and symlink rejection, and opened-file identity checks
- expose `ctx.integrations.executeAction()` and materialize at most 5 local files / 25 MiB total into Canvas action props after runtime containment checks
- route Canvas actions through the configured Canvas REST URL, API key, and user identity with a 120-second action timeout
- increase automation authoring output capacity to 8,192 tokens, classify empty structured output correctly, and guide authored scripts toward trusted local-file action execution
- resolve named Slack channels before authoring and reject invented channel IDs

## Dependency

- requires [canvasxai/canvas-ai#798](https://github.com/canvasxai/canvas-ai/pull/798) to deploy first for ClickUp attachment actions and the bounded direct-action request limit

## Verification

- `pnpm biome check .` — passed
- `pnpm typecheck` — passed
- `pnpm test` — passed; 4,732 server tests and 435 web tests, with 20 documented live-provider skips
- `pnpm build` — passed
- Node 24 pre-push hook repeated all four gates successfully
- live local Canvas execution created ClickUp task `86d3vcd97` with the original 1.59 MB Slack JPEG attached
- independent attachment-transport security review completed with blocking findings resolved

## Risk / Rollout

- no migration, configuration, feature flag, or production deployment change
- deploy Canvas PR #798 before this PR
- attachment handling is bounded to 5 files and 25 MiB total and fails closed when source or destination containment cannot be established
- existing automation delivery behavior remains unchanged; Sketch's own bot output remains excluded to avoid feedback loops

