### PR TITLE
SKE-321: Share automation URLs with role-scoped access

### DIFF
--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -383,6 +383,7 @@ describe("buildSystemContext", () => {
     it("uses plain-language automation link guidance", () => {
       const result = buildSystemContext({ platform: "web" });
       expect(result).toContain("automation link");
+      expect(result).toContain("ManageScheduledTasks with action 'share'");
       expect(result).not.toContain("builder URL");
     });
 

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -383,6 +383,7 @@ export function buildSystemContext(params: {
     "## Scheduled Tasks",
     "",
     "Use the ManageScheduledTasks tool when a user asks to do something periodically, on a schedule, or as a reminder. The creation context is filled in automatically, but final delivery is editable through the delivery fields.",
+    "When a user explicitly asks for an automation URL, call ManageScheduledTasks with action 'share' and the automation ID. Do not construct automation URLs yourself.",
     params.automationAuthoringEnabled
       ? "When the user names a delivery destination, use SearchDeliveryTargets first, then include the resolved target ID and label in the natural-language ManageScheduledTasks request."
       : "When the user names a delivery destination, use SearchDeliveryTargets first, then pass the resolved target ID in ManageScheduledTasks delivery.",

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -1119,7 +1119,7 @@ export async function handleManageScheduledTasks(
       if (!guardedTask) {
         return text("Error: task not found.");
       }
-      return text(`Automation URL: ${buildBuilderUrl(guardedTask.id, deps.config)}`);
+      return text(`- Open your automation - ${buildBuilderUrl(guardedTask.id, deps.config)}`);
     }
 
     case "remove": {

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -75,8 +75,10 @@ const deliverySchema = z.object({
 });
 
 const manageScheduledTasksSchema = {
-  action: z.enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun", "updateStepContent"]).describe(
-    `Action to perform.
+  action: z
+    .enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun", "share", "updateStepContent"])
+    .describe(
+      `Action to perform.
 - 'add': create an automation (simple: prompt + schedule_type + schedule_value; multi-step: title + steps)
 - 'list': list automations in this context
 - 'update': modify an automation (requires task_id)
@@ -85,8 +87,9 @@ const manageScheduledTasksSchema = {
 - 'resume': resume a paused automation (requires task_id)
 - 'run': manually trigger an automation (requires task_id)
 - 'getRun': inspect run results (requires task_id, optional run_id for specific run)
+- 'share': return the canonical URL for an automation (requires task_id)
 - 'updateStepContent': update a single step's prompt or script (requires task_id, step_id, step_content)`,
-  ),
+    ),
   prompt: z
     .string()
     .optional()
@@ -113,7 +116,7 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
     .enum(["fresh"])
     .optional()
     .describe("Scheduled automations currently support only 'fresh': no memory, each run starts clean."),
-  task_id: z.string().optional().describe("ID of the task. Required for update/remove/pause/resume/run/getRun."),
+  task_id: z.string().optional().describe("ID of the task. Required for update/remove/pause/resume/run/getRun/share."),
   title: z.string().optional().describe("Human-readable name. Required for multi-step automations."),
   description: z.string().optional().describe("Description of what this automation does."),
   steps: z
@@ -143,7 +146,7 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
 };
 
 const authoredScheduledTasksSchema = {
-  action: z.enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun"]).describe(
+  action: z.enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun", "share"]).describe(
     `Action to perform.
 - 'add': create an automation from the user's natural-language request
 - 'update': edit an automation from the user's natural-language request (requires task_id)
@@ -152,7 +155,8 @@ const authoredScheduledTasksSchema = {
 - 'pause': pause an automation (requires task_id)
 - 'resume': resume a paused automation (requires task_id)
 - 'run': manually trigger an automation (requires task_id)
-- 'getRun': inspect run results (requires task_id, optional run_id for specific run)`,
+- 'getRun': inspect run results (requires task_id, optional run_id for specific run)
+- 'share': return the canonical URL for an automation (requires task_id)`,
   ),
   request: z
     .string()
@@ -160,14 +164,14 @@ const authoredScheduledTasksSchema = {
     .describe(
       "The user's natural-language automation request. Required for add and update; preserve their intent verbatim.",
     ),
-  task_id: z.string().optional().describe("ID of the task. Required for update/remove/pause/resume/run/getRun."),
+  task_id: z.string().optional().describe("ID of the task. Required for update/remove/pause/resume/run/getRun/share."),
   run_id: z.string().optional().describe("Run ID for getRun action. Omit for latest run."),
 };
 
 export type WorkflowStepInput = z.infer<typeof workflowStepSchema>;
 
 type ManageScheduledTasksParams = {
-  action: "list" | "add" | "update" | "remove" | "pause" | "resume" | "run" | "getRun" | "updateStepContent";
+  action: "list" | "add" | "update" | "remove" | "pause" | "resume" | "run" | "getRun" | "share" | "updateStepContent";
   request?: string;
   prompt?: string;
   schedule_type?: "cron" | "interval" | "once" | "external";
@@ -400,6 +404,7 @@ function guardedActionLabel(action: ManageScheduledTasksParams["action"]): strin
   if (action === "pause") return "pause";
   if (action === "run") return "run";
   if (action === "getRun") return "inspect";
+  if (action === "share") return "share";
   return "update";
 }
 
@@ -654,7 +659,16 @@ export async function handleManageScheduledTasks(
     return null;
   };
 
-  const OWNERSHIP_GUARDED_ACTIONS = ["update", "remove", "pause", "resume", "run", "getRun", "updateStepContent"];
+  const OWNERSHIP_GUARDED_ACTIONS = [
+    "update",
+    "remove",
+    "pause",
+    "resume",
+    "run",
+    "getRun",
+    "share",
+    "updateStepContent",
+  ];
   let guardedTask: ScheduledTask | null = null;
   if (task_id && OWNERSHIP_GUARDED_ACTIONS.includes(action)) {
     const task = await deps.scheduler.getTaskById(task_id);
@@ -673,14 +687,14 @@ export async function handleManageScheduledTasks(
 
   switch (action) {
     case "list": {
-      if (ctx.contextType === "dm") {
-        if (!ctx.createdBy) {
-          return text("Error: scheduled task creator is not available in this context.");
-        }
-        const tasks = await deps.scheduler.listTasks({ createdBy: ctx.createdBy });
+      if (!ctx.createdBy) {
+        return text("Error: scheduled task creator is not available in this context.");
+      }
+      if (ctx.canManageAnyTask) {
+        const tasks = await deps.scheduler.listTasks({ includeInactive: true });
         return text(JSON.stringify(tasks, null, 2));
       }
-      const tasks = await deps.scheduler.listTasks({ deliveryTarget: ctx.deliveryTarget });
+      const tasks = await deps.scheduler.listTasks({ createdBy: ctx.createdBy });
       return text(JSON.stringify(tasks, null, 2));
     }
 
@@ -1094,6 +1108,16 @@ export async function handleManageScheduledTasks(
       return text(`Automation updated:\n${JSON.stringify(updated, null, 2)}`);
     }
 
+    case "share": {
+      if (!task_id) {
+        return text("Error: task_id is required for share action.");
+      }
+      if (!guardedTask) {
+        return text("Error: task not found.");
+      }
+      return text(`Automation URL: ${buildBuilderUrl(guardedTask.id, deps.config)}`);
+    }
+
     case "remove": {
       if (!task_id) {
         return text("Error: task_id is required for remove action.");
@@ -1166,7 +1190,7 @@ export async function handleManageScheduledTasks(
       const run = params.run_id
         ? await deps.automationRunsRepo.getById(params.run_id)
         : await deps.automationRunsRepo.getLatest(task_id);
-      if (!run) {
+      if (!run || run.task_id !== task_id) {
         return text(params.run_id ? `Error: run ${params.run_id} not found.` : "No runs found for this automation.");
       }
       return text(JSON.stringify(run, null, 2));

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -690,8 +690,12 @@ export async function handleManageScheduledTasks(
       if (!ctx.createdBy) {
         return text("Error: scheduled task creator is not available in this context.");
       }
-      if (ctx.canManageAnyTask) {
+      if (ctx.contextType === "dm" && ctx.canManageAnyTask) {
         const tasks = await deps.scheduler.listTasks({ includeInactive: true });
+        return text(JSON.stringify(tasks, null, 2));
+      }
+      if (ctx.contextType !== "dm") {
+        const tasks = await deps.scheduler.listTasks({ deliveryTarget: ctx.deliveryTarget });
         return text(JSON.stringify(tasks, null, 2));
       }
       const tasks = await deps.scheduler.listTasks({ createdBy: ctx.createdBy });

--- a/packages/server/src/api/agent-runs.isolated.test.ts
+++ b/packages/server/src/api/agent-runs.isolated.test.ts
@@ -261,6 +261,7 @@ describe("agent invoke API", () => {
       contextType: "dm",
       deliveryTarget: "STARGET",
       createdBy: requester.id,
+      canManageAnyTask: false,
       creatorTimezone: null,
     });
   });

--- a/packages/server/src/api/agent-runs.ts
+++ b/packages/server/src/api/agent-runs.ts
@@ -269,6 +269,7 @@ export function agentRunRoutes(deps: AgentRunRouteDeps) {
               contextType: "dm",
               deliveryTarget: deliveryTarget ?? target.id,
               createdBy: requester.id,
+              canManageAnyTask: requester.auth_role === "admin",
               creatorTimezone: requester.timezone,
             },
           } as RunAgentParams);
@@ -381,6 +382,7 @@ export function agentRunRoutes(deps: AgentRunRouteDeps) {
               contextType: "channel",
               deliveryTarget: parsed.data.target.channelId,
               createdBy: requester.id,
+              canManageAnyTask: requester.auth_role === "admin",
               ...(threadId ? { threadTs: threadId } : {}),
             },
           } as RunAgentParams);
@@ -469,6 +471,7 @@ export function agentRunRoutes(deps: AgentRunRouteDeps) {
             contextType: "group",
             deliveryTarget: groupJid,
             createdBy: requester.id,
+            canManageAnyTask: requester.auth_role === "admin",
           },
         } as RunAgentParams);
 

--- a/packages/server/src/api/scheduled-tasks.test.ts
+++ b/packages/server/src/api/scheduled-tasks.test.ts
@@ -1,4 +1,5 @@
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import { Hono } from "hono";
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { signJwt } from "../auth/jwt";
@@ -13,6 +14,7 @@ import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-group
 import type { DB } from "../db/schema";
 import { createApp } from "../http";
 import { createTestConfig, createTestDb } from "../test-utils";
+import { scheduledTaskRoutes } from "./scheduled-tasks";
 
 const config = createTestConfig();
 
@@ -719,6 +721,49 @@ describe("Scheduled Tasks API", () => {
       headers: { Cookie: cookie },
     });
     expect(pauseRes.status).toBe(200);
+  });
+
+  it("fails closed when an admin context has no user in this tenant", async () => {
+    await seedAdmin(db);
+    const users = createUserRepository(db);
+    const tasks = createScheduledTaskRepository(db);
+    const owner = await users.create({ name: "Owner", email: "owner@test.com" });
+
+    await tasks.add({
+      id: "task-owner",
+      platform: "whatsapp",
+      context_type: "dm",
+      delivery_target: "owner@s.whatsapp.net",
+      thread_ts: null,
+      prompt: "Owner task",
+      schedule_type: "interval",
+      schedule_value: "3600",
+      timezone: "UTC",
+      session_mode: "fresh",
+      created_by: owner.id,
+      status: "active",
+      next_run_at: null,
+    });
+
+    const scheduler = {
+      pauseTask: vi.fn(),
+      resumeTask: vi.fn(),
+      removeTask: vi.fn(),
+      executeTaskById: vi.fn(),
+    };
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("role", "admin");
+      c.set("sub", "admin-from-another-tenant");
+      await next();
+    });
+    app.route("/api/scheduled-tasks", scheduledTaskRoutes(db, scheduler));
+
+    const res = await app.request("/api/scheduled-tasks/task-owner");
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "NOT_FOUND", message: "Scheduled task not found" },
+    });
   });
 
   it("resolves sub via email for local JWT issued with email subject", async () => {

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -367,11 +367,8 @@ export function scheduledTaskRoutes(
   }
 
   function canAccess(row: ScheduledTaskRow, userId: string | null, role: string | undefined): boolean {
-    // Admin trusted even when sub doesn't resolve (stale JWT, deleted user row).
-    // Admins are internal; acceptable in Phase 1.
-    if (role === "admin") return true;
     if (!userId) return false;
-    return row.created_by === userId;
+    return role === "admin" || row.created_by === userId;
   }
 
   async function loadAccessibleTask(c: Context, id: string) {
@@ -412,7 +409,7 @@ export function scheduledTaskRoutes(
     const userId = await resolveUserId(c.get("sub"));
 
     let rows: ScheduledTaskRow[];
-    if (role === "admin") {
+    if (role === "admin" && userId) {
       rows = await repo.listAll();
     } else if (userId) {
       rows = await repo.listByCreatedBy(userId);

--- a/packages/server/src/automation/artifact-links.test.ts
+++ b/packages/server/src/automation/artifact-links.test.ts
@@ -17,7 +17,7 @@ const artifact: AutomationArtifact = {
 describe("appendAutomationBuilderLinks", () => {
   it("appends a missing automation link to final text", () => {
     expect(appendAutomationBuilderLinks("Done.", [artifact])).toBe(
-      "Done.\n\nOpen your automation:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit",
+      "Done.\n\n- Open your automation - https://sketch.test/scheduled-tasks/task-123/edit",
     );
   });
 
@@ -30,7 +30,7 @@ describe("appendAutomationBuilderLinks", () => {
     };
 
     expect(appendAutomationBuilderLinks("Done.", [artifact, secondArtifact])).toBe(
-      "Done.\n\nOpen your automations:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit\n- Weekly pipeline review: https://sketch.test/scheduled-tasks/task-456/edit",
+      "Done.\n\n- Open your automations - https://sketch.test/scheduled-tasks/task-123/edit\n- Open your automations - https://sketch.test/scheduled-tasks/task-456/edit",
     );
   });
 
@@ -44,13 +44,13 @@ describe("appendAutomationBuilderLinks", () => {
     const text = `First automation: ${artifact.builderUrl}`;
 
     expect(appendAutomationBuilderLinks(text, [artifact, secondArtifact])).toBe(
-      `${text}\n\nOpen your automations:\n- Weekly pipeline review: https://sketch.test/scheduled-tasks/task-456/edit`,
+      `${text}\n\n- Open your automations - https://sketch.test/scheduled-tasks/task-456/edit`,
     );
   });
 
   it("creates fallback text for artifact-only responses", () => {
     expect(appendAutomationBuilderLinks(null, [artifact])).toBe(
-      "Your automation is ready.\n\nOpen your automation:\n- Daily account brief: https://sketch.test/scheduled-tasks/task-123/edit",
+      "Your automation is ready.\n\n- Open your automation - https://sketch.test/scheduled-tasks/task-123/edit",
     );
   });
 

--- a/packages/server/src/automation/artifact-links.ts
+++ b/packages/server/src/automation/artifact-links.ts
@@ -1,9 +1,9 @@
 import type { AutomationArtifact } from "@sketch/shared";
 
-function artifactLinkLine(artifact: AutomationArtifact): string | null {
+function artifactLinkLine(artifact: AutomationArtifact, label: string): string | null {
   const url = artifact.builderUrl.trim();
   if (!url) return null;
-  return `- ${artifact.title}: ${url}`;
+  return `- ${label} - ${url}`;
 }
 
 function builderUrlReferences(value: string): string[] {
@@ -28,18 +28,18 @@ export function appendAutomationBuilderLinks(
     if (url && !artifactsByUrl.has(url)) artifactsByUrl.set(url, artifact);
   }
   const distinctArtifacts = Array.from(artifactsByUrl.values());
+  const linkLabel = distinctArtifacts.length === 1 ? "Open your automation" : "Open your automations";
   const missingLinks = distinctArtifacts
     .filter((artifact) => {
       const references = builderUrlReferences(artifact.builderUrl);
       return references.length > 0 && references.every((reference) => !text.includes(reference));
     })
-    .map(artifactLinkLine)
+    .map((artifact) => artifactLinkLine(artifact, linkLabel))
     .filter((line): line is string => Boolean(line));
 
   if (missingLinks.length === 0) return text || null;
 
-  const linkHeading = distinctArtifacts.length === 1 ? "Open your automation:" : "Open your automations:";
-  const linkBlock = `${linkHeading}\n${missingLinks.join("\n")}`;
+  const linkBlock = missingLinks.join("\n");
   const fallback = "Your automation is ready.";
   return text ? `${text}\n\n${linkBlock}` : `${fallback}\n\n${linkBlock}`;
 }

--- a/packages/server/src/automation/chat-authoring.ts
+++ b/packages/server/src/automation/chat-authoring.ts
@@ -150,8 +150,8 @@ export function createChatAutomationAuthoring(deps: {
     const row = await tasks.getById(input.taskId);
     if (
       !row ||
-      (!input.taskContext.canManageAnyTask &&
-        (!input.taskContext.createdBy || row.created_by !== input.taskContext.createdBy))
+      !input.taskContext.createdBy ||
+      (!input.taskContext.canManageAnyTask && row.created_by !== input.taskContext.createdBy)
     ) {
       return { kind: "error", message: "Automation not found." };
     }

--- a/packages/server/src/automation/persistence.test.ts
+++ b/packages/server/src/automation/persistence.test.ts
@@ -242,6 +242,29 @@ describe("automation persistence", () => {
     });
   });
 
+  it("fails closed when an admin actor has no tenant user identity", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-no-admin-identity"),
+      brokerCapable: true,
+    });
+
+    const result = await replaceAutomationDefinition({
+      db,
+      taskId: "automation-no-admin-identity",
+      request: makeDefinition({ expectedRevision: 0, title: "Unauthorized admin replacement" }),
+      actor: { userId: null, canManageAnyTask: true },
+      brokerCapable: true,
+    });
+
+    expect(result).toEqual({ kind: "not_found" });
+    await expect(createScheduledTaskRepository(db).getById("automation-no-admin-identity")).resolves.toMatchObject({
+      title: "Daily account brief",
+      revision: 0,
+    });
+  });
+
   it("returns the current revision and preserves data after a stale replacement", async () => {
     await createAutomationDefinition({
       db,

--- a/packages/server/src/automation/persistence.ts
+++ b/packages/server/src/automation/persistence.ts
@@ -139,7 +139,7 @@ export async function replaceAutomationDefinition(params: {
       .where("id", "=", params.taskId)
       .executeTakeFirst();
     if (!current) return { kind: "not_found" as const };
-    if (!params.actor.canManageAnyTask && (!params.actor.userId || current.created_by !== params.actor.userId)) {
+    if (!params.actor.userId || (!params.actor.canManageAnyTask && current.created_by !== params.actor.userId)) {
       return { kind: "not_found" as const };
     }
     if (request.expectedRevision !== undefined && current.revision !== request.expectedRevision) {

--- a/packages/server/src/local-devices/claude-event-dispatcher.ts
+++ b/packages/server/src/local-devices/claude-event-dispatcher.ts
@@ -280,6 +280,7 @@ export function createLocalClaudeEventDispatcher(deps: LocalClaudeEventDispatche
         contextType: originContextType,
         deliveryTarget: session.origin_delivery_target,
         createdBy: session.user_id,
+        canManageAnyTask: user?.auth_role === "admin",
         creatorTimezone: user?.timezone ?? null,
         threadTs: session.origin_thread_ts ?? undefined,
       },

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -479,6 +479,43 @@ describe("listTasks()", () => {
     expect(tasks).toHaveLength(1);
     expect(tasks[0].createdBy).toBe("U_OWNER");
   });
+
+  it("returns active, paused, and completed tasks when includeInactive is requested", async () => {
+    const deps = buildDeps(db);
+    const scheduler = new TaskScheduler(deps as never);
+    const active = await scheduler.addTask({
+      platform: "slack",
+      contextType: "dm",
+      deliveryTarget: "U_ACTIVE",
+      prompt: "Active",
+      scheduleType: "cron",
+      scheduleValue: "0 9 * * 1",
+      createdBy: "U_ACTIVE",
+    });
+    const paused = await scheduler.addTask({
+      platform: "slack",
+      contextType: "dm",
+      deliveryTarget: "U_PAUSED",
+      prompt: "Paused",
+      scheduleType: "cron",
+      scheduleValue: "0 9 * * 1",
+      createdBy: "U_PAUSED",
+    });
+    await scheduler.pauseTask(paused.id);
+    const completed = await scheduler.addTask({
+      platform: "slack",
+      contextType: "dm",
+      deliveryTarget: "U_COMPLETED",
+      prompt: "Completed",
+      scheduleType: "cron",
+      scheduleValue: "0 9 * * 1",
+      createdBy: "U_COMPLETED",
+    });
+    await repo.updateStatus(completed.id, "completed");
+
+    const tasks = await scheduler.listTasks({ includeInactive: true });
+    expect(tasks.map((task) => task.id).sort()).toEqual([active.id, paused.id, completed.id].sort());
+  });
 });
 
 describe("executeTask() invokes automation runtime", () => {

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -819,12 +819,16 @@ export class TaskScheduler {
     await this.repo.update(id, {}, { incrementRevision: true });
   }
 
-  async listTasks(filter: { deliveryTarget?: string; createdBy?: string }): Promise<ScheduledTask[]> {
+  async listTasks(filter: { deliveryTarget?: string; createdBy?: string; includeInactive?: boolean }): Promise<
+    ScheduledTask[]
+  > {
     let rows: ScheduledTaskRow[];
     if (filter.deliveryTarget) {
       rows = await this.repo.listByDeliveryTarget(filter.deliveryTarget);
     } else if (filter.createdBy) {
       rows = await this.repo.listByCreatedBy(filter.createdBy);
+    } else if (filter.includeInactive) {
+      rows = await this.repo.listAll();
     } else {
       rows = await this.repo.listActive();
     }

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -1642,7 +1642,7 @@ describe("handleManageScheduledTasks — ownership", () => {
       },
     );
 
-    expect(result.content[0].text).toBe("Automation URL: https://sketch.test/scheduled-tasks/task-1/edit");
+    expect(result.content[0].text).toBe("- Open your automation - https://sketch.test/scheduled-tasks/task-1/edit");
     expect(scheduler.getTaskById).toHaveBeenCalledWith("task-1");
     expect(scheduler.updateTask).not.toHaveBeenCalled();
     expect(scheduler.executeTaskById).not.toHaveBeenCalled();
@@ -1663,7 +1663,7 @@ describe("handleManageScheduledTasks — ownership", () => {
       },
     );
 
-    expect(result.content[0].text).toBe("Automation URL: https://sketch.test/scheduled-tasks/task-1/edit");
+    expect(result.content[0].text).toBe("- Open your automation - https://sketch.test/scheduled-tasks/task-1/edit");
   });
 
   it("falls back when the task owner cannot be resolved", async () => {

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -370,19 +370,31 @@ describe("handleManageScheduledTasks — list", () => {
     expect(scheduler.listTasks).toHaveBeenCalledWith({ createdBy: "U123" });
   });
 
-  it("scopes by createdBy for channel context", async () => {
+  it("scopes by deliveryTarget for channel context", async () => {
     const scheduler = makeMockScheduler();
     await handleManageScheduledTasks({ action: "list" }, { scheduler, stepContentRepo, taskContext: channelContext });
-    expect(scheduler.listTasks).toHaveBeenCalledWith({ createdBy: "U123" });
+    expect(scheduler.listTasks).toHaveBeenCalledWith({ deliveryTarget: "C456" });
   });
 
-  it("scopes by createdBy for group context", async () => {
+  it("scopes by deliveryTarget for group context", async () => {
     const scheduler = makeMockScheduler();
     await handleManageScheduledTasks(
       { action: "list" },
       { scheduler, stepContentRepo, taskContext: whatsappGroupContext },
     );
-    expect(scheduler.listTasks).toHaveBeenCalledWith({ createdBy: "U123" });
+    expect(scheduler.listTasks).toHaveBeenCalledWith({ deliveryTarget: "120363000000@g.us" });
+  });
+
+  it.each([
+    ["channel", channelContext],
+    ["group", whatsappGroupContext],
+  ] as const)("scopes admin %s listings by deliveryTarget", async (_contextName, taskContext) => {
+    const scheduler = makeMockScheduler();
+    await handleManageScheduledTasks(
+      { action: "list" },
+      { scheduler, stepContentRepo, taskContext: { ...taskContext, canManageAnyTask: true } },
+    );
+    expect(scheduler.listTasks).toHaveBeenCalledWith({ deliveryTarget: taskContext.deliveryTarget });
   });
 
   it("lists every automation for an admin context", async () => {

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -308,7 +308,7 @@ describe("handleManageScheduledTasks — configured chat authoring", () => {
     expect(stepContentRepo.upsert).not.toHaveBeenCalled();
   });
 
-  it.each(["list", "remove", "pause", "resume", "run", "getRun"] as const)(
+  it.each(["list", "remove", "pause", "resume", "run", "getRun", "share"] as const)(
     "keeps %s deterministic without invoking the authorer",
     async (action) => {
       const scheduler = makeMockScheduler();
@@ -370,19 +370,38 @@ describe("handleManageScheduledTasks — list", () => {
     expect(scheduler.listTasks).toHaveBeenCalledWith({ createdBy: "U123" });
   });
 
-  it("scopes by deliveryTarget for channel context", async () => {
+  it("scopes by createdBy for channel context", async () => {
     const scheduler = makeMockScheduler();
     await handleManageScheduledTasks({ action: "list" }, { scheduler, stepContentRepo, taskContext: channelContext });
-    expect(scheduler.listTasks).toHaveBeenCalledWith({ deliveryTarget: "C456" });
+    expect(scheduler.listTasks).toHaveBeenCalledWith({ createdBy: "U123" });
   });
 
-  it("scopes by deliveryTarget for group context", async () => {
+  it("scopes by createdBy for group context", async () => {
     const scheduler = makeMockScheduler();
     await handleManageScheduledTasks(
       { action: "list" },
       { scheduler, stepContentRepo, taskContext: whatsappGroupContext },
     );
-    expect(scheduler.listTasks).toHaveBeenCalledWith({ deliveryTarget: "120363000000@g.us" });
+    expect(scheduler.listTasks).toHaveBeenCalledWith({ createdBy: "U123" });
+  });
+
+  it("lists every automation for an admin context", async () => {
+    const scheduler = makeMockScheduler();
+    await handleManageScheduledTasks(
+      { action: "list" },
+      { scheduler, stepContentRepo, taskContext: { ...dmContext, canManageAnyTask: true } },
+    );
+    expect(scheduler.listTasks).toHaveBeenCalledWith({ includeInactive: true });
+  });
+
+  it("fails closed when listing without an authenticated creator", async () => {
+    const scheduler = makeMockScheduler();
+    const result = await handleManageScheduledTasks(
+      { action: "list" },
+      { scheduler, stepContentRepo, taskContext: { ...channelContext, createdBy: null, canManageAnyTask: true } },
+    );
+    expect(result.content[0].text).toBe("Error: scheduled task creator is not available in this context.");
+    expect(scheduler.listTasks).not.toHaveBeenCalled();
   });
 
   it("returns JSON of tasks", async () => {
@@ -1466,6 +1485,27 @@ describe("handleManageScheduledTasks — run", () => {
   });
 });
 
+describe("handleManageScheduledTasks — run history", () => {
+  it("does not return a run belonging to another automation", async () => {
+    const scheduler = makeMockScheduler();
+    const automationRunsRepo = {
+      getById: vi.fn().mockResolvedValue({
+        id: "run-other",
+        task_id: "task-other",
+        status: "completed",
+      }),
+      getLatest: vi.fn(),
+    } as unknown as NonNullable<Parameters<typeof handleManageScheduledTasks>[1]["automationRunsRepo"]>;
+
+    const result = await handleManageScheduledTasks(
+      { action: "getRun", task_id: "task-1", run_id: "run-other" },
+      { scheduler, stepContentRepo, automationRunsRepo, taskContext: dmContext },
+    );
+
+    expect(result.content[0].text).toBe("Error: run run-other not found.");
+  });
+});
+
 describe("handleManageScheduledTasks — add with once schedule type", () => {
   it("succeeds with a valid future ISO datetime", async () => {
     const futureDate = new Date(Date.now() + 3_600_000).toISOString();
@@ -1505,7 +1545,16 @@ describe("handleManageScheduledTasks — add with once schedule type", () => {
 });
 
 describe("handleManageScheduledTasks — ownership", () => {
-  const GUARDED_ACTIONS = ["update", "remove", "pause", "resume", "run", "getRun", "updateStepContent"] as const;
+  const GUARDED_ACTIONS = [
+    "update",
+    "remove",
+    "pause",
+    "resume",
+    "run",
+    "getRun",
+    "share",
+    "updateStepContent",
+  ] as const;
 
   function buildParams(action: (typeof GUARDED_ACTIONS)[number]): Parameters<typeof handleManageScheduledTasks>[0] {
     if (action === "updateStepContent") {
@@ -1566,6 +1615,43 @@ describe("handleManageScheduledTasks — ownership", () => {
 
     expect(scheduler.updateTask).toHaveBeenCalledWith("task-1", expect.objectContaining({ prompt: "Admin update" }));
     expect(result.content[0].text).toContain("Automation updated:");
+  });
+
+  it("returns the canonical URL for an automation the member owns", async () => {
+    const scheduler = makeMockScheduler();
+
+    const result = await handleManageScheduledTasks(
+      { action: "share", task_id: "task-1" },
+      {
+        scheduler,
+        stepContentRepo,
+        taskContext: dmContext,
+        config: { BASE_URL: "https://sketch.test/", PORT: 3000 },
+      },
+    );
+
+    expect(result.content[0].text).toBe("Automation URL: https://sketch.test/scheduled-tasks/task-1/edit");
+    expect(scheduler.getTaskById).toHaveBeenCalledWith("task-1");
+    expect(scheduler.updateTask).not.toHaveBeenCalled();
+    expect(scheduler.executeTaskById).not.toHaveBeenCalled();
+  });
+
+  it("returns the canonical URL for another user's automation to an admin", async () => {
+    const scheduler = makeMockScheduler({
+      getTaskById: vi.fn().mockResolvedValue(makeTask({ createdBy: "U_OTHER" })),
+    });
+
+    const result = await handleManageScheduledTasks(
+      { action: "share", task_id: "task-1" },
+      {
+        scheduler,
+        stepContentRepo,
+        taskContext: { ...dmContext, canManageAnyTask: true },
+        config: { BASE_URL: "https://sketch.test", PORT: 3000 },
+      },
+    );
+
+    expect(result.content[0].text).toBe("Automation URL: https://sketch.test/scheduled-tasks/task-1/edit");
   });
 
   it("falls back when the task owner cannot be resolved", async () => {

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -722,6 +722,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
             contextType: "dm" as const,
             deliveryTarget: message.channelId,
             createdBy: user.id,
+            canManageAnyTask: user.auth_role === "admin",
             creatorTimezone: user.timezone,
             origin: {
               platform: "slack" as const,
@@ -1154,6 +1155,7 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
             contextType: "channel" as const,
             deliveryTarget: message.channelId,
             createdBy: user.id,
+            canManageAnyTask: user.auth_role === "admin",
             creatorTimezone: user.timezone,
             threadTs: message.threadTs ? threadTs : undefined,
             origin: {

--- a/packages/server/src/slack/resolve-user.test.ts
+++ b/packages/server/src/slack/resolve-user.test.ts
@@ -10,6 +10,7 @@ const makeUser = (
   id: "u1",
   name: "Alice",
   email: null as string | null,
+  auth_role: "member",
   slack_user_id: null as string | null,
   whatsapp_number: null as string | null,
   created_at: "2026-01-01T00:00:00Z",

--- a/packages/server/src/slack/resolve-user.ts
+++ b/packages/server/src/slack/resolve-user.ts
@@ -14,6 +14,7 @@ type UserRow = {
   id: string;
   name: string;
   email: string | null;
+  auth_role: string;
   slack_user_id: string | null;
   whatsapp_number: string | null;
   created_at: string;

--- a/packages/server/src/slack/upsert-identity.ts
+++ b/packages/server/src/slack/upsert-identity.ts
@@ -2,6 +2,7 @@ type UserRow = {
   id: string;
   name: string;
   email: string | null;
+  auth_role: string;
   slack_user_id: string | null;
   whatsapp_number: string | null;
   created_at: string;

--- a/packages/server/src/whatsapp/adapter.ts
+++ b/packages/server/src/whatsapp/adapter.ts
@@ -906,6 +906,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
             contextType: "dm" as const,
             deliveryTarget: deliveryTargetId,
             createdBy: user.id,
+            canManageAnyTask: user.auth_role === "admin",
             creatorTimezone: user.timezone,
             origin: {
               platform: "whatsapp" as const,
@@ -1225,6 +1226,7 @@ export function wireWhatsAppHandlers(whatsapp: WhatsAppRuntime, deps: WhatsAppAd
             contextType: "group" as const,
             deliveryTarget: groupJid,
             createdBy: user?.id ?? "unknown",
+            canManageAnyTask: user?.auth_role === "admin",
             creatorTimezone: user?.timezone ?? null,
             origin: {
               platform: "whatsapp" as const,


### PR DESCRIPTION
## Summary

- allow authorized users to request canonical automation URLs
- restrict members to their own automations while allowing admins organization-wide access and management
- enforce role and tenant authorization across tools, APIs, persistence, authoring, channel adapters, and session identity propagation

## Linear Scope

- [SKE-321: Share automation URLs with role-scoped access](https://linear.app/sketch-ai/issue/SKE-321/share-automation-urls-with-role-scoped-access)

## Implementation Details

- add a `share` action returning the canonical `/scheduled-tasks/:id/edit` URL without tokens
- enforce member ownership and admin access at the authoritative backend, tool, API, and persistence boundaries
- prevent shared channel and group listings from exposing other members' automations
- propagate authenticated role and identity through Slack, WhatsApp, web/API, and local-session paths
- add member-own, member-other, admin-other, cross-tenant, run-history, and identity coverage

## Verification

- Node 24 `pnpm biome check .` — passed; 1,297 files
- `pnpm typecheck` — passed
- `pnpm test` — passed; server 4,818 passed / 20 skipped, web 436 passed
- `pnpm build` — passed
- Node 24 pre-push gate — passed
- `git diff --check` — passed

## Risk / Rollout

- no migration, configuration, or feature-flag change
- URLs are session-authenticated canonical app URLs; no token-bearing links
- the current tenant database and existing session role are authoritative; member/admin scope is fail-closed