### PR TITLE
fix: enforce managed onboarding readiness

### DIFF
--- a/packages/server/src/api/middleware.ts
+++ b/packages/server/src/api/middleware.ts
@@ -52,7 +52,7 @@ export interface AuthMiddlewareOpts {
   managedUrl?: string;
   findUserByEmail?: (email: string) => Promise<{ id: string; authRole?: string | null; email?: string | null } | null>;
   verifySketchApiKey?: (token: string) => Promise<boolean>;
-  hasLocalAdmin?: () => Promise<boolean>;
+  hasSetupAdmin?: () => Promise<boolean>;
   resolveLocalSessionUser?: (
     sub: string,
   ) => Promise<{ id: string; authRole?: string | null; email?: string | null } | null>;
@@ -109,7 +109,7 @@ export function createAuthMiddleware(settings: SettingsRepo, opts?: AuthMiddlewa
     try {
       const row = await settings.get();
       setupComplete = Boolean(row?.onboarding_completed_at);
-      hasAdmin = opts?.hasLocalAdmin ? await opts.hasLocalAdmin() : Boolean(row?.admin_email);
+      hasAdmin = opts?.hasSetupAdmin ? await opts.hasSetupAdmin() : Boolean(row?.admin_email);
       jwtSecret = row?.jwt_secret ?? null;
       if (jwtSecret) cachedSecret = jwtSecret;
       adminCanReadAllFiles = row?.admin_can_read_all_files === 1;

--- a/packages/server/src/api/onboarding-readiness.test.ts
+++ b/packages/server/src/api/onboarding-readiness.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingReadiness } from "./onboarding-readiness";
+
+type SettingsRow = NonNullable<Parameters<typeof getOnboardingReadiness>[0]>;
+
+function readySettings(overrides: Partial<SettingsRow> = {}): SettingsRow {
+  return {
+    admin_email: "admin@test.com",
+    org_name: "Acme",
+    bot_name: "Sketch",
+    llm_provider: null,
+    anthropic_api_key: null,
+    aws_access_key_id: null,
+    aws_secret_access_key: null,
+    aws_region: null,
+    model_id: null,
+    ...overrides,
+  } as SettingsRow;
+}
+
+describe("getOnboardingReadiness", () => {
+  it.each([
+    ["Anthropic", { ANTHROPIC_API_KEY: "sk-ant-env" }],
+    ["Bedrock with ambient AWS credentials", { CLAUDE_CODE_USE_BEDROCK: "1" }],
+    ["Vertex", { CLAUDE_CODE_USE_VERTEX: "1" }],
+    [
+      "a custom Anthropic endpoint",
+      {
+        ANTHROPIC_BASE_URL: "https://anthropic-gateway.example.com",
+        ANTHROPIC_AUTH_TOKEN: "gateway-token",
+        ANTHROPIC_MODEL: "gateway-model",
+      },
+    ],
+  ])("counts environment-backed %s configuration as ready", (_name, env) => {
+    expect(getOnboardingReadiness(readySettings(), undefined, env)).toMatchObject({
+      hasLlm: true,
+      readyToComplete: true,
+      missing: [],
+    });
+  });
+
+  it("still rejects an incomplete environment-backed configuration", () => {
+    expect(
+      getOnboardingReadiness(readySettings(), undefined, {
+        ANTHROPIC_BASE_URL: "https://anthropic-gateway.example.com",
+        ANTHROPIC_AUTH_TOKEN: "gateway-token",
+      }),
+    ).toMatchObject({
+      hasLlm: false,
+      readyToComplete: false,
+      missing: ["llm"],
+    });
+  });
+});

--- a/packages/server/src/api/onboarding-readiness.test.ts
+++ b/packages/server/src/api/onboarding-readiness.test.ts
@@ -20,9 +20,9 @@ function readySettings(overrides: Partial<SettingsRow> = {}): SettingsRow {
 
 describe("getOnboardingReadiness", () => {
   it.each([
-    ["Anthropic", { ANTHROPIC_API_KEY: "sk-ant-env" }],
-    ["Bedrock with ambient AWS credentials", { CLAUDE_CODE_USE_BEDROCK: "1" }],
-    ["Vertex", { CLAUDE_CODE_USE_VERTEX: "1" }],
+    ["Anthropic", { ANTHROPIC_API_KEY: "sk-ant-env" }, "anthropic"],
+    ["Bedrock with ambient AWS credentials", { CLAUDE_CODE_USE_BEDROCK: "1" }, "bedrock"],
+    ["Vertex", { CLAUDE_CODE_USE_VERTEX: "1" }, "vertex"],
     [
       "a custom Anthropic endpoint",
       {
@@ -30,10 +30,12 @@ describe("getOnboardingReadiness", () => {
         ANTHROPIC_AUTH_TOKEN: "gateway-token",
         ANTHROPIC_MODEL: "gateway-model",
       },
+      "anthropic",
     ],
-  ])("counts environment-backed %s configuration as ready", (_name, env) => {
+  ])("counts environment-backed %s configuration as ready", (_name, env, llmProvider) => {
     expect(getOnboardingReadiness(readySettings(), undefined, env)).toMatchObject({
       hasLlm: true,
+      llmProvider,
       readyToComplete: true,
       missing: [],
     });

--- a/packages/server/src/api/onboarding-readiness.test.ts
+++ b/packages/server/src/api/onboarding-readiness.test.ts
@@ -53,4 +53,40 @@ describe("getOnboardingReadiness", () => {
       missing: ["llm"],
     });
   });
+
+  it("rejects incomplete persisted Bedrock settings without ambient Bedrock routing", () => {
+    expect(
+      getOnboardingReadiness(
+        readySettings({
+          llm_provider: "bedrock",
+          model_id: "us.anthropic.claude-sonnet-4-6",
+        }),
+        undefined,
+        {},
+      ),
+    ).toMatchObject({
+      hasLlm: false,
+      llmProvider: null,
+      readyToComplete: false,
+      missing: ["llm"],
+    });
+  });
+
+  it("uses ambient Bedrock routing when persisted Bedrock settings are incomplete", () => {
+    expect(
+      getOnboardingReadiness(
+        readySettings({
+          llm_provider: "bedrock",
+          model_id: "us.anthropic.claude-sonnet-4-6",
+        }),
+        undefined,
+        { CLAUDE_CODE_USE_BEDROCK: "1" },
+      ),
+    ).toMatchObject({
+      hasLlm: true,
+      llmProvider: "bedrock",
+      readyToComplete: true,
+      missing: [],
+    });
+  });
 });

--- a/packages/server/src/api/onboarding-readiness.test.ts
+++ b/packages/server/src/api/onboarding-readiness.test.ts
@@ -89,4 +89,22 @@ describe("getOnboardingReadiness", () => {
       missing: [],
     });
   });
+
+  it("rejects a different ambient provider when persisted settings select Bedrock", () => {
+    expect(
+      getOnboardingReadiness(
+        readySettings({
+          llm_provider: "bedrock",
+          model_id: "us.anthropic.claude-sonnet-4-6",
+        }),
+        undefined,
+        { ANTHROPIC_API_KEY: "sk-ant-env" },
+      ),
+    ).toMatchObject({
+      hasLlm: false,
+      llmProvider: null,
+      readyToComplete: false,
+      missing: ["llm"],
+    });
+  });
 });

--- a/packages/server/src/api/onboarding-readiness.ts
+++ b/packages/server/src/api/onboarding-readiness.ts
@@ -1,3 +1,4 @@
+import { resolveAgentRuntimeProviderConfigFromSettings } from "../agent/runtime/provider";
 import type { createSettingsRepository } from "../db/repositories/settings";
 
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
@@ -13,16 +14,14 @@ export interface OnboardingReadiness {
   missing: OnboardingPrerequisite[];
 }
 
-export function getOnboardingReadiness(row: SettingsRow, hasAdminUser?: boolean): OnboardingReadiness {
+export function getOnboardingReadiness(
+  row: SettingsRow,
+  hasAdminUser?: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): OnboardingReadiness {
   const hasAdmin = hasAdminUser ?? Boolean(row?.admin_email?.trim());
   const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
-  const hasAnthropic = row?.llm_provider === "anthropic" && Boolean(row?.anthropic_api_key?.trim());
-  const hasBedrock =
-    row?.llm_provider === "bedrock" &&
-    Boolean(row?.aws_access_key_id?.trim() && row?.aws_secret_access_key?.trim() && row?.aws_region?.trim());
-  const hasOpenRouter =
-    row?.llm_provider === "openrouter" && Boolean(row?.anthropic_api_key?.trim() && row?.model_id?.trim());
-  const hasLlm = hasAnthropic || hasBedrock || hasOpenRouter;
+  const hasLlm = Boolean(resolveAgentRuntimeProviderConfigFromSettings(row ?? null, env));
   const missing: OnboardingPrerequisite[] = [];
 
   if (!hasAdmin) missing.push("admin");

--- a/packages/server/src/api/onboarding-readiness.ts
+++ b/packages/server/src/api/onboarding-readiness.ts
@@ -29,6 +29,16 @@ function hasCompletePersistedLlmSettings(row: SettingsRow): boolean {
   return false;
 }
 
+function resolveReadinessLlmConfig(row: SettingsRow, env: NodeJS.ProcessEnv) {
+  const runtimeConfig = resolveAgentRuntimeProviderConfigFromSettings(row ?? null, env);
+  if (!row?.llm_provider || hasCompletePersistedLlmSettings(row)) {
+    return runtimeConfig;
+  }
+
+  const environmentConfig = resolveAgentRuntimeProviderConfigFromSettings(null, env);
+  return environmentConfig?.provider === row.llm_provider ? runtimeConfig : null;
+}
+
 export function getOnboardingReadiness(
   row: SettingsRow,
   hasAdminUser?: boolean,
@@ -36,9 +46,7 @@ export function getOnboardingReadiness(
 ): OnboardingReadiness {
   const hasAdmin = hasAdminUser ?? Boolean(row?.admin_email?.trim());
   const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
-  const llmConfig = hasCompletePersistedLlmSettings(row)
-    ? resolveAgentRuntimeProviderConfigFromSettings(row ?? null, env)
-    : resolveAgentRuntimeProviderConfigFromSettings(null, env);
+  const llmConfig = resolveReadinessLlmConfig(row, env);
   const hasLlm = Boolean(llmConfig);
   const missing: OnboardingPrerequisite[] = [];
 

--- a/packages/server/src/api/onboarding-readiness.ts
+++ b/packages/server/src/api/onboarding-readiness.ts
@@ -1,3 +1,4 @@
+import type { AgentRuntimeProviderKind } from "../agent/runtime/contracts";
 import { resolveAgentRuntimeProviderConfigFromSettings } from "../agent/runtime/provider";
 import type { createSettingsRepository } from "../db/repositories/settings";
 
@@ -10,6 +11,7 @@ export interface OnboardingReadiness {
   hasAdmin: boolean;
   hasIdentity: boolean;
   hasLlm: boolean;
+  llmProvider: AgentRuntimeProviderKind | null;
   readyToComplete: boolean;
   missing: OnboardingPrerequisite[];
 }
@@ -21,7 +23,8 @@ export function getOnboardingReadiness(
 ): OnboardingReadiness {
   const hasAdmin = hasAdminUser ?? Boolean(row?.admin_email?.trim());
   const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
-  const hasLlm = Boolean(resolveAgentRuntimeProviderConfigFromSettings(row ?? null, env));
+  const llmConfig = resolveAgentRuntimeProviderConfigFromSettings(row ?? null, env);
+  const hasLlm = Boolean(llmConfig);
   const missing: OnboardingPrerequisite[] = [];
 
   if (!hasAdmin) missing.push("admin");
@@ -32,6 +35,7 @@ export function getOnboardingReadiness(
     hasAdmin,
     hasIdentity,
     hasLlm,
+    llmProvider: llmConfig?.provider ?? null,
     readyToComplete: missing.length === 0,
     missing,
   };

--- a/packages/server/src/api/onboarding-readiness.ts
+++ b/packages/server/src/api/onboarding-readiness.ts
@@ -13,8 +13,8 @@ export interface OnboardingReadiness {
   missing: OnboardingPrerequisite[];
 }
 
-export function getOnboardingReadiness(row: SettingsRow, hasAdminUser = false): OnboardingReadiness {
-  const hasAdmin = hasAdminUser || Boolean(row?.admin_email?.trim());
+export function getOnboardingReadiness(row: SettingsRow, hasAdminUser?: boolean): OnboardingReadiness {
+  const hasAdmin = hasAdminUser ?? Boolean(row?.admin_email?.trim());
   const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
   const hasAnthropic = row?.llm_provider === "anthropic" && Boolean(row?.anthropic_api_key?.trim());
   const hasBedrock =

--- a/packages/server/src/api/onboarding-readiness.ts
+++ b/packages/server/src/api/onboarding-readiness.ts
@@ -13,8 +13,8 @@ export interface OnboardingReadiness {
   missing: OnboardingPrerequisite[];
 }
 
-export function getOnboardingReadiness(row: SettingsRow, hasLocalAdmin = false): OnboardingReadiness {
-  const hasAdmin = hasLocalAdmin || Boolean(row?.admin_email?.trim());
+export function getOnboardingReadiness(row: SettingsRow, hasAdminUser = false): OnboardingReadiness {
+  const hasAdmin = hasAdminUser || Boolean(row?.admin_email?.trim());
   const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
   const hasAnthropic = row?.llm_provider === "anthropic" && Boolean(row?.anthropic_api_key?.trim());
   const hasBedrock =

--- a/packages/server/src/api/onboarding-readiness.ts
+++ b/packages/server/src/api/onboarding-readiness.ts
@@ -1,0 +1,39 @@
+import type { createSettingsRepository } from "../db/repositories/settings";
+
+type SettingsRepo = ReturnType<typeof createSettingsRepository>;
+type SettingsRow = Awaited<ReturnType<SettingsRepo["get"]>>;
+
+export type OnboardingPrerequisite = "admin" | "identity" | "llm";
+
+export interface OnboardingReadiness {
+  hasAdmin: boolean;
+  hasIdentity: boolean;
+  hasLlm: boolean;
+  readyToComplete: boolean;
+  missing: OnboardingPrerequisite[];
+}
+
+export function getOnboardingReadiness(row: SettingsRow, hasLocalAdmin = false): OnboardingReadiness {
+  const hasAdmin = hasLocalAdmin || Boolean(row?.admin_email?.trim());
+  const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
+  const hasAnthropic = row?.llm_provider === "anthropic" && Boolean(row?.anthropic_api_key?.trim());
+  const hasBedrock =
+    row?.llm_provider === "bedrock" &&
+    Boolean(row?.aws_access_key_id?.trim() && row?.aws_secret_access_key?.trim() && row?.aws_region?.trim());
+  const hasOpenRouter =
+    row?.llm_provider === "openrouter" && Boolean(row?.anthropic_api_key?.trim() && row?.model_id?.trim());
+  const hasLlm = hasAnthropic || hasBedrock || hasOpenRouter;
+  const missing: OnboardingPrerequisite[] = [];
+
+  if (!hasAdmin) missing.push("admin");
+  if (!hasIdentity) missing.push("identity");
+  if (!hasLlm) missing.push("llm");
+
+  return {
+    hasAdmin,
+    hasIdentity,
+    hasLlm,
+    readyToComplete: missing.length === 0,
+    missing,
+  };
+}

--- a/packages/server/src/api/onboarding-readiness.ts
+++ b/packages/server/src/api/onboarding-readiness.ts
@@ -16,6 +16,19 @@ export interface OnboardingReadiness {
   missing: OnboardingPrerequisite[];
 }
 
+function hasCompletePersistedLlmSettings(row: SettingsRow): boolean {
+  if (row?.llm_provider === "anthropic") {
+    return Boolean(row.anthropic_api_key?.trim());
+  }
+  if (row?.llm_provider === "bedrock") {
+    return Boolean(row.aws_access_key_id?.trim() && row.aws_secret_access_key?.trim() && row.aws_region?.trim());
+  }
+  if (row?.llm_provider === "openrouter") {
+    return Boolean(row.anthropic_api_key?.trim() && row.model_id?.trim());
+  }
+  return false;
+}
+
 export function getOnboardingReadiness(
   row: SettingsRow,
   hasAdminUser?: boolean,
@@ -23,7 +36,9 @@ export function getOnboardingReadiness(
 ): OnboardingReadiness {
   const hasAdmin = hasAdminUser ?? Boolean(row?.admin_email?.trim());
   const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
-  const llmConfig = resolveAgentRuntimeProviderConfigFromSettings(row ?? null, env);
+  const llmConfig = hasCompletePersistedLlmSettings(row)
+    ? resolveAgentRuntimeProviderConfigFromSettings(row ?? null, env)
+    : resolveAgentRuntimeProviderConfigFromSettings(null, env);
   const hasLlm = Boolean(llmConfig);
   const missing: OnboardingPrerequisite[] = [];
 

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -2,13 +2,17 @@ import { Hono } from "hono";
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import { createTestDb } from "../test-utils";
 import { setupRoutes } from "./setup";
 
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 
-function createTestSetupApp(settings: SettingsRepo, deps?: { managedUrl?: string }) {
+function createTestSetupApp(
+  settings: SettingsRepo,
+  deps?: { managedUrl?: string; userRepo?: ReturnType<typeof createUserRepository> },
+) {
   const app = new Hono();
   app.route("/api/setup", setupRoutes(settings, deps));
   return app;
@@ -112,6 +116,50 @@ describe("GET /api/setup/status", () => {
       const body = await res.json();
       expect(body.currentStep).toBe(5);
       expect(body.readyToComplete).toBe(true);
+    });
+
+    it("reports a passwordless managed admin as ready", async () => {
+      await settings.create();
+      const userRepo = createUserRepository(db);
+      await userRepo.create({
+        name: "Admin",
+        email: "admin@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "admin",
+      });
+      await settings.update({
+        orgName: "Acme",
+        botName: "Sketch",
+        llmProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
+      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+
+      expect(body.currentStep).toBe(5);
+      expect(body.readyToComplete).toBe(true);
+      expect(body.adminEmail).toBe("admin@test.com");
+    });
+
+    it("completes setup for a passwordless managed admin", async () => {
+      await settings.create();
+      const userRepo = createUserRepository(db);
+      await userRepo.create({
+        name: "Admin",
+        email: "admin@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "admin",
+      });
+      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+
+      const res = await app.request("/api/setup/complete", { method: "POST" });
+
+      expect(res.status).toBe(200);
+      expect((await settings.get())?.onboarding_completed_at).not.toBeNull();
     });
 
     it("does not report ready when an LLM exists without admin or identity", async () => {

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -157,6 +157,24 @@ describe("GET /api/setup/status", () => {
       expect(body.adminEmail).toBe("admin@test.com");
     });
 
+    it("does not report a stale legacy admin when the repository has no admin", async () => {
+      await settings.create({ adminEmail: "legacy-admin@test.com" });
+      await settings.update({
+        orgName: "Acme",
+        botName: "Sketch",
+        llmProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
+      const userRepo = createUserRepository(db);
+      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+
+      expect(body.readyToComplete).toBe(false);
+      expect(body.adminEmail).toBeNull();
+    });
+
     it("completes setup for a passwordless managed admin", async () => {
       await settings.create();
       const userRepo = createUserRepository(db);

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -185,6 +185,54 @@ describe("GET /api/setup/status", () => {
       expect(body.adminEmail).toBe("admin@test.com");
     });
 
+    it("allows a passwordless managed admin to configure identity and LLM settings", async () => {
+      await settings.create();
+      const userRepo = createUserRepository(db);
+      await userRepo.create({
+        name: "Admin",
+        email: "admin@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "admin",
+      });
+      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+
+      const identityRes = await app.request("/api/setup/identity", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgName: "Acme", botName: "Ignored in managed mode" }),
+      });
+      expect(identityRes.status).toBe(200);
+
+      const llmSettings = {
+        provider: "bedrock",
+        awsAccessKeyId: "AKIA-test",
+        awsSecretAccessKey: "secret-test",
+        awsRegion: "ap-south-1",
+      };
+      const verifyRes = await app.request("/api/setup/llm/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(llmSettings),
+      });
+      expect(verifyRes.status).toBe(200);
+
+      const llmRes = await app.request("/api/setup/llm", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(llmSettings),
+      });
+      expect(llmRes.status).toBe(200);
+      expect(await settings.get()).toMatchObject({
+        org_name: "Acme",
+        bot_name: "Sketch",
+        llm_provider: "bedrock",
+        aws_access_key_id: "AKIA-test",
+        aws_secret_access_key: "secret-test",
+        aws_region: "ap-south-1",
+      });
+    });
+
     it("does not report a stale legacy admin when the repository has no admin", async () => {
       await settings.create({ adminEmail: "legacy-admin@test.com" });
       await settings.update({

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -166,7 +166,7 @@ describe("GET /api/setup/status", () => {
       expect(body.readyToComplete).toBe(true);
     });
 
-    it("reports a passwordless managed admin as ready", async () => {
+    it("reports a passwordless managed admin as ready without exposing its email", async () => {
       await settings.create();
       const userRepo = createUserRepository(db);
       await userRepo.create({
@@ -190,7 +190,7 @@ describe("GET /api/setup/status", () => {
       expect(body.currentStep).toBe(5);
       expect(body.readyToComplete).toBe(true);
       expect(body.managed).toBe(true);
-      expect(body.adminEmail).toBe("admin@test.com");
+      expect(body.adminEmail).toBeNull();
     });
 
     it("allows a passwordless managed admin to configure identity and LLM settings", async () => {

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -98,6 +98,34 @@ describe("GET /api/setup/status", () => {
       const body = await res.json();
       expect(body.currentStep).toBe(5);
     });
+
+    it("does not treat a passwordless admin as a configured self-hosted admin", async () => {
+      await settings.create();
+      const userRepo = createUserRepository(db);
+      await userRepo.create({
+        name: "Admin",
+        email: "admin@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "admin",
+      });
+      await settings.update({
+        orgName: "Acme",
+        botName: "Sketch",
+        slackBotToken: "xoxb-test",
+        slackAppToken: "xapp-test",
+        llmProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
+      const app = createTestSetupApp(settings, { userRepo });
+
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+
+      expect(body.currentStep).toBe(4);
+      expect(body.readyToComplete).toBe(false);
+      expect(body.adminEmail).toBeNull();
+    });
   });
 
   describe("managed mode (managedUrl set)", () => {

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -11,7 +11,11 @@ type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 
 function createTestSetupApp(
   settings: SettingsRepo,
-  deps?: { managedUrl?: string; userRepo?: ReturnType<typeof createUserRepository> },
+  deps?: {
+    managedUrl?: string;
+    slackMode?: "socket" | "http";
+    userRepo?: ReturnType<typeof createUserRepository>;
+  },
 ) {
   const app = new Hono();
   app.route("/api/setup", setupRoutes(settings, deps));
@@ -63,6 +67,15 @@ describe("GET /api/setup/status", () => {
       const res = await app.request("/api/setup/status");
       const body = await res.json();
       expect(body.slackConnected).toBe(false);
+    });
+
+    it("reports bot-only Slack connected in HTTP mode", async () => {
+      await settings.create({ adminEmail: "admin@test.com", adminPasswordHash: "hash" });
+      await settings.update({ slackBotToken: "xoxb-test" });
+      const app = createTestSetupApp(settings, { slackMode: "http" });
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+      expect(body.slackConnected).toBe(true);
     });
 
     it("returns currentStep 4 when admin, identity, and slack are set", async () => {
@@ -172,13 +185,22 @@ describe("GET /api/setup/status", () => {
       expect(body.readyToComplete).toBe(false);
     });
 
-    it("treats a managed bot token as a connected Slack installation", async () => {
+    it("treats a managed HTTP bot token as a connected Slack installation", async () => {
       await settings.create({ adminEmail: "admin@test.com", adminPasswordHash: "hash" });
       await settings.update({ slackBotToken: "xoxb-test" });
-      const app = createTestSetupApp(settings, { managedUrl });
+      const app = createTestSetupApp(settings, { managedUrl, slackMode: "http" });
       const res = await app.request("/api/setup/status");
       const body = await res.json();
       expect(body.slackConnected).toBe(true);
+    });
+
+    it("requires an app token for managed Socket Mode", async () => {
+      await settings.create({ adminEmail: "admin@test.com", adminPasswordHash: "hash" });
+      await settings.update({ slackBotToken: "xoxb-test" });
+      const app = createTestSetupApp(settings, { managedUrl, slackMode: "socket" });
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+      expect(body.slackConnected).toBe(false);
     });
   });
 

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -167,12 +167,43 @@ describe("GET /api/setup/status", () => {
         passwordHash: null,
         authRole: "admin",
       });
+      await settings.update({
+        orgName: "Acme",
+        botName: "Sketch",
+        llmProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
       const app = createTestSetupApp(settings, { managedUrl, userRepo });
 
       const res = await app.request("/api/setup/complete", { method: "POST" });
 
       expect(res.status).toBe(200);
       expect((await settings.get())?.onboarding_completed_at).not.toBeNull();
+    });
+
+    it("rejects completion when managed prerequisites are missing", async () => {
+      await settings.create();
+      const userRepo = createUserRepository(db);
+      await userRepo.create({
+        name: "Admin",
+        email: "admin@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "admin",
+      });
+      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+
+      const res = await app.request("/api/setup/complete", { method: "POST" });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({
+        error: {
+          code: "SETUP_INCOMPLETE",
+          message: "Tenant onboarding prerequisites are incomplete",
+          missing: ["identity", "llm"],
+        },
+      });
+      expect((await settings.get())?.onboarding_completed_at).toBeNull();
     });
 
     it("does not report ready when an LLM exists without admin or identity", async () => {

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -12,6 +12,7 @@ type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 function createTestSetupApp(
   settings: SettingsRepo,
   deps?: {
+    managedAuthEnabled?: boolean;
     managedUrl?: string;
     slackMode?: "socket" | "http";
     userRepo?: ReturnType<typeof createUserRepository>;
@@ -175,7 +176,7 @@ describe("GET /api/setup/status", () => {
         llmProvider: "anthropic",
         anthropicApiKey: "sk-ant-test",
       });
-      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+      const app = createTestSetupApp(settings, { managedAuthEnabled: true, userRepo });
 
       const res = await app.request("/api/setup/status");
       const body = await res.json();
@@ -195,7 +196,7 @@ describe("GET /api/setup/status", () => {
         passwordHash: null,
         authRole: "admin",
       });
-      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+      const app = createTestSetupApp(settings, { managedAuthEnabled: true, userRepo });
 
       const identityRes = await app.request("/api/setup/identity", {
         method: "POST",
@@ -242,7 +243,7 @@ describe("GET /api/setup/status", () => {
         anthropicApiKey: "sk-ant-test",
       });
       const userRepo = createUserRepository(db);
-      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+      const app = createTestSetupApp(settings, { managedAuthEnabled: true, userRepo });
 
       const res = await app.request("/api/setup/status");
       const body = await res.json();
@@ -267,7 +268,7 @@ describe("GET /api/setup/status", () => {
         llmProvider: "anthropic",
         anthropicApiKey: "sk-ant-test",
       });
-      const app = createTestSetupApp(settings, { managedUrl, userRepo });
+      const app = createTestSetupApp(settings, { managedAuthEnabled: true, userRepo });
 
       const res = await app.request("/api/setup/complete", { method: "POST" });
 

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -42,6 +42,7 @@ describe("GET /api/setup/status", () => {
       const res = await app.request("/api/setup/status");
       const body = await res.json();
       expect(body.currentStep).toBe(0);
+      expect(body.managed).toBe(false);
     });
 
     it("returns currentStep 2 when admin exists", async () => {
@@ -183,6 +184,7 @@ describe("GET /api/setup/status", () => {
 
       expect(body.currentStep).toBe(5);
       expect(body.readyToComplete).toBe(true);
+      expect(body.managed).toBe(true);
       expect(body.adminEmail).toBe("admin@test.com");
     });
 

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -19,6 +19,10 @@ function createTestSetupApp(
   },
 ) {
   const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("role", "admin");
+    await next();
+  });
   app.route("/api/setup", setupRoutes(settings, deps));
   return app;
 }
@@ -78,6 +82,7 @@ describe("GET /api/setup/status", () => {
       const res = await app.request("/api/setup/status");
       const body = await res.json();
       expect(body.slackConnected).toBe(true);
+      expect(body.currentStep).toBe(2);
     });
 
     it("returns currentStep 4 when admin, identity, and slack are set", async () => {
@@ -124,7 +129,7 @@ describe("GET /api/setup/status", () => {
       const res = await app.request("/api/setup/status");
       const body = await res.json();
 
-      expect(body.currentStep).toBe(4);
+      expect(body.currentStep).toBe(0);
       expect(body.readyToComplete).toBe(false);
       expect(body.adminEmail).toBeNull();
     });

--- a/packages/server/src/api/setup-managed.test.ts
+++ b/packages/server/src/api/setup-managed.test.ts
@@ -52,6 +52,15 @@ describe("GET /api/setup/status", () => {
       expect(body.currentStep).toBe(3);
     });
 
+    it("does not report Slack connected when only a bot token is configured", async () => {
+      await settings.create({ adminEmail: "admin@test.com", adminPasswordHash: "hash" });
+      await settings.update({ slackBotToken: "xoxb-test" });
+      const app = createTestSetupApp(settings);
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+      expect(body.slackConnected).toBe(false);
+    });
+
     it("returns currentStep 4 when admin, identity, and slack are set", async () => {
       await settings.create({ adminEmail: "admin@test.com", adminPasswordHash: "hash" });
       await settings.update({ orgName: "Acme", botName: "Sketch" });
@@ -102,6 +111,26 @@ describe("GET /api/setup/status", () => {
       const res = await app.request("/api/setup/status");
       const body = await res.json();
       expect(body.currentStep).toBe(5);
+      expect(body.readyToComplete).toBe(true);
+    });
+
+    it("does not report ready when an LLM exists without admin or identity", async () => {
+      await settings.create();
+      await settings.update({ llmProvider: "anthropic", anthropicApiKey: "sk-ant-test" });
+      const app = createTestSetupApp(settings, { managedUrl });
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+      expect(body.currentStep).toBe(0);
+      expect(body.readyToComplete).toBe(false);
+    });
+
+    it("treats a managed bot token as a connected Slack installation", async () => {
+      await settings.create({ adminEmail: "admin@test.com", adminPasswordHash: "hash" });
+      await settings.update({ slackBotToken: "xoxb-test" });
+      const app = createTestSetupApp(settings, { managedUrl });
+      const res = await app.request("/api/setup/status");
+      const body = await res.json();
+      expect(body.slackConnected).toBe(true);
     });
   });
 

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -90,6 +90,10 @@ async function verifyAnthropicApiKey(apiKey: string): Promise<void> {
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 type UserRepo = ReturnType<typeof createUserRepository>;
 
+function findSetupAdmin(userRepo: UserRepo, isManaged: boolean) {
+  return isManaged ? userRepo.findFirstAdmin() : userRepo.findFirstLocalAdmin();
+}
+
 interface SetupDeps {
   managedUrl?: string;
   slackMode?: "socket" | "http";
@@ -160,9 +164,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
    */
   routes.get("/status", async (c) => {
     const row = await settings.get();
-    const adminUser = deps.userRepo
-      ? await (deps.managedUrl ? deps.userRepo.findFirstAdmin() : deps.userRepo.findFirstLocalAdmin())
-      : undefined;
+    const adminUser = deps.userRepo ? await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)) : undefined;
     const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(
       row,
       deps.userRepo ? Boolean(adminUser) : undefined,
@@ -270,7 +272,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.post("/identity", async (c) => {
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await deps.userRepo.findFirstLocalAdmin())
+      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -304,7 +306,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
 
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await deps.userRepo.findFirstLocalAdmin())
+      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -348,7 +350,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.post("/llm/verify", async (c) => {
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await deps.userRepo.findFirstLocalAdmin())
+      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -386,7 +388,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.post("/llm", async (c) => {
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await deps.userRepo.findFirstLocalAdmin())
+      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -433,9 +435,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       return c.json({ success: true });
     }
 
-    const adminUser = deps.userRepo
-      ? await (deps.managedUrl ? deps.userRepo.findFirstAdmin() : deps.userRepo.findFirstLocalAdmin())
-      : undefined;
+    const adminUser = deps.userRepo ? await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)) : undefined;
     const readiness = getOnboardingReadiness(existing, deps.userRepo ? Boolean(adminUser) : undefined);
     if (!readiness.readyToComplete) {
       return c.json(

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -12,6 +12,7 @@ import type { createUserRepository } from "../db/repositories/users";
 import { slackApiCall } from "../slack/api";
 import { createSession } from "./auth";
 import { denyIfNotAdmin } from "./auth-helpers";
+import { getOnboardingReadiness } from "./onboarding-readiness";
 
 async function verifySlackTokens(botToken: string, appToken: string): Promise<{ workspaceName?: string }> {
   const auth = await slackApiCall(botToken, "auth.test");
@@ -159,24 +160,16 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.get("/status", async (c) => {
     const row = await settings.get();
     const adminUser = deps.userRepo ? await deps.userRepo.findFirstLocalAdmin() : undefined;
-    const hasAdmin = Boolean(adminUser ?? row?.admin_email);
-    const hasIdentity = Boolean(row?.org_name?.trim() && row?.bot_name?.trim());
-    const hasSlack = Boolean(row?.slack_bot_token?.trim() && row?.slack_app_token?.trim());
-    const hasAnthropic = row?.llm_provider === "anthropic" && Boolean(row?.anthropic_api_key?.trim());
-    const hasBedrock =
-      row?.llm_provider === "bedrock" &&
-      Boolean(row?.aws_access_key_id?.trim() && row?.aws_secret_access_key?.trim() && row?.aws_region?.trim());
-    const hasOpenRouter =
-      row?.llm_provider === "openrouter" && Boolean(row?.anthropic_api_key?.trim() && row?.model_id?.trim());
-    const hasLlm = Boolean(hasAnthropic || hasBedrock || hasOpenRouter);
+    const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(row, Boolean(adminUser));
+    const isManaged = Boolean(deps.managedUrl);
+    const hasSlack = Boolean(row?.slack_bot_token?.trim() && (isManaged || row?.slack_app_token?.trim()));
     const provider = row?.llm_provider;
     const llmProvider = isLlmProvider(provider) ? provider : null;
     const isCompleted = Boolean(row?.onboarding_completed_at);
-    const isManaged = Boolean(deps.managedUrl);
     let currentStep: number;
     if (isCompleted) {
       currentStep = 5;
-    } else if (hasLlm) {
+    } else if (readyToComplete) {
       currentStep = 5;
     } else if (isManaged) {
       currentStep = hasIdentity ? 4 : hasAdmin ? 2 : 0;
@@ -185,6 +178,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
     }
     return c.json({
       completed: isCompleted,
+      readyToComplete,
       currentStep,
       adminEmail: adminUser?.email ?? row?.admin_email ?? null,
       orgName: row?.org_name ?? null,

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -161,7 +161,10 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.get("/status", async (c) => {
     const row = await settings.get();
     const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
-    const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(row, Boolean(adminUser));
+    const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(
+      row,
+      deps.userRepo ? Boolean(adminUser) : undefined,
+    );
     const isManaged = Boolean(deps.managedUrl);
     const hasSlack = Boolean(
       row?.slack_bot_token?.trim() && ((deps.slackMode ?? "socket") === "http" || row?.slack_app_token?.trim()),
@@ -183,7 +186,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       completed: isCompleted,
       readyToComplete,
       currentStep,
-      adminEmail: adminUser?.email ?? row?.admin_email ?? null,
+      adminEmail: deps.userRepo ? (adminUser?.email ?? null) : (row?.admin_email ?? null),
       orgName: row?.org_name ?? null,
       botName: row?.bot_name ?? "Sketch",
       slackConnected: hasSlack,
@@ -429,7 +432,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
     }
 
     const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
-    const readiness = getOnboardingReadiness(existing, Boolean(adminUser));
+    const readiness = getOnboardingReadiness(existing, deps.userRepo ? Boolean(adminUser) : undefined);
     if (!readiness.readyToComplete) {
       return c.json(
         {

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -95,6 +95,7 @@ function findSetupAdmin(userRepo: UserRepo, isManaged: boolean) {
 }
 
 interface SetupDeps {
+  managedAuthEnabled?: boolean;
   managedUrl?: string;
   slackMode?: "socket" | "http";
   onSlackTokensUpdated?: (tokens?: { botToken: string; appToken: string }) => Promise<void>;
@@ -156,6 +157,7 @@ async function upsertSetupAdmin(userRepo: UserRepo, email: string, passwordHash:
 
 export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   const routes = new Hono();
+  const isManaged = deps.managedAuthEnabled ?? Boolean(deps.managedUrl);
 
   /**
    * Reports onboarding progress as a step index. Self-hosted runs the full flow
@@ -164,12 +166,11 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
    */
   routes.get("/status", async (c) => {
     const row = await settings.get();
-    const adminUser = deps.userRepo ? await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)) : undefined;
+    const adminUser = deps.userRepo ? await findSetupAdmin(deps.userRepo, isManaged) : undefined;
     const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(
       row,
       deps.userRepo ? Boolean(adminUser) : undefined,
     );
-    const isManaged = Boolean(deps.managedUrl);
     const hasSlack = Boolean(
       row?.slack_bot_token?.trim() && ((deps.slackMode ?? "socket") === "http" || row?.slack_app_token?.trim()),
     );
@@ -205,7 +206,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
     const denied = denyIfNotAdmin(c);
     if (denied) return denied;
 
-    if (deps.managedUrl) {
+    if (isManaged) {
       return c.json({ error: { code: "FORBIDDEN", message: "Slack is managed via Marketplace" } }, 403);
     }
 
@@ -272,7 +273,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.post("/identity", async (c) => {
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
+      ? Boolean(await findSetupAdmin(deps.userRepo, isManaged))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -290,7 +291,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
 
     await settings.update({
       orgName: parsed.data.orgName.trim(),
-      botName: deps.managedUrl ? "Sketch" : parsed.data.botName.trim(),
+      botName: isManaged ? "Sketch" : parsed.data.botName.trim(),
     });
 
     return c.json({ success: true });
@@ -300,13 +301,13 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
     const denied = denyIfNotAdmin(c);
     if (denied) return denied;
 
-    if (deps.managedUrl) {
+    if (isManaged) {
       return c.json({ error: { code: "FORBIDDEN", message: "Slack is managed via Marketplace" } }, 403);
     }
 
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
+      ? Boolean(await findSetupAdmin(deps.userRepo, isManaged))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -350,7 +351,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.post("/llm/verify", async (c) => {
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
+      ? Boolean(await findSetupAdmin(deps.userRepo, isManaged))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -388,7 +389,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.post("/llm", async (c) => {
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
-      ? Boolean(await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)))
+      ? Boolean(await findSetupAdmin(deps.userRepo, isManaged))
       : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
@@ -435,7 +436,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       return c.json({ success: true });
     }
 
-    const adminUser = deps.userRepo ? await findSetupAdmin(deps.userRepo, Boolean(deps.managedUrl)) : undefined;
+    const adminUser = deps.userRepo ? await findSetupAdmin(deps.userRepo, isManaged) : undefined;
     const readiness = getOnboardingReadiness(existing, deps.userRepo ? Boolean(adminUser) : undefined);
     if (!readiness.readyToComplete) {
       return c.json(

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -92,6 +92,7 @@ type UserRepo = ReturnType<typeof createUserRepository>;
 
 interface SetupDeps {
   managedUrl?: string;
+  slackMode?: "socket" | "http";
   onSlackTokensUpdated?: (tokens?: { botToken: string; appToken: string }) => Promise<void>;
   onLlmSettingsUpdated?: () => Promise<void>;
   userRepo?: UserRepo;
@@ -162,7 +163,9 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
     const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
     const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(row, Boolean(adminUser));
     const isManaged = Boolean(deps.managedUrl);
-    const hasSlack = Boolean(row?.slack_bot_token?.trim() && (isManaged || row?.slack_app_token?.trim()));
+    const hasSlack = Boolean(
+      row?.slack_bot_token?.trim() && ((deps.slackMode ?? "socket") === "http" || row?.slack_app_token?.trim()),
+    );
     const provider = row?.llm_provider;
     const llmProvider = isLlmProvider(provider) ? provider : null;
     const isCompleted = Boolean(row?.onboarding_completed_at);

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -182,10 +182,14 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       currentStep = 5;
     } else if (readyToComplete) {
       currentStep = 5;
+    } else if (!hasAdmin) {
+      currentStep = 0;
+    } else if (!hasIdentity) {
+      currentStep = 2;
     } else if (isManaged) {
-      currentStep = hasIdentity ? 4 : hasAdmin ? 2 : 0;
+      currentStep = 4;
     } else {
-      currentStep = hasSlack ? 4 : hasIdentity ? 3 : hasAdmin ? 2 : 0;
+      currentStep = hasSlack ? 4 : 3;
     }
     return c.json({
       completed: isCompleted,
@@ -272,6 +276,9 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   });
 
   routes.post("/identity", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
       ? Boolean(await findSetupAdmin(deps.userRepo, isManaged))
@@ -350,6 +357,9 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   });
 
   routes.post("/llm/verify", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
       ? Boolean(await findSetupAdmin(deps.userRepo, isManaged))
@@ -388,6 +398,9 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   });
 
   routes.post("/llm", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
     const existing = await settings.get();
     const hasAdmin = deps.userRepo
       ? Boolean(await findSetupAdmin(deps.userRepo, isManaged))
@@ -432,6 +445,9 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   });
 
   routes.post("/complete", async (c) => {
+    const denied = denyIfNotAdmin(c);
+    if (denied) return denied;
+
     const existing = await settings.get();
     if (existing?.onboarding_completed_at) {
       return c.json({ success: true });

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -196,7 +196,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       readyToComplete,
       managed: isManaged,
       currentStep,
-      adminEmail: deps.userRepo ? (adminUser?.email ?? null) : (row?.admin_email ?? null),
+      adminEmail: isManaged ? null : deps.userRepo ? (adminUser?.email ?? null) : (row?.admin_email ?? null),
       orgName: row?.org_name ?? null,
       botName: row?.bot_name ?? "Sketch",
       slackConnected: hasSlack,

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -424,10 +424,21 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
 
   routes.post("/complete", async (c) => {
     const existing = await settings.get();
-    const hasAdmin = deps.userRepo ? Boolean(await deps.userRepo.findFirstAdmin()) : Boolean(existing?.admin_email);
-    if (!hasAdmin) {
+    if (existing?.onboarding_completed_at) {
+      return c.json({ success: true });
+    }
+
+    const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
+    const readiness = getOnboardingReadiness(existing, Boolean(adminUser));
+    if (!readiness.readyToComplete) {
       return c.json(
-        { error: { code: "SETUP_INCOMPLETE", message: "Admin account must be created before completing setup" } },
+        {
+          error: {
+            code: "SETUP_INCOMPLETE",
+            message: "Tenant onboarding prerequisites are incomplete",
+            missing: readiness.missing,
+          },
+        },
         409,
       );
     }

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -3,7 +3,6 @@
  * Only status/account are public; subsequent setup steps require auth.
  */
 import { randomBytes } from "node:crypto";
-import { isLlmProvider } from "@sketch/shared";
 import { Hono } from "hono";
 import { z } from "zod";
 import { hashPassword } from "../auth/password";
@@ -167,15 +166,13 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
   routes.get("/status", async (c) => {
     const row = await settings.get();
     const adminUser = deps.userRepo ? await findSetupAdmin(deps.userRepo, isManaged) : undefined;
-    const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(
+    const { hasAdmin, hasIdentity, hasLlm, llmProvider, readyToComplete } = getOnboardingReadiness(
       row,
       deps.userRepo ? Boolean(adminUser) : undefined,
     );
     const hasSlack = Boolean(
       row?.slack_bot_token?.trim() && ((deps.slackMode ?? "socket") === "http" || row?.slack_app_token?.trim()),
     );
-    const provider = row?.llm_provider;
-    const llmProvider = isLlmProvider(provider) ? provider : null;
     const isCompleted = Boolean(row?.onboarding_completed_at);
     let currentStep: number;
     if (isCompleted) {

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -190,6 +190,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
     return c.json({
       completed: isCompleted,
       readyToComplete,
+      managed: isManaged,
       currentStep,
       adminEmail: deps.userRepo ? (adminUser?.email ?? null) : (row?.admin_email ?? null),
       orgName: row?.org_name ?? null,

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -160,7 +160,9 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
    */
   routes.get("/status", async (c) => {
     const row = await settings.get();
-    const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
+    const adminUser = deps.userRepo
+      ? await (deps.managedUrl ? deps.userRepo.findFirstAdmin() : deps.userRepo.findFirstLocalAdmin())
+      : undefined;
     const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(
       row,
       deps.userRepo ? Boolean(adminUser) : undefined,
@@ -431,7 +433,9 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       return c.json({ success: true });
     }
 
-    const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
+    const adminUser = deps.userRepo
+      ? await (deps.managedUrl ? deps.userRepo.findFirstAdmin() : deps.userRepo.findFirstLocalAdmin())
+      : undefined;
     const readiness = getOnboardingReadiness(existing, deps.userRepo ? Boolean(adminUser) : undefined);
     if (!readiness.readyToComplete) {
       return c.json(

--- a/packages/server/src/api/setup.ts
+++ b/packages/server/src/api/setup.ts
@@ -159,7 +159,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
    */
   routes.get("/status", async (c) => {
     const row = await settings.get();
-    const adminUser = deps.userRepo ? await deps.userRepo.findFirstLocalAdmin() : undefined;
+    const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
     const { hasAdmin, hasIdentity, hasLlm, readyToComplete } = getOnboardingReadiness(row, Boolean(adminUser));
     const isManaged = Boolean(deps.managedUrl);
     const hasSlack = Boolean(row?.slack_bot_token?.trim() && (isManaged || row?.slack_app_token?.trim()));
@@ -421,9 +421,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
 
   routes.post("/complete", async (c) => {
     const existing = await settings.get();
-    const hasAdmin = deps.userRepo
-      ? Boolean(await deps.userRepo.findFirstLocalAdmin())
-      : Boolean(existing?.admin_email);
+    const hasAdmin = deps.userRepo ? Boolean(await deps.userRepo.findFirstAdmin()) : Boolean(existing?.admin_email);
     if (!hasAdmin) {
       return c.json(
         { error: { code: "SETUP_INCOMPLETE", message: "Admin account must be created before completing setup" } },
@@ -431,9 +429,7 @@ export function setupRoutes(settings: SettingsRepo, deps: SetupDeps = {}) {
       );
     }
 
-    await settings.update({
-      onboardingCompletedAt: new Date().toISOString(),
-    });
+    await settings.completeOnboarding(new Date().toISOString());
 
     return c.json({ success: true });
   });

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -2180,7 +2180,7 @@ describe("POST /api/system/onboarding-introductions", () => {
   });
 });
 
-describe("POST /api/system/onboarding/complete", () => {
+describe("POST /api/system/onboarding/ensure-complete", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
@@ -2196,7 +2196,7 @@ describe("POST /api/system/onboarding/complete", () => {
     const settingsRepo = createSettingsRepository(db);
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET });
 
-    const res = await app.request("/api/system/onboarding/complete", {
+    const res = await app.request("/api/system/onboarding/ensure-complete", {
       method: "POST",
     });
 
@@ -2207,7 +2207,7 @@ describe("POST /api/system/onboarding/complete", () => {
     const settingsRepo = createSettingsRepository(db);
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET });
 
-    const res = await app.request("/api/system/onboarding/complete", {
+    const res = await app.request("/api/system/onboarding/ensure-complete", {
       method: "POST",
       headers: { Authorization: "Bearer wrong-secret" },
     });
@@ -2215,12 +2215,75 @@ describe("POST /api/system/onboarding/complete", () => {
     expect(res.status).toBe(401);
   });
 
-  it("sets onboarding_completed_at in settings", async () => {
+  it("returns 409 without changing settings when prerequisites are incomplete", async () => {
     const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+
+    const res = await app.request("/api/system/onboarding/ensure-complete", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "SETUP_INCOMPLETE",
+        message: "Tenant onboarding prerequisites are incomplete",
+        missing: ["identity", "llm"],
+      },
+    });
+
+    expect((await settingsRepo.get())?.onboarding_completed_at).toBeNull();
+  });
+
+  it("sets onboarding_completed_at when all prerequisites are ready", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    await settingsRepo.update({
+      orgName: "Acme",
+      botName: "Sketch",
+      llmProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+    });
+    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+
+    const res = await app.request("/api/system/onboarding/ensure-complete", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, completed: true, changed: true });
+    expect((await settingsRepo.get())?.onboarding_completed_at).not.toBeNull();
+  });
+
+  it("keeps the original completion timestamp when called again", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const originalTimestamp = "2026-07-29T09:52:19.000Z";
+    await settingsRepo.update({ onboardingCompletedAt: originalTimestamp });
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET });
 
-    const before = await settingsRepo.get();
-    expect(before?.onboarding_completed_at).toBeNull();
+    const res = await app.request("/api/system/onboarding/ensure-complete", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, completed: true, changed: false });
+    expect((await settingsRepo.get())?.onboarding_completed_at).toBe(originalTimestamp);
+  });
+
+  it("keeps the existing onboarding/complete endpoint as a validated alias", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    await settingsRepo.update({
+      orgName: "Acme",
+      botName: "Sketch",
+      llmProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+    });
+    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
 
     const res = await app.request("/api/system/onboarding/complete", {
       method: "POST",
@@ -2228,36 +2291,7 @@ describe("POST /api/system/onboarding/complete", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toEqual({ ok: true });
-
-    const after = await settingsRepo.get();
-    expect(after?.onboarding_completed_at).toBeDefined();
-    expect(after?.onboarding_completed_at).not.toBeNull();
-  });
-
-  it("is idempotent: calling again when already completed returns 200", async () => {
-    const settingsRepo = createSettingsRepository(db);
-    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET });
-
-    const res1 = await app.request("/api/system/onboarding/complete", {
-      method: "POST",
-      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
-    });
-    expect(res1.status).toBe(200);
-
-    const afterFirst = await settingsRepo.get();
-    const firstTimestamp = afterFirst?.onboarding_completed_at;
-
-    const res2 = await app.request("/api/system/onboarding/complete", {
-      method: "POST",
-      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
-    });
-    expect(res2.status).toBe(200);
-
-    const afterSecond = await settingsRepo.get();
-    expect(afterSecond?.onboarding_completed_at).toBeDefined();
-    expect(afterSecond?.onboarding_completed_at).not.toBeNull();
+    expect(await res.json()).toEqual({ ok: true, completed: true, changed: true });
   });
 });
 

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -2180,7 +2180,7 @@ describe("POST /api/system/onboarding-introductions", () => {
   });
 });
 
-describe("POST /api/system/onboarding/ensure-complete", () => {
+describe("PUT /api/system/onboarding/completion", () => {
   let db: Kysely<DB>;
 
   beforeEach(async () => {
@@ -2196,8 +2196,8 @@ describe("POST /api/system/onboarding/ensure-complete", () => {
     const settingsRepo = createSettingsRepository(db);
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET });
 
-    const res = await app.request("/api/system/onboarding/ensure-complete", {
-      method: "POST",
+    const res = await app.request("/api/system/onboarding/completion", {
+      method: "PUT",
     });
 
     expect(res.status).toBe(401);
@@ -2207,8 +2207,8 @@ describe("POST /api/system/onboarding/ensure-complete", () => {
     const settingsRepo = createSettingsRepository(db);
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET });
 
-    const res = await app.request("/api/system/onboarding/ensure-complete", {
-      method: "POST",
+    const res = await app.request("/api/system/onboarding/completion", {
+      method: "PUT",
       headers: { Authorization: "Bearer wrong-secret" },
     });
 
@@ -2220,8 +2220,8 @@ describe("POST /api/system/onboarding/ensure-complete", () => {
     const userRepo = createUserRepository(db);
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
 
-    const res = await app.request("/api/system/onboarding/ensure-complete", {
-      method: "POST",
+    const res = await app.request("/api/system/onboarding/completion", {
+      method: "PUT",
       headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
     });
 
@@ -2248,8 +2248,8 @@ describe("POST /api/system/onboarding/ensure-complete", () => {
     });
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
 
-    const res = await app.request("/api/system/onboarding/ensure-complete", {
-      method: "POST",
+    const res = await app.request("/api/system/onboarding/completion", {
+      method: "PUT",
       headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
     });
 
@@ -2258,20 +2258,66 @@ describe("POST /api/system/onboarding/ensure-complete", () => {
     expect((await settingsRepo.get())?.onboarding_completed_at).not.toBeNull();
   });
 
+  it("counts a passwordless managed admin as an onboarding admin", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    const admin = await userRepo.findFirstAdmin();
+    if (!admin) throw new Error("Expected seeded admin");
+    await userRepo.update(admin.id, { passwordHash: null });
+    await settingsRepo.update({
+      orgName: "Acme",
+      botName: "Sketch",
+      llmProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+    });
+    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+
+    const res = await app.request("/api/system/onboarding/completion", {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, completed: true, changed: true });
+  });
+
   it("keeps the original completion timestamp when called again", async () => {
     const settingsRepo = createSettingsRepository(db);
     const originalTimestamp = "2026-07-29T09:52:19.000Z";
     await settingsRepo.update({ onboardingCompletedAt: originalTimestamp });
     const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET });
 
-    const res = await app.request("/api/system/onboarding/ensure-complete", {
-      method: "POST",
+    const res = await app.request("/api/system/onboarding/completion", {
+      method: "PUT",
       headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
     });
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, completed: true, changed: false });
     expect((await settingsRepo.get())?.onboarding_completed_at).toBe(originalTimestamp);
+  });
+
+  it("only reports one change when completion requests race", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    await settingsRepo.update({
+      orgName: "Acme",
+      botName: "Sketch",
+      llmProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+    });
+    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+    const request = () =>
+      app.request("/api/system/onboarding/completion", {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+      });
+
+    const responses = await Promise.all([request(), request()]);
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    expect(bodies.filter((body) => body.changed)).toHaveLength(1);
   });
 
   it("keeps the existing onboarding/complete endpoint as a validated alias", async () => {

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -2237,6 +2237,37 @@ describe("PUT /api/system/onboarding/completion", () => {
     expect((await settingsRepo.get())?.onboarding_completed_at).toBeNull();
   });
 
+  it("does not use legacy admin_email when the user repository has no admin", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    const admin = await userRepo.findFirstAdmin();
+    if (!admin) throw new Error("Expected seeded admin");
+    await userRepo.update(admin.id, { authRole: "member" });
+    await settingsRepo.update({
+      adminEmail: admin.email ?? "admin@test.com",
+      orgName: "Acme",
+      botName: "Sketch",
+      llmProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+    });
+    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+
+    const res = await app.request("/api/system/onboarding/completion", {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "SETUP_INCOMPLETE",
+        message: "Tenant onboarding prerequisites are incomplete",
+        missing: ["admin"],
+      },
+    });
+    expect((await settingsRepo.get())?.onboarding_completed_at).toBeNull();
+  });
+
   it("sets onboarding_completed_at when all prerequisites are ready", async () => {
     const settingsRepo = createSettingsRepository(db);
     const userRepo = createUserRepository(db);

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -854,7 +854,7 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       return c.json({ ok: true, completed: true, changed: false });
     }
 
-    const adminUser = deps.userRepo ? await deps.userRepo.findFirstLocalAdmin() : undefined;
+    const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
     const readiness = getOnboardingReadiness(row, Boolean(adminUser));
     if (!readiness.readyToComplete) {
       return c.json(
@@ -869,12 +869,12 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       );
     }
 
-    await settings.update({ onboardingCompletedAt: new Date().toISOString() });
-    return c.json({ ok: true, completed: true, changed: true });
+    const changed = await settings.completeOnboarding(new Date().toISOString());
+    return c.json({ ok: true, completed: true, changed });
   };
 
   routes.post("/onboarding/complete", ensureOnboardingComplete);
-  routes.post("/onboarding/ensure-complete", ensureOnboardingComplete);
+  routes.put("/onboarding/completion", ensureOnboardingComplete);
 
   return routes;
 }

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -855,7 +855,7 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     }
 
     const adminUser = deps.userRepo ? await deps.userRepo.findFirstAdmin() : undefined;
-    const readiness = getOnboardingReadiness(row, Boolean(adminUser));
+    const readiness = getOnboardingReadiness(row, deps.userRepo ? Boolean(adminUser) : undefined);
     if (!readiness.readyToComplete) {
       return c.json(
         {

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -4,7 +4,7 @@ import { whatsappNumberSchema } from "@sketch/shared";
  * System API routes — internal management endpoints authenticated by bearer token.
  * Used by managed deployments to update configuration (e.g. Slack tokens) remotely.
  */
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { z } from "zod";
 import type { createEntityRepository } from "../db/repositories/entities";
 import type { createInboxMessagesRepository } from "../db/repositories/inbox-messages";
@@ -17,6 +17,7 @@ import type { ManagedWhatsAppProvider } from "../whatsapp/providers/managed";
 import { buildIntroductionTemplate } from "../whatsapp/templates";
 import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
 import { upsertWhatsAppIdentity } from "../whatsapp/upsert-identity";
+import { getOnboardingReadiness } from "./onboarding-readiness";
 
 type InboxMessagesRepo = ReturnType<typeof createInboxMessagesRepository>;
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
@@ -847,10 +848,33 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     }
   });
 
-  routes.post("/onboarding/complete", async (c) => {
+  const ensureOnboardingComplete = async (c: Context) => {
+    const row = await settings.get();
+    if (row?.onboarding_completed_at) {
+      return c.json({ ok: true, completed: true, changed: false });
+    }
+
+    const adminUser = deps.userRepo ? await deps.userRepo.findFirstLocalAdmin() : undefined;
+    const readiness = getOnboardingReadiness(row, Boolean(adminUser));
+    if (!readiness.readyToComplete) {
+      return c.json(
+        {
+          error: {
+            code: "SETUP_INCOMPLETE",
+            message: "Tenant onboarding prerequisites are incomplete",
+            missing: readiness.missing,
+          },
+        },
+        409,
+      );
+    }
+
     await settings.update({ onboardingCompletedAt: new Date().toISOString() });
-    return c.json({ ok: true });
-  });
+    return c.json({ ok: true, completed: true, changed: true });
+  };
+
+  routes.post("/onboarding/complete", ensureOnboardingComplete);
+  routes.post("/onboarding/ensure-complete", ensureOnboardingComplete);
 
   return routes;
 }

--- a/packages/server/src/db/repositories/settings.test.ts
+++ b/packages/server/src/db/repositories/settings.test.ts
@@ -62,6 +62,27 @@ describe("Settings repository", () => {
     expect(row?.admin_email).toBe("a@b.com");
   });
 
+  it("sets the onboarding completion timestamp only once", async () => {
+    await settings.create();
+
+    expect(await settings.completeOnboarding("2026-07-29T10:00:00.000Z")).toBe(true);
+    expect(await settings.completeOnboarding("2026-07-29T10:01:00.000Z")).toBe(false);
+    expect((await settings.get())?.onboarding_completed_at).toBe("2026-07-29T10:00:00.000Z");
+  });
+
+  it("refreshes a cached incomplete row after another process completes onboarding", async () => {
+    await settings.create();
+    expect((await settings.get())?.onboarding_completed_at).toBeNull();
+    await db
+      .updateTable("settings")
+      .set({ onboarding_completed_at: "2026-07-29T10:00:00.000Z" })
+      .where("id", "=", "default")
+      .execute();
+
+    expect(await settings.completeOnboarding("2026-07-29T10:01:00.000Z")).toBe(false);
+    expect((await settings.get())?.onboarding_completed_at).toBe("2026-07-29T10:00:00.000Z");
+  });
+
   it("update() persists Slack and LLM settings fields", async () => {
     await settings.create({ adminEmail: "a@b.com", adminPasswordHash: "hash" });
     await settings.update({

--- a/packages/server/src/db/repositories/settings.ts
+++ b/packages/server/src/db/repositories/settings.ts
@@ -301,6 +301,17 @@ export function createSettingsRepository(db: Kysely<DB>, encryptionKey?: string,
       return decrypted.sketch_api_key;
     },
 
+    async completeOnboarding(completedAt: string): Promise<boolean> {
+      const result = await db
+        .updateTable("settings")
+        .set({ onboarding_completed_at: completedAt })
+        .where("id", "=", "default")
+        .where("onboarding_completed_at", "is", null)
+        .executeTakeFirst();
+      invalidateCache();
+      return result.numUpdatedRows > 0n;
+    },
+
     async update(
       data: Partial<{
         adminEmail: string;

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1086,6 +1086,65 @@ describe("Auth endpoints", () => {
       expect((await settings.get())?.onboarding_completed_at).not.toBeNull();
     });
 
+    it("rejects managed members from setup mutations", async () => {
+      const settings = createSettingsRepository(db);
+      const users = createUserRepository(db);
+      await settings.create();
+      await users.create({
+        name: "Platform Admin",
+        email: "platform-admin@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "admin",
+      });
+      await users.create({
+        name: "Platform Member",
+        email: "platform-member@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "member",
+      });
+      await settings.completeOnboarding(new Date().toISOString());
+
+      const app = createApp(db, createTestConfig({ MANAGED_AUTH_SECRET: MANAGED_SECRET }));
+      const token = await makePlatformToken("platform-member@test.com", "member");
+      const cookie = `sketch_platform_session=${token}`;
+      const llmSettings = {
+        provider: "bedrock",
+        awsAccessKeyId: "AKIA-test",
+        awsSecretAccessKey: "secret-test",
+        awsRegion: "ap-south-1",
+      };
+      const requests = [
+        app.request("/api/setup/identity", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Cookie: cookie },
+          body: JSON.stringify({ orgName: "Hijacked", botName: "Hijacked" }),
+        }),
+        app.request("/api/setup/llm/verify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Cookie: cookie },
+          body: JSON.stringify(llmSettings),
+        }),
+        app.request("/api/setup/llm", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Cookie: cookie },
+          body: JSON.stringify(llmSettings),
+        }),
+        app.request("/api/setup/complete", {
+          method: "POST",
+          headers: { Cookie: cookie },
+        }),
+      ];
+
+      for (const response of await Promise.all(requests)) {
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({
+          error: { code: "FORBIDDEN", message: "Admin role required" },
+        });
+      }
+    });
+
     it("uses auth_role for managed platform cookie sessions", async () => {
       await seedAdmin(db);
       const users = createUserRepository(db);

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1044,6 +1044,33 @@ describe("Auth endpoints", () => {
       expect(body.role).toBe("admin");
     });
 
+    it("lets a passwordless managed admin complete setup through the full middleware stack", async () => {
+      const settings = createSettingsRepository(db);
+      const users = createUserRepository(db);
+      await settings.create();
+      await users.create({
+        name: "Platform Admin",
+        email: "platform-admin@test.com",
+        emailVerified: true,
+        passwordHash: null,
+        authRole: "admin",
+      });
+      const managedConfig = createTestConfig({
+        MANAGED_AUTH_SECRET: MANAGED_SECRET,
+        MANAGED_URL: "https://app.getsketch.ai",
+      });
+      const app = createApp(db, managedConfig);
+      const token = await makePlatformToken("platform-admin@test.com", "admin");
+
+      const res = await app.request("/api/setup/complete", {
+        method: "POST",
+        headers: { Cookie: `sketch_platform_session=${token}` },
+      });
+
+      expect(res.status).toBe(200);
+      expect((await settings.get())?.onboarding_completed_at).not.toBeNull();
+    });
+
     it("uses auth_role for managed platform cookie sessions", async () => {
       await seedAdmin(db);
       const users = createUserRepository(db);

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1044,7 +1044,7 @@ describe("Auth endpoints", () => {
       expect(body.role).toBe("admin");
     });
 
-    it("lets a passwordless managed admin complete setup through the full middleware stack", async () => {
+    it("routes a passwordless managed admin through middleware and enforces setup readiness", async () => {
       const settings = createSettingsRepository(db);
       const users = createUserRepository(db);
       await settings.create();
@@ -1067,7 +1067,25 @@ describe("Auth endpoints", () => {
         headers: { Cookie: `sketch_platform_session=${token}` },
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(409);
+      expect(await res.json()).toMatchObject({
+        error: { code: "SETUP_INCOMPLETE", missing: ["identity", "llm"] },
+      });
+      expect((await settings.get())?.onboarding_completed_at).toBeNull();
+
+      await settings.update({
+        orgName: "Acme",
+        botName: "Sketch",
+        llmProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
+      const readyRes = await app.request("/api/setup/complete", {
+        method: "POST",
+        headers: { Cookie: `sketch_platform_session=${token}` },
+      });
+
+      expect(readyRes.status).toBe(200);
+      await readyRes.text();
       expect((await settings.get())?.onboarding_completed_at).not.toBeNull();
     });
 
@@ -1456,6 +1474,13 @@ describe("Setup endpoints", () => {
 
     it("returns completed true after onboarding completion", async () => {
       await seedAdmin(db);
+      const settings = createSettingsRepository(db);
+      await settings.update({
+        orgName: "Acme",
+        botName: "Sketch",
+        llmProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
       const app = createApp(db, config);
       const cookie = await loginAdmin(app);
       await app.request("/api/setup/complete", { method: "POST", headers: { Cookie: cookie } });
@@ -1900,6 +1925,13 @@ describe("Setup endpoints", () => {
   describe("POST /api/setup/complete", () => {
     it("stores onboarding completion timestamp", async () => {
       await seedAdmin(db);
+      const settings = createSettingsRepository(db);
+      await settings.update({
+        orgName: "Acme",
+        botName: "Sketch",
+        llmProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
       const app = createApp(db, config);
       const cookie = await loginAdmin(app);
 
@@ -1909,7 +1941,6 @@ describe("Setup endpoints", () => {
       });
       expect(res.status).toBe(200);
 
-      const settings = createSettingsRepository(db);
       const row = await settings.get();
       expect(row?.onboarding_completed_at).toBeTruthy();
     });

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1044,7 +1044,7 @@ describe("Auth endpoints", () => {
       expect(body.role).toBe("admin");
     });
 
-    it("routes a passwordless managed admin through middleware and enforces setup readiness", async () => {
+    it("routes a passwordless managed admin through setup without requiring a managed URL", async () => {
       const settings = createSettingsRepository(db);
       const users = createUserRepository(db);
       await settings.create();
@@ -1055,10 +1055,7 @@ describe("Auth endpoints", () => {
         passwordHash: null,
         authRole: "admin",
       });
-      const managedConfig = createTestConfig({
-        MANAGED_AUTH_SECRET: MANAGED_SECRET,
-        MANAGED_URL: "https://app.getsketch.ai",
-      });
+      const managedConfig = createTestConfig({ MANAGED_AUTH_SECRET: MANAGED_SECRET });
       const app = createApp(db, managedConfig);
       const token = await makePlatformToken("platform-admin@test.com", "admin");
 

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -307,7 +307,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     createAuthMiddleware(settings, {
       managedAuthSecret: config.MANAGED_AUTH_SECRET,
       managedUrl: config.MANAGED_URL,
-      hasLocalAdmin: async () => Boolean(await users.findFirstLocalAdmin()),
+      hasSetupAdmin: async () =>
+        Boolean(await (config.MANAGED_AUTH_SECRET ? users.findFirstAdmin() : users.findFirstLocalAdmin())),
       resolveLocalSessionUser: async (sub) => {
         let user = await users.findById(sub);
         if (!user && sub.includes("@")) {
@@ -415,6 +416,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     "/api/setup",
     setupRoutes(settings, {
       managedUrl: config.MANAGED_URL,
+      slackMode: config.SLACK_MODE,
       onSlackTokensUpdated: deps?.onSlackTokensUpdated,
       onLlmSettingsUpdated: deps?.onLlmSettingsUpdated,
       userRepo: users,

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -415,6 +415,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   app.route(
     "/api/setup",
     setupRoutes(settings, {
+      managedAuthEnabled: Boolean(config.MANAGED_AUTH_SECRET),
       managedUrl: config.MANAGED_URL,
       slackMode: config.SLACK_MODE,
       onSlackTokensUpdated: deps?.onSlackTokensUpdated,

--- a/packages/web/src/components/onboarding/step-completion.tsx
+++ b/packages/web/src/components/onboarding/step-completion.tsx
@@ -10,13 +10,15 @@ interface OnboardingData {
   slackWorkspace?: string;
   whatsappConnected: boolean;
   whatsappPhone?: string;
-  llmProvider: LlmProvider;
+  llmProvider: LlmProvider | "vertex" | "openai-compatible";
 }
 
-const LLM_LABELS: Record<LlmProvider, string> = {
+const LLM_LABELS: Record<LlmProvider | "vertex" | "openai-compatible", string> = {
   anthropic: "Anthropic (Sonnet)",
   bedrock: "AWS Bedrock (Sonnet)",
   openrouter: "OpenRouter",
+  vertex: "Google Vertex (Sonnet)",
+  "openai-compatible": "OpenAI-compatible",
 };
 
 interface StepCompletionProps {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -249,6 +249,7 @@ export interface WhatsAppGroupMemberLabel {
 export interface SetupStatus {
   completed: boolean;
   readyToComplete: boolean;
+  managed?: boolean;
   currentStep: number;
   adminEmail: string | null;
   orgName: string | null;

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -257,7 +257,7 @@ export interface SetupStatus {
   slackConnected: boolean;
   whatsappConnected?: boolean;
   llmConnected: boolean;
-  llmProvider: LlmProvider | null;
+  llmProvider: LlmProvider | "vertex" | "openai-compatible" | null;
   managedUrl?: string;
 }
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -248,6 +248,7 @@ export interface WhatsAppGroupMemberLabel {
 
 export interface SetupStatus {
   completed: boolean;
+  readyToComplete: boolean;
   currentStep: number;
   adminEmail: string | null;
   orgName: string | null;

--- a/packages/web/src/routes/home.isolated.test.tsx
+++ b/packages/web/src/routes/home.isolated.test.tsx
@@ -35,6 +35,7 @@ describe("Home route", () => {
   it("sends authenticated users to Home from the root route", async () => {
     vi.mocked(api.setup.status).mockResolvedValue({
       completed: true,
+      readyToComplete: true,
       currentStep: 5,
       adminEmail: "admin@example.com",
       orgName: "Acme",

--- a/packages/web/src/routes/onboarding.isolated.test.tsx
+++ b/packages/web/src/routes/onboarding.isolated.test.tsx
@@ -587,7 +587,7 @@ describe("Managed mode onboarding", () => {
     expect(screen.queryByRole("button", { name: "Channels" })).not.toBeInTheDocument();
   });
 
-  it("renders bot name input as disabled when managedUrl is set", () => {
+  it("renders bot name input as disabled when managed mode is set", () => {
     renderWithProviders(
       <OnboardingPage
         initialSetupStatus={{
@@ -600,7 +600,7 @@ describe("Managed mode onboarding", () => {
           slackConnected: false,
           llmConnected: false,
           llmProvider: null,
-          managedUrl: "https://app.getsketch.ai",
+          managed: true,
         }}
       />,
     );
@@ -630,7 +630,7 @@ describe("Managed mode onboarding", () => {
           slackConnected: false,
           llmConnected: false,
           llmProvider: null,
-          managedUrl: "https://app.getsketch.ai",
+          managed: true,
         }}
       />,
     );

--- a/packages/web/src/routes/onboarding.isolated.test.tsx
+++ b/packages/web/src/routes/onboarding.isolated.test.tsx
@@ -414,6 +414,26 @@ describe("OnboardingPage navigation and flow", () => {
     expect(screen.getByText("Sketch is ready")).toBeInTheDocument();
   });
 
+  it("shows the resolved environment LLM provider on the completion step", () => {
+    renderWithProviders(
+      <OnboardingPage
+        initialSetupStatus={{
+          completed: false,
+          readyToComplete: true,
+          currentStep: 5,
+          adminEmail: "admin@test.com",
+          orgName: "Acme",
+          botName: "Sketch",
+          slackConnected: true,
+          llmConnected: true,
+          llmProvider: "vertex",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Google Vertex (Sonnet)")).toBeInTheDocument();
+  });
+
   it("allows navigating back to Account step from progress indicator", async () => {
     server.use(
       http.post("/api/setup/slack/verify", () => {

--- a/packages/web/src/routes/onboarding.isolated.test.tsx
+++ b/packages/web/src/routes/onboarding.isolated.test.tsx
@@ -352,6 +352,7 @@ describe("OnboardingPage navigation and flow", () => {
       <OnboardingPage
         initialSetupStatus={{
           completed: false,
+          readyToComplete: false,
           currentStep: 2,
           adminEmail: "admin@test.com",
           orgName: null,
@@ -391,6 +392,7 @@ describe("OnboardingPage navigation and flow", () => {
       <OnboardingPage
         initialSetupStatus={{
           completed: false,
+          readyToComplete: false,
           currentStep: 4,
           adminEmail: "admin@test.com",
           orgName: "Acme",
@@ -451,6 +453,7 @@ describe("OnboardingPage navigation and flow", () => {
       <OnboardingPage
         initialSetupStatus={{
           completed: false,
+          readyToComplete: false,
           currentStep: 4,
           adminEmail: "admin@test.com",
           orgName: "Acme",
@@ -565,6 +568,7 @@ describe("Managed mode onboarding", () => {
       <OnboardingPage
         initialSetupStatus={{
           completed: false,
+          readyToComplete: false,
           currentStep: 2,
           adminEmail: "admin@managed.com",
           orgName: null,
@@ -588,6 +592,7 @@ describe("Managed mode onboarding", () => {
       <OnboardingPage
         initialSetupStatus={{
           completed: false,
+          readyToComplete: false,
           currentStep: 2,
           adminEmail: "admin@managed.com",
           orgName: null,
@@ -617,6 +622,7 @@ describe("Managed mode onboarding", () => {
       <OnboardingPage
         initialSetupStatus={{
           completed: false,
+          readyToComplete: false,
           currentStep: 2,
           adminEmail: "admin@managed.com",
           orgName: null,

--- a/packages/web/src/routes/onboarding.tsx
+++ b/packages/web/src/routes/onboarding.tsx
@@ -36,6 +36,7 @@ function OnboardingRoutePage() {
 
 const defaultSetupStatus: SetupStatus = {
   completed: false,
+  readyToComplete: false,
   currentStep: 0,
   adminEmail: null,
   orgName: null,

--- a/packages/web/src/routes/onboarding.tsx
+++ b/packages/web/src/routes/onboarding.tsx
@@ -91,10 +91,8 @@ export function OnboardingPage({ initialSetupStatus }: { initialSetupStatus?: Se
   const [whatsappConnected, setWhatsappConnected] = useState(false);
   const [whatsappPhone, setWhatsappPhone] = useState<string | undefined>(undefined);
 
-  const [llmProvider, setLlmProvider] = useState<"anthropic" | "bedrock">(
-    setupStatus.llmProvider === "anthropic" || setupStatus.llmProvider === "bedrock"
-      ? setupStatus.llmProvider
-      : "anthropic",
+  const [llmProvider, setLlmProvider] = useState<NonNullable<SetupStatus["llmProvider"]>>(
+    setupStatus.llmProvider ?? "anthropic",
   );
   const [llmConnected, setLlmConnected] = useState(setupStatus.llmConnected);
 
@@ -291,7 +289,7 @@ export function OnboardingPage({ initialSetupStatus }: { initialSetupStatus?: Se
     case 4:
       content = (
         <StepConfigureLLM
-          initialProvider={llmProvider}
+          initialProvider={llmProvider === "bedrock" ? "bedrock" : "anthropic"}
           initialConnected={llmConnected}
           onNext={({ provider, connected }) => {
             setLlmProvider(provider);

--- a/packages/web/src/routes/onboarding.tsx
+++ b/packages/web/src/routes/onboarding.tsx
@@ -37,6 +37,7 @@ function OnboardingRoutePage() {
 const defaultSetupStatus: SetupStatus = {
   completed: false,
   readyToComplete: false,
+  managed: false,
   currentStep: 0,
   adminEmail: null,
   orgName: null,
@@ -50,7 +51,7 @@ export function OnboardingPage({ initialSetupStatus }: { initialSetupStatus?: Se
   const navigate = useNavigate();
   const { logoSrc } = useTheme();
   const setupStatus = initialSetupStatus ?? defaultSetupStatus;
-  const isManaged = Boolean(setupStatus.managedUrl);
+  const isManaged = setupStatus.managed ?? Boolean(setupStatus.managedUrl);
 
   const managedInternalSteps = [2, 4] as const;
   const managedDisplaySteps = [


### PR DESCRIPTION
## Summary

Fixes managed tenants landing on the final onboarding screen after a successful wake when `onboarding_completed_at` is still unset.

- Centralizes readiness checks for the required admin, identity, and LLM configuration.
- Enforces the same prerequisite contract on customer and system completion paths.
- Adds an authenticated, idempotent `PUT /api/system/onboarding/completion` endpoint.
- Recognizes passwordless managed OAuth admins in both readiness checks and bootstrap middleware.
- Treats the users repository as authoritative when checking for an admin, while preserving the legacy settings fallback for callers without a repository.
- Completes onboarding with a conditional database update so concurrent retries preserve the first completion timestamp.
- Bases Slack readiness on `SLACK_MODE`: HTTP mode needs only a bot token; Socket Mode also needs an app token.

## Completion behavior

| Tenant state | Result |
| --- | --- |
| Required setup is missing | `409 SETUP_INCOMPLETE` with the missing prerequisites |
| Ready but not completed | Sets `onboarding_completed_at` and reports a successful completion |
| Already completed | Preserves the existing timestamp and returns success without another update |

## Validation

- `pnpm lint`
- `pnpm typecheck`
- Focused auth/onboarding/system suite: 224 passed
- Full local tests: server 4,725 passed / 20 skipped; web 433 passed
- `pnpm build`

## Rollout

Release this tenant-side API across the managed fleet before deploying the dependent wake continuation in [sketch-platform#99](https://github.com/canvasxai/sketch-platform/pull/99).