### PR TITLE
feat: make WhatsApp disconnect alerts user-friendly via WATI reconnect template

### DIFF
--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -59,7 +59,7 @@ import { LocalClaudeSessionService } from "./local-devices/claude-sessions";
 import { LocalDeviceGateway } from "./local-devices/gateway";
 import { createLogger } from "./logger";
 import { runManagedSeed } from "./managed-seed";
-import { createOperationalAlertDefinitions } from "./operational-alerts/definitions";
+import { channelsReconnectUrl, createOperationalAlertDefinitions } from "./operational-alerts/definitions";
 import { createOperationalAlertService } from "./operational-alerts/service";
 import { createWhatsAppOperationalAlertTransport } from "./operational-alerts/whatsapp-transport";
 import { OperationalAlertWorker } from "./operational-alerts/worker";
@@ -472,6 +472,8 @@ export async function createServer(config: Config, options?: CreateServerOptions
               whatsappSupervisor
                 ? whatsappSupervisor.requiresPairing || !whatsappSupervisor.isConnected
                 : Boolean(whatsappBot && !whatsappBot.isConnected),
+            getConnectedWhatsAppNumber: async () => (await whatsapp.pairing.status()).phoneNumber ?? null,
+            reconnectUrl: channelsReconnectUrl(config.BASE_URL),
           }),
           transports: {
             whatsapp: createWhatsAppOperationalAlertTransport({

--- a/packages/server/src/operational-alerts/definitions.ts
+++ b/packages/server/src/operational-alerts/definitions.ts
@@ -1,9 +1,14 @@
 import type { OperationalAlertRow } from "../db/repositories/operational-alerts";
+import { buildReconnectNotificationTemplate } from "../whatsapp/templates";
 import {
   BAILEYS_DISCONNECTED_ALERT_TYPE,
   type BaileysDisconnectedAlertPayload,
   type OperationalAlertDefinition,
+  type OperationalAlertRenderContext,
+  type OperationalAlertRenderResult,
 } from "./types";
+
+const RECONNECT_LOCATION_FALLBACK = "Settings > Channels in your Sketch dashboard";
 
 function parseBaileysPayload(alert: OperationalAlertRow): BaileysDisconnectedAlertPayload {
   const parsed = JSON.parse(alert.payload) as BaileysDisconnectedAlertPayload;
@@ -13,28 +18,70 @@ function parseBaileysPayload(alert: OperationalAlertRow): BaileysDisconnectedAle
   return parsed;
 }
 
-function renderBaileysAlert(alert: OperationalAlertRow, context: { orgName: string; botName: string }) {
-  const payload = parseBaileysPayload(alert);
-  const status = payload.socketState === "logged-out" ? "logged out" : "disconnected";
-  const diagnostic = [
-    payload.statusCode === undefined ? null : `status code ${payload.statusCode}`,
-    payload.reason ? `reason ${payload.reason}` : null,
-  ]
-    .filter(Boolean)
-    .join(", ");
-  const diagnosticSuffix = diagnostic ? ` (${diagnostic})` : "";
-  const directMessage = alert.resolved_at
-    ? `Operational alert for ${context.orgName}: the Baileys WhatsApp connection ${status} at ${payload.occurredAt}${diagnosticSuffix} and recovered at ${alert.resolved_at}. This notification was delayed until after the connection recovered.`
-    : `Operational alert for ${context.orgName}: the Baileys WhatsApp connection ${status} at ${payload.occurredAt}${diagnosticSuffix}. WhatsApp messages may be delayed until an admin reconnects it in Settings > Channels.`;
-  return {
-    directMessage,
-    templateSummary: directMessage,
-  };
+/**
+ * Builds the reconnect page URL from the configured public base URL. Returns null
+ * when the base URL is missing or malformed so callers can fall back to
+ * describing the location in words instead of sending a broken link.
+ */
+export function channelsReconnectUrl(baseUrl: string | undefined): string | null {
+  const configured = baseUrl?.trim().replace(/\/+$/, "");
+  if (!configured) return null;
+  try {
+    const url = new URL("/channels", `${configured}/`);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
 }
 
 export function createOperationalAlertDefinitions(params: {
   isBaileysGatewayDisconnected: () => Promise<boolean> | boolean;
+  getConnectedWhatsAppNumber?: () => Promise<string | null> | string | null;
+  reconnectUrl?: string | null;
 }): Map<string, OperationalAlertDefinition> {
+  /**
+   * The connection lookup can fail while the gateway is down, which is exactly
+   * when this alert fires, so failures degrade to the org-name label instead of
+   * blocking delivery.
+   */
+  async function connectionLabel(context: OperationalAlertRenderContext): Promise<string> {
+    try {
+      const phoneNumber = await params.getConnectedWhatsAppNumber?.();
+      return phoneNumber?.trim() || context.orgName;
+    } catch {
+      return context.orgName;
+    }
+  }
+
+  /**
+   * Copy is aligned with the Meta-approved `whatsapp_reconnect_notification`
+   * template and must stay free of technical jargon: no status codes, no
+   * Baileys references, no raw timestamps (SKE-309).
+   */
+  async function renderBaileysAlert(
+    alert: OperationalAlertRow,
+    context: OperationalAlertRenderContext,
+  ): Promise<OperationalAlertRenderResult> {
+    parseBaileysPayload(alert);
+    const label = await connectionLabel(context);
+    if (alert.resolved_at) {
+      const directMessage = `Hi ${context.recipientName}, your WhatsApp connection for ${label} was briefly interrupted and is now reconnected. Everything is back to normal and no action is needed.`;
+      return { directMessage, templateSummary: directMessage };
+    }
+    const reconnectLocation = params.reconnectUrl ?? RECONNECT_LOCATION_FALLBACK;
+    const directMessage = `Hi ${context.recipientName}, your WhatsApp connection for ${label} needs a quick reconnect. Please rescan the QR code on ${reconnectLocation} to restore the group updates.`;
+    return {
+      directMessage,
+      templateSummary: directMessage,
+      template: buildReconnectNotificationTemplate({
+        recipientName: context.recipientName,
+        phoneNumber: label,
+        reconnectUrl: reconnectLocation,
+        fallbackText: directMessage,
+      }),
+    };
+  }
+
   return new Map([
     [
       BAILEYS_DISCONNECTED_ALERT_TYPE,

--- a/packages/server/src/operational-alerts/operational-alerts.test.ts
+++ b/packages/server/src/operational-alerts/operational-alerts.test.ts
@@ -1,11 +1,11 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createOperationalAlertsRepository } from "../db/repositories/operational-alerts";
+import { type OperationalAlertRow, createOperationalAlertsRepository } from "../db/repositories/operational-alerts";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
-import { createOperationalAlertDefinitions } from "./definitions";
+import { channelsReconnectUrl, createOperationalAlertDefinitions } from "./definitions";
 import { BAILEYS_DISCONNECT_GRACE_MS, createOperationalAlertService } from "./service";
 import { BAILEYS_DISCONNECTED_ALERT_TYPE, BAILEYS_GATEWAY_RESOURCE_KEY, OperationalAlertRetryableError } from "./types";
 import { OperationalAlertWorker } from "./worker";
@@ -77,7 +77,11 @@ describe("operational alerts", () => {
       alerts,
       users,
       settings,
-      definitions: createOperationalAlertDefinitions({ isBaileysGatewayDisconnected: () => true }),
+      definitions: createOperationalAlertDefinitions({
+        isBaileysGatewayDisconnected: () => true,
+        getConnectedWhatsAppNumber: () => "+91 9980470200",
+        reconnectUrl: "https://goosebumps.getsketch.ai/channels",
+      }),
       transports: { whatsapp: { send } },
       logger: createTestLogger(),
       now: () => now,
@@ -91,7 +95,16 @@ describe("operational alerts", () => {
       expect.objectContaining({
         recipient: expect.objectContaining({ id: "admin-1", destination: "+919876543210" }),
         orgName: "Goosebumps",
-        directMessage: expect.stringContaining("status code 413"),
+        directMessage:
+          "Hi Admin One, your WhatsApp connection for +91 9980470200 needs a quick reconnect. Please rescan the QR code on https://goosebumps.getsketch.ai/channels to restore the group updates.",
+        template: expect.objectContaining({
+          key: "whatsapp.reconnect_notification",
+          params: {
+            recipientName: "Admin One",
+            phoneNumber: "+91 9980470200",
+            reconnectUrl: "https://goosebumps.getsketch.ai/channels",
+          },
+        }),
       }),
     );
     const opened = await alerts.findActive(BAILEYS_DISCONNECTED_ALERT_TYPE, BAILEYS_GATEWAY_RESOURCE_KEY);
@@ -320,9 +333,10 @@ describe("operational alerts", () => {
     await worker.drain();
     await worker.stop();
 
-    expect(transport.send).toHaveBeenLastCalledWith(
-      expect.objectContaining({ directMessage: expect.stringContaining(`recovered at ${now.toISOString()}`) }),
-    );
+    const recoverySend = transport.send.mock.calls.at(-1)?.[0] as { directMessage: string; template?: unknown };
+    expect(recoverySend.directMessage).toContain("is now reconnected");
+    expect(recoverySend.directMessage).not.toContain(now.toISOString());
+    expect(recoverySend.template).toBeUndefined();
     await expect(alerts.listDeliveries(active?.id ?? "missing")).resolves.toEqual([
       expect.objectContaining({ state: "sent", attempts: 0, provider_message_id: "recovery-message" }),
     ]);
@@ -349,5 +363,63 @@ describe("operational alerts", () => {
       expect.objectContaining({ socketState: "disconnected", statusCode: 413 }),
       "Operational alert observation failed",
     );
+  });
+});
+
+describe("baileys disconnect alert copy", () => {
+  const context = { orgName: "Goosebumps", botName: "Sketch", recipientName: "Ashish" };
+  const alertRow = {
+    payload: JSON.stringify({
+      version: 1,
+      socketState: "disconnected",
+      occurredAt: "2026-07-29T06:55:47.436Z",
+      statusCode: 428,
+      reason: "inprocess_disconnected",
+    }),
+    resolved_at: null,
+  } as OperationalAlertRow;
+
+  it("falls back to the org name and a described location when the number and URL are unavailable", async () => {
+    const definitions = createOperationalAlertDefinitions({
+      isBaileysGatewayDisconnected: () => true,
+      getConnectedWhatsAppNumber: () => {
+        throw new Error("gateway down");
+      },
+    });
+    const definition = definitions.get(BAILEYS_DISCONNECTED_ALERT_TYPE);
+    const rendered = await definition?.render(alertRow, context);
+
+    expect(rendered?.directMessage).toBe(
+      "Hi Ashish, your WhatsApp connection for Goosebumps needs a quick reconnect. Please rescan the QR code on Settings > Channels in your Sketch dashboard to restore the group updates.",
+    );
+    expect(rendered?.template?.params).toMatchObject({ phoneNumber: "Goosebumps" });
+  });
+
+  it("never leaks technical jargon into the delivered copy", async () => {
+    const definitions = createOperationalAlertDefinitions({
+      isBaileysGatewayDisconnected: () => true,
+      getConnectedWhatsAppNumber: () => "+91 9980470200",
+      reconnectUrl: "https://goosebumps.getsketch.ai/channels",
+    });
+    const definition = definitions.get(BAILEYS_DISCONNECTED_ALERT_TYPE);
+    const rendered = await definition?.render(alertRow, context);
+
+    for (const text of [rendered?.directMessage ?? "", rendered?.templateSummary ?? ""]) {
+      expect(text).not.toMatch(/baileys|status code|428|inprocess_disconnected|\d{4}-\d{2}-\d{2}T/i);
+    }
+  });
+});
+
+describe("channelsReconnectUrl", () => {
+  it("builds the channels page URL from a configured base URL", () => {
+    expect(channelsReconnectUrl("https://goosebumps.getsketch.ai")).toBe("https://goosebumps.getsketch.ai/channels");
+    expect(channelsReconnectUrl("https://goosebumps.getsketch.ai/")).toBe("https://goosebumps.getsketch.ai/channels");
+  });
+
+  it("returns null for missing or malformed base URLs", () => {
+    expect(channelsReconnectUrl(undefined)).toBeNull();
+    expect(channelsReconnectUrl("")).toBeNull();
+    expect(channelsReconnectUrl("not a url")).toBeNull();
+    expect(channelsReconnectUrl("ftp://example.com")).toBeNull();
   });
 });

--- a/packages/server/src/operational-alerts/types.ts
+++ b/packages/server/src/operational-alerts/types.ts
@@ -1,4 +1,5 @@
 import type { OperationalAlertRow } from "../db/repositories/operational-alerts";
+import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 
 export const BAILEYS_DISCONNECTED_ALERT_TYPE = "whatsapp.baileys.disconnected";
 export const BAILEYS_GATEWAY_RESOURCE_KEY = "whatsapp:baileys:gateway";
@@ -12,17 +13,31 @@ export interface BaileysDisconnectedAlertPayload {
   gatewayGeneration?: number;
 }
 
+export interface OperationalAlertRenderContext {
+  orgName: string;
+  botName: string;
+  recipientName: string;
+}
+
+/**
+ * `template` lets a definition pick a purpose-built provider template for
+ * out-of-window delivery; transports fall back to the generic proactive-update
+ * template when it is absent.
+ */
+export interface OperationalAlertRenderResult {
+  directMessage: string;
+  templateSummary: string;
+  template?: WhatsAppTemplateRequest;
+}
+
 export interface OperationalAlertDefinition {
   type: string;
   channels: readonly ("whatsapp" | "slack")[];
   isStillActive: (alert: OperationalAlertRow) => Promise<boolean> | boolean;
   render: (
     alert: OperationalAlertRow,
-    context: { orgName: string; botName: string },
-  ) => {
-    directMessage: string;
-    templateSummary: string;
-  };
+    context: OperationalAlertRenderContext,
+  ) => OperationalAlertRenderResult | Promise<OperationalAlertRenderResult>;
 }
 
 export interface OperationalAlertTransportResult {
@@ -53,6 +68,7 @@ export interface OperationalAlertChannelTransport {
     recipient: OperationalAlertRecipient;
     directMessage: string;
     templateSummary: string;
+    template?: WhatsAppTemplateRequest;
     orgName: string;
     botName: string;
     now: Date;

--- a/packages/server/src/operational-alerts/whatsapp-transport.test.ts
+++ b/packages/server/src/operational-alerts/whatsapp-transport.test.ts
@@ -29,6 +29,15 @@ const recipient: OperationalAlertRecipient = {
   name: "Admin",
   destination: "+919876543210",
 };
+const reconnectTemplate = {
+  key: WHATSAPP_TEMPLATE_KEYS.reconnectNotification,
+  params: {
+    recipientName: "Admin",
+    phoneNumber: "+91 9980470200",
+    reconnectUrl: "https://goosebumps.getsketch.ai/channels",
+  },
+  fallbackText: "Baileys disconnected",
+};
 
 function createDeps(lastInbound: { receivedAt: string; providerTimestamp: string | null } | null) {
   return {
@@ -84,6 +93,77 @@ describe("WhatsApp operational alert transport", () => {
         params: expect.objectContaining({ recipientName: "Admin", botName: "Sketch" }),
       }),
     );
+  });
+
+  it("prefers the alert's own template over the proactive update template", async () => {
+    const deps = createDeps({ receivedAt: "2026-07-15T09:00:00.000Z", providerTimestamp: null });
+    const transport = createWhatsAppOperationalAlertTransport(deps);
+
+    await transport.send({ ...sendInput(new Date("2026-07-17T10:00:00.000Z")), template: reconnectTemplate });
+
+    expect(deps.whatsapp.sendText).not.toHaveBeenCalled();
+    expect(deps.whatsapp.sendTemplate).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+919876543210" },
+      reconnectTemplate,
+    );
+  });
+
+  it("still sends a direct message inside the customer service window when a template is provided", async () => {
+    const deps = createDeps({ receivedAt: "2026-07-17T09:00:00.000Z", providerTimestamp: null });
+    const transport = createWhatsAppOperationalAlertTransport(deps);
+
+    await transport.send({ ...sendInput(new Date("2026-07-17T10:00:00.000Z")), template: reconnectTemplate });
+
+    expect(deps.whatsapp.sendText).toHaveBeenCalledTimes(1);
+    expect(deps.whatsapp.sendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("uses the alert's template after an apparently in-window direct message is rejected", async () => {
+    const deps = createDeps({ receivedAt: "2026-07-17T09:00:00.000Z", providerTimestamp: null });
+    vi.mocked(deps.whatsapp.sendText).mockRejectedValue(
+      Object.assign(new Error("window expired"), { providerCode: "window_expired" }),
+    );
+    const transport = createWhatsAppOperationalAlertTransport(deps);
+
+    await transport.send({ ...sendInput(new Date("2026-07-17T10:00:00.000Z")), template: reconnectTemplate });
+
+    expect(deps.whatsapp.sendTemplate).toHaveBeenCalledWith(
+      { kind: "dm", phoneE164: "+919876543210" },
+      reconnectTemplate,
+    );
+  });
+
+  it("falls back to the proactive update template when the alert's template has no approved mapping", async () => {
+    const deps = createDeps({ receivedAt: "2026-07-15T09:00:00.000Z", providerTimestamp: null });
+    vi.mocked(deps.whatsapp.sendTemplate).mockImplementation(async (_target, template) => {
+      if (template.key === WHATSAPP_TEMPLATE_KEYS.reconnectNotification) {
+        throw Object.assign(new Error("no approved mapping"), { providerCode: "template_not_found" });
+      }
+      return sent;
+    });
+    const transport = createWhatsAppOperationalAlertTransport(deps);
+
+    await expect(
+      transport.send({ ...sendInput(new Date("2026-07-17T10:00:00.000Z")), template: reconnectTemplate }),
+    ).resolves.toEqual({ providerMessageId: "message-1" });
+    expect(deps.whatsapp.sendTemplate).toHaveBeenCalledTimes(2);
+    expect(deps.whatsapp.sendTemplate).toHaveBeenLastCalledWith(
+      { kind: "dm", phoneE164: "+919876543210" },
+      expect.objectContaining({ key: WHATSAPP_TEMPLATE_KEYS.proactiveUpdate }),
+    );
+  });
+
+  it("does not swallow non-mapping template errors for the alert's template", async () => {
+    const deps = createDeps({ receivedAt: "2026-07-15T09:00:00.000Z", providerTimestamp: null });
+    vi.mocked(deps.whatsapp.sendTemplate).mockRejectedValue(
+      Object.assign(new Error("provider unavailable"), { providerCode: "503" }),
+    );
+    const transport = createWhatsAppOperationalAlertTransport(deps);
+
+    await expect(
+      transport.send({ ...sendInput(new Date("2026-07-17T10:00:00.000Z")), template: reconnectTemplate }),
+    ).rejects.toMatchObject({ providerCode: "503" });
+    expect(deps.whatsapp.sendTemplate).toHaveBeenCalledTimes(1);
   });
 
   it("sends text outside the customer service window when the provider does not support templates", async () => {

--- a/packages/server/src/operational-alerts/whatsapp-transport.ts
+++ b/packages/server/src/operational-alerts/whatsapp-transport.ts
@@ -5,6 +5,7 @@ import { buildProactiveUpdateTemplate } from "../whatsapp/templates";
 import { type OperationalAlertChannelTransport, OperationalAlertRetryableError } from "./types";
 
 const TEMPLATE_FALLBACK_PROVIDER_CODES = new Set(["contact_not_found", "window_expired"]);
+const TEMPLATE_MAPPING_MISSING_PROVIDER_CODE = "template_not_found";
 
 function providerCodeFromError(error: unknown): string | null {
   if (!error || typeof error !== "object") return null;
@@ -56,6 +57,20 @@ export function createWhatsAppOperationalAlertTransport(params: {
         }
       }
 
+      /**
+       * A purpose-built alert template needs an ops-provisioned mapping row that
+       * may not exist yet on an upgraded tenant. Falling back to the generic
+       * proactive-update template keeps the alert deliverable instead of letting
+       * the delivery retry to death on a configuration gap.
+       */
+      if (input.template) {
+        try {
+          const sent = requireSent(await params.whatsapp.sendTemplate(target, input.template));
+          return { providerMessageId: sent.providerMessageId };
+        } catch (error) {
+          if (providerCodeFromError(error) !== TEMPLATE_MAPPING_MISSING_PROVIDER_CODE) throw error;
+        }
+      }
       const sent = requireSent(
         await params.whatsapp.sendTemplate(
           target,

--- a/packages/server/src/operational-alerts/worker.ts
+++ b/packages/server/src/operational-alerts/worker.ts
@@ -178,7 +178,7 @@ export class OperationalAlertWorker {
         const settings = await this.params.settings.get();
         const orgName = settings?.org_name?.trim() || "your organisation";
         const botName = settings?.bot_name?.trim() || "Sketch";
-        const rendered = definition.render(alert, { orgName, botName });
+        const rendered = await definition.render(alert, { orgName, botName, recipientName: recipient.name });
         const sent = await transport.send({
           alert,
           recipient: { id: recipient.id, name: recipient.name, destination },

--- a/packages/server/src/whatsapp/providers/wati.ts
+++ b/packages/server/src/whatsapp/providers/wati.ts
@@ -161,7 +161,9 @@ export function createWatiWhatsAppProvider(config: WatiWhatsAppConfig): WatiWhat
       template.language,
     );
     if (!mapping) {
-      throw new Error(`No approved WhatsApp template mapping configured for ${template.key}`);
+      throw Object.assign(new Error(`No approved WhatsApp template mapping configured for ${template.key}`), {
+        providerCode: "template_not_found",
+      });
     }
 
     const phone = targetPhoneDigits(target);

--- a/packages/server/src/whatsapp/template-params.test.ts
+++ b/packages/server/src/whatsapp/template-params.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeTemplateParamValue } from "./template-params";
+import { mapTemplateParams, sanitizeTemplateParamValue } from "./template-params";
+import { buildReconnectNotificationTemplate } from "./templates";
 
 describe("sanitizeTemplateParamValue", () => {
   it("replaces newlines and tabs with spaces", () => {
@@ -31,5 +32,24 @@ describe("sanitizeTemplateParamValue", () => {
     expect(result.startsWith("first second  xxx")).toBe(true);
     expect(result).not.toMatch(/[\n\r\t]/u);
     expect(result).not.toMatch(/ {3,}/u);
+  });
+});
+
+describe("mapTemplateParams", () => {
+  it("binds the reconnect notification params to the approved provider placeholders in order", () => {
+    const template = buildReconnectNotificationTemplate({
+      recipientName: "Ashish",
+      phoneNumber: "+91 9980470200",
+      reconnectUrl: "https://goosebumps.getsketch.ai/channels",
+      fallbackText: "fallback",
+    });
+
+    expect(
+      mapTemplateParams({ "1": "recipientName", "2": "phoneNumber", "3": "reconnectUrl" }, template.params),
+    ).toEqual([
+      ["1", "Ashish"],
+      ["2", "+91 9980470200"],
+      ["3", "https://goosebumps.getsketch.ai/channels"],
+    ]);
   });
 });

--- a/packages/server/src/whatsapp/templates.ts
+++ b/packages/server/src/whatsapp/templates.ts
@@ -3,6 +3,7 @@ export const WHATSAPP_TEMPLATE_KEYS = {
   taskNudge: "whatsapp.task_nudge",
   magicLink: "whatsapp.magic_link",
   introduction: "whatsapp.introduction",
+  reconnectNotification: "whatsapp.reconnect_notification",
 } as const;
 
 export type WhatsAppTemplateKey = (typeof WHATSAPP_TEMPLATE_KEYS)[keyof typeof WHATSAPP_TEMPLATE_KEYS] | string;
@@ -31,6 +32,31 @@ export function buildProactiveUpdateTemplate(params: {
       messageSummary: params.messageSummary,
     },
     fallbackText: params.fallbackText ?? params.messageSummary,
+    language: params.language,
+  };
+}
+
+/**
+ * Matches the Meta-approved `whatsapp_reconnect_notification` provider template:
+ * "Hi {{1}}, your WhatsApp connection for {{2}} needs a quick reconnect. Please rescan
+ * the QR code on {{3}} to restore the group updates." Provider mappings bind the
+ * numbered placeholders to the logical params recipientName, phoneNumber, reconnectUrl.
+ */
+export function buildReconnectNotificationTemplate(params: {
+  recipientName?: string | null;
+  phoneNumber: string;
+  reconnectUrl: string;
+  fallbackText: string;
+  language?: string;
+}): WhatsAppTemplateRequest {
+  return {
+    key: WHATSAPP_TEMPLATE_KEYS.reconnectNotification,
+    params: {
+      recipientName: params.recipientName ?? "there",
+      phoneNumber: params.phoneNumber,
+      reconnectUrl: params.reconnectUrl,
+    },
+    fallbackText: params.fallbackText,
     language: params.language,
   };
 }


### PR DESCRIPTION
## What & Why

WhatsApp disconnect alerts were sent to admins as raw technical logs (status codes, Baileys jargon, ISO timestamps). This reads like a software bug to the end user. This PR replaces the copy with plain language and a direct reconnect link, and uses the Meta-approved WATI template `whatsapp_reconnect_notification` when the alert has to go out as a template (outside the 24h customer service window).

Closes SKE-309.

## How

- New logical template key `whatsapp.reconnect_notification` with builder (params: recipientName, phoneNumber, reconnectUrl matching the approved {{1}}/{{2}}/{{3}} placeholders)
- Alert definitions can now return a purpose-built template; the WhatsApp alert transport prefers it over the generic proactive-update template
- New copy: "Hi {name}, your WhatsApp connection for {number} needs a quick reconnect. Please rescan the QR code on {url} to restore the group updates." Recovered variant has no jargon either
- Reconnect URL is built from `BASE_URL` + `/channels` (the page with the QR rescan). Missing or malformed `BASE_URL` falls back to describing the location in words
- Connected phone number comes from `whatsapp.pairing.status()`; lookup failure degrades to the org name label (the lookup can fail exactly when the alert fires)
- If the template mapping row is not provisioned yet, the transport falls back to the generic proactive-update template on `template_not_found` instead of letting the delivery retry to death

## Ops step after rollout

Upsert the platform-global mapping once via `PUT /api/managed-whatsapp/template-mappings`: logical key `whatsapp.reconnect_notification`, provider template `whatsapp_reconnect_notification`, parameter map `{"1": "recipientName", "2": "phoneNumber", "3": "reconnectUrl"}`. Habuild is intentionally skipped (own WATI account).

## Testing

- Exact-copy render tests plus a no-jargon regression test (rejects Baileys/status code/ISO date patterns)
- Transport tests: template preference, in-window text still wins, `window_expired` fallback uses the reconnect template, `template_not_found` falls back to the generic template, other errors propagate
- Provider-level placeholder ordering test via `mapTemplateParams`
- Full suite: biome, typecheck, unit + integration, build