### PR TITLE
fix: use recent scoped conversation context

### DIFF
--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -981,8 +981,9 @@ describe("buildSketchContext", () => {
       expect(result).toContain(
         "If the user asks for a targeted keyword, topic, decision, person, project, or phrase lookup, you must call SearchChatHistory first instead of paging sequentially.",
       );
+      expect(result).toContain("Only the newest 0 missed messages are inlined.");
       expect(result).toContain(
-        "For chronological continuation, use ReadChatHistory with afterMessageId 25, beforeMessageId 50, and includeBotMessages false.",
+        "For the omitted older messages, use ReadChatHistory with afterMessageId 0, beforeMessageId 25, and includeBotMessages false.",
       );
     });
   });

--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -983,7 +983,29 @@ describe("buildSketchContext", () => {
       );
       expect(result).toContain("Only the newest 0 missed messages are inlined.");
       expect(result).toContain(
-        "For the omitted older messages, use ReadChatHistory with afterMessageId 0, beforeMessageId 25, and includeBotMessages false.",
+        "For the omitted older messages, use ReadChatHistory with beforeMessageId 25, and includeBotMessages false.",
+      );
+      expect(result).not.toContain("ReadChatHistory with afterMessageId 0");
+    });
+
+    it("preserves an existing lower bound when continuing a truncated backlog", () => {
+      const result = buildSketchContext({
+        messages: [],
+        currentUserName: "Alice",
+        currentMessage: "summarize",
+        workspaceDir: "/data/workspaces/u123",
+        orgDir: "/data/.claude",
+        conversationBacklog: {
+          afterMessageId: 10,
+          beforeMessageId: 50,
+          hasMore: true,
+          nextCursor: 25,
+          messages: [],
+        },
+      });
+
+      expect(result).toContain(
+        "For the omitted older messages, use ReadChatHistory with afterMessageId 10, beforeMessageId 25, and includeBotMessages false.",
       );
     });
   });

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -132,7 +132,7 @@ function buildConversationBacklogNotice(params: ConversationBacklogContext): str
   ];
   if (params.hasMore) {
     lines.push(
-      `Only ${params.messages.length} missed messages are inlined. If the user asks for a targeted keyword, topic, decision, person, project, or phrase lookup, you must call SearchChatHistory first instead of paging sequentially. For chronological continuation, use ReadChatHistory with afterMessageId ${params.nextCursor ?? lowerBound}, beforeMessageId ${params.beforeMessageId}, and includeBotMessages false.`,
+      `Only the newest ${params.messages.length} missed messages are inlined. If the user asks for a targeted keyword, topic, decision, person, project, or phrase lookup, you must call SearchChatHistory first instead of paging sequentially. For the omitted older messages, use ReadChatHistory with afterMessageId ${lowerBound}, beforeMessageId ${params.nextCursor ?? params.beforeMessageId}, and includeBotMessages false.`,
     );
   }
   return lines.join("\n");

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -127,12 +127,16 @@ function formatConversationBacklogMessages(messages: ConversationBacklogMessage[
 
 function buildConversationBacklogNotice(params: ConversationBacklogContext): string {
   const lowerBound = params.afterMessageId ?? 0;
+  const olderHistoryBounds =
+    lowerBound > 0
+      ? `afterMessageId ${lowerBound}, beforeMessageId ${params.nextCursor ?? params.beforeMessageId}`
+      : `beforeMessageId ${params.nextCursor ?? params.beforeMessageId}`;
   const lines = [
     `Missed chat messages are shown below using durable row ids. Included messages are after messageId ${lowerBound} and before the current messageId ${params.beforeMessageId}.`,
   ];
   if (params.hasMore) {
     lines.push(
-      `Only the newest ${params.messages.length} missed messages are inlined. If the user asks for a targeted keyword, topic, decision, person, project, or phrase lookup, you must call SearchChatHistory first instead of paging sequentially. For the omitted older messages, use ReadChatHistory with afterMessageId ${lowerBound}, beforeMessageId ${params.nextCursor ?? params.beforeMessageId}, and includeBotMessages false.`,
+      `Only the newest ${params.messages.length} missed messages are inlined. If the user asks for a targeted keyword, topic, decision, person, project, or phrase lookup, you must call SearchChatHistory first instead of paging sequentially. For the omitted older messages, use ReadChatHistory with ${olderHistoryBounds}, and includeBotMessages false.`,
     );
   }
   return lines.join("\n");

--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -374,6 +374,7 @@ export interface RunAgentParams {
     conversationId: number;
     currentMessageId?: number;
     providerThreadId?: string | null;
+    isThreadReply?: boolean;
   };
   agentRuntime?: AgentRuntimeKind;
   loadAgentRuntimeProviderConfig?: () => Promise<AgentRuntimeProviderFactoryConfig | null>;

--- a/packages/server/src/agent/sketch-tools.test.ts
+++ b/packages/server/src/agent/sketch-tools.test.ts
@@ -312,6 +312,42 @@ describe("createSketchMcpServer", () => {
     });
   });
 
+  it("ReadChatHistory keeps top-level Slack history separate from thread replies", async () => {
+    const collector = new UploadCollector();
+    const listMessages = vi.fn().mockResolvedValue({ messages: [], hasMore: false });
+    const server = createSketchMcpServer({
+      uploadCollector: collector,
+      workspaceDir: tmpDir,
+      conversationRepo: { listMessages } as never,
+      conversationContext: { conversationId: 1, currentMessageId: 12, isThreadReply: false },
+    });
+    const tools = (
+      server.instance as unknown as {
+        _registeredTools: Record<
+          string,
+          {
+            handler: (input: {
+              beforeMessageId?: number;
+              scope?: "conversation" | "current_thread";
+            }) => Promise<{ content: { text: string }[] }>;
+          }
+        >;
+      }
+    )._registeredTools;
+
+    await tools.ReadChatHistory.handler({});
+
+    expect(listMessages).toHaveBeenCalledWith(1, {
+      afterMessageId: undefined,
+      beforeMessageId: 12,
+      limit: undefined,
+      order: undefined,
+      includeBotMessages: undefined,
+      providerThreadId: undefined,
+      isThreadReply: false,
+    });
+  });
+
   it("does not expose TranscribeAudio when transcription is disabled", () => {
     const collector = new UploadCollector();
     const server = createSketchMcpServer({ uploadCollector: collector, workspaceDir: tmpDir });

--- a/packages/server/src/agent/tools/chat-history.ts
+++ b/packages/server/src/agent/tools/chat-history.ts
@@ -60,6 +60,7 @@ export function createReadChatHistoryTool(deps: SketchMcpDeps) {
         return { content: [{ type: "text" as const, text: "Chat history is not available in this run." }] };
       }
       const providerThreadId = deps.conversationContext?.providerThreadId;
+      const isThreadReply = deps.conversationContext?.isThreadReply;
       const currentMessageId = deps.conversationContext?.currentMessageId;
       const effectiveBeforeMessageId =
         beforeMessageId && currentMessageId
@@ -79,6 +80,7 @@ export function createReadChatHistoryTool(deps: SketchMcpDeps) {
         order,
         includeBotMessages,
         providerThreadId: effectiveScope === "current_thread" ? providerThreadId : undefined,
+        ...(effectiveScope === "conversation" && isThreadReply !== undefined ? { isThreadReply } : {}),
       });
 
       return {

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -139,6 +139,7 @@ export interface SketchMcpDeps {
     conversationId: number;
     currentMessageId?: number;
     providerThreadId?: string | null;
+    isThreadReply?: boolean;
   };
   agentInstructions?: string | null;
   agentAllowedTools?: string[] | null;

--- a/packages/server/src/db/repositories/conversations.integration.test.ts
+++ b/packages/server/src/db/repositories/conversations.integration.test.ts
@@ -319,6 +319,65 @@ function runRepositorySuite(label: string, getDb: () => Promise<Kysely<DB>>, opt
       expect(backlog.hasMore).toBe(false);
     });
 
+    it.each([
+      ["WhatsApp DM", "whatsapp", "dm", "dm:+15550000001"],
+      ["WhatsApp group", "whatsapp", "group", "busy-group@g.us"],
+      ["Slack DM", "slack", "dm", "D-busy"],
+    ])("returns the newest backlog tail in chronological order for %s", async (_label, platform, kind, providerId) => {
+      const repo = createConversationRepository(db);
+      const conversation = await repo.getOrCreate({
+        platform,
+        kind,
+        providerConversationId: providerId,
+      });
+      const watermark = await repo.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: "watermark",
+        senderJid: "111@s.whatsapp.net",
+        senderName: "Alice",
+        text: "already seen",
+      });
+      const missedIds: number[] = [];
+      for (let index = 1; index <= 17; index += 1) {
+        const message = await repo.insertMessage({
+          conversationId: conversation.id,
+          providerMessageId: `missed-${index}`,
+          senderJid: "222@s.whatsapp.net",
+          senderName: "Bob",
+          text: `missed ${index}`,
+        });
+        missedIds.push(message.row.id);
+      }
+      await repo.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: "bot",
+        senderJid: "bot",
+        senderName: "Sketch",
+        text: "bot reply",
+        isBot: true,
+      });
+      const trigger = await repo.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: "trigger",
+        senderJid: "333@s.whatsapp.net",
+        senderName: "Carol",
+        text: "@Sketch respond",
+        addressedToSketch: true,
+      });
+
+      const backlog = await repo.listBacklog({
+        conversationId: conversation.id,
+        afterMessageId: watermark.row.id,
+        beforeMessageId: trigger.row.id,
+        limit: 10,
+      });
+
+      const expected = missedIds.slice(-10);
+      expect(backlog.messages.map((message) => message.id)).toEqual(expected);
+      expect(backlog.hasMore).toBe(true);
+      expect(backlog.nextCursor).toBe(expected[0]);
+    });
+
     it("pages history with limit plus one and optional bot inclusion", async () => {
       const repo = createConversationRepository(db);
       const conversation = await repo.getOrCreate({
@@ -690,6 +749,117 @@ function runRepositorySuite(label: string, getDb: () => Promise<Kysely<DB>>, opt
       expect(backlog.messages[0].providerThreadId).toBe("1");
       expect(backlog.messages[0].providerParentMessageId).toBe("1");
       expect(backlog.messages[0].isThreadReply).toBe(true);
+    });
+
+    it("returns the newest top-level Slack backlog without replies from other threads", async () => {
+      const repo = createConversationRepository(db);
+      const conversation = await repo.getOrCreate({
+        platform: "slack",
+        kind: "channel",
+        providerConversationId: "C-top-level",
+      });
+      const rootIds: number[] = [];
+      for (let index = 1; index <= 17; index += 1) {
+        const providerThreadId = `root-${index}`;
+        const root = await repo.insertMessage({
+          conversationId: conversation.id,
+          providerMessageId: providerThreadId,
+          senderJid: "S1",
+          senderName: "Alice",
+          text: `root ${index}`,
+          providerThreadId,
+        });
+        rootIds.push(root.row.id);
+        await repo.insertMessage({
+          conversationId: conversation.id,
+          providerMessageId: `reply-${index}`,
+          senderJid: "S2",
+          senderName: "Bob",
+          text: `reply ${index}`,
+          providerThreadId,
+          providerParentMessageId: providerThreadId,
+          isThreadReply: true,
+        });
+      }
+      const trigger = await repo.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: "trigger",
+        senderJid: "S1",
+        senderName: "Alice",
+        text: "@Sketch help",
+        addressedToSketch: true,
+        providerThreadId: "trigger",
+      });
+
+      const backlog = await repo.listBacklog({
+        conversationId: conversation.id,
+        beforeMessageId: trigger.row.id,
+        limit: 10,
+        isThreadReply: false,
+      });
+
+      const expected = rootIds.slice(-10);
+      expect(backlog.messages.map((message) => message.id)).toEqual(expected);
+      expect(backlog.messages.every((message) => !message.isThreadReply)).toBe(true);
+      expect(backlog.hasMore).toBe(true);
+      expect(backlog.nextCursor).toBe(expected[0]);
+    });
+
+    it("returns the newest backlog tail from the active Slack thread", async () => {
+      const repo = createConversationRepository(db);
+      const conversation = await repo.getOrCreate({
+        platform: "slack",
+        kind: "channel",
+        providerConversationId: "C-thread-tail",
+      });
+      const targetIds: number[] = [];
+      for (let index = 1; index <= 17; index += 1) {
+        const target = await repo.insertMessage({
+          conversationId: conversation.id,
+          providerMessageId: `target-${index}`,
+          senderJid: "S1",
+          senderName: "Alice",
+          text: `target reply ${index}`,
+          providerThreadId: "target-root",
+          providerParentMessageId: "target-root",
+          isThreadReply: true,
+        });
+        targetIds.push(target.row.id);
+        await repo.insertMessage({
+          conversationId: conversation.id,
+          providerMessageId: `other-${index}`,
+          senderJid: "S2",
+          senderName: "Bob",
+          text: `other reply ${index}`,
+          providerThreadId: "other-root",
+          providerParentMessageId: "other-root",
+          isThreadReply: true,
+        });
+      }
+      const trigger = await repo.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: "thread-trigger",
+        senderJid: "S1",
+        senderName: "Alice",
+        text: "@Sketch help",
+        addressedToSketch: true,
+        providerThreadId: "target-root",
+        providerParentMessageId: "target-root",
+        isThreadReply: true,
+      });
+
+      const backlog = await repo.listBacklog({
+        conversationId: conversation.id,
+        beforeMessageId: trigger.row.id,
+        limit: 10,
+        providerThreadId: "target-root",
+      });
+
+      const expected = targetIds.slice(-10);
+      expect(backlog.messages.map((message) => message.id)).toEqual(expected);
+      expect(backlog.messages.every((message) => message.providerThreadId === "target-root")).toBe(true);
+      expect(backlog.hasMore).toBe(true);
+      expect(backlog.nextCursor).toBe(expected[0]);
     });
 
     it("stores independent scoped cursors", async () => {

--- a/packages/server/src/db/repositories/conversations.ts
+++ b/packages/server/src/db/repositories/conversations.ts
@@ -70,6 +70,7 @@ export interface ListConversationMessagesOptions {
   order?: "asc" | "desc";
   includeBotMessages?: boolean;
   providerThreadId?: string | null;
+  isThreadReply?: boolean;
 }
 
 export interface ListConversationMessagesInWindowOptions {
@@ -631,6 +632,9 @@ export function createConversationRepository(db: ConversationDb) {
           query = query.where("provider_thread_id", "=", options.providerThreadId);
         }
       }
+      if (options.isThreadReply !== undefined) {
+        query = query.where("is_thread_reply", "=", options.isThreadReply ? 1 : 0);
+      }
 
       const order = options.order ?? "asc";
       const rows = await query
@@ -902,15 +906,18 @@ export function createConversationRepository(db: ConversationDb) {
       beforeMessageId: number;
       limit?: number;
       providerThreadId?: string | null;
+      isThreadReply?: boolean;
     }): Promise<{ messages: StoredConversationMessage[]; hasMore: boolean; nextCursor?: number }> {
-      return this.listMessages(params.conversationId, {
+      const result = await this.listMessages(params.conversationId, {
         afterMessageId: params.afterMessageId ?? undefined,
         beforeMessageId: params.beforeMessageId,
         limit: params.limit,
-        order: "asc",
+        order: "desc",
         includeBotMessages: false,
         providerThreadId: params.providerThreadId,
+        isThreadReply: params.isThreadReply,
       });
+      return { ...result, messages: result.messages.reverse() };
     },
 
     async getMaxMessageId(

--- a/packages/server/src/slack/adapter.isolated.test.ts
+++ b/packages/server/src/slack/adapter.isolated.test.ts
@@ -423,6 +423,22 @@ describe("slack/adapter", () => {
       );
     });
 
+    it("loads durable DM backlog without a Slack thread filter", async () => {
+      const deps = makeDeps();
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { dm } = getHandlers();
+
+      await dm({ text: "hello", userId: "S1", channelId: "D1", ts: "1", type: "dm" });
+      await flush();
+
+      expect(deps.repos.conversations.listBacklog).toHaveBeenCalledWith({
+        conversationId: 1,
+        afterMessageId: null,
+        beforeMessageId: 1,
+        limit: 10,
+      });
+    });
+
     it("appends an integration connection link to DM replies", async () => {
       const deps = makeDeps({
         config: createTestConfig({
@@ -1114,17 +1130,8 @@ describe("slack/adapter", () => {
       expect(deps.repos.channels.create).not.toHaveBeenCalled();
     });
 
-    it("loads channel-wide backlog on top-level mention", async () => {
+    it("loads only top-level backlog on a new top-level mention", async () => {
       const deps = makeDeps();
-      vi.mocked(deps.repos.conversations.getCursor).mockResolvedValueOnce({
-        id: 1,
-        conversation_id: 1,
-        scope_type: "slack_thread",
-        scope_key: "1",
-        last_seen_message_id: 10,
-        created_at: "2025-01-01",
-        updated_at: "2025-01-01",
-      });
       createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
       const { mention } = getHandlers();
 
@@ -1134,15 +1141,21 @@ describe("slack/adapter", () => {
       expect(deps.repos.conversations.listBacklog).toHaveBeenCalledWith(
         expect.objectContaining({
           conversationId: 1,
-          afterMessageId: 10,
+          afterMessageId: undefined,
           beforeMessageId: 1,
           limit: 10,
           providerThreadId: undefined,
+          isThreadReply: false,
         }),
       );
       expect(deps.runAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          conversationContext: { conversationId: 1, currentMessageId: 1, providerThreadId: undefined },
+          conversationContext: {
+            conversationId: 1,
+            currentMessageId: 1,
+            providerThreadId: undefined,
+            isThreadReply: false,
+          },
         }),
       );
     });
@@ -1171,6 +1184,7 @@ describe("slack/adapter", () => {
           beforeMessageId: 1,
           limit: 10,
           providerThreadId: "1",
+          isThreadReply: undefined,
         }),
       );
       expect(deps.runAgent).toHaveBeenCalledWith(

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -1017,6 +1017,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
           beforeMessageId: capture.captured.id,
           limit: INLINE_BACKLOG_LIMIT,
           providerThreadId: message.threadTs ? threadTs : undefined,
+          isThreadReply: message.threadTs ? undefined : false,
         });
         const conversationBacklog =
           backlog.messages.length > 0 || backlog.hasMore
@@ -1119,6 +1120,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
             conversationId: capture.conversation.id,
             currentMessageId: capture.captured.id,
             providerThreadId: message.threadTs ? threadTs : undefined,
+            ...(message.threadTs ? {} : { isThreadReply: false }),
           },
         });
 

--- a/packages/server/src/whatsapp/adapter.isolated.test.ts
+++ b/packages/server/src/whatsapp/adapter.isolated.test.ts
@@ -503,6 +503,59 @@ describe("whatsapp/adapter", () => {
       expect(agentCall.userName).toBe("Alice");
     });
 
+    it("injects durable missed messages into Baileys DM context", async () => {
+      const deps = makeDeps();
+      vi.mocked(deps.repos.conversations.listBacklog).mockResolvedValue({
+        messages: [
+          {
+            id: 42,
+            conversationId: 1,
+            providerMessageId: "recent-dm",
+            senderJid: "1234567890@s.whatsapp.net",
+            senderName: "Alice",
+            senderUserId: "u1",
+            isBot: false,
+            addressedToSketch: false,
+            text: "latest missed DM message",
+            attachments: [],
+            providerThreadId: null,
+            providerParentMessageId: null,
+            isThreadReply: false,
+            providerTimestamp: null,
+            receivedAt: "2025-01-01T00:00:00.000Z",
+            source: "live",
+            effectiveAt: "2025-01-01T00:00:00.000Z",
+            connectionKey: null,
+            backfillRangeId: null,
+            createdAt: "2025-01-01T00:00:00.000Z",
+          },
+        ],
+        hasMore: false,
+      });
+      const { mock, getHandler } = createMockWhatsApp();
+      wireWhatsAppHandlers(mock as never, deps);
+      const handler = getHandler();
+
+      await handler({
+        type: "dm",
+        text: "what did I just say?",
+        jid: "1234@s.whatsapp.net",
+        messageId: "m1",
+        pushName: "Alice",
+        rawMessage: {},
+        phoneNumber: "+1234567890",
+      });
+      await flush();
+
+      expect(deps.repos.conversations.listBacklog).toHaveBeenCalledWith({
+        conversationId: 1,
+        afterMessageId: null,
+        beforeMessageId: 1,
+        limit: 10,
+      });
+      expect(vi.mocked(deps.runAgent).mock.calls[0][0].userMessage).toContain("latest missed DM message");
+    });
+
     it("runs the durable dispatch hook before queued DM work", async () => {
       const deps = makeDeps();
       const { mock } = createMockWhatsApp();
@@ -1950,9 +2003,12 @@ describe("whatsapp/adapter", () => {
       });
       await flush();
 
-      expect(deps.repos.conversations.listBacklog).toHaveBeenCalledWith(
-        expect.objectContaining({ conversationId: 1, beforeMessageId: expect.any(Number), limit: 10 }),
-      );
+      expect(deps.repos.conversations.listBacklog).toHaveBeenCalledWith({
+        conversationId: 1,
+        afterMessageId: null,
+        beforeMessageId: expect.any(Number),
+        limit: 10,
+      });
       const agentCall = vi.mocked(deps.runAgent).mock.calls[0][0];
       expect(agentCall.userMessage).toContain("Bob");
       expect(agentCall.userMessage).toContain("earlier msg");


### PR DESCRIPTION
## Summary

- select the newest eligible conversation backlog before restoring chronological prompt order
- scope new Slack top-level mentions to channel roots and active-thread mentions to that thread
- preserve chat-history filters and cover Slack, WhatsApp, SQLite, and Postgres behavior

## Root cause

The backlog query ordered eligible messages oldest-first before applying its limit. New Slack top-level mentions also read replies from unrelated threads. Together, stale nearby topics could outrank the message being acted on and lead the agent to create the wrong issue.

## Impact

New top-level Slack mentions now receive the latest top-level channel context, thread mentions receive only unseen messages from their thread, and WhatsApp/DM context uses the newest eligible messages. Returned context remains chronological for the agent.

## Validation

- `pnpm biome check .`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- manually verified Slack top-level, thread, and DM behavior against persisted transcripts
- manually verified Baileys WhatsApp group and DM behavior against persisted transcripts