### PR TITLE
feat: sync managed WhatsApp member mappings

### DIFF
--- a/packages/server/src/api/managed-whatsapp-system.test.ts
+++ b/packages/server/src/api/managed-whatsapp-system.test.ts
@@ -107,6 +107,33 @@ describe("POST /api/system/whatsapp/managed/events", () => {
     expect(handleInboundEvent).toHaveBeenCalledWith(payload);
   });
 
+  it("fails closed when the forwarded tenant user no longer owns the sender phone", async () => {
+    const handleInboundEvent = vi.fn();
+    const validateManagedWhatsappInboundIdentity = vi.fn(async () => false);
+    const app = new Hono();
+    app.route(
+      "/api/system",
+      systemRoutes(createSettingsRepository(db), {
+        systemSecret: SYSTEM_SECRET,
+        managedWhatsappInbound: { handleInboundEvent },
+        validateManagedWhatsappInboundIdentity,
+      }),
+    );
+
+    const res = await app.request("/api/system/whatsapp/managed/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${SYSTEM_SECRET}` },
+      body: JSON.stringify(validPayload({ tenantUserId: "stale-user-id" })),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: { code: "IDENTITY_MISMATCH", message: "Managed WhatsApp sender identity is stale" },
+    });
+    expect(validateManagedWhatsappInboundIdentity).toHaveBeenCalledWith("stale-user-id", "+15551234567");
+    expect(handleInboundEvent).not.toHaveBeenCalled();
+  });
+
   it("accepts explicit null optional fields as omitted text message metadata", async () => {
     const provider = createManagedWhatsAppProvider({
       platformUrl: "https://app.getsketch.ai",

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -623,7 +623,14 @@ describe("PUT /api/system/identity", () => {
   it("creates admin user row with WhatsApp number", async () => {
     const settingsRepo = createSettingsRepository(db);
     const userRepo = createUserRepository(db);
-    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+    const lockRecorder = createManagedMemberLockRecorder();
+    const syncManagedMemberMapping = vi.fn(async () => {});
+    const app = createTestSystemApp(settingsRepo, {
+      systemSecret: SYSTEM_SECRET,
+      userRepo,
+      withManagedMemberSyncLocks: lockRecorder.withLocks,
+      syncManagedMemberMapping,
+    });
 
     const res = await app.request("/api/system/identity", {
       method: "PUT",
@@ -642,6 +649,14 @@ describe("PUT /api/system/identity", () => {
     const user = await userRepo.findByEmail("wa-admin@acme.com");
     expect(user?.auth_role).toBe("admin");
     expect(user?.whatsapp_number).toBe("+14155552671");
+    expect(lockRecorder.calls).toEqual([[], [user?.id]]);
+    expect(syncManagedMemberMapping).toHaveBeenCalledWith({
+      tenantUserId: user?.id,
+      email: "wa-admin@acme.com",
+      name: "WhatsApp Admin",
+      phoneNumber: "+14155552671",
+      sendInvite: false,
+    });
   });
 
   it("updates existing user row with name and verified email when user already exists", async () => {
@@ -712,7 +727,7 @@ describe("PUT /api/system/identity", () => {
     expect(user?.name).toBe("Admin Updated");
     expect(user?.auth_role).toBe("admin");
     expect(user?.whatsapp_number).toBe("+919876543210");
-    expect(lockRecorder.calls).toEqual([[existing.id]]);
+    expect(lockRecorder.calls).toEqual([[existing.id], [existing.id]]);
     expect(syncManagedMemberMapping).toHaveBeenCalledWith({
       tenantUserId: existing.id,
       email: "admin-wa-update@acme.com",

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -1162,7 +1162,7 @@ describe("PUT /api/system/users", () => {
     expect(bob?.email).toBe("bob@acme.com");
     expect(bob?.name).toBe("Bob WhatsApp");
     expect(bob?.auth_role).toBe("member");
-    expect(lockRecorder.calls).toEqual([[existing.id]]);
+    expect(lockRecorder.calls).toEqual([[existing.id], [existing.id], [bob?.id]]);
     expect(syncManagedMemberMapping.mock.calls).toEqual([
       [
         {

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -73,11 +73,23 @@ function createTestSystemApp(
       conflictUserIds: string[];
       failedUserIds: string[];
     }>;
+    withManagedMemberSyncLocks?: <T>(tenantUserIds: string[], operation: () => Promise<T>) => Promise<T>;
   },
 ) {
   const app = new Hono();
   app.route("/api/system", systemRoutes(settingsRepo, deps));
   return app;
+}
+
+function createManagedMemberLockRecorder() {
+  const calls: string[][] = [];
+  return {
+    calls,
+    withLocks: async <T>(tenantUserIds: string[], operation: () => Promise<T>): Promise<T> => {
+      calls.push(tenantUserIds);
+      return operation();
+    },
+  };
 }
 
 describe("PUT /api/system/slack/tokens", () => {
@@ -665,8 +677,13 @@ describe("PUT /api/system/identity", () => {
       emailVerified: true,
       authRole: "admin",
     });
+    const lockRecorder = createManagedMemberLockRecorder();
 
-    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+    const app = createTestSystemApp(settingsRepo, {
+      systemSecret: SYSTEM_SECRET,
+      userRepo,
+      withManagedMemberSyncLocks: lockRecorder.withLocks,
+    });
 
     const res = await app.request("/api/system/identity", {
       method: "PUT",
@@ -686,6 +703,7 @@ describe("PUT /api/system/identity", () => {
     expect(user?.name).toBe("Admin Updated");
     expect(user?.auth_role).toBe("admin");
     expect(user?.whatsapp_number).toBe("+919876543210");
+    expect(lockRecorder.calls).toEqual([[existing.id]]);
   });
 
   it("returns 409 when admin WhatsApp number belongs to another user", async () => {
@@ -851,6 +869,40 @@ describe("POST /api/system/users", () => {
     expect(user?.email_verified_at).toBeTruthy();
   });
 
+  it("serializes an existing WhatsApp member update by stable user id", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    const existing = await userRepo.create({
+      email: "member@acme.com",
+      name: "Member",
+      whatsappNumber: "+14155550111",
+      type: "human",
+    });
+    const lockRecorder = createManagedMemberLockRecorder();
+    const app = createTestSystemApp(settingsRepo, {
+      systemSecret: SYSTEM_SECRET,
+      userRepo,
+      withManagedMemberSyncLocks: lockRecorder.withLocks,
+    });
+
+    const res = await app.request("/api/system/users", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${SYSTEM_SECRET}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: "member@acme.com",
+        name: "Member Updated",
+        whatsappNumber: "+14155550111",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((await userRepo.findById(existing.id))?.name).toBe("Member Updated");
+    expect(lockRecorder.calls).toEqual([[existing.id]]);
+  });
+
   it("returns and verifies the existing user when the email already exists", async () => {
     const settingsRepo = createSettingsRepository(db);
     const userRepo = createUserRepository(db);
@@ -1013,7 +1065,12 @@ describe("PUT /api/system/users", () => {
       name: "Alice Old",
       emailVerified: true,
     });
-    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+    const lockRecorder = createManagedMemberLockRecorder();
+    const app = createTestSystemApp(settingsRepo, {
+      systemSecret: SYSTEM_SECRET,
+      userRepo,
+      withManagedMemberSyncLocks: lockRecorder.withLocks,
+    });
 
     const res = await app.request("/api/system/users", {
       method: "PUT",
@@ -1040,6 +1097,7 @@ describe("PUT /api/system/users", () => {
     expect(bob?.email).toBe("bob@acme.com");
     expect(bob?.name).toBe("Bob WhatsApp");
     expect(bob?.auth_role).toBe("member");
+    expect(lockRecorder.calls).toEqual([[existing.id]]);
   });
 
   it("bulk upserts Slack and WhatsApp identities from one row", async () => {

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -859,7 +859,12 @@ describe("POST /api/system/users", () => {
   it("creates a verified WhatsApp member user and returns userId", async () => {
     const settingsRepo = createSettingsRepository(db);
     const userRepo = createUserRepository(db);
-    const app = createTestSystemApp(settingsRepo, { systemSecret: SYSTEM_SECRET, userRepo });
+    const syncManagedMemberMapping = vi.fn(async () => {});
+    const app = createTestSystemApp(settingsRepo, {
+      systemSecret: SYSTEM_SECRET,
+      userRepo,
+      syncManagedMemberMapping,
+    });
 
     const res = await app.request("/api/system/users", {
       method: "POST",
@@ -883,6 +888,13 @@ describe("POST /api/system/users", () => {
     expect(user?.email).toBe("contractor@gmail.com");
     expect(user?.name).toBe("Contractor");
     expect(user?.email_verified_at).toBeTruthy();
+    expect(syncManagedMemberMapping).toHaveBeenCalledWith({
+      tenantUserId: user?.id,
+      email: "contractor@gmail.com",
+      name: "Contractor",
+      phoneNumber: "+14155550111",
+      sendInvite: false,
+    });
   });
 
   it("serializes an existing WhatsApp member update by stable user id", async () => {
@@ -1117,10 +1129,12 @@ describe("PUT /api/system/users", () => {
       emailVerified: true,
     });
     const lockRecorder = createManagedMemberLockRecorder();
+    const syncManagedMemberMapping = vi.fn(async () => {});
     const app = createTestSystemApp(settingsRepo, {
       systemSecret: SYSTEM_SECRET,
       userRepo,
       withManagedMemberSyncLocks: lockRecorder.withLocks,
+      syncManagedMemberMapping,
     });
 
     const res = await app.request("/api/system/users", {
@@ -1149,6 +1163,26 @@ describe("PUT /api/system/users", () => {
     expect(bob?.name).toBe("Bob WhatsApp");
     expect(bob?.auth_role).toBe("member");
     expect(lockRecorder.calls).toEqual([[existing.id]]);
+    expect(syncManagedMemberMapping.mock.calls).toEqual([
+      [
+        {
+          tenantUserId: existing.id,
+          email: "alice@acme.com",
+          name: "Alice WhatsApp",
+          phoneNumber: "+14155552671",
+          sendInvite: false,
+        },
+      ],
+      [
+        {
+          tenantUserId: bob?.id,
+          email: "bob@acme.com",
+          name: "Bob WhatsApp",
+          phoneNumber: "+919876543210",
+          sendInvite: false,
+        },
+      ],
+    ]);
   });
 
   it("bulk upserts Slack and WhatsApp identities from one row", async () => {

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -73,6 +73,13 @@ function createTestSystemApp(
       conflictUserIds: string[];
       failedUserIds: string[];
     }>;
+    syncManagedMemberMapping?: (input: {
+      tenantUserId: string;
+      email: string;
+      name: string;
+      phoneNumber: string;
+      sendInvite?: boolean;
+    }) => Promise<void>;
     withManagedMemberSyncLocks?: <T>(tenantUserIds: string[], operation: () => Promise<T>) => Promise<T>;
   },
 ) {
@@ -678,11 +685,13 @@ describe("PUT /api/system/identity", () => {
       authRole: "admin",
     });
     const lockRecorder = createManagedMemberLockRecorder();
+    const syncManagedMemberMapping = vi.fn(async () => {});
 
     const app = createTestSystemApp(settingsRepo, {
       systemSecret: SYSTEM_SECRET,
       userRepo,
       withManagedMemberSyncLocks: lockRecorder.withLocks,
+      syncManagedMemberMapping,
     });
 
     const res = await app.request("/api/system/identity", {
@@ -704,6 +713,13 @@ describe("PUT /api/system/identity", () => {
     expect(user?.auth_role).toBe("admin");
     expect(user?.whatsapp_number).toBe("+919876543210");
     expect(lockRecorder.calls).toEqual([[existing.id]]);
+    expect(syncManagedMemberMapping).toHaveBeenCalledWith({
+      tenantUserId: existing.id,
+      email: "admin-wa-update@acme.com",
+      name: "Admin Updated",
+      phoneNumber: "+919876543210",
+      sendInvite: false,
+    });
   });
 
   it("returns 409 when admin WhatsApp number belongs to another user", async () => {

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -66,6 +66,13 @@ function createTestSystemApp(
     startWhatsAppPairing?: ReturnType<typeof vi.fn>;
     cancelWhatsAppPairing?: ReturnType<typeof vi.fn>;
     disconnectWhatsApp?: () => Promise<void>;
+    reconcileManagedMembers?: () => Promise<{
+      skipped: boolean;
+      total: number;
+      synced: number;
+      conflictUserIds: string[];
+      failedUserIds: string[];
+    }>;
   },
 ) {
   const app = new Hono();
@@ -196,6 +203,59 @@ describe("PUT /api/system/slack/tokens", () => {
 
     const decrypted = await settingsRepo.get();
     expect(decrypted?.slack_bot_token).toBe("xoxb-encrypted-token");
+  });
+});
+
+describe("POST /api/system/managed-member-reconciliations", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedAdmin(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("runs the configured reconciliation behind system authentication", async () => {
+    const reconcileManagedMembers = vi.fn(async () => ({
+      skipped: false,
+      total: 3,
+      synced: 2,
+      conflictUserIds: [],
+      failedUserIds: ["user-3"],
+    }));
+    const app = createTestSystemApp(createSettingsRepository(db), {
+      systemSecret: SYSTEM_SECRET,
+      reconcileManagedMembers,
+    });
+
+    const res = await app.request("/api/system/managed-member-reconciliations", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      skipped: false,
+      total: 3,
+      synced: 2,
+      conflictUserIds: [],
+      failedUserIds: ["user-3"],
+    });
+    expect(reconcileManagedMembers).toHaveBeenCalledOnce();
+  });
+
+  it("returns unavailable when reconciliation is not configured", async () => {
+    const app = createTestSystemApp(createSettingsRepository(db), { systemSecret: SYSTEM_SECRET });
+
+    const res = await app.request("/api/system/managed-member-reconciliations", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${SYSTEM_SECRET}` },
+    });
+
+    expect(res.status).toBe(503);
   });
 });
 

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -1057,6 +1057,41 @@ describe("PUT /api/system/users", () => {
     expect(syncedAdmin?.password_hash).toBeNull();
   });
 
+  it("locks an existing Slack user when the bulk sync changes their email", async () => {
+    const settingsRepo = createSettingsRepository(db);
+    const userRepo = createUserRepository(db);
+    const existing = await userRepo.create({
+      email: "alice-old@acme.com",
+      name: "Alice Old",
+      slackUserId: "U111",
+      emailVerified: true,
+    });
+    const lockRecorder = createManagedMemberLockRecorder();
+    const app = createTestSystemApp(settingsRepo, {
+      systemSecret: SYSTEM_SECRET,
+      userRepo,
+      withManagedMemberSyncLocks: lockRecorder.withLocks,
+    });
+
+    const res = await app.request("/api/system/users", {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${SYSTEM_SECRET}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        users: [{ email: "alice-new@acme.com", name: "Alice Updated", slackUserId: "U111" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, created: 0, updated: 1 });
+    expect(lockRecorder.calls).toEqual([[existing.id]]);
+    const synced = await userRepo.findById(existing.id);
+    expect(synced?.email).toBe("alice-new@acme.com");
+    expect(synced?.name).toBe("Alice Updated");
+  });
+
   it("bulk upserts users by WhatsApp number and email", async () => {
     const settingsRepo = createSettingsRepository(db);
     const userRepo = createUserRepository(db);

--- a/packages/server/src/api/system.test.ts
+++ b/packages/server/src/api/system.test.ts
@@ -1092,13 +1092,16 @@ describe("PUT /api/system/users", () => {
       email: "alice-old@acme.com",
       name: "Alice Old",
       slackUserId: "U111",
+      whatsappNumber: "+14155552671",
       emailVerified: true,
     });
     const lockRecorder = createManagedMemberLockRecorder();
+    const syncManagedMemberMapping = vi.fn(async () => {});
     const app = createTestSystemApp(settingsRepo, {
       systemSecret: SYSTEM_SECRET,
       userRepo,
       withManagedMemberSyncLocks: lockRecorder.withLocks,
+      syncManagedMemberMapping,
     });
 
     const res = await app.request("/api/system/users", {
@@ -1114,10 +1117,17 @@ describe("PUT /api/system/users", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, created: 0, updated: 1 });
-    expect(lockRecorder.calls).toEqual([[existing.id]]);
+    expect(lockRecorder.calls).toEqual([[existing.id], [existing.id]]);
     const synced = await userRepo.findById(existing.id);
     expect(synced?.email).toBe("alice-new@acme.com");
     expect(synced?.name).toBe("Alice Updated");
+    expect(syncManagedMemberMapping).toHaveBeenCalledWith({
+      tenantUserId: existing.id,
+      email: "alice-new@acme.com",
+      name: "Alice Updated",
+      phoneNumber: "+14155552671",
+      sendInvite: false,
+    });
   });
 
   it("bulk upserts users by WhatsApp number and email", async () => {

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -391,7 +391,7 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
 
     if (deps.userRepo) {
       const userRepo = deps.userRepo;
-      await withManagedMemberMutationLocks(deps, existingUser ? [existingUser.id] : [], async () => {
+      const userId = await withManagedMemberMutationLocks(deps, existingUser ? [existingUser.id] : [], async () => {
         const displayName = parsed.data.name || normalizedAdminEmail.split("@")[0];
         const currentUser = await userRepo.findByEmail(normalizedAdminEmail);
         const user = currentUser
@@ -411,8 +411,12 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
               ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
               authRole: "admin",
             });
-        if (user.type === "human") {
-          const memberToSync = managedMemberRegistrationInput(user);
+        return user.id;
+      });
+      await withManagedMemberMutationLocks(deps, [userId], async () => {
+        const currentUser = await userRepo.findById(userId);
+        if (currentUser?.type === "human") {
+          const memberToSync = managedMemberRegistrationInput(currentUser);
           if (memberToSync) await deps.syncManagedMemberMapping?.(memberToSync);
         }
       });

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -59,6 +59,14 @@ interface SystemDeps {
   // biome-ignore lint/complexity/noBannedTypes: Function is needed here to accommodate Vitest mock types in tests
   cancelWhatsAppPairing?: Function;
   disconnectWhatsApp?: () => Promise<void>;
+  reconcileManagedMembers?: () => Promise<{
+    skipped: boolean;
+    total: number;
+    synced: number;
+    conflictUserIds: string[];
+    failedUserIds: string[];
+  }>;
+  validateManagedWhatsappInboundIdentity?: (tenantUserId: string, senderPhoneE164: string) => Promise<boolean>;
 }
 
 const tokenSchema = z.object({
@@ -284,6 +292,13 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     }
 
     return c.json({ success: true });
+  });
+
+  routes.post("/managed-member-reconciliations", async (c) => {
+    if (!deps.reconcileManagedMembers) {
+      return c.json({ error: { code: "UNAVAILABLE", message: "Managed member reconciliation is unavailable" } }, 503);
+    }
+    return c.json(await deps.reconcileManagedMembers());
   });
 
   routes.put("/identity", async (c) => {
@@ -547,6 +562,23 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     const body = await c.req.json().catch(() => undefined);
     if (body === undefined) {
       return c.json({ error: { code: "BAD_REQUEST", message: "Invalid JSON body" } }, 400);
+    }
+    if (deps.validateManagedWhatsappInboundIdentity && typeof body === "object" && body !== null) {
+      const event = body as Record<string, unknown>;
+      if (event.type === "message") {
+        const tenantUserId = typeof event.tenantUserId === "string" ? event.tenantUserId.trim() : "";
+        const senderPhoneE164 = typeof event.senderPhoneE164 === "string" ? event.senderPhoneE164.trim() : "";
+        if (
+          !tenantUserId ||
+          !senderPhoneE164 ||
+          !(await deps.validateManagedWhatsappInboundIdentity(tenantUserId, senderPhoneE164))
+        ) {
+          return c.json(
+            { error: { code: "IDENTITY_MISMATCH", message: "Managed WhatsApp sender identity is stale" } },
+            409,
+          );
+        }
+      }
     }
 
     try {

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -66,6 +66,7 @@ interface SystemDeps {
     conflictUserIds: string[];
     failedUserIds: string[];
   }>;
+  withManagedMemberSyncLocks?: <T>(tenantUserIds: string[], operation: () => Promise<T>) => Promise<T>;
   validateManagedWhatsappInboundIdentity?: (tenantUserId: string, senderPhoneE164: string) => Promise<boolean>;
 }
 
@@ -205,6 +206,32 @@ function parseWorkflowMetadata(value: string | null): { openingMessageSent?: boo
 
 class SystemUserSyncConflictError extends Error {}
 
+async function resolveManagedMemberMutationIds(
+  userRepo: UserRepo,
+  users: Array<{ email?: string; whatsappNumber?: string }>,
+): Promise<string[]> {
+  const ids = new Set<string>();
+  for (const user of users) {
+    if (user.email) {
+      const existingByEmail = await userRepo.findByEmail(user.email.trim().toLowerCase());
+      if (existingByEmail) ids.add(existingByEmail.id);
+    }
+    if (user.whatsappNumber) {
+      const existingByWhatsapp = await userRepo.findByWhatsappNumber(user.whatsappNumber);
+      if (existingByWhatsapp) ids.add(existingByWhatsapp.id);
+    }
+  }
+  return [...ids];
+}
+
+function withManagedMemberMutationLocks<T>(
+  deps: SystemDeps,
+  tenantUserIds: string[],
+  operation: () => Promise<T>,
+): Promise<T> {
+  return deps.withManagedMemberSyncLocks ? deps.withManagedMemberSyncLocks(tenantUserIds, operation) : operation();
+}
+
 function buildWhatsAppIntroMessage(botName: string, orgName: string | null | undefined): string {
   const orgLabel = orgName?.trim() || "your workspace";
   return `Hi, I'm ${botName}, your AI coworker in ${orgLabel}. You can message me here when you need help with your workspace.`;
@@ -341,26 +368,30 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     }
 
     if (deps.userRepo) {
-      const displayName = parsed.data.name || normalizedAdminEmail.split("@")[0];
-      if (existingUser) {
-        await deps.userRepo.update(existingUser.id, {
-          name: displayName,
-          email: normalizedAdminEmail,
-          emailVerified: true,
-          ...(adminPasswordHash !== undefined ? { passwordHash: adminPasswordHash } : {}),
-          ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
-          authRole: "admin",
-        });
-      } else {
-        await deps.userRepo.create({
-          name: displayName,
-          email: normalizedAdminEmail,
-          emailVerified: true,
-          passwordHash: adminPasswordHash ?? null,
-          ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
-          authRole: "admin",
-        });
-      }
+      const userRepo = deps.userRepo;
+      await withManagedMemberMutationLocks(deps, existingUser ? [existingUser.id] : [], async () => {
+        const displayName = parsed.data.name || normalizedAdminEmail.split("@")[0];
+        const currentUser = await userRepo.findByEmail(normalizedAdminEmail);
+        if (currentUser) {
+          await userRepo.update(currentUser.id, {
+            name: displayName,
+            email: normalizedAdminEmail,
+            emailVerified: true,
+            ...(adminPasswordHash !== undefined ? { passwordHash: adminPasswordHash } : {}),
+            ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
+            authRole: "admin",
+          });
+        } else {
+          await userRepo.create({
+            name: displayName,
+            email: normalizedAdminEmail,
+            emailVerified: true,
+            passwordHash: adminPasswordHash ?? null,
+            ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
+            authRole: "admin",
+          });
+        }
+      });
     }
 
     return c.json({ ok: true });
@@ -444,41 +475,47 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     }
 
     const email = parsed.data.email.toLowerCase();
-    if (parsed.data.whatsappNumber) {
-      const result = await upsertWhatsAppIdentity(deps.userRepo, {
+    const userRepo = deps.userRepo;
+    const mutationIds = parsed.data.whatsappNumber
+      ? await resolveManagedMemberMutationIds(userRepo, [{ email, whatsappNumber: parsed.data.whatsappNumber }])
+      : [];
+    return withManagedMemberMutationLocks(deps, mutationIds, async () => {
+      if (parsed.data.whatsappNumber) {
+        const result = await upsertWhatsAppIdentity(userRepo, {
+          email,
+          name: parsed.data.name,
+          whatsappNumber: parsed.data.whatsappNumber,
+        });
+        if (result.status === "conflict") {
+          return c.json(
+            {
+              error: {
+                code: "CONFLICT",
+                message: "User is already linked to a different WhatsApp identity",
+              },
+            },
+            409,
+          );
+        }
+        return c.json({ ok: true, userId: result.user.id });
+      }
+
+      const existing = await userRepo.findByEmail(email);
+      if (existing) {
+        if (!existing.email_verified_at) {
+          await userRepo.update(existing.id, { emailVerified: true });
+        }
+        return c.json({ ok: true, userId: existing.id });
+      }
+
+      const user = await userRepo.create({
         email,
         name: parsed.data.name,
-        whatsappNumber: parsed.data.whatsappNumber,
+        emailVerified: true,
       });
-      if (result.status === "conflict") {
-        return c.json(
-          {
-            error: {
-              code: "CONFLICT",
-              message: "User is already linked to a different WhatsApp identity",
-            },
-          },
-          409,
-        );
-      }
-      return c.json({ ok: true, userId: result.user.id });
-    }
 
-    const existing = await deps.userRepo.findByEmail(email);
-    if (existing) {
-      if (!existing.email_verified_at) {
-        await deps.userRepo.update(existing.id, { emailVerified: true });
-      }
-      return c.json({ ok: true, userId: existing.id });
-    }
-
-    const user = await deps.userRepo.create({
-      email,
-      name: parsed.data.name,
-      emailVerified: true,
+      return c.json({ ok: true, userId: user.id });
     });
-
-    return c.json({ ok: true, userId: user.id });
   });
 
   routes.put("/users", async (c) => {
@@ -492,49 +529,60 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       return c.json({ error: { code: "BAD_REQUEST", message: parsed.error.message } }, 400);
     }
 
+    const userRepo = deps.userRepo;
+    const mutationIds = await resolveManagedMemberMutationIds(
+      userRepo,
+      parsed.data.users.map((user) => ({
+        ...(user.email ? { email: user.email } : {}),
+        ...(user.whatsappNumber ? { whatsappNumber: user.whatsappNumber } : {}),
+      })),
+    );
+
     try {
-      const result = await deps.userRepo.transaction(async (users) => {
-        let created = 0;
-        let updated = 0;
+      const result = await withManagedMemberMutationLocks(deps, mutationIds, () =>
+        userRepo.transaction(async (users) => {
+          let created = 0;
+          let updated = 0;
 
-        for (const user of parsed.data.users) {
-          let rowCreated = false;
-          let rowUpdated = false;
+          for (const user of parsed.data.users) {
+            let rowCreated = false;
+            let rowUpdated = false;
 
-          if (user.slackUserId) {
-            const slackResult = await upsertSlackIdentity(users, {
-              name: user.name,
-              email: user.email as string,
-              slackUserId: user.slackUserId,
-            });
-            if (slackResult.status === "conflict") {
-              throw new SystemUserSyncConflictError(
-                `User ${slackResult.conflict.email} is already linked to another Slack user`,
-              );
+            if (user.slackUserId) {
+              const slackResult = await upsertSlackIdentity(users, {
+                name: user.name,
+                email: user.email as string,
+                slackUserId: user.slackUserId,
+              });
+              if (slackResult.status === "conflict") {
+                throw new SystemUserSyncConflictError(
+                  `User ${slackResult.conflict.email} is already linked to another Slack user`,
+                );
+              }
+              if (slackResult.status === "created") rowCreated = true;
+              if (slackResult.status === "updated") rowUpdated = true;
             }
-            if (slackResult.status === "created") rowCreated = true;
-            if (slackResult.status === "updated") rowUpdated = true;
+
+            if (user.whatsappNumber) {
+              const whatsappResult = await upsertWhatsAppIdentity(users, {
+                name: user.name,
+                email: user.email,
+                whatsappNumber: user.whatsappNumber,
+              });
+              if (whatsappResult.status === "conflict") {
+                throw new SystemUserSyncConflictError("User is already linked to a different WhatsApp identity");
+              }
+              if (whatsappResult.status === "created") rowCreated = true;
+              if (whatsappResult.status === "updated") rowUpdated = true;
+            }
+
+            if (rowCreated) created += 1;
+            else if (rowUpdated) updated += 1;
           }
 
-          if (user.whatsappNumber) {
-            const whatsappResult = await upsertWhatsAppIdentity(users, {
-              name: user.name,
-              email: user.email,
-              whatsappNumber: user.whatsappNumber,
-            });
-            if (whatsappResult.status === "conflict") {
-              throw new SystemUserSyncConflictError("User is already linked to a different WhatsApp identity");
-            }
-            if (whatsappResult.status === "created") rowCreated = true;
-            if (whatsappResult.status === "updated") rowUpdated = true;
-          }
-
-          if (rowCreated) created += 1;
-          else if (rowUpdated) updated += 1;
-        }
-
-        return { created, updated };
-      });
+          return { created, updated };
+        }),
+      );
 
       return c.json({ ok: true, created: result.created, updated: result.updated });
     } catch (error) {

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -566,11 +566,11 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     );
 
     try {
-      const result = await withManagedMemberMutationLocks(deps, mutationIds, async () => {
-        const transactionResult = await userRepo.transaction(async (users) => {
+      const result = await withManagedMemberMutationLocks(deps, mutationIds, () =>
+        userRepo.transaction(async (users) => {
           let created = 0;
           let updated = 0;
-          const membersToSync = new Map<string, ManagedMemberRegistrationInput>();
+          const memberIdsToSync = new Set<string>();
 
           for (const user of parsed.data.users) {
             let rowCreated = false;
@@ -602,21 +602,24 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
               }
               if (whatsappResult.status === "created") rowCreated = true;
               if (whatsappResult.status === "updated") rowUpdated = true;
-              const memberToSync = managedMemberRegistrationInput(whatsappResult.user);
-              if (memberToSync) membersToSync.set(memberToSync.tenantUserId, memberToSync);
+              memberIdsToSync.add(whatsappResult.user.id);
             }
 
             if (rowCreated) created += 1;
             else if (rowUpdated) updated += 1;
           }
 
-          return { created, updated, membersToSync: [...membersToSync.values()] };
+          return { created, updated, memberIdsToSync: [...memberIdsToSync] };
+        }),
+      );
+      for (const memberId of result.memberIdsToSync) {
+        await withManagedMemberMutationLocks(deps, [memberId], async () => {
+          const currentUser = await userRepo.findById(memberId);
+          if (currentUser?.type !== "human") return;
+          const memberToSync = managedMemberRegistrationInput(currentUser);
+          if (memberToSync) await deps.syncManagedMemberMapping?.(memberToSync);
         });
-        for (const memberToSync of transactionResult.membersToSync) {
-          await deps.syncManagedMemberMapping?.(memberToSync);
-        }
-        return transactionResult;
-      });
+      }
 
       return c.json({ ok: true, created: result.created, updated: result.updated });
     } catch (error) {

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -11,6 +11,7 @@ import type { createInboxMessagesRepository } from "../db/repositories/inbox-mes
 import type { createMcpServerRepository } from "../db/repositories/mcp-servers";
 import type { createSettingsRepository } from "../db/repositories/settings";
 import type { createUserRepository } from "../db/repositories/users";
+import type { ManagedMemberRegistrationInput } from "../managed-members";
 import { upsertSlackIdentity } from "../slack/upsert-identity";
 import { InvalidManagedWhatsAppInboundEventError } from "../whatsapp/providers/managed";
 import type { ManagedWhatsAppProvider } from "../whatsapp/providers/managed";
@@ -66,6 +67,7 @@ interface SystemDeps {
     conflictUserIds: string[];
     failedUserIds: string[];
   }>;
+  syncManagedMemberMapping?: (input: ManagedMemberRegistrationInput) => Promise<void>;
   withManagedMemberSyncLocks?: <T>(tenantUserIds: string[], operation: () => Promise<T>) => Promise<T>;
   validateManagedWhatsappInboundIdentity?: (tenantUserId: string, senderPhoneE164: string) => Promise<boolean>;
 }
@@ -376,24 +378,32 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       await withManagedMemberMutationLocks(deps, existingUser ? [existingUser.id] : [], async () => {
         const displayName = parsed.data.name || normalizedAdminEmail.split("@")[0];
         const currentUser = await userRepo.findByEmail(normalizedAdminEmail);
-        if (currentUser) {
-          await userRepo.update(currentUser.id, {
-            name: displayName,
-            email: normalizedAdminEmail,
-            emailVerified: true,
-            ...(adminPasswordHash !== undefined ? { passwordHash: adminPasswordHash } : {}),
-            ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
-            authRole: "admin",
-          });
-        } else {
-          await userRepo.create({
-            name: displayName,
-            email: normalizedAdminEmail,
-            emailVerified: true,
-            passwordHash: adminPasswordHash ?? null,
-            ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
-            authRole: "admin",
-          });
+        const user = currentUser
+          ? await userRepo.update(currentUser.id, {
+              name: displayName,
+              email: normalizedAdminEmail,
+              emailVerified: true,
+              ...(adminPasswordHash !== undefined ? { passwordHash: adminPasswordHash } : {}),
+              ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
+              authRole: "admin",
+            })
+          : await userRepo.create({
+              name: displayName,
+              email: normalizedAdminEmail,
+              emailVerified: true,
+              passwordHash: adminPasswordHash ?? null,
+              ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
+              authRole: "admin",
+            });
+        if (user.type === "human" && user.email && user.whatsapp_number) {
+          const memberToSync: ManagedMemberRegistrationInput = {
+            tenantUserId: user.id,
+            email: user.email,
+            name: user.name,
+            phoneNumber: user.whatsapp_number,
+            sendInvite: false,
+          };
+          await deps.syncManagedMemberMapping?.(memberToSync);
         }
       });
     }

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -589,6 +589,7 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
               }
               if (slackResult.status === "created") rowCreated = true;
               if (slackResult.status === "updated") rowUpdated = true;
+              if (slackResult.user.whatsapp_number) memberIdsToSync.add(slackResult.user.id);
             }
 
             if (user.whatsappNumber) {

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -208,10 +208,14 @@ class SystemUserSyncConflictError extends Error {}
 
 async function resolveManagedMemberMutationIds(
   userRepo: UserRepo,
-  users: Array<{ email?: string; whatsappNumber?: string }>,
+  users: Array<{ email?: string; slackUserId?: string; whatsappNumber?: string }>,
 ): Promise<string[]> {
   const ids = new Set<string>();
   for (const user of users) {
+    if (user.slackUserId) {
+      const existingBySlack = await userRepo.findBySlackId(user.slackUserId);
+      if (existingBySlack) ids.add(existingBySlack.id);
+    }
     if (user.email) {
       const existingByEmail = await userRepo.findByEmail(user.email.trim().toLowerCase());
       if (existingByEmail) ids.add(existingByEmail.id);
@@ -534,6 +538,7 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
       userRepo,
       parsed.data.users.map((user) => ({
         ...(user.email ? { email: user.email } : {}),
+        ...(user.slackUserId ? { slackUserId: user.slackUserId } : {}),
         ...(user.whatsappNumber ? { whatsappNumber: user.whatsappNumber } : {}),
       })),
     );

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -238,6 +238,22 @@ function withManagedMemberMutationLocks<T>(
   return deps.withManagedMemberSyncLocks ? deps.withManagedMemberSyncLocks(tenantUserIds, operation) : operation();
 }
 
+function managedMemberRegistrationInput(user: {
+  id: string;
+  email: string | null;
+  name: string;
+  whatsapp_number: string | null;
+}): ManagedMemberRegistrationInput | undefined {
+  if (!user.email || !user.whatsapp_number) return undefined;
+  return {
+    tenantUserId: user.id,
+    email: user.email,
+    name: user.name,
+    phoneNumber: user.whatsapp_number,
+    sendInvite: false,
+  };
+}
+
 function buildWhatsAppIntroMessage(botName: string, orgName: string | null | undefined): string {
   const orgLabel = orgName?.trim() || "your workspace";
   return `Hi, I'm ${botName}, your AI coworker in ${orgLabel}. You can message me here when you need help with your workspace.`;
@@ -395,15 +411,9 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
               ...(whatsappNumber !== undefined ? { whatsappNumber } : {}),
               authRole: "admin",
             });
-        if (user.type === "human" && user.email && user.whatsapp_number) {
-          const memberToSync: ManagedMemberRegistrationInput = {
-            tenantUserId: user.id,
-            email: user.email,
-            name: user.name,
-            phoneNumber: user.whatsapp_number,
-            sendInvite: false,
-          };
-          await deps.syncManagedMemberMapping?.(memberToSync);
+        if (user.type === "human") {
+          const memberToSync = managedMemberRegistrationInput(user);
+          if (memberToSync) await deps.syncManagedMemberMapping?.(memberToSync);
         }
       });
     }
@@ -511,6 +521,8 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
             409,
           );
         }
+        const memberToSync = managedMemberRegistrationInput(result.user);
+        if (memberToSync) await deps.syncManagedMemberMapping?.(memberToSync);
         return c.json({ ok: true, userId: result.user.id });
       }
 
@@ -554,10 +566,11 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
     );
 
     try {
-      const result = await withManagedMemberMutationLocks(deps, mutationIds, () =>
-        userRepo.transaction(async (users) => {
+      const result = await withManagedMemberMutationLocks(deps, mutationIds, async () => {
+        const transactionResult = await userRepo.transaction(async (users) => {
           let created = 0;
           let updated = 0;
+          const membersToSync = new Map<string, ManagedMemberRegistrationInput>();
 
           for (const user of parsed.data.users) {
             let rowCreated = false;
@@ -589,15 +602,21 @@ export function systemRoutes(settings: SettingsRepo, deps: SystemDeps) {
               }
               if (whatsappResult.status === "created") rowCreated = true;
               if (whatsappResult.status === "updated") rowUpdated = true;
+              const memberToSync = managedMemberRegistrationInput(whatsappResult.user);
+              if (memberToSync) membersToSync.set(memberToSync.tenantUserId, memberToSync);
             }
 
             if (rowCreated) created += 1;
             else if (rowUpdated) updated += 1;
           }
 
-          return { created, updated };
-        }),
-      );
+          return { created, updated, membersToSync: [...membersToSync.values()] };
+        });
+        for (const memberToSync of transactionResult.membersToSync) {
+          await deps.syncManagedMemberMapping?.(memberToSync);
+        }
+        return transactionResult;
+      });
 
       return c.json({ ok: true, created: result.created, updated: result.updated });
     } catch (error) {

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -213,20 +213,24 @@ describe("Users API — agent fields", () => {
     fetchMock.mockRestore();
   });
 
-  it("registers managed human members with the platform before local create", async () => {
+  it("sends the invite before local create and activates managed routing after local create", async () => {
     const managedApp = createApp(
       db,
       createTestConfig({
         MANAGED_URL: "https://platform.test",
         MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
       }),
       { logger: createTestLogger() },
     );
     const managedCookie = await login(managedApp, ADMIN_EMAIL);
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
+      .mockResolvedValueOnce(
         new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, mappingStatus: "active", emailSent: false }), { status: 200 }),
       );
 
     const res = await managedApp.request("/api/users", {
@@ -242,7 +246,8 @@ describe("Users API — agent fields", () => {
 
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
       "https://platform.test/api/tenant/members",
       expect.objectContaining({
         method: "PUT",
@@ -259,6 +264,238 @@ describe("Users API — agent fields", () => {
         }),
       }),
     );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://platform.test/api/tenant/members",
+      expect.objectContaining({
+        body: JSON.stringify({
+          tenantUserId: body.user.id,
+          email: "managed.person@gmail.com",
+          name: "Managed Person",
+          phoneNumber: "+14155550106",
+          sendInvite: false,
+          managedWhatsappDmEnabled: true,
+        }),
+      }),
+    );
+    expect(body.managedWhatsappMappingStatus).toBe("active");
+    fetchMock.mockRestore();
+  });
+
+  it("preserves membership sync without enabling shared routing for non-managed DMs", async () => {
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "baileys",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, mappingStatus: "inactive", emailSent: false }), { status: 200 }),
+      );
+
+    const res = await managedApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Baileys Person",
+        type: "human",
+        email: "baileys.person@gmail.com",
+        whatsappNumber: "+14155550116",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const request = fetchMock.mock.calls[1]?.[1];
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      email: "baileys.person@gmail.com",
+      sendInvite: false,
+      managedWhatsappDmEnabled: false,
+    });
+    fetchMock.mockRestore();
+  });
+
+  it("reconciles managed routing after a human phone number changes", async () => {
+    const users = createUserRepository(db);
+    const member = await users.create({
+      name: "Changing Number",
+      type: "human",
+      email: "changing.number@gmail.com",
+      whatsappNumber: "+14155550120",
+    });
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, mappingStatus: "active" }), { status: 200 }));
+
+    const res = await managedApp.request(`/api/users/${member.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({ whatsappNumber: "+14155550121" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).managedWhatsappMappingStatus).toBe("active");
+    const preCommitBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const postCommitBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(preCommitBody).toMatchObject({
+      tenantUserId: member.id,
+      phoneNumber: "+14155550121",
+      sendInvite: false,
+    });
+    expect(preCommitBody).not.toHaveProperty("managedWhatsappDmEnabled");
+    expect(postCommitBody).toMatchObject({
+      tenantUserId: member.id,
+      phoneNumber: "+14155550121",
+      sendInvite: false,
+      managedWhatsappDmEnabled: true,
+    });
+    fetchMock.mockRestore();
+  });
+
+  it("reconciles existing managed human members through the authenticated system endpoint", async () => {
+    const users = createUserRepository(db);
+    const member = await users.create({
+      name: "Existing Managed Person",
+      type: "human",
+      email: "existing.managed@gmail.com",
+      whatsappNumber: "+14155550117",
+    });
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
+        SYSTEM_SECRET: "system-secret",
+      }),
+      { logger: createTestLogger() },
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, mappingStatus: "active", emailSent: false, whatsappSent: false }), {
+        status: 200,
+      }),
+    );
+
+    const res = await managedApp.request("/api/system/managed-member-reconciliations", {
+      method: "POST",
+      headers: { Authorization: "Bearer system-secret" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      skipped: false,
+      total: 1,
+      synced: 1,
+      conflictUserIds: [],
+      failedUserIds: [],
+    });
+    const memberRequest = fetchMock.mock.calls
+      .map((call) => JSON.parse(String(call[1]?.body)))
+      .find((body) => body.tenantUserId === member.id);
+    expect(memberRequest).toMatchObject({
+      email: "existing.managed@gmail.com",
+      phoneNumber: "+14155550117",
+      sendInvite: false,
+      managedWhatsappDmEnabled: true,
+    });
+    fetchMock.mockRestore();
+  });
+
+  it("reports inactive mapping conflicts separately from successful reconciliation", async () => {
+    const users = createUserRepository(db);
+    const member = await users.create({
+      name: "Conflicted Member",
+      type: "human",
+      email: "conflicted.member@gmail.com",
+      whatsappNumber: "+14155550122",
+    });
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
+        SYSTEM_SECRET: "system-secret",
+      }),
+      { logger: createTestLogger() },
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, mappingStatus: "inactive_conflict" }), { status: 200 }),
+      );
+
+    const res = await managedApp.request("/api/system/managed-member-reconciliations", {
+      method: "POST",
+      headers: { Authorization: "Bearer system-secret" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      skipped: false,
+      total: 1,
+      synced: 0,
+      conflictUserIds: [member.id],
+      failedUserIds: [],
+    });
+    fetchMock.mockRestore();
+  });
+
+  it("reconciliation deactivates shared routing when the tenant uses another WhatsApp provider", async () => {
+    const users = createUserRepository(db);
+    const member = await users.create({
+      name: "Baileys Member",
+      type: "human",
+      email: "baileys.reconcile@gmail.com",
+      whatsappNumber: "+14155550119",
+    });
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "baileys",
+        SYSTEM_SECRET: "system-secret",
+      }),
+      { logger: createTestLogger() },
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true, mappingStatus: "inactive" }), { status: 200 }));
+
+    const res = await managedApp.request("/api/system/managed-member-reconciliations", {
+      method: "POST",
+      headers: { Authorization: "Bearer system-secret" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ skipped: false, total: 1, synced: 1 });
+    const request = fetchMock.mock.calls
+      .map((call) => JSON.parse(String(call[1]?.body)))
+      .find((body) => body.tenantUserId === member.id);
+    expect(request).toMatchObject({
+      sendInvite: false,
+      managedWhatsappDmEnabled: false,
+    });
     fetchMock.mockRestore();
   });
 
@@ -300,6 +537,46 @@ describe("Users API — agent fields", () => {
     fetchMock.mockRestore();
   });
 
+  it("keeps the local human and reports failure when routing sync is not confirmed", async () => {
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, emailSent: false, whatsappSent: false }), { status: 200 }),
+      );
+
+    const res = await managedApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Mapping Retry",
+        type: "human",
+        email: "mapping.retry@gmail.com",
+        whatsappNumber: "+14155550118",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.managedWhatsappMappingStatus).toBe("failed");
+    await expect(createUserRepository(db).findById(body.user.id)).resolves.toMatchObject({
+      email: "mapping.retry@gmail.com",
+    });
+    fetchMock.mockRestore();
+  });
+
   it("removes managed tenant members before deleting local human users", async () => {
     const managedApp = createApp(
       db,
@@ -315,6 +592,7 @@ describe("Users API — agent fields", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
       )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, mappingStatus: "inactive" }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
     const create = await managedApp.request("/api/users", {
@@ -337,8 +615,8 @@ describe("Users API — agent fields", () => {
 
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      "https://platform.test/api/tenant/members/managed.delete%40gmail.com",
+      3,
+      `https://platform.test/api/tenant/members/managed.delete%40gmail.com?tenantUserId=${user.id}`,
       expect.objectContaining({
         method: "DELETE",
         headers: expect.objectContaining({
@@ -437,6 +715,7 @@ describe("Users API — agent fields", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 }),
       )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, mappingStatus: "inactive" }), { status: 200 }))
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ error: { code: "REMOVE_FAILED", message: "Could not remove managed member" } }), {
           status: 502,

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -285,6 +285,78 @@ describe("Users API — agent fields", () => {
     fetchMock.mockRestore();
   });
 
+  it("locks and re-reads a new member before post-create routing sync", async () => {
+    const users = createUserRepository(db);
+    const managedApp = createApp(
+      db,
+      createTestConfig({
+        MANAGED_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
+      }),
+      { logger: createTestLogger() },
+    );
+    const managedCookie = await login(managedApp, ADMIN_EMAIL);
+    let memberId = "";
+    let releaseLock = () => {};
+    let confirmLockAcquired = () => {};
+    const lockAcquired = new Promise<void>((resolve) => {
+      confirmLockAcquired = resolve;
+    });
+    const holdLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    let blocker = Promise.resolve();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async (_url, init) => {
+        memberId = JSON.parse(String(init?.body)).tenantUserId;
+        blocker = withManagedMemberSyncLock(memberId, async () => {
+          confirmLockAcquired();
+          await holdLock;
+        });
+        await lockAcquired;
+        return new Response(JSON.stringify({ ok: true, emailSent: true, whatsappSent: false }), { status: 200 });
+      })
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, mappingStatus: "active", emailSent: false }), { status: 200 }),
+      );
+
+    const createRequest = managedApp.request("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: managedCookie },
+      body: JSON.stringify({
+        name: "Before Create Sync",
+        type: "human",
+        email: "create.sync@gmail.com",
+        whatsappNumber: "+14155550130",
+      }),
+    });
+    await vi.waitFor(async () => {
+      expect(memberId).not.toBe("");
+      expect(await users.findById(memberId)).toBeDefined();
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    await users.update(memberId, {
+      name: "After Create Sync",
+      whatsappNumber: "+14155550131",
+    });
+
+    releaseLock();
+    await blocker;
+    const res = await createRequest;
+    expect(res.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toMatchObject({
+      tenantUserId: memberId,
+      name: "After Create Sync",
+      phoneNumber: "+14155550131",
+      sendInvite: false,
+      managedWhatsappDmEnabled: true,
+    });
+    fetchMock.mockRestore();
+  });
+
   it("preserves membership sync without enabling shared routing for non-managed DMs", async () => {
     const managedApp = createApp(
       db,

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -15,7 +15,7 @@ import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
 import { createApp } from "../http";
-import { withManagedMemberSyncLock } from "../managed-members";
+import * as managedMembers from "../managed-members";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 
 const PASSWORD = "testpassword123";
@@ -311,7 +311,7 @@ describe("Users API — agent fields", () => {
       .spyOn(globalThis, "fetch")
       .mockImplementationOnce(async (_url, init) => {
         memberId = JSON.parse(String(init?.body)).tenantUserId;
-        blocker = withManagedMemberSyncLock(memberId, async () => {
+        blocker = managedMembers.withManagedMemberSyncLock(memberId, async () => {
           confirmLockAcquired();
           await holdLock;
         });
@@ -960,11 +960,12 @@ describe("Users API — agent fields", () => {
     const holdLock = new Promise<void>((resolve) => {
       releaseLock = resolve;
     });
-    const blocker = withManagedMemberSyncLock(agent.id, async () => {
+    const blocker = managedMembers.withManagedMemberSyncLock(agent.id, async () => {
       confirmLockAcquired();
       await holdLock;
     });
     await lockAcquired;
+    const lockSpy = vi.spyOn(managedMembers, "withManagedMemberSyncLock");
 
     let mutationSettled = false;
     const mutation = Promise.resolve(
@@ -977,7 +978,7 @@ describe("Users API — agent fields", () => {
       mutationSettled = true;
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await vi.waitFor(() => expect(lockSpy).toHaveBeenCalledWith(agent.id, expect.any(Function)));
     expect(mutationSettled).toBe(false);
     expect((await users.findById(agent.id))?.name).toBe("Before reconciliation");
 

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -15,6 +15,7 @@ import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
 import { createApp } from "../http";
+import { withManagedMemberSyncLock } from "../managed-members";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 
 const PASSWORD = "testpassword123";
@@ -874,6 +875,45 @@ describe("Users API — agent fields", () => {
     expect(update.status).toBe(400);
     const body = await update.json();
     expect(body.error.message).toContain("allowedTools");
+  });
+
+  it("serializes member mutations with managed member reconciliation", async () => {
+    const users = createUserRepository(db);
+    const agent = await users.create({ name: "Before reconciliation", type: "agent" });
+    let releaseLock = () => {};
+    let confirmLockAcquired = () => {};
+    const lockAcquired = new Promise<void>((resolve) => {
+      confirmLockAcquired = resolve;
+    });
+    const holdLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const blocker = withManagedMemberSyncLock(async () => {
+      confirmLockAcquired();
+      await holdLock;
+    });
+    await lockAcquired;
+
+    let mutationSettled = false;
+    const mutation = Promise.resolve(
+      app.request(`/api/users/${agent.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Cookie: cookie },
+        body: JSON.stringify({ name: "After reconciliation" }),
+      }),
+    ).finally(() => {
+      mutationSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(mutationSettled).toBe(false);
+    expect((await users.findById(agent.id))?.name).toBe("Before reconciliation");
+
+    releaseLock();
+    await blocker;
+    const response = await mutation;
+    expect(response.status).toBe(200);
+    expect((await users.findById(agent.id))?.name).toBe("After reconciliation");
   });
 
   describe("Slack channel bindings", () => {

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -262,6 +262,7 @@ describe("Users API — agent fields", () => {
           phoneNumber: "+14155550106",
           sendInvite: true,
         }),
+        signal: expect.any(AbortSignal),
       }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -276,6 +277,7 @@ describe("Users API — agent fields", () => {
           sendInvite: false,
           managedWhatsappDmEnabled: true,
         }),
+        signal: expect.any(AbortSignal),
       }),
     );
     expect(body.managedWhatsappMappingStatus).toBe("active");

--- a/packages/server/src/api/users.test.ts
+++ b/packages/server/src/api/users.test.ts
@@ -888,7 +888,7 @@ describe("Users API — agent fields", () => {
     const holdLock = new Promise<void>((resolve) => {
       releaseLock = resolve;
     });
-    const blocker = withManagedMemberSyncLock(async () => {
+    const blocker = withManagedMemberSyncLock(agent.id, async () => {
       confirmLockAcquired();
       await holdLock;
     });

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -11,7 +11,7 @@ import {
   parseAllowedTools,
   whatsappNumberSchema,
 } from "@sketch/shared";
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
 import { z } from "zod";
@@ -240,19 +240,14 @@ async function syncManagedMemberMapping(
 
 export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
   const routes = new Hono();
-
-  routes.use("*", async (c, next) => {
-    const isMemberMutation =
-      c.req.method === "PATCH" ||
-      c.req.method === "DELETE" ||
-      (c.req.method === "POST" && !c.req.path.endsWith("/verification"));
-    if (!isMemberMutation) {
+  const serializeManagedMemberMutation: MiddlewareHandler = async (c, next) => {
+    const tenantUserId = c.req.param("id");
+    if (!tenantUserId) {
       await next();
       return;
     }
-
-    await withManagedMemberSyncLock(next);
-  });
+    await withManagedMemberSyncLock(tenantUserId, next);
+  };
 
   routes.get("/", async (c) => {
     const list = await users.list();
@@ -513,7 +508,7 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     }
   });
 
-  routes.patch("/:id", async (c) => {
+  routes.patch("/:id", serializeManagedMemberMutation, async (c) => {
     const id = c.req.param("id");
 
     const existing = await users.findById(id);
@@ -751,7 +746,7 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     }
   });
 
-  routes.post("/:id/promote", async (c) => {
+  routes.post("/:id/promote", serializeManagedMemberMutation, async (c) => {
     const id = c.req.param("id");
     const existing = await users.findById(id);
     if (!existing) {
@@ -878,7 +873,7 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     return c.json({ success: true, sent: result.sent });
   });
 
-  routes.delete("/:id", async (c) => {
+  routes.delete("/:id", serializeManagedMemberMutation, async (c) => {
     const sub = c.get("sub");
     const id = c.req.param("id");
     if (id === sub) {

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -452,16 +452,20 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
         reportsTo: reportsTo ?? undefined,
         allowedTools: parsed.data.allowedTools ?? undefined,
       });
-      const managedWhatsappMappingStatus =
-        user.type === "human" && user.email && user.whatsapp_number
-          ? await syncManagedMemberMapping(deps, {
-              tenantUserId: user.id,
-              email: user.email,
-              name: user.name,
-              phoneNumber: user.whatsapp_number,
-              sendInvite: false,
-            })
-          : undefined;
+      let managedWhatsappMappingStatus: ManagedMemberRegistrationResult["mappingStatus"] | "failed" | undefined;
+      if (user.type === "human" && user.email && user.whatsapp_number) {
+        await withManagedMemberSyncLock(user.id, async () => {
+          const currentUser = await users.findById(user.id);
+          if (currentUser?.type !== "human" || !currentUser.email || !currentUser.whatsapp_number) return;
+          managedWhatsappMappingStatus = await syncManagedMemberMapping(deps, {
+            tenantUserId: currentUser.id,
+            email: currentUser.email,
+            name: currentUser.name,
+            phoneNumber: currentUser.whatsapp_number,
+            sendInvite: false,
+          });
+        });
+      }
 
       let boundSlackChannelIds: string[] = [];
       if (parsed.data.slackChannelIds && deps.channels) {

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -30,6 +30,7 @@ import {
   type ManagedMemberRegistrationInput,
   type ManagedMemberRegistrationResult,
   type ManagedMemberRemovalInput,
+  withManagedMemberSyncLock,
 } from "../managed-members";
 import type { SlackBot } from "../slack/bot";
 
@@ -239,6 +240,19 @@ async function syncManagedMemberMapping(
 
 export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
   const routes = new Hono();
+
+  routes.use("*", async (c, next) => {
+    const isMemberMutation =
+      c.req.method === "PATCH" ||
+      c.req.method === "DELETE" ||
+      (c.req.method === "POST" && !c.req.path.endsWith("/verification"));
+    if (!isMemberMutation) {
+      await next();
+      return;
+    }
+
+    await withManagedMemberSyncLock(next);
+  });
 
   routes.get("/", async (c) => {
     const list = await users.list();

--- a/packages/server/src/api/users.ts
+++ b/packages/server/src/api/users.ts
@@ -28,6 +28,7 @@ import { createEmailTransport, sendVerificationEmail } from "../email";
 import {
   ManagedMemberRegistrationError,
   type ManagedMemberRegistrationInput,
+  type ManagedMemberRegistrationResult,
   type ManagedMemberRemovalInput,
 } from "../managed-members";
 import type { SlackBot } from "../slack/bot";
@@ -49,6 +50,7 @@ interface UserRoutesDeps {
   whatsappGroups?: WhatsAppGroupRepo;
   getSlack?: () => SlackBot | null;
   registerManagedMember?: (input: ManagedMemberRegistrationInput) => Promise<unknown>;
+  syncManagedMemberMapping?: (input: ManagedMemberRegistrationInput) => Promise<ManagedMemberRegistrationResult>;
   removeManagedMember?: (input: ManagedMemberRemovalInput) => Promise<unknown>;
 }
 
@@ -221,6 +223,20 @@ function managedRegistrationResponse(err: unknown) {
   };
 }
 
+async function syncManagedMemberMapping(
+  deps: UserRoutesDeps,
+  input: ManagedMemberRegistrationInput,
+): Promise<ManagedMemberRegistrationResult["mappingStatus"] | "failed" | undefined> {
+  if (!deps.syncManagedMemberMapping) return undefined;
+  try {
+    const result = await deps.syncManagedMemberMapping(input);
+    return result.mappingStatus;
+  } catch (err) {
+    deps.logger.warn({ err, userId: input.tenantUserId }, "Managed WhatsApp member mapping sync failed");
+    return "failed";
+  }
+}
+
 export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
   const routes = new Hono();
 
@@ -286,6 +302,10 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     const userType = parsed.data.type ?? "human";
     const humanEmail = parsed.data.email?.trim().toLowerCase() ?? null;
     const humanWhatsappNumber = parsed.data.whatsappNumber ?? null;
+
+    if (userType === "human" && c.get("role") !== "admin") {
+      return c.json({ error: { code: "FORBIDDEN", message: "Admin role required" } }, 403);
+    }
 
     if (userType === "human" && (!humanEmail || !humanWhatsappNumber)) {
       return c.json(humanContactError(), 400);
@@ -423,6 +443,16 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
         reportsTo: reportsTo ?? undefined,
         allowedTools: parsed.data.allowedTools ?? undefined,
       });
+      const managedWhatsappMappingStatus =
+        user.type === "human" && user.email && user.whatsapp_number
+          ? await syncManagedMemberMapping(deps, {
+              tenantUserId: user.id,
+              email: user.email,
+              name: user.name,
+              phoneNumber: user.whatsapp_number,
+              sendInvite: false,
+            })
+          : undefined;
 
       let boundSlackChannelIds: string[] = [];
       if (parsed.data.slackChannelIds && deps.channels) {
@@ -454,6 +484,7 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
         {
           user: serializeUser(user, boundSlackChannelIds, boundWhatsAppGroupJids, isWhatsappFallback),
           verificationSent,
+          ...(managedWhatsappMappingStatus ? { managedWhatsappMappingStatus } : {}),
         },
         201,
       );
@@ -481,6 +512,14 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     if (!parsed.success) {
       const message = parsed.error.issues[0]?.message ?? "Invalid request";
       return c.json({ error: { code: "VALIDATION_ERROR", message } }, 400);
+    }
+
+    if (
+      existing.type === "human" &&
+      (parsed.data.email !== undefined || parsed.data.whatsappNumber !== undefined) &&
+      c.get("role") !== "admin"
+    ) {
+      return c.json({ error: { code: "FORBIDDEN", message: "Admin role required" } }, 403);
     }
 
     if (parsed.data.authRole !== undefined) {
@@ -640,6 +679,16 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
         reportsTo: reportsToValue,
         allowedTools: parsed.data.allowedTools,
       });
+      const managedWhatsappMappingStatus =
+        user.type === "human" && user.email && user.whatsapp_number
+          ? await syncManagedMemberMapping(deps, {
+              tenantUserId: user.id,
+              email: user.email,
+              name: user.name,
+              phoneNumber: user.whatsapp_number,
+              sendInvite: false,
+            })
+          : undefined;
 
       if (parsed.data.slackChannelIds !== undefined && deps.channels) {
         await deps.channels.setAgentForSlackChannelIds(user.id, parsed.data.slackChannelIds);
@@ -675,6 +724,7 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
       return c.json({
         user: serializeUser(user, boundSlackChannelIds, boundWhatsAppGroupJids, isWhatsappFallback),
         verificationSent,
+        ...(managedWhatsappMappingStatus ? { managedWhatsappMappingStatus } : {}),
       });
     } catch (err: unknown) {
       if (err instanceof Error && err.message.includes("UNIQUE constraint failed")) {
@@ -695,6 +745,9 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     }
     if (existing.type !== "external") {
       return c.json({ error: { code: "VALIDATION_ERROR", message: "Only external users can be promoted" } }, 400);
+    }
+    if (c.get("role") !== "admin") {
+      return c.json({ error: { code: "FORBIDDEN", message: "Admin role required" } }, 403);
     }
 
     const body = await c.req.json();
@@ -756,6 +809,16 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     if (!promoted) {
       return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
     }
+    const managedWhatsappMappingStatus =
+      promoted.email && promoted.whatsapp_number
+        ? await syncManagedMemberMapping(deps, {
+            tenantUserId: promoted.id,
+            email: promoted.email,
+            name: promoted.name,
+            phoneNumber: promoted.whatsapp_number,
+            sendInvite: false,
+          })
+        : undefined;
 
     let verificationSent = false;
     if (promoted.email) {
@@ -764,7 +827,11 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
       verificationSent = result.sent;
     }
 
-    return c.json({ user: serializeUser(promoted), verificationSent });
+    return c.json({
+      user: serializeUser(promoted),
+      verificationSent,
+      ...(managedWhatsappMappingStatus ? { managedWhatsappMappingStatus } : {}),
+    });
   });
 
   // Resend verification email
@@ -810,10 +877,13 @@ export function userRoutes(users: UserRepo, deps: UserRoutesDeps) {
     if (sub.includes("@") && existing.email?.toLowerCase() === sub.toLowerCase()) {
       return c.json({ error: { code: "FORBIDDEN", message: "Cannot delete your own account" } }, 403);
     }
+    if (existing.type === "human" && c.get("role") !== "admin") {
+      return c.json({ error: { code: "FORBIDDEN", message: "Admin role required" } }, 403);
+    }
 
     if (existing.type === "human" && existing.email && deps.removeManagedMember) {
       try {
-        await deps.removeManagedMember({ email: existing.email });
+        await deps.removeManagedMember({ tenantUserId: existing.id, email: existing.email });
       } catch (err) {
         const response = managedRegistrationResponse(err);
         return c.json(response.body, response.status as 400);

--- a/packages/server/src/bootstrap.integration.test.ts
+++ b/packages/server/src/bootstrap.integration.test.ts
@@ -289,4 +289,40 @@ describe("bootstrap", () => {
     await expect(shutdown).resolves.toBeUndefined();
     expect(shutdownCompleted).toBe(true);
   });
+
+  it("waits for manual managed member reconciliation during shutdown", async () => {
+    const { reconcileManagedTenantMembers } = await import("./managed-members");
+    let confirmStarted = () => {};
+    let releaseReconciliation = () => {};
+    const started = new Promise<void>((resolve) => {
+      confirmStarted = resolve;
+    });
+    const blocked = new Promise<void>((resolve) => {
+      releaseReconciliation = resolve;
+    });
+    vi.mocked(reconcileManagedTenantMembers).mockImplementationOnce(async () => {
+      confirmStarted();
+      await blocked;
+      return { skipped: false, total: 0, synced: 0, conflictUserIds: [], failedUserIds: [] };
+    });
+    const h = await boot({ SYSTEM_SECRET: "test-system-secret" }, false, false);
+    const reconciliation = request("/api/system/managed-member-reconciliations", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-system-secret" },
+    });
+    await started;
+
+    let shutdownCompleted = false;
+    const shutdown = h.shutdown().then(() => {
+      shutdownCompleted = true;
+    });
+    handle = null;
+    await Promise.resolve();
+    expect(shutdownCompleted).toBe(false);
+
+    releaseReconciliation();
+    await expect(reconciliation.then((response) => response.status)).resolves.toBe(200);
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(shutdownCompleted).toBe(true);
+  });
 });

--- a/packages/server/src/bootstrap.integration.test.ts
+++ b/packages/server/src/bootstrap.integration.test.ts
@@ -319,6 +319,19 @@ describe("bootstrap", () => {
     handle = null;
     await Promise.resolve();
     expect(shutdownCompleted).toBe(false);
+    const lateReconciliation = await request("/api/system/managed-member-reconciliations", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-system-secret" },
+    });
+    expect(lateReconciliation.status).toBe(200);
+    await expect(lateReconciliation.json()).resolves.toEqual({
+      skipped: true,
+      total: 0,
+      synced: 0,
+      conflictUserIds: [],
+      failedUserIds: [],
+    });
+    expect(reconcileManagedTenantMembers).toHaveBeenCalledOnce();
 
     releaseReconciliation();
     await expect(reconciliation.then((response) => response.status)).resolves.toBe(200);

--- a/packages/server/src/bootstrap.integration.test.ts
+++ b/packages/server/src/bootstrap.integration.test.ts
@@ -258,4 +258,35 @@ describe("bootstrap", () => {
     await expect(h.shutdown()).resolves.toBeUndefined();
     handle = null; // prevent double-shutdown in afterEach
   });
+
+  it("waits for active managed member reconciliation during shutdown", async () => {
+    const { reconcileManagedTenantMembers } = await import("./managed-members");
+    let confirmStarted = () => {};
+    let releaseReconciliation = () => {};
+    const started = new Promise<void>((resolve) => {
+      confirmStarted = resolve;
+    });
+    const blocked = new Promise<void>((resolve) => {
+      releaseReconciliation = resolve;
+    });
+    vi.mocked(reconcileManagedTenantMembers).mockImplementationOnce(async () => {
+      confirmStarted();
+      await blocked;
+      return { skipped: false, total: 0, synced: 0, conflictUserIds: [], failedUserIds: [] };
+    });
+    const h = await boot();
+    await started;
+
+    let shutdownCompleted = false;
+    const shutdown = h.shutdown().then(() => {
+      shutdownCompleted = true;
+    });
+    handle = null;
+    await Promise.resolve();
+    expect(shutdownCompleted).toBe(false);
+
+    releaseReconciliation();
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(shutdownCompleted).toBe(true);
+  });
 });

--- a/packages/server/src/bootstrap.integration.test.ts
+++ b/packages/server/src/bootstrap.integration.test.ts
@@ -48,6 +48,20 @@ vi.mock("./connectors/managed-credential-migration", () => ({
   migrateManagedConnectorCredentialsToCanvas: vi.fn(),
 }));
 
+vi.mock("./managed-members", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./managed-members")>();
+  return {
+    ...actual,
+    reconcileManagedTenantMembers: vi.fn().mockResolvedValue({
+      skipped: false,
+      total: 0,
+      synced: 0,
+      conflictUserIds: [],
+      failedUserIds: [],
+    }),
+  };
+});
+
 // Avoid managed seed side effects during tests
 vi.mock("./managed-seed", () => ({
   runManagedSeed: vi.fn(),
@@ -104,21 +118,32 @@ describe("bootstrap", () => {
   it("runs remote startup work by default", async () => {
     const { syncFeaturedSkills } = await import("./skills/sync");
     const { migrateManagedConnectorCredentialsToCanvas } = await import("./connectors/managed-credential-migration");
+    const { reconcileManagedTenantMembers } = await import("./managed-members");
 
     await boot();
 
     expect(syncFeaturedSkills).toHaveBeenCalledOnce();
     expect(migrateManagedConnectorCredentialsToCanvas).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(reconcileManagedTenantMembers).toHaveBeenCalledOnce());
   });
 
   it("skips remote startup work when external startup is disabled", async () => {
     const { syncFeaturedSkills } = await import("./skills/sync");
     const { migrateManagedConnectorCredentialsToCanvas } = await import("./connectors/managed-credential-migration");
+    const { reconcileManagedTenantMembers } = await import("./managed-members");
 
-    await boot({}, false, false);
+    await boot(
+      {
+        MANAGED_WHATSAPP_PLATFORM_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      },
+      false,
+      false,
+    );
 
     expect(syncFeaturedSkills).not.toHaveBeenCalled();
     expect(migrateManagedConnectorCredentialsToCanvas).not.toHaveBeenCalled();
+    expect(reconcileManagedTenantMembers).not.toHaveBeenCalled();
   });
 
   it("keeps schedulers and inbound consumers stopped when background work is disabled", async () => {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -819,6 +819,38 @@ export async function createServer(config: Config, options?: CreateServerOptions
       })
     : null;
 
+  let managedMemberReconciliationPromise: ReturnType<typeof reconcileManagedTenantMembers> | null = null;
+  const runManagedMemberReconciliation = () => {
+    if (managedMemberReconciliationPromise) return managedMemberReconciliationPromise;
+    const run = reconcileManagedTenantMembers(config, users, logger).then((result) => {
+      if (!result.skipped) {
+        logger.info(
+          {
+            total: result.total,
+            synced: result.synced,
+            conflicts: result.conflictUserIds.length,
+            failed: result.failedUserIds.length,
+          },
+          "Managed member reconciliation completed",
+        );
+      }
+      return result;
+    });
+    managedMemberReconciliationPromise = run;
+    const clearRun = () => {
+      if (managedMemberReconciliationPromise === run) {
+        managedMemberReconciliationPromise = null;
+      }
+    };
+    void run.then(clearRun, clearRun);
+    return run;
+  };
+  const startManagedMemberReconciliation = () => {
+    void runManagedMemberReconciliation().catch((err) => {
+      logger.warn({ err }, "Managed member reconciliation could not start");
+    });
+  };
+
   // 9. HTTP server
   const app = createApp(db, config, {
     whatsapp,
@@ -880,6 +912,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     localClaudeSessionService,
     agentRunService,
     limitAgentExecution,
+    reconcileManagedMembers: runManagedMemberReconciliation,
     ...(whatsapp instanceof GatewayClientFacade
       ? {
           whatsappWakeToken: whatsapp.gatewayToken,
@@ -903,41 +936,12 @@ export async function createServer(config: Config, options?: CreateServerOptions
   localDeviceGateway.attach(server);
   logger.info({ port: config.PORT }, "HTTP server started");
 
-  let managedMemberReconciliationPromise: Promise<void> | null = null;
-  const runManagedMemberReconciliation = async () => {
-    if (managedMemberReconciliationPromise) return managedMemberReconciliationPromise;
-    const run = (async () => {
-      try {
-        const result = await reconcileManagedTenantMembers(config, users, logger);
-        if (!result.skipped) {
-          logger.info(
-            {
-              total: result.total,
-              synced: result.synced,
-              conflicts: result.conflictUserIds.length,
-              failed: result.failedUserIds.length,
-            },
-            "Managed member reconciliation completed",
-          );
-        }
-      } catch (err) {
-        logger.warn({ err }, "Managed member reconciliation could not start");
-      }
-    })();
-    managedMemberReconciliationPromise = run;
-    void run.then(() => {
-      if (managedMemberReconciliationPromise === run) {
-        managedMemberReconciliationPromise = null;
-      }
-    });
-    return run;
-  };
   const managedMemberReconciliationEnabled = backgroundWork && externalStartup;
   const managedMemberReconciliationTimer = managedMemberReconciliationEnabled
-    ? setInterval(() => void runManagedMemberReconciliation(), 5 * 60 * 1000)
+    ? setInterval(startManagedMemberReconciliation, 5 * 60 * 1000)
     : null;
   managedMemberReconciliationTimer?.unref();
-  if (managedMemberReconciliationEnabled) void runManagedMemberReconciliation();
+  if (managedMemberReconciliationEnabled) startManagedMemberReconciliation();
 
   // 10. Start platforms
   if (connect) {
@@ -966,7 +970,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     whatsappInboundRetention?.stop();
     normalizationBackfill?.stop();
     if (managedMemberReconciliationTimer) clearInterval(managedMemberReconciliationTimer);
-    await managedMemberReconciliationPromise;
+    await managedMemberReconciliationPromise?.catch(() => undefined);
     await telemetry.shutdown();
     await syncScheduler?.stop();
     whatsappWindowKeepAliveJob?.stop();

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -820,7 +820,11 @@ export async function createServer(config: Config, options?: CreateServerOptions
     : null;
 
   let managedMemberReconciliationPromise: ReturnType<typeof reconcileManagedTenantMembers> | null = null;
+  let managedMemberReconciliationShuttingDown = false;
   const runManagedMemberReconciliation = () => {
+    if (managedMemberReconciliationShuttingDown) {
+      return Promise.resolve({ skipped: true, total: 0, synced: 0, conflictUserIds: [], failedUserIds: [] });
+    }
     if (managedMemberReconciliationPromise) return managedMemberReconciliationPromise;
     const run = reconcileManagedTenantMembers(config, users, logger).then((result) => {
       if (!result.skipped) {
@@ -962,6 +966,8 @@ export async function createServer(config: Config, options?: CreateServerOptions
   // 11. Shutdown handle
   async function shutdown() {
     logger.info("Shutting down...");
+    managedMemberReconciliationShuttingDown = true;
+    if (managedMemberReconciliationTimer) clearInterval(managedMemberReconciliationTimer);
     await operationalAlertWorker?.stop();
     if (backgroundWork) {
       await whatsappBackfillWorker?.stop();
@@ -969,7 +975,6 @@ export async function createServer(config: Config, options?: CreateServerOptions
     }
     whatsappInboundRetention?.stop();
     normalizationBackfill?.stop();
-    if (managedMemberReconciliationTimer) clearInterval(managedMemberReconciliationTimer);
     await managedMemberReconciliationPromise?.catch(() => undefined);
     await telemetry.shutdown();
     await syncScheduler?.stop();

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -58,6 +58,7 @@ import type { IntegrationProvider, IntegrationStatus } from "./integrations/type
 import { LocalClaudeSessionService } from "./local-devices/claude-sessions";
 import { LocalDeviceGateway } from "./local-devices/gateway";
 import { createLogger } from "./logger";
+import { reconcileManagedTenantMembers } from "./managed-members";
 import { runManagedSeed } from "./managed-seed";
 import { channelsReconnectUrl, createOperationalAlertDefinitions } from "./operational-alerts/definitions";
 import { createOperationalAlertService } from "./operational-alerts/service";
@@ -902,6 +903,35 @@ export async function createServer(config: Config, options?: CreateServerOptions
   localDeviceGateway.attach(server);
   logger.info({ port: config.PORT }, "HTTP server started");
 
+  let managedMemberReconciliationRunning = false;
+  const runManagedMemberReconciliation = async () => {
+    if (managedMemberReconciliationRunning) return;
+    managedMemberReconciliationRunning = true;
+    try {
+      const result = await reconcileManagedTenantMembers(config, await users.list(), logger);
+      if (!result.skipped) {
+        logger.info(
+          {
+            total: result.total,
+            synced: result.synced,
+            conflicts: result.conflictUserIds.length,
+            failed: result.failedUserIds.length,
+          },
+          "Managed member reconciliation completed",
+        );
+      }
+    } catch (err) {
+      logger.warn({ err }, "Managed member reconciliation could not start");
+    } finally {
+      managedMemberReconciliationRunning = false;
+    }
+  };
+  const managedMemberReconciliationTimer = backgroundWork
+    ? setInterval(() => void runManagedMemberReconciliation(), 5 * 60 * 1000)
+    : null;
+  managedMemberReconciliationTimer?.unref();
+  if (backgroundWork) void runManagedMemberReconciliation();
+
   // 10. Start platforms
   if (connect) {
     await startSlackBotIfConfigured().catch(() => {});
@@ -928,6 +958,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     }
     whatsappInboundRetention?.stop();
     normalizationBackfill?.stop();
+    if (managedMemberReconciliationTimer) clearInterval(managedMemberReconciliationTimer);
     await telemetry.shutdown();
     await syncScheduler?.stop();
     whatsappWindowKeepAliveJob?.stop();

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -903,28 +903,34 @@ export async function createServer(config: Config, options?: CreateServerOptions
   localDeviceGateway.attach(server);
   logger.info({ port: config.PORT }, "HTTP server started");
 
-  let managedMemberReconciliationRunning = false;
+  let managedMemberReconciliationPromise: Promise<void> | null = null;
   const runManagedMemberReconciliation = async () => {
-    if (managedMemberReconciliationRunning) return;
-    managedMemberReconciliationRunning = true;
-    try {
-      const result = await reconcileManagedTenantMembers(config, users, logger);
-      if (!result.skipped) {
-        logger.info(
-          {
-            total: result.total,
-            synced: result.synced,
-            conflicts: result.conflictUserIds.length,
-            failed: result.failedUserIds.length,
-          },
-          "Managed member reconciliation completed",
-        );
+    if (managedMemberReconciliationPromise) return managedMemberReconciliationPromise;
+    const run = (async () => {
+      try {
+        const result = await reconcileManagedTenantMembers(config, users, logger);
+        if (!result.skipped) {
+          logger.info(
+            {
+              total: result.total,
+              synced: result.synced,
+              conflicts: result.conflictUserIds.length,
+              failed: result.failedUserIds.length,
+            },
+            "Managed member reconciliation completed",
+          );
+        }
+      } catch (err) {
+        logger.warn({ err }, "Managed member reconciliation could not start");
       }
-    } catch (err) {
-      logger.warn({ err }, "Managed member reconciliation could not start");
-    } finally {
-      managedMemberReconciliationRunning = false;
-    }
+    })();
+    managedMemberReconciliationPromise = run;
+    void run.then(() => {
+      if (managedMemberReconciliationPromise === run) {
+        managedMemberReconciliationPromise = null;
+      }
+    });
+    return run;
   };
   const managedMemberReconciliationEnabled = backgroundWork && externalStartup;
   const managedMemberReconciliationTimer = managedMemberReconciliationEnabled
@@ -960,6 +966,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     whatsappInboundRetention?.stop();
     normalizationBackfill?.stop();
     if (managedMemberReconciliationTimer) clearInterval(managedMemberReconciliationTimer);
+    await managedMemberReconciliationPromise;
     await telemetry.shutdown();
     await syncScheduler?.stop();
     whatsappWindowKeepAliveJob?.stop();

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -908,7 +908,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     if (managedMemberReconciliationRunning) return;
     managedMemberReconciliationRunning = true;
     try {
-      const result = await reconcileManagedTenantMembers(config, await users.list(), logger);
+      const result = await reconcileManagedTenantMembers(config, () => users.list(), logger);
       if (!result.skipped) {
         logger.info(
           {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -926,11 +926,12 @@ export async function createServer(config: Config, options?: CreateServerOptions
       managedMemberReconciliationRunning = false;
     }
   };
-  const managedMemberReconciliationTimer = backgroundWork
+  const managedMemberReconciliationEnabled = backgroundWork && externalStartup;
+  const managedMemberReconciliationTimer = managedMemberReconciliationEnabled
     ? setInterval(() => void runManagedMemberReconciliation(), 5 * 60 * 1000)
     : null;
   managedMemberReconciliationTimer?.unref();
-  if (backgroundWork) void runManagedMemberReconciliation();
+  if (managedMemberReconciliationEnabled) void runManagedMemberReconciliation();
 
   // 10. Start platforms
   if (connect) {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -908,7 +908,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     if (managedMemberReconciliationRunning) return;
     managedMemberReconciliationRunning = true;
     try {
-      const result = await reconcileManagedTenantMembers(config, () => users.list(), logger);
+      const result = await reconcileManagedTenantMembers(config, users, logger);
       if (!result.skipped) {
         logger.info(
           {

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -2462,6 +2462,31 @@ describe("RBAC", () => {
       expect(body.user.name).toBe("Updated by Peer");
     });
 
+    it("requires an admin for human contact mutations that can change managed routing", async () => {
+      const app = createApp(db, config);
+      const { jwtSecret } = await setupWithAdmin(app);
+      const { memberId, memberCookie } = await createMemberSession(jwtSecret);
+
+      const createRes = await app.request("/api/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: memberCookie },
+        body: JSON.stringify({
+          name: "Claimed User",
+          type: "human",
+          email: "claimed-user@test.com",
+          whatsappNumber: "+14155550017",
+        }),
+      });
+      expect(createRes.status).toBe(403);
+
+      const updateRes = await app.request(`/api/users/${memberId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Cookie: memberCookie },
+        body: JSON.stringify({ whatsappNumber: "+14155550018" }),
+      });
+      expect(updateRes.status).toBe(403);
+    });
+
     it("POST /api/users/:id/verification returns 400 NO_EMAIL for user without email", async () => {
       const app = createApp(db, config);
       const { jwtSecret } = await setupWithAdmin(app);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -78,6 +78,7 @@ import type { LocalClaudeSessionService } from "./local-devices/claude-sessions"
 import type { LocalDeviceGateway } from "./local-devices/gateway";
 import {
   type ManagedMemberReconciliationResult,
+  type ManagedMemberRegistrationInput,
   reconcileManagedTenantMembers,
   registerManagedTenantMember,
   removeManagedTenantMember,
@@ -210,6 +211,11 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   const mcpServers = createMcpServerRepository(db);
   const logger = deps?.logger ?? (console as unknown as Logger);
   const identities = createProviderIdentityRepository(db, config.ENCRYPTION_KEY);
+  const syncManagedMemberMapping = (input: ManagedMemberRegistrationInput) =>
+    registerManagedTenantMember(config, {
+      ...input,
+      managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
+    });
   const localClaudeEventDispatcher =
     deps?.localClaudeSessionService && deps.runAgent && deps.queueManager
       ? createLocalClaudeEventDispatcher({
@@ -442,11 +448,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       whatsappGroups,
       getSlack: deps?.getSlack,
       registerManagedMember: (input) => registerManagedTenantMember(config, input),
-      syncManagedMemberMapping: (input) =>
-        registerManagedTenantMember(config, {
-          ...input,
-          managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
-        }),
+      syncManagedMemberMapping,
       removeManagedMember: (input) => removeManagedTenantMember(config, input),
     }),
   );
@@ -633,6 +635,13 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
         managedWhatsappInbound: deps?.managedWhatsapp,
         reconcileManagedMembers:
           deps?.reconcileManagedMembers ?? (async () => reconcileManagedTenantMembers(config, users, logger)),
+        syncManagedMemberMapping: async (input) => {
+          try {
+            await syncManagedMemberMapping(input);
+          } catch (err) {
+            logger.warn({ err, userId: input.tenantUserId }, "Managed WhatsApp member mapping sync failed");
+          }
+        },
         withManagedMemberSyncLocks,
         validateManagedWhatsappInboundIdentity: async (tenantUserId, senderPhoneE164) => {
           const user = await users.findById(tenantUserId);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -77,6 +77,7 @@ import { createLocalClaudeEventDispatcher } from "./local-devices/claude-event-d
 import type { LocalClaudeSessionService } from "./local-devices/claude-sessions";
 import type { LocalDeviceGateway } from "./local-devices/gateway";
 import {
+  type ManagedMemberReconciliationResult,
   reconcileManagedTenantMembers,
   registerManagedTenantMember,
   removeManagedTenantMember,
@@ -142,6 +143,7 @@ interface AppDeps {
   onWhatsAppWake?: () => Promise<void> | void;
   onWhatsAppSocketStateChange?: (change: WhatsAppSocketStateChange) => Promise<void> | void;
   getWhatsAppHealth?: () => { missingProviderIdEvents: number };
+  reconcileManagedMembers?: () => Promise<ManagedMemberReconciliationResult>;
 }
 
 /**
@@ -629,7 +631,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
           : undefined,
         sendDm: deps?.sendDm,
         managedWhatsappInbound: deps?.managedWhatsapp,
-        reconcileManagedMembers: async () => reconcileManagedTenantMembers(config, users, logger),
+        reconcileManagedMembers:
+          deps?.reconcileManagedMembers ?? (async () => reconcileManagedTenantMembers(config, users, logger)),
         withManagedMemberSyncLocks,
         validateManagedWhatsappInboundIdentity: async (tenantUserId, senderPhoneE164) => {
           const user = await users.findById(tenantUserId);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -80,6 +80,7 @@ import {
   reconcileManagedTenantMembers,
   registerManagedTenantMember,
   removeManagedTenantMember,
+  withManagedMemberSyncLocks,
 } from "./managed-members";
 import { createManagedLoginUrl } from "./managed-url";
 import { mcpOAuthRoutes } from "./mcp/oauth/routes";
@@ -628,7 +629,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
           : undefined,
         sendDm: deps?.sendDm,
         managedWhatsappInbound: deps?.managedWhatsapp,
-        reconcileManagedMembers: async () => reconcileManagedTenantMembers(config, () => users.list(), logger),
+        reconcileManagedMembers: async () => reconcileManagedTenantMembers(config, users, logger),
+        withManagedMemberSyncLocks,
         validateManagedWhatsappInboundIdentity: async (tenantUserId, senderPhoneE164) => {
           const user = await users.findById(tenantUserId);
           return user?.type === "human" && user.whatsapp_number === senderPhoneE164;

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -76,7 +76,11 @@ import type { IntegrationProvider } from "./integrations/types";
 import { createLocalClaudeEventDispatcher } from "./local-devices/claude-event-dispatcher";
 import type { LocalClaudeSessionService } from "./local-devices/claude-sessions";
 import type { LocalDeviceGateway } from "./local-devices/gateway";
-import { registerManagedTenantMember, removeManagedTenantMember } from "./managed-members";
+import {
+  reconcileManagedTenantMembers,
+  registerManagedTenantMember,
+  removeManagedTenantMember,
+} from "./managed-members";
 import { createManagedLoginUrl } from "./managed-url";
 import { mcpOAuthRoutes } from "./mcp/oauth/routes";
 import { mountPublicMcpServer } from "./mcp/server/transport";
@@ -435,6 +439,11 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       whatsappGroups,
       getSlack: deps?.getSlack,
       registerManagedMember: (input) => registerManagedTenantMember(config, input),
+      syncManagedMemberMapping: (input) =>
+        registerManagedTenantMember(config, {
+          ...input,
+          managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
+        }),
       removeManagedMember: (input) => removeManagedTenantMember(config, input),
     }),
   );
@@ -619,6 +628,11 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
           : undefined,
         sendDm: deps?.sendDm,
         managedWhatsappInbound: deps?.managedWhatsapp,
+        reconcileManagedMembers: async () => reconcileManagedTenantMembers(config, await users.list(), logger),
+        validateManagedWhatsappInboundIdentity: async (tenantUserId, senderPhoneE164) => {
+          const user = await users.findById(tenantUserId);
+          return user?.type === "human" && user.whatsapp_number === senderPhoneE164;
+        },
         whatsappStatus: whatsapp
           ? async () => ({
               ...(await whatsapp.pairing.status()),

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -628,7 +628,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
           : undefined,
         sendDm: deps?.sendDm,
         managedWhatsappInbound: deps?.managedWhatsapp,
-        reconcileManagedMembers: async () => reconcileManagedTenantMembers(config, await users.list(), logger),
+        reconcileManagedMembers: async () => reconcileManagedTenantMembers(config, () => users.list(), logger),
         validateManagedWhatsappInboundIdentity: async (tenantUserId, senderPhoneE164) => {
           const user = await users.findById(tenantUserId);
           return user?.type === "human" && user.whatsapp_number === senderPhoneE164;

--- a/packages/server/src/managed-members.test.ts
+++ b/packages/server/src/managed-members.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { reconcileManagedTenantMembers, withManagedMemberSyncLock } from "./managed-members";
+import { createTestConfig, createTestLogger } from "./test-utils";
+
+describe("managed member reconciliation", () => {
+  it("loads the current member snapshot only after acquiring the synchronization lock", async () => {
+    let releaseLock = () => {};
+    let confirmLockAcquired = () => {};
+    const lockAcquired = new Promise<void>((resolve) => {
+      confirmLockAcquired = resolve;
+    });
+    const holdLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const blocker = withManagedMemberSyncLock(async () => {
+      confirmLockAcquired();
+      await holdLock;
+    });
+    await lockAcquired;
+
+    const loadUsers = vi.fn().mockResolvedValue([]);
+    const reconciliation = reconcileManagedTenantMembers(
+      createTestConfig({
+        MANAGED_WHATSAPP_PLATFORM_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+      }),
+      loadUsers,
+      createTestLogger(),
+    );
+
+    await Promise.resolve();
+    expect(loadUsers).not.toHaveBeenCalled();
+
+    releaseLock();
+    await blocker;
+    await expect(reconciliation).resolves.toEqual({
+      skipped: false,
+      total: 0,
+      synced: 0,
+      conflictUserIds: [],
+      failedUserIds: [],
+    });
+    expect(loadUsers).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/server/src/managed-members.test.ts
+++ b/packages/server/src/managed-members.test.ts
@@ -94,4 +94,39 @@ describe("managed member reconciliation", () => {
     releaseLock();
     await blocker;
   });
+
+  it("counts unchanged mappings as synchronized", async () => {
+    const user: ManagedMemberUser = {
+      id: "user-a",
+      type: "human",
+      email: "member@example.com",
+      whatsapp_number: "+14155550100",
+      name: "Member",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ ok: true, mappingStatus: "unchanged", emailSent: false, whatsappSent: false })),
+    );
+
+    const result = await reconcileManagedTenantMembers(
+      createTestConfig({
+        MANAGED_WHATSAPP_PLATFORM_URL: "https://platform.test",
+        MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
+      }),
+      {
+        list: vi.fn(async () => [user]),
+        findById: vi.fn(async () => user),
+      },
+      createTestLogger(),
+    );
+
+    expect(result).toEqual({
+      skipped: false,
+      total: 1,
+      synced: 1,
+      conflictUserIds: [],
+      failedUserIds: [],
+    });
+  });
 });

--- a/packages/server/src/managed-members.test.ts
+++ b/packages/server/src/managed-members.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { type ManagedMemberUser, reconcileManagedTenantMembers, withManagedMemberSyncLock } from "./managed-members";
+import {
+  type ManagedMemberUser,
+  reconcileManagedTenantMembers,
+  registerManagedTenantMember,
+  withManagedMemberSyncLock,
+} from "./managed-members";
 import { createTestConfig, createTestLogger } from "./test-utils";
 
 describe("managed member reconciliation", () => {
@@ -127,6 +132,43 @@ describe("managed member reconciliation", () => {
       synced: 1,
       conflictUserIds: [],
       failedUserIds: [],
+    });
+  });
+});
+
+describe("managed member registration", () => {
+  it.each([
+    { managedWhatsappDmEnabled: true, mappingStatus: "inactive" },
+    { managedWhatsappDmEnabled: false, mappingStatus: "active" },
+  ] as const)("rejects $mappingStatus when managed DMs are $managedWhatsappDmEnabled", async (testCase) => {
+    const requestFetch = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        mappingStatus: testCase.mappingStatus,
+        emailSent: false,
+        whatsappSent: false,
+      }),
+    );
+
+    await expect(
+      registerManagedTenantMember(
+        createTestConfig({
+          MANAGED_WHATSAPP_PLATFORM_URL: "https://platform.test",
+          MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        }),
+        {
+          tenantUserId: "user-a",
+          email: "member@example.com",
+          name: "Member",
+          phoneNumber: "+14155550100",
+          sendInvite: false,
+          managedWhatsappDmEnabled: testCase.managedWhatsappDmEnabled,
+        },
+        requestFetch,
+      ),
+    ).rejects.toMatchObject({
+      status: 502,
+      code: "ROUTING_SYNC_UNCONFIRMED",
     });
   });
 });

--- a/packages/server/src/managed-members.test.ts
+++ b/packages/server/src/managed-members.test.ts
@@ -1,9 +1,30 @@
-import { describe, expect, it, vi } from "vitest";
-import { reconcileManagedTenantMembers, withManagedMemberSyncLock } from "./managed-members";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ManagedMemberUser, reconcileManagedTenantMembers, withManagedMemberSyncLock } from "./managed-members";
 import { createTestConfig, createTestLogger } from "./test-utils";
 
 describe("managed member reconciliation", () => {
-  it("loads the current member snapshot only after acquiring the synchronization lock", async () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("re-reads each member after acquiring that member's synchronization lock", async () => {
+    const snapshotUser: ManagedMemberUser = {
+      id: "user-a",
+      type: "human",
+      email: "member@example.com",
+      whatsapp_number: "+14155550100",
+      name: "Before",
+    };
+    let currentUser = snapshotUser;
+    const users = {
+      list: vi.fn(async () => [snapshotUser]),
+      findById: vi.fn(async () => currentUser),
+    };
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ ok: true, mappingStatus: "active", emailSent: false, whatsappSent: false }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
     let releaseLock = () => {};
     let confirmLockAcquired = () => {};
     const lockAcquired = new Promise<void>((resolve) => {
@@ -12,34 +33,65 @@ describe("managed member reconciliation", () => {
     const holdLock = new Promise<void>((resolve) => {
       releaseLock = resolve;
     });
-    const blocker = withManagedMemberSyncLock(async () => {
+    const blocker = withManagedMemberSyncLock(snapshotUser.id, async () => {
       confirmLockAcquired();
       await holdLock;
     });
     await lockAcquired;
 
-    const loadUsers = vi.fn().mockResolvedValue([]);
     const reconciliation = reconcileManagedTenantMembers(
       createTestConfig({
         MANAGED_WHATSAPP_PLATFORM_URL: "https://platform.test",
         MANAGED_WHATSAPP_TENANT_TOKEN: "tenant-token",
+        WHATSAPP_DM_PROVIDER: "managed",
       }),
-      loadUsers,
+      users,
       createTestLogger(),
     );
-
     await Promise.resolve();
-    expect(loadUsers).not.toHaveBeenCalled();
+    expect(users.list).toHaveBeenCalledOnce();
+    expect(users.findById).not.toHaveBeenCalled();
+
+    currentUser = {
+      ...snapshotUser,
+      name: "After",
+      whatsapp_number: "+14155550101",
+    };
+    releaseLock();
+    await blocker;
+    await reconciliation;
+
+    expect(users.findById).toHaveBeenCalledWith(snapshotUser.id);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const request = fetchMock.mock.calls[0]?.[1];
+    if (!request) throw new Error("Expected managed member request options");
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      tenantUserId: snapshotUser.id,
+      name: "After",
+      phoneNumber: "+14155550101",
+    });
+  });
+
+  it("does not block synchronization work for a different member", async () => {
+    let releaseLock = () => {};
+    let confirmLockAcquired = () => {};
+    const lockAcquired = new Promise<void>((resolve) => {
+      confirmLockAcquired = resolve;
+    });
+    const holdLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const blocker = withManagedMemberSyncLock("user-a", async () => {
+      confirmLockAcquired();
+      await holdLock;
+    });
+    await lockAcquired;
+
+    const differentMemberOperation = vi.fn(async () => "completed");
+    await expect(withManagedMemberSyncLock("user-b", differentMemberOperation)).resolves.toBe("completed");
+    expect(differentMemberOperation).toHaveBeenCalledOnce();
 
     releaseLock();
     await blocker;
-    await expect(reconciliation).resolves.toEqual({
-      skipped: false,
-      total: 0,
-      synced: 0,
-      conflictUserIds: [],
-      failedUserIds: [],
-    });
-    expect(loadUsers).toHaveBeenCalledOnce();
   });
 });

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -156,6 +156,19 @@ export async function registerManagedTenantMember(
       "Managed WhatsApp routing sync was not confirmed",
     );
   }
+  const routingStatusMatchesIntent =
+    input.managedWhatsappDmEnabled === undefined ||
+    mappingStatus === "unchanged" ||
+    (input.managedWhatsappDmEnabled
+      ? mappingStatus === "active" || mappingStatus === "inactive_conflict"
+      : mappingStatus === "inactive");
+  if (!routingStatusMatchesIntent) {
+    throw new ManagedMemberRegistrationError(
+      502,
+      "ROUTING_SYNC_UNCONFIRMED",
+      "Managed WhatsApp routing sync was not confirmed",
+    );
+  }
   if (input.sendInvite !== false && !emailSent) {
     throw new ManagedMemberRegistrationError(502, "INVITE_DELIVERY_FAILED", "Managed member invite delivery failed");
   }

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "pino";
 import type { Config } from "./config";
 
 export interface ManagedMemberRegistrationInput {
@@ -6,9 +7,11 @@ export interface ManagedMemberRegistrationInput {
   name: string;
   phoneNumber: string;
   sendInvite?: boolean;
+  managedWhatsappDmEnabled?: boolean;
 }
 
 export interface ManagedMemberRemovalInput {
+  tenantUserId: string;
   email: string;
 }
 
@@ -16,6 +19,15 @@ export interface ManagedMemberRegistrationResult {
   registered: boolean;
   emailSent?: boolean;
   whatsappSent?: boolean;
+  mappingStatus?: "active" | "inactive" | "inactive_conflict" | "unchanged";
+}
+
+export interface ManagedMemberReconciliationResult {
+  skipped: boolean;
+  total: number;
+  synced: number;
+  conflictUserIds: string[];
+  failedUserIds: string[];
 }
 
 export class ManagedMemberRegistrationError extends Error {
@@ -83,6 +95,20 @@ export async function registerManagedTenantMember(
   const record = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
   const emailSent = record.emailSent === true;
   const whatsappSent = record.whatsappSent === true;
+  const mappingStatus =
+    record.mappingStatus === "active" ||
+    record.mappingStatus === "inactive" ||
+    record.mappingStatus === "inactive_conflict" ||
+    record.mappingStatus === "unchanged"
+      ? record.mappingStatus
+      : undefined;
+  if (input.managedWhatsappDmEnabled !== undefined && !mappingStatus) {
+    throw new ManagedMemberRegistrationError(
+      502,
+      "ROUTING_SYNC_UNCONFIRMED",
+      "Managed WhatsApp routing sync was not confirmed",
+    );
+  }
   if (input.sendInvite !== false && !emailSent) {
     throw new ManagedMemberRegistrationError(502, "INVITE_DELIVERY_FAILED", "Managed member invite delivery failed");
   }
@@ -91,6 +117,7 @@ export async function registerManagedTenantMember(
     registered: true,
     emailSent,
     whatsappSent,
+    ...(mappingStatus ? { mappingStatus } : {}),
   };
 }
 
@@ -107,8 +134,9 @@ export async function removeManagedTenantMember(
   }
 
   const email = input.email.trim().toLowerCase();
+  const query = new URLSearchParams({ tenantUserId: input.tenantUserId });
   const response = await requestFetch(
-    `${platformUrl.replace(/\/+$/u, "")}/api/tenant/members/${encodeURIComponent(email)}`,
+    `${platformUrl.replace(/\/+$/u, "")}/api/tenant/members/${encodeURIComponent(email)}?${query.toString()}`,
     {
       method: "DELETE",
       headers: {
@@ -124,4 +152,57 @@ export async function removeManagedTenantMember(
   }
 
   return { removed: true };
+}
+
+export async function reconcileManagedTenantMembers(
+  config: Config,
+  users: Array<{
+    id: string;
+    type: string;
+    email: string | null;
+    whatsapp_number: string | null;
+    name: string;
+  }>,
+  logger: Logger,
+): Promise<ManagedMemberReconciliationResult> {
+  if (!(managedPlatformUrl(config) && config.MANAGED_WHATSAPP_TENANT_TOKEN)) {
+    return { skipped: true, total: 0, synced: 0, conflictUserIds: [], failedUserIds: [] };
+  }
+
+  const humanUsers = users.flatMap((user) =>
+    user.type === "human" && user.email && user.whatsapp_number
+      ? [{ ...user, email: user.email, whatsappNumber: user.whatsapp_number }]
+      : [],
+  );
+  const desiredStatus = config.WHATSAPP_DM_PROVIDER === "managed" ? "active" : "inactive";
+  const conflictUserIds: string[] = [];
+  const failedUserIds: string[] = [];
+  let synced = 0;
+
+  for (const user of humanUsers) {
+    try {
+      const result = await registerManagedTenantMember(config, {
+        tenantUserId: user.id,
+        email: user.email,
+        name: user.name,
+        phoneNumber: user.whatsappNumber,
+        sendInvite: false,
+        managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
+      });
+      if (result.mappingStatus === desiredStatus) synced += 1;
+      else if (result.mappingStatus === "inactive_conflict") conflictUserIds.push(user.id);
+      else failedUserIds.push(user.id);
+    } catch (err) {
+      failedUserIds.push(user.id);
+      logger.warn({ err, userId: user.id }, "Managed member reconciliation failed");
+    }
+  }
+
+  return {
+    skipped: false,
+    total: humanUsers.length,
+    synced,
+    conflictUserIds,
+    failedUserIds,
+  };
 }

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -234,7 +234,7 @@ export async function reconcileManagedTenantMembers(
           sendInvite: false,
           managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
         });
-        if (result.mappingStatus === desiredStatus) synced += 1;
+        if (result.mappingStatus === desiredStatus || result.mappingStatus === "unchanged") synced += 1;
         else if (result.mappingStatus === "inactive_conflict") conflictUserIds.push(user.id);
         else failedUserIds.push(user.id);
       } catch (err) {

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -3,6 +3,23 @@ import type { Config } from "./config";
 
 const MANAGED_MEMBER_REQUEST_TIMEOUT_MS = 30_000;
 
+let managedMemberSyncTail = Promise.resolve();
+
+export async function withManagedMemberSyncLock<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = managedMemberSyncTail;
+  let release = () => {};
+  managedMemberSyncTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
 export interface ManagedMemberRegistrationInput {
   tenantUserId: string;
   email: string;
@@ -160,53 +177,66 @@ export async function removeManagedTenantMember(
 
 export async function reconcileManagedTenantMembers(
   config: Config,
-  users: Array<{
-    id: string;
-    type: string;
-    email: string | null;
-    whatsapp_number: string | null;
-    name: string;
-  }>,
+  users:
+    | Array<{
+        id: string;
+        type: string;
+        email: string | null;
+        whatsapp_number: string | null;
+        name: string;
+      }>
+    | (() => Promise<
+        Array<{
+          id: string;
+          type: string;
+          email: string | null;
+          whatsapp_number: string | null;
+          name: string;
+        }>
+      >),
   logger: Logger,
 ): Promise<ManagedMemberReconciliationResult> {
   if (!(managedPlatformUrl(config) && config.MANAGED_WHATSAPP_TENANT_TOKEN)) {
     return { skipped: true, total: 0, synced: 0, conflictUserIds: [], failedUserIds: [] };
   }
 
-  const humanUsers = users.flatMap((user) =>
-    user.type === "human" && user.email && user.whatsapp_number
-      ? [{ ...user, email: user.email, whatsappNumber: user.whatsapp_number }]
-      : [],
-  );
-  const desiredStatus = config.WHATSAPP_DM_PROVIDER === "managed" ? "active" : "inactive";
-  const conflictUserIds: string[] = [];
-  const failedUserIds: string[] = [];
-  let synced = 0;
+  return withManagedMemberSyncLock(async () => {
+    const currentUsers = typeof users === "function" ? await users() : users;
+    const humanUsers = currentUsers.flatMap((user) =>
+      user.type === "human" && user.email && user.whatsapp_number
+        ? [{ ...user, email: user.email, whatsappNumber: user.whatsapp_number }]
+        : [],
+    );
+    const desiredStatus = config.WHATSAPP_DM_PROVIDER === "managed" ? "active" : "inactive";
+    const conflictUserIds: string[] = [];
+    const failedUserIds: string[] = [];
+    let synced = 0;
 
-  for (const user of humanUsers) {
-    try {
-      const result = await registerManagedTenantMember(config, {
-        tenantUserId: user.id,
-        email: user.email,
-        name: user.name,
-        phoneNumber: user.whatsappNumber,
-        sendInvite: false,
-        managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
-      });
-      if (result.mappingStatus === desiredStatus) synced += 1;
-      else if (result.mappingStatus === "inactive_conflict") conflictUserIds.push(user.id);
-      else failedUserIds.push(user.id);
-    } catch (err) {
-      failedUserIds.push(user.id);
-      logger.warn({ err, userId: user.id }, "Managed member reconciliation failed");
+    for (const user of humanUsers) {
+      try {
+        const result = await registerManagedTenantMember(config, {
+          tenantUserId: user.id,
+          email: user.email,
+          name: user.name,
+          phoneNumber: user.whatsappNumber,
+          sendInvite: false,
+          managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
+        });
+        if (result.mappingStatus === desiredStatus) synced += 1;
+        else if (result.mappingStatus === "inactive_conflict") conflictUserIds.push(user.id);
+        else failedUserIds.push(user.id);
+      } catch (err) {
+        failedUserIds.push(user.id);
+        logger.warn({ err, userId: user.id }, "Managed member reconciliation failed");
+      }
     }
-  }
 
-  return {
-    skipped: false,
-    total: humanUsers.length,
-    synced,
-    conflictUserIds,
-    failedUserIds,
-  };
+    return {
+      skipped: false,
+      total: humanUsers.length,
+      synced,
+      conflictUserIds,
+      failedUserIds,
+    };
+  });
 }

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -3,21 +3,48 @@ import type { Config } from "./config";
 
 const MANAGED_MEMBER_REQUEST_TIMEOUT_MS = 30_000;
 
-let managedMemberSyncTail = Promise.resolve();
+const managedMemberSyncTails = new Map<string, Promise<void>>();
 
-export async function withManagedMemberSyncLock<T>(operation: () => Promise<T>): Promise<T> {
-  const previous = managedMemberSyncTail;
+export async function withManagedMemberSyncLock<T>(tenantUserId: string, operation: () => Promise<T>): Promise<T> {
+  const previous = managedMemberSyncTails.get(tenantUserId) ?? Promise.resolve();
   let release = () => {};
-  managedMemberSyncTail = new Promise<void>((resolve) => {
+  const current = new Promise<void>((resolve) => {
     release = resolve;
   });
+  managedMemberSyncTails.set(tenantUserId, current);
 
   await previous;
   try {
     return await operation();
   } finally {
     release();
+    if (managedMemberSyncTails.get(tenantUserId) === current) {
+      managedMemberSyncTails.delete(tenantUserId);
+    }
   }
+}
+
+export async function withManagedMemberSyncLocks<T>(tenantUserIds: string[], operation: () => Promise<T>): Promise<T> {
+  const uniqueIds = [...new Set(tenantUserIds)].sort();
+  const acquire = (index: number): Promise<T> => {
+    const tenantUserId = uniqueIds[index];
+    if (!tenantUserId) return operation();
+    return withManagedMemberSyncLock(tenantUserId, () => acquire(index + 1));
+  };
+  return acquire(0);
+}
+
+export interface ManagedMemberUser {
+  id: string;
+  type: string;
+  email: string | null;
+  whatsapp_number: string | null;
+  name: string;
+}
+
+export interface ManagedMemberUserSource {
+  list(): Promise<ManagedMemberUser[]>;
+  findById(id: string): Promise<ManagedMemberUser | undefined>;
 }
 
 export interface ManagedMemberRegistrationInput {
@@ -177,48 +204,33 @@ export async function removeManagedTenantMember(
 
 export async function reconcileManagedTenantMembers(
   config: Config,
-  users:
-    | Array<{
-        id: string;
-        type: string;
-        email: string | null;
-        whatsapp_number: string | null;
-        name: string;
-      }>
-    | (() => Promise<
-        Array<{
-          id: string;
-          type: string;
-          email: string | null;
-          whatsapp_number: string | null;
-          name: string;
-        }>
-      >),
+  users: ManagedMemberUserSource,
   logger: Logger,
 ): Promise<ManagedMemberReconciliationResult> {
   if (!(managedPlatformUrl(config) && config.MANAGED_WHATSAPP_TENANT_TOKEN)) {
     return { skipped: true, total: 0, synced: 0, conflictUserIds: [], failedUserIds: [] };
   }
 
-  return withManagedMemberSyncLock(async () => {
-    const currentUsers = typeof users === "function" ? await users() : users;
-    const humanUsers = currentUsers.flatMap((user) =>
-      user.type === "human" && user.email && user.whatsapp_number
-        ? [{ ...user, email: user.email, whatsappNumber: user.whatsapp_number }]
-        : [],
-    );
-    const desiredStatus = config.WHATSAPP_DM_PROVIDER === "managed" ? "active" : "inactive";
-    const conflictUserIds: string[] = [];
-    const failedUserIds: string[] = [];
-    let synced = 0;
+  const currentUsers = await users.list();
+  const humanUserIds = currentUsers.flatMap((user) =>
+    user.type === "human" && user.email && user.whatsapp_number ? [user.id] : [],
+  );
+  const desiredStatus = config.WHATSAPP_DM_PROVIDER === "managed" ? "active" : "inactive";
+  const conflictUserIds: string[] = [];
+  const failedUserIds: string[] = [];
+  let synced = 0;
 
-    for (const user of humanUsers) {
+  for (const tenantUserId of humanUserIds) {
+    await withManagedMemberSyncLock(tenantUserId, async () => {
+      const user = await users.findById(tenantUserId);
+      if (user?.type !== "human" || !user.email || !user.whatsapp_number) return;
+
       try {
         const result = await registerManagedTenantMember(config, {
           tenantUserId: user.id,
           email: user.email,
           name: user.name,
-          phoneNumber: user.whatsappNumber,
+          phoneNumber: user.whatsapp_number,
           sendInvite: false,
           managedWhatsappDmEnabled: config.WHATSAPP_DM_PROVIDER === "managed",
         });
@@ -229,14 +241,14 @@ export async function reconcileManagedTenantMembers(
         failedUserIds.push(user.id);
         logger.warn({ err, userId: user.id }, "Managed member reconciliation failed");
       }
-    }
+    });
+  }
 
-    return {
-      skipped: false,
-      total: humanUsers.length,
-      synced,
-      conflictUserIds,
-      failedUserIds,
-    };
-  });
+  return {
+    skipped: false,
+    total: humanUserIds.length,
+    synced,
+    conflictUserIds,
+    failedUserIds,
+  };
 }

--- a/packages/server/src/managed-members.ts
+++ b/packages/server/src/managed-members.ts
@@ -1,6 +1,8 @@
 import type { Logger } from "pino";
 import type { Config } from "./config";
 
+const MANAGED_MEMBER_REQUEST_TIMEOUT_MS = 30_000;
+
 export interface ManagedMemberRegistrationInput {
   tenantUserId: string;
   email: string;
@@ -84,6 +86,7 @@ export async function registerManagedTenantMember(
       "Content-Type": "application/json",
     },
     body: JSON.stringify(input),
+    signal: AbortSignal.timeout(MANAGED_MEMBER_REQUEST_TIMEOUT_MS),
   });
 
   const body = await response.json().catch(() => null);
@@ -142,6 +145,7 @@ export async function removeManagedTenantMember(
       headers: {
         Authorization: `Bearer ${config.MANAGED_WHATSAPP_TENANT_TOKEN}`,
       },
+      signal: AbortSignal.timeout(MANAGED_MEMBER_REQUEST_TIMEOUT_MS),
     },
   );
 

--- a/packages/web/src/components/team/add-member-dialog.tsx
+++ b/packages/web/src/components/team/add-member-dialog.tsx
@@ -53,15 +53,17 @@ const addAgentSchema = z.object({
 export function AddMemberDialog({
   open,
   users,
+  canAddHuman = true,
   onOpenChange,
   onSuccess,
 }: {
   open: boolean;
   users: User[];
+  canAddHuman?: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
 }) {
-  const [memberType, setMemberType] = useState<"human" | "agent">("human");
+  const [memberType, setMemberType] = useState<"human" | "agent">(() => (canAddHuman ? "human" : "agent"));
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
   const [email, setEmail] = useState("");
@@ -101,7 +103,11 @@ export function AddMemberDialog({
             }),
       }),
     onSuccess: (data) => {
-      if (data.verificationSent) {
+      if (data.managedWhatsappMappingStatus === "inactive_conflict") {
+        toast.warning("Member added, but WhatsApp DMs are inactive because this number is active on another tenant.");
+      } else if (data.managedWhatsappMappingStatus === "failed") {
+        toast.warning("Member added, but WhatsApp routing is still syncing and will retry automatically.");
+      } else if (data.verificationSent) {
         toast.success("Member added. Verification email sent.");
       } else {
         toast.success(memberType === "agent" ? "Agent added" : "Member added");
@@ -119,7 +125,7 @@ export function AddMemberDialog({
   });
 
   const resetAndClose = () => {
-    setMemberType("human");
+    setMemberType(canAddHuman ? "human" : "agent");
     setName("");
     setRole("");
     setEmail("");
@@ -165,17 +171,19 @@ export function AddMemberDialog({
 
         <div className="max-h-[50vh] space-y-4 overflow-y-auto py-2 pr-1">
           <div className="flex rounded-md border border-border">
-            <button
-              type="button"
-              className={`flex-1 rounded-l-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                memberType === "human"
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-transparent text-muted-foreground hover:text-foreground"
-              }`}
-              onClick={() => setMemberType("human")}
-            >
-              Human
-            </button>
+            {canAddHuman && (
+              <button
+                type="button"
+                className={`flex-1 rounded-l-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                  memberType === "human"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-transparent text-muted-foreground hover:text-foreground"
+                }`}
+                onClick={() => setMemberType("human")}
+              >
+                Human
+              </button>
+            )}
             <button
               type="button"
               className={`flex-1 rounded-r-md px-3 py-1.5 text-sm font-medium transition-colors ${

--- a/packages/web/src/components/team/edit-member-dialog.tsx
+++ b/packages/web/src/components/team/edit-member-dialog.tsx
@@ -65,6 +65,7 @@ export function EditMemberDialog({
   users,
   currentUserId,
   canManageAuthRoles,
+  canEditContact = true,
   onOpenChange,
   onSuccess,
 }: {
@@ -72,6 +73,7 @@ export function EditMemberDialog({
   users: User[];
   currentUserId?: string;
   canManageAuthRoles: boolean;
+  canEditContact?: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
 }) {
@@ -125,14 +127,20 @@ export function EditMemberDialog({
         description: description.trim() || null,
         ...(isAgent
           ? { allowedTools, slackChannelIds, whatsappGroupJids, isWhatsappFallback }
-          : {
-              email: email.trim() || null,
-              whatsappNumber: normalizedPhone,
-              ...(canEditAuthRole ? { authRole } : {}),
-            }),
+          : canEditContact
+            ? {
+                email: email.trim() || null,
+                whatsappNumber: normalizedPhone,
+                ...(canEditAuthRole ? { authRole } : {}),
+              }
+            : {}),
       }),
     onSuccess: (data) => {
-      if (data.verificationSent) {
+      if (data.managedWhatsappMappingStatus === "inactive_conflict") {
+        toast.warning("Member updated, but WhatsApp DMs are inactive because this number is active on another tenant.");
+      } else if (data.managedWhatsappMappingStatus === "failed") {
+        toast.warning("Member updated, but WhatsApp routing is still syncing and will retry automatically.");
+      } else if (data.verificationSent) {
         toast.success("Member updated. Verification email sent.");
       } else {
         toast.success("Member updated");
@@ -198,15 +206,18 @@ export function EditMemberDialog({
       whatsappGroupJidsDirty ||
       isWhatsappFallbackDirty ||
       (!isAgent &&
+        canEditContact &&
         ((email.trim() || null) !== (user.email ?? null) || normalizedPhone !== (user.whatsapp_number ?? null))));
 
   const canSubmit =
     isDirty &&
     (isAgent
       ? name.trim().length > 0
-      : !phoneError &&
-        editMemberSchema.safeParse({ name: name.trim(), email: email.trim(), whatsappNumber: normalizedPhone ?? "" })
-          .success);
+      : !canEditContact
+        ? name.trim().length > 0
+        : !phoneError &&
+          editMemberSchema.safeParse({ name: name.trim(), email: email.trim(), whatsappNumber: normalizedPhone ?? "" })
+            .success);
 
   const otherUsers = users.filter((u) => u.id !== user?.id);
 
@@ -354,7 +365,7 @@ export function EditMemberDialog({
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="name@example.com"
-                  disabled={updateMutation.isPending}
+                  disabled={updateMutation.isPending || !canEditContact}
                 />
                 {user?.email && email === user.email && (
                   <div className="flex items-center gap-1.5">
@@ -401,7 +412,7 @@ export function EditMemberDialog({
                   setPhoneNationalNumber(value);
                   setError("");
                 }}
-                disabled={updateMutation.isPending}
+                disabled={updateMutation.isPending || !canEditContact}
                 error={error || phoneError}
               />
             </>

--- a/packages/web/src/components/team/member-list.tsx
+++ b/packages/web/src/components/team/member-list.tsx
@@ -33,12 +33,14 @@ export function MemberList({
   onEdit,
   onRemove,
   onLink,
+  canManageHumanMembers = true,
 }: {
   users: User[];
   auth: AuthContext;
   onEdit: (user: User) => void;
   onRemove: (user: User) => void;
   onLink: (user: User) => void;
+  canManageHumanMembers?: boolean;
 }) {
   return (
     <>
@@ -53,6 +55,7 @@ export function MemberList({
               user={user}
               isCurrentUser={isCurrentUser}
               isLast={i === users.length - 1}
+              canRemove={user.type === "agent" || canManageHumanMembers}
               onEdit={() => onEdit(user)}
               onRemove={() => onRemove(user)}
               onLink={() => onLink(user)}
@@ -68,6 +71,7 @@ function MemberRow({
   user,
   isCurrentUser,
   isLast,
+  canRemove,
   onEdit,
   onRemove,
   onLink,
@@ -75,6 +79,7 @@ function MemberRow({
   user: User;
   isCurrentUser: boolean;
   isLast: boolean;
+  canRemove: boolean;
   onEdit: () => void;
   onRemove: () => void;
   onLink: () => void;
@@ -158,7 +163,7 @@ function MemberRow({
             <PencilSimpleIcon size={14} className="mr-2" />
             Edit
           </DropdownMenuItem>
-          {!isCurrentUser && (
+          {canRemove && !isCurrentUser && (
             <>
               <DropdownMenuSeparator />
               <DropdownMenuItem className="text-destructive" onClick={onRemove}>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -94,6 +94,8 @@ export interface User {
   created_at: string;
 }
 
+export type ManagedWhatsappMappingStatus = "active" | "inactive" | "inactive_conflict" | "unchanged" | "failed";
+
 export interface ScheduledTaskListItem {
   id: string;
   platform: "slack" | "whatsapp";
@@ -2193,7 +2195,11 @@ export const api = {
       whatsappGroupJids?: string[] | null;
       isWhatsappFallback?: boolean;
     }) {
-      return request<{ user: User; verificationSent?: boolean }>("/api/users", {
+      return request<{
+        user: User;
+        verificationSent?: boolean;
+        managedWhatsappMappingStatus?: ManagedWhatsappMappingStatus;
+      }>("/api/users", {
         method: "POST",
         body: JSON.stringify(data),
       });
@@ -2214,7 +2220,11 @@ export const api = {
         isWhatsappFallback?: boolean;
       },
     ) {
-      return request<{ user: User; verificationSent?: boolean }>(`/api/users/${id}`, {
+      return request<{
+        user: User;
+        verificationSent?: boolean;
+        managedWhatsappMappingStatus?: ManagedWhatsappMappingStatus;
+      }>(`/api/users/${id}`, {
         method: "PATCH",
         body: JSON.stringify(data),
       });
@@ -2235,7 +2245,11 @@ export const api = {
       );
     },
     promote(id: string, data: { name: string; email?: string | null; role?: string | null }) {
-      return request<{ user: User; verificationSent?: boolean }>(`/api/users/${id}/promote`, {
+      return request<{
+        user: User;
+        verificationSent?: boolean;
+        managedWhatsappMappingStatus?: ManagedWhatsappMappingStatus;
+      }>(`/api/users/${id}/promote`, {
         method: "POST",
         body: JSON.stringify(data),
       });

--- a/packages/web/src/routes/team.tsx
+++ b/packages/web/src/routes/team.tsx
@@ -82,6 +82,7 @@ export function TeamPage() {
               onEdit={setEditingUser}
               onRemove={setRemovingUser}
               onLink={setLinkingUser}
+              canManageHumanMembers={auth.role === "admin"}
             />
           )
         ) : isLoading ? (
@@ -94,6 +95,7 @@ export function TeamPage() {
       <AddMemberDialog
         open={showAddDialog}
         users={users}
+        canAddHuman={auth.role === "admin"}
         onOpenChange={setShowAddDialog}
         onSuccess={() => {
           queryClient.invalidateQueries({ queryKey: ["users"] });
@@ -105,6 +107,7 @@ export function TeamPage() {
         users={users}
         currentUserId={auth.userId}
         canManageAuthRoles={auth.role === "admin"}
+        canEditContact={auth.role === "admin"}
         onOpenChange={(open) => !open && setEditingUser(null)}
         onSuccess={() => {
           setEditingUser(null);


### PR DESCRIPTION
## Summary
- sync managed WhatsApp mapping intent only after the local member mutation commits
- reconcile all human members at startup and every five minutes, covering retries, backfill, phone changes, provider changes, and released conflicts
- keep local user creation successful when routing is inactive or temporarily fails, while surfacing the state to admins
- fail closed when a forwarded managed WhatsApp identity no longer matches the tenant's current user ID and phone
- keep contact and human-membership mutations admin-only in both API and UI

## Dependency
Requires canvasxai/sketch-platform#100 and must be deployed after it. Explicit routing sync requires the platform's mapping-status response, preventing an older platform from being mistaken for success.

## Flow

```text
member change commits locally
          |
          v
send desired routing state to platform
          |
          +-- active ----------> ready
          +-- inactive conflict -> keep member + warn + retry
          +-- transient failure -> keep member + warn + retry

startup / every 5 min ----------> reconcile current local truth
```

## Validation
- server: 409 files passed, 4,718 tests passed, 20 skipped
- web: 51 files passed, 433 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

All repository pre-push checks passed.