### PR TITLE
SKE-330: Bind current automation context and canonicalize mutations

### DIFF
--- a/packages/server/src/agent/runner.ts
+++ b/packages/server/src/agent/runner.ts
@@ -37,7 +37,7 @@ import type { LocalClaudeSessionService } from "../local-devices/claude-sessions
 import type { LocalDeviceGateway } from "../local-devices/gateway";
 import type { Logger } from "../logger";
 import type { TaskScheduler } from "../scheduler/service";
-import type { TaskContext } from "../scheduler/types";
+import type { CurrentAutomation, TaskContext } from "../scheduler/types";
 import type { SlackBot } from "../slack/bot";
 import type { TranscriptionSettings } from "../transcription/service";
 import { resolveTranscriptionConfig } from "../transcription/service";
@@ -312,6 +312,7 @@ export interface RunAgentParams {
   sessionMode?: "fresh" | "persistent" | "chat";
   persistSession?: boolean;
   taskContext?: TaskContext;
+  currentAutomation?: CurrentAutomation;
   getSlack?: () => SlackBot | null;
   scheduler?: TaskScheduler;
   chatAutomationAuthoring?: ChatAutomationAuthoring;
@@ -1208,6 +1209,7 @@ async function runAgentWithClaudeSdk(params: RunAgentParams): Promise<RunAgentRe
     getSlack: params.getSlack,
     loadIntegrationProvider: params.loadIntegrationProvider,
     taskContext: params.taskContext,
+    currentAutomation: params.currentAutomation ?? params.taskContext?.currentAutomation,
     scheduler: params.scheduler,
     chatAuthoring: params.chatAutomationAuthoring,
     stepContentRepo: params.stepContentRepo,

--- a/packages/server/src/agent/runtime/custom-tools.ts
+++ b/packages/server/src/agent/runtime/custom-tools.ts
@@ -175,6 +175,7 @@ function buildSketchMcpDeps(params: RunAgentParams, deps: AgentRuntimeCustomTool
     getSlack: params.getSlack,
     loadIntegrationProvider: params.loadIntegrationProvider,
     taskContext: params.taskContext,
+    currentAutomation: params.currentAutomation ?? params.taskContext?.currentAutomation,
     scheduler: params.scheduler,
     chatAuthoring: params.chatAutomationAuthoring,
     stepContentRepo: params.stepContentRepo,

--- a/packages/server/src/agent/sketch-tools.test.ts
+++ b/packages/server/src/agent/sketch-tools.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { Selectable } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UsersTable } from "../db/schema";
+import { createTestDb } from "../test-utils";
 import {
   AutomationArtifactCollector,
   UploadCollector,
@@ -86,12 +87,15 @@ describe("UploadCollector", () => {
 
 describe("createSketchMcpServer", () => {
   let tmpDir: string;
+  let db: Awaited<ReturnType<typeof createTestDb>>;
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), "sketch-upload-test-"));
+    db = await createTestDb();
   });
 
   afterEach(async () => {
+    await db.destroy();
     await rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -125,10 +129,9 @@ describe("createSketchMcpServer", () => {
   it("forwards automation artifacts from the scheduled task tool", async () => {
     const uploadCollector = new UploadCollector();
     const automationArtifactCollector = new AutomationArtifactCollector();
-    const stepContentRepo = { upsert: vi.fn().mockResolvedValue(undefined) };
     const scheduler = {
-      addTask: vi.fn().mockResolvedValue({
-        id: "new-task",
+      refreshTaskSchedule: vi.fn().mockImplementation(async (id: string) => ({
+        id,
         platform: "slack",
         contextType: "dm",
         deliveryTarget: "D123",
@@ -148,8 +151,8 @@ describe("createSketchMcpServer", () => {
         originChat: null,
         steps: null,
         edges: null,
-        outputTarget: null,
-        outputPlatform: null,
+        outputTarget: "D123",
+        outputPlatform: "slack",
         outputThreadTs: null,
         outputMode: "deliver",
         delivery: {
@@ -159,14 +162,14 @@ describe("createSketchMcpServer", () => {
           threadTs: null,
           mode: "deliver",
         },
-      }),
+      })),
     };
     const server = createSketchMcpServer({
       uploadCollector,
       automationArtifactCollector,
       workspaceDir: tmpDir,
+      db,
       scheduler: scheduler as never,
-      stepContentRepo: stepContentRepo as never,
       taskContext: { platform: "slack", contextType: "dm", deliveryTarget: "D123", createdBy: "user-1" },
     });
     const tools = (
@@ -182,12 +185,14 @@ describe("createSketchMcpServer", () => {
       schedule_value: "0 9 * * 1",
     });
 
-    expect(automationArtifactCollector.drain()).toEqual([
+    const artifacts = automationArtifactCollector.drain();
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]).toEqual(
       expect.objectContaining({
-        taskId: "new-task",
-        builderUrl: "http://localhost:3000/scheduled-tasks/new-task/edit",
+        taskId: expect.any(String),
+        builderUrl: expect.stringMatching(/^http:\/\/localhost:3000\/scheduled-tasks\/[^/]+\/edit$/),
       }),
-    ]);
+    );
   });
 
   it("SearchChatHistory searches the scoped conversation", async () => {

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -48,6 +48,7 @@ export function createSketchMcpToolDefinitions(deps: SketchMcpDeps) {
       scheduler: deps.scheduler,
       chatAuthoring: deps.chatAuthoring,
       taskContext: deps.taskContext,
+      currentAutomation: deps.currentAutomation ?? deps.taskContext?.currentAutomation,
       stepContentRepo: deps.stepContentRepo,
       automationRunsRepo: deps.automationRunsRepo,
       userRepo: deps.userRepo,

--- a/packages/server/src/agent/sketch-tools.ts
+++ b/packages/server/src/agent/sketch-tools.ts
@@ -46,6 +46,7 @@ export function createSketchMcpToolDefinitions(deps: SketchMcpDeps) {
     createLocalClaudeSessionTool(deps),
     createManageScheduledTasksTool({
       scheduler: deps.scheduler,
+      db: deps.db,
       chatAuthoring: deps.chatAuthoring,
       taskContext: deps.taskContext,
       currentAutomation: deps.currentAutomation ?? deps.taskContext?.currentAutomation,

--- a/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
@@ -63,6 +63,58 @@ function definition(overrides: Partial<AutomationBuilderSaveRequest> = {}): Auto
   };
 }
 
+function actionDefinition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
+  return {
+    ...definition(),
+    title: "Broker action",
+    prompt: "Run a broker action.",
+    steps: [
+      definition().steps[0],
+      {
+        id: "action",
+        type: "action",
+        label: "Run broker action",
+        icon: "zap",
+        position: { x: 260, y: 0 },
+      },
+    ],
+    edges: [{ id: "trigger-action", from: "trigger", to: "action" }],
+    stepContent: {
+      action: {
+        taskId: "client-task-id",
+        stepId: "action",
+        contentType: "script",
+        content: "return input;",
+        apps: ["clickup"],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function actionStepInputs() {
+  return [
+    definition().steps[0],
+    {
+      id: "action",
+      type: "action" as const,
+      label: "Run broker action",
+      icon: "zap",
+      position: { x: 260, y: 0 },
+      script: "return input;",
+      apps: ["clickup"],
+    },
+  ];
+}
+
+const brokerUnavailableLoaders = [
+  { label: "unavailable", loadIntegrationProvider: async () => null },
+  {
+    label: "not broker-capable",
+    loadIntegrationProvider: async () => ({ isBrokerCapable: () => false }) as never,
+  },
+] as const;
+
 function context(id: string, createdBy = "owner-1") {
   return {
     id,
@@ -310,6 +362,66 @@ describe("ManageScheduledTasks canonical structured mutations", () => {
       session_mode: "fresh",
     });
   });
+
+  it.each(brokerUnavailableLoaders)(
+    "rejects broker-requiring direct creates when the provider is $label",
+    async ({ loadIntegrationProvider }) => {
+      const scheduler = schedulerFor("broker-create-task");
+      const result = await handleManageScheduledTasks(
+        {
+          action: "add",
+          title: "Broker action",
+          schedule_type: "interval",
+          schedule_value: "120",
+          steps: actionStepInputs(),
+          edges: [{ id: "trigger-action", from: "trigger", to: "action" }],
+        },
+        {
+          db,
+          scheduler,
+          loadIntegrationProvider,
+          taskContext: taskContextFor("broker-create-task"),
+        },
+      );
+
+      expect(result.content[0].text).toContain("broker-capable integration provider");
+      await expect(createScheduledTaskRepository(db).listAll()).resolves.toEqual([]);
+    },
+  );
+
+  it.each(brokerUnavailableLoaders)(
+    "rejects broker-requiring direct updates when the provider is $label",
+    async ({ loadIntegrationProvider }) => {
+      await createAutomationDefinition({
+        db,
+        request: actionDefinition(),
+        context: context("broker-update-task"),
+        brokerCapable: true,
+      });
+      const scheduler = schedulerFor("broker-update-task");
+
+      const update = await handleManageScheduledTasks(
+        { action: "update", task_id: "broker-update-task", prompt: "Update the action" },
+        { db, scheduler, loadIntegrationProvider, taskContext: taskContextFor("broker-update-task") },
+      );
+      expect(update.content[0].text).toContain("BROKER_REQUIRED");
+
+      const stepContentUpdate = await handleManageScheduledTasks(
+        {
+          action: "updateStepContent",
+          task_id: "broker-update-task",
+          step_id: "action",
+          step_content: "return updatedInput;",
+        },
+        { db, scheduler, loadIntegrationProvider, taskContext: taskContextFor("broker-update-task") },
+      );
+      expect(stepContentUpdate.content[0].text).toContain("BROKER_REQUIRED");
+
+      await expect(createScheduledTaskRepository(db).getById("broker-update-task")).resolves.toMatchObject({
+        revision: 0,
+      });
+    },
+  );
 
   it("preserves unspecified fields during a partial update and records the acting editor", async () => {
     await createAutomationDefinition({
@@ -680,5 +792,174 @@ describe("ManageScheduledTasks canonical structured mutations", () => {
       { db, scheduler, taskContext },
     );
     expect(stale.content[0].text).toContain("revision conflict");
+  });
+
+  it("uses the ambient revision for an explicit same-task update and rejects a stale race", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("explicit-same-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("explicit-same-task");
+    const taskContext = taskContextFor("explicit-same-task", "owner-1", currentAutomationFor("explicit-same-task", 0));
+
+    const results = await Promise.all([
+      handleManageScheduledTasks(
+        { action: "update", task_id: "explicit-same-task", prompt: "First explicit edit" },
+        { db, scheduler, taskContext },
+      ),
+      handleManageScheduledTasks(
+        { action: "update", task_id: "explicit-same-task", prompt: "Second explicit edit" },
+        { db, scheduler, taskContext },
+      ),
+    ]);
+
+    const messages = results.map((result) => result.content[0].text);
+    expect(messages.filter((message) => message.includes("Automation updated:"))).toHaveLength(1);
+    expect(messages.filter((message) => message.includes("revision conflict"))).toHaveLength(1);
+    await expect(createScheduledTaskRepository(db).getById("explicit-same-task")).resolves.toMatchObject({
+      revision: 1,
+    });
+  });
+
+  it("uses the ambient revision for an explicit same-task step-content race", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("explicit-same-content-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("explicit-same-content-task");
+    const taskContext = taskContextFor(
+      "explicit-same-content-task",
+      "owner-1",
+      currentAutomationFor("explicit-same-content-task", 0),
+    );
+
+    const results = await Promise.all([
+      handleManageScheduledTasks(
+        {
+          action: "updateStepContent",
+          task_id: "explicit-same-content-task",
+          step_id: "agent",
+          step_content: "First explicit content edit",
+        },
+        { db, scheduler, taskContext },
+      ),
+      handleManageScheduledTasks(
+        {
+          action: "updateStepContent",
+          task_id: "explicit-same-content-task",
+          step_id: "agent",
+          step_content: "Second explicit content edit",
+        },
+        { db, scheduler, taskContext },
+      ),
+    ]);
+
+    const messages = results.map((result) => result.content[0].text);
+    expect(messages.filter((message) => message.includes("content updated at revision 1"))).toHaveLength(1);
+    expect(messages.filter((message) => message.includes("revision conflict"))).toHaveLength(1);
+    await expect(createScheduledTaskRepository(db).getById("explicit-same-content-task")).resolves.toMatchObject({
+      revision: 1,
+    });
+  });
+
+  it("honors a supplied revision for an explicit same-task update", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("explicit-supplied-revision"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("explicit-supplied-revision");
+    const taskContext = taskContextFor(
+      "explicit-supplied-revision",
+      "owner-1",
+      currentAutomationFor("explicit-supplied-revision", 0),
+    );
+
+    const first = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "explicit-supplied-revision",
+        prompt: "First edit",
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext },
+    );
+    expect(first.content[0].text).toContain("Automation updated:");
+
+    const second = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "explicit-supplied-revision",
+        prompt: "Second edit",
+        expected_revision: 1,
+      },
+      { db, scheduler, taskContext },
+    );
+    expect(second.content[0].text).toContain("Automation updated:");
+    await expect(createScheduledTaskRepository(db).getById("explicit-supplied-revision")).resolves.toMatchObject({
+      prompt: "Second edit",
+      revision: 2,
+    });
+  });
+
+  it("does not inherit the ambient revision for an explicit different accessible task", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("ambient-task-for-explicit-target"),
+      brokerCapable: true,
+    });
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("explicit-different-task"),
+      brokerCapable: true,
+    });
+
+    const taskForId = (id: string) => taskFor(id);
+    const scheduler = {
+      getTaskById: vi.fn().mockImplementation(async (id: string) => taskForId(id)),
+      refreshTaskSchedule: vi.fn().mockImplementation(async (id: string) => ({ ...taskForId(id), id })),
+      addTask: vi.fn(),
+      updateTask: vi.fn(),
+    } as never;
+    const initial = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "explicit-different-task",
+        prompt: "Initial explicit edit",
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("explicit-different-task") },
+    );
+    expect(initial.content[0].text).toContain("Automation updated:");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "explicit-different-task",
+        prompt: "Second explicit edit",
+      },
+      {
+        db,
+        scheduler,
+        taskContext: taskContextFor(
+          "ambient-task-for-explicit-target",
+          "owner-1",
+          currentAutomationFor("ambient-task-for-explicit-target", 99),
+        ),
+      },
+    );
+
+    expect(result.content[0].text).toContain("Automation updated:");
+    await expect(createScheduledTaskRepository(db).getById("explicit-different-task")).resolves.toMatchObject({
+      prompt: "Second explicit edit",
+      revision: 2,
+    });
   });
 });

--- a/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
@@ -1,0 +1,684 @@
+import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAutomationDefinition, getAutomationDefinition } from "../../automation/persistence";
+import { createAutomationStepContentRepository } from "../../db/repositories/automation-step-content";
+import { createScheduledTaskRepository } from "../../db/repositories/scheduled-tasks";
+import { createTestDb } from "../../test-utils";
+import { handleManageScheduledTasks } from "./scheduled-tasks";
+
+function definition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
+  return {
+    title: "Daily account brief",
+    description: "Summarize account activity.",
+    prompt: "Summarize account activity.",
+    scheduleType: "interval",
+    scheduleValue: "120",
+    timezone: "UTC",
+    status: "active",
+    delivery: {
+      platform: "slack",
+      targetType: "thread",
+      targetId: "C123",
+      threadTs: "123.456",
+      mode: "deliver",
+    },
+    steps: [
+      {
+        id: "trigger",
+        type: "trigger",
+        label: "Every two minutes",
+        icon: "clock",
+        position: { x: 0, y: 0 },
+        triggerConfig: {
+          type: "schedule",
+          scheduleType: "interval",
+          scheduleValue: "120",
+          timezone: "UTC",
+        },
+      },
+      {
+        id: "agent",
+        type: "agent",
+        label: "Summarize activity",
+        icon: "sketch-ai",
+        position: { x: 260, y: 0 },
+        agentMode: "sketch",
+        agentSkills: ["reports"],
+        agentModel: "model-a",
+        agentMcpServers: ["slack"],
+        timeout: 600,
+      },
+    ],
+    edges: [{ id: "trigger-agent", from: "trigger", to: "agent" }],
+    stepContent: {
+      agent: {
+        taskId: "client-task-id",
+        stepId: "agent",
+        contentType: "prompt",
+        content: "Check activity and summarize changes.",
+        apps: ["clickup", "slack"],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function context(id: string, createdBy = "owner-1") {
+  return {
+    id,
+    platform: "slack" as const,
+    contextType: "dm" as const,
+    deliveryTarget: "D123",
+    threadTs: null,
+    createdBy,
+    originPlatform: "web" as const,
+    originConversationId: "conversation-1",
+    originProviderThreadId: null,
+    originMessageId: 12,
+  };
+}
+
+function taskContextFor(
+  id: string,
+  createdBy = "owner-1",
+  currentAutomation?: ReturnType<typeof currentAutomationFor>,
+) {
+  return {
+    ...context(id, createdBy),
+    threadTs: undefined,
+    ...(currentAutomation ? { currentAutomation } : {}),
+  };
+}
+
+function currentAutomationFor(taskId: string, revision: number) {
+  const current = definition();
+  return {
+    taskId,
+    revision,
+    builderConversationId: "builder-1",
+    builderState: {
+      title: current.title,
+      description: current.description,
+      prompt: current.prompt,
+      scheduleType: current.scheduleType,
+      scheduleValue: current.scheduleValue,
+      timezone: current.timezone,
+      status: current.status,
+      delivery: current.delivery,
+      steps: current.steps,
+      edges: current.edges,
+      stepContent: Object.fromEntries(
+        Object.entries(current.stepContent).map(([stepId, content]) => [
+          stepId,
+          {
+            contentType: content.contentType,
+            content: content.content,
+            apps: content.apps,
+          },
+        ]),
+      ),
+    },
+  };
+}
+
+function taskFor(id: string, createdBy = "owner-1") {
+  return {
+    id,
+    platform: "slack",
+    contextType: "dm",
+    deliveryTarget: "D123",
+    threadTs: null,
+    prompt: "Summarize account activity.",
+    scheduleType: "interval",
+    scheduleValue: "120",
+    timezone: "UTC",
+    sessionMode: "fresh",
+    nextRunAt: null,
+    lastRunAt: null,
+    status: "active",
+    createdBy,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    revision: 0,
+    title: "Daily account brief",
+    description: "Summarize account activity.",
+    originChat: null,
+    steps: null,
+    edges: null,
+    outputTarget: "C123",
+    outputPlatform: "slack",
+    outputThreadTs: "123.456",
+    outputMode: "deliver",
+    delivery: {
+      platform: "slack",
+      targetType: "thread",
+      targetId: "C123",
+      threadTs: "123.456",
+      mode: "deliver",
+    },
+  };
+}
+
+function schedulerFor(taskId: string, createdBy = "owner-1") {
+  const task = taskFor(taskId, createdBy);
+  return {
+    getTaskById: vi.fn().mockResolvedValue(task),
+    refreshTaskSchedule: vi.fn().mockImplementation(async (id: string) => ({ ...task, id })),
+    addTask: vi.fn(),
+    updateTask: vi.fn(),
+  } as never;
+}
+
+describe("ManageScheduledTasks canonical structured mutations", () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("creates the complete definition atomically and refreshes scheduler state after commit", async () => {
+    const scheduler = schedulerFor("new-task");
+    const result = await handleManageScheduledTasks(
+      {
+        action: "add",
+        title: "Daily account brief",
+        prompt: "Summarize account activity.",
+        schedule_type: "interval",
+        schedule_value: "120",
+        timezone: "UTC",
+        delivery: { targetType: "thread", targetId: "C123", threadTs: "123.456" },
+        steps: [
+          definition().steps[0],
+          {
+            ...definition().steps[1],
+            agentPrompt: "Check activity and summarize changes.",
+            apps: ["clickup", "slack"],
+          },
+        ],
+        edges: [{ id: "trigger-agent", from: "trigger", to: "agent" }],
+      },
+      {
+        db,
+        scheduler,
+        taskContext: {
+          ...taskContextFor("new-task"),
+          origin: {
+            platform: "web",
+            conversationId: "conversation-1",
+            providerThreadId: null,
+            currentMessageId: 12,
+          },
+        },
+      },
+    );
+
+    expect(result.content[0].text).toContain("Automation created:");
+    expect((scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule).toHaveBeenCalledOnce();
+
+    const rows = await createScheduledTaskRepository(db).listAll();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      platform: "slack",
+      context_type: "dm",
+      delivery_target: "D123",
+      schedule_type: "interval",
+      schedule_value: "120",
+      prompt: "Summarize account activity.",
+      output_target: "C123",
+      output_thread_ts: "123.456",
+      created_by: "owner-1",
+      origin_platform: "web",
+      origin_conversation_id: "conversation-1",
+      origin_message_id: 12,
+    });
+    expect(JSON.parse(rows[0].steps ?? "[]")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "agent", agentModel: "model-a" })]),
+    );
+    await expect(createAutomationStepContentRepository(db).getByTask(rows[0].id)).resolves.toEqual([
+      expect.objectContaining({
+        step_id: "agent",
+        content: "Check activity and summarize changes.",
+        apps: JSON.stringify(["clickup", "slack"]),
+      }),
+    ]);
+  });
+
+  it("rejects unsupported fan-out graphs through canonical validation before persistence", async () => {
+    const scheduler = schedulerFor("fanout-task");
+    const result = await handleManageScheduledTasks(
+      {
+        action: "add",
+        title: "Fan out",
+        schedule_type: "cron",
+        schedule_value: "0 9 * * 1",
+        steps: [
+          definition().steps[0],
+          { ...definition().steps[1], id: "agent1", agentPrompt: "First prompt." },
+          { ...definition().steps[1], id: "agent2", agentPrompt: "Second prompt." },
+        ],
+        edges: [
+          { id: "trigger-agent1", from: "trigger", to: "agent1" },
+          { id: "trigger-agent2", from: "trigger", to: "agent2" },
+        ],
+      },
+      { db, scheduler, taskContext: taskContextFor("fanout-task") },
+    );
+
+    expect(result.content[0].text).toContain("FAN_OUT_UNSUPPORTED");
+    expect((scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule).not.toHaveBeenCalled();
+    await expect(createScheduledTaskRepository(db).listAll()).resolves.toEqual([]);
+  });
+
+  it("retains creator timezone fallback through canonical creation", async () => {
+    const scheduler = schedulerFor("timezone-task");
+    await handleManageScheduledTasks(
+      {
+        action: "add",
+        prompt: "Use the creator timezone",
+        schedule_type: "cron",
+        schedule_value: "0 9 * * 1",
+      },
+      {
+        db,
+        scheduler,
+        taskContext: { ...taskContextFor("timezone-task"), creatorTimezone: "Asia/Kolkata" },
+      },
+    );
+
+    await expect(createScheduledTaskRepository(db).listAll()).resolves.toEqual([
+      expect.objectContaining({ timezone: "Asia/Kolkata", schedule_type: "cron" }),
+    ]);
+  });
+
+  it("persists a valid future once schedule through the canonical create path", async () => {
+    const futureDate = new Date(Date.now() + 3_600_000).toISOString();
+    const scheduler = schedulerFor("once-task");
+    const result = await handleManageScheduledTasks(
+      { action: "add", prompt: "Run it once", schedule_type: "once", schedule_value: futureDate },
+      { db, scheduler, taskContext: taskContextFor("once-task") },
+    );
+
+    expect(result.content[0].text).toContain("Automation created:");
+    const rows = await createScheduledTaskRepository(db).listAll();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      schedule_type: "once",
+      schedule_value: futureDate,
+      session_mode: "fresh",
+    });
+  });
+
+  it("preserves unspecified fields during a partial update and records the acting editor", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("partial-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("partial-task");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "partial-task",
+        prompt: "A more focused summary.",
+        title: "Focused brief",
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("partial-task") },
+    );
+
+    expect(result.content[0].text).toContain("Automation updated:");
+    const updated = await getAutomationDefinition({ db, taskId: "partial-task" });
+    expect(updated).toMatchObject({
+      prompt: "A more focused summary.",
+      title: "Focused brief",
+      description: "Summarize account activity.",
+      scheduleType: "interval",
+      scheduleValue: "120",
+      timezone: "UTC",
+      status: "active",
+      delivery: definition().delivery,
+      edges: definition().edges,
+      revision: 1,
+    });
+    const storedRow = await createScheduledTaskRepository(db).getById("partial-task");
+    expect(JSON.parse(storedRow?.steps ?? "[]")).toEqual(definition().steps);
+    expect(updated?.stepContent.agent).toMatchObject({
+      content: "Check activity and summarize changes.",
+      apps: ["clickup", "slack"],
+    });
+    await expect(createScheduledTaskRepository(db).getById("partial-task")).resolves.toMatchObject({
+      created_by: "owner-1",
+      last_edited_by: "owner-1",
+      revision: 1,
+    });
+  });
+
+  it("updates step content through the full-definition CAS path", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("content-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("content-task");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "updateStepContent",
+        task_id: "content-task",
+        step_id: "agent",
+        step_content: "Use the activity report and call out blockers.",
+        step_apps: ["linear"],
+        expectedRevision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("content-task") },
+    );
+
+    expect(result.content[0].text).toContain("content updated at revision 1");
+    expect((scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule).toHaveBeenCalledWith(
+      "content-task",
+    );
+    const updated = await getAutomationDefinition({ db, taskId: "content-task" });
+    expect(updated?.revision).toBe(1);
+    expect(updated?.stepContent.agent).toMatchObject({
+      content: "Use the activity report and call out blockers.",
+      apps: ["linear"],
+    });
+    expect(updated?.scheduleValue).toBe("120");
+    expect(updated?.edges).toEqual(definition().edges);
+  });
+
+  it("retains delivery update semantics and synchronizes schedule trigger metadata", async () => {
+    const initial = definition({
+      scheduleType: "cron",
+      scheduleValue: "*/5 * * * *",
+      delivery: { platform: "slack", targetType: "channel", targetId: "C123", threadTs: null, mode: "deliver" },
+      steps: [
+        {
+          ...definition().steps[0],
+          label: "Every five minutes",
+          triggerConfig: {
+            type: "schedule",
+            scheduleType: "cron",
+            scheduleValue: "*/5 * * * *",
+            timezone: "UTC",
+          },
+        },
+        definition().steps[1],
+      ],
+    });
+    await createAutomationDefinition({ db, request: initial, context: context("metadata-task"), brokerCapable: true });
+    const scheduler = schedulerFor("metadata-task");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "metadata-task",
+        schedule_type: "cron",
+        schedule_value: "*/10 * * * *",
+        delivery: { platform: "slack", targetType: "channel", targetId: "C456" },
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("metadata-task") },
+    );
+
+    expect(result.content[0].text).toContain("Automation updated:");
+    const updated = await getAutomationDefinition({ db, taskId: "metadata-task" });
+    expect(updated).toMatchObject({ scheduleType: "cron", scheduleValue: "*/10 * * * *" });
+    expect(updated?.delivery).toMatchObject({ targetType: "channel", targetId: "C456", threadTs: null });
+    expect(updated?.steps[0]).toMatchObject({
+      label: "Every 10 minutes",
+      triggerConfig: { type: "schedule", scheduleType: "cron", scheduleValue: "*/10 * * * *", timezone: "UTC" },
+    });
+  });
+
+  it("preserves graph edges and step content when only step metadata changes", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("step-metadata-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("step-metadata-task");
+    const currentSteps = definition().steps;
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "step-metadata-task",
+        steps: [currentSteps[0], { ...currentSteps[1], label: "Check priority activity", position: { x: 320, y: 20 } }],
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("step-metadata-task") },
+    );
+
+    expect(result.content[0].text).toContain("Automation updated:");
+    const updated = await getAutomationDefinition({ db, taskId: "step-metadata-task" });
+    expect(updated?.edges).toEqual(definition().edges);
+    expect(updated?.steps[1]).toMatchObject({
+      label: "Check priority activity",
+      position: { x: 320, y: 20 },
+      agentModel: "model-a",
+      agentSkills: ["reports"],
+    });
+    expect(updated?.stepContent.agent).toMatchObject({
+      content: "Check activity and summarize changes.",
+      apps: ["clickup", "slack"],
+    });
+  });
+
+  it("normalizes Canvas-managed trigger updates through the canonical definition", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("canvas-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("canvas-task");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "canvas-task",
+        steps: [
+          {
+            id: "trigger",
+            type: "trigger",
+            label: "Linear issue created",
+            icon: "linear",
+            position: { x: 0, y: 0 },
+            triggerConfig: {
+              type: "canvas",
+              app: "linear",
+              eventDescription: "new issue created",
+              componentKey: "linear.issue.created",
+            },
+          },
+          {
+            ...definition().steps[1],
+            agentPrompt: "Handle the issue.",
+          },
+        ],
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("canvas-task") },
+    );
+
+    expect(result.content[0].text).toContain("Automation updated:");
+    const updated = await getAutomationDefinition({ db, taskId: "canvas-task" });
+    expect(updated).toMatchObject({ scheduleType: "external", scheduleValue: "canvas" });
+    expect(updated?.steps[0].triggerConfig).toMatchObject({ type: "canvas", status: "pending_canvas_setup" });
+  });
+
+  it("rejects an incompatible trigger update without changing the persisted definition", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("trigger-validation-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("trigger-validation-task");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "trigger-validation-task",
+        steps: [
+          {
+            id: "trigger",
+            type: "trigger",
+            label: "Webhook",
+            icon: "webhook",
+            position: { x: 0, y: 0 },
+            triggerConfig: { type: "webhook" },
+          },
+          definition().steps[1],
+        ],
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("trigger-validation-task") },
+    );
+
+    expect(result.content[0].text).toContain("TRIGGER_CONFIG_MISMATCH");
+    await expect(createScheduledTaskRepository(db).getById("trigger-validation-task")).resolves.toMatchObject({
+      revision: 0,
+      schedule_value: "120",
+    });
+  });
+
+  it("provides deterministic full-definition inspection without changing list semantics", async () => {
+    await createAutomationDefinition({ db, request: definition(), context: context("get-task"), brokerCapable: true });
+    const scheduler = schedulerFor("get-task");
+
+    const result = await handleManageScheduledTasks(
+      { action: "get", task_id: "get-task" },
+      { db, scheduler, taskContext: taskContextFor("get-task") },
+    );
+
+    const inspected = JSON.parse(result.content[0].text);
+    expect(inspected).toMatchObject({ id: "get-task", prompt: definition().prompt, revision: 0 });
+    expect(inspected.stepContent.agent).toMatchObject({ content: definition().stepContent.agent.content });
+    expect((scheduler as { getTaskById: ReturnType<typeof vi.fn> }).getTaskById).toHaveBeenCalledWith("get-task");
+  });
+
+  it("allows exactly one save for concurrent editors at the same revision", async () => {
+    await createAutomationDefinition({ db, request: definition(), context: context("race-task"), brokerCapable: true });
+    const scheduler = schedulerFor("race-task");
+
+    const results = await Promise.all([
+      handleManageScheduledTasks(
+        { action: "update", task_id: "race-task", prompt: "First editor", expected_revision: 0 },
+        { db, scheduler, taskContext: taskContextFor("race-task") },
+      ),
+      handleManageScheduledTasks(
+        { action: "update", task_id: "race-task", prompt: "Second editor", expected_revision: 0 },
+        { db, scheduler, taskContext: taskContextFor("race-task") },
+      ),
+    ]);
+
+    const messages = results.map((result) => result.content[0].text);
+    expect(messages.filter((message) => message.includes("Automation updated:"))).toHaveLength(1);
+    expect(messages.filter((message) => message.includes("revision conflict"))).toHaveLength(1);
+    await expect(createScheduledTaskRepository(db).getById("race-task")).resolves.toMatchObject({ revision: 1 });
+    await expect(createAutomationStepContentRepository(db).getByTask("race-task")).resolves.toEqual([
+      expect.objectContaining({ content: definition().stepContent.agent.content }),
+    ]);
+  });
+
+  it("leaves both tables unchanged when the merged definition fails validation", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("invalid-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("invalid-task");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "invalid-task",
+        schedule_type: "interval",
+        schedule_value: "30",
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("invalid-task") },
+    );
+
+    expect(result.content[0].text).toContain("automation definition is invalid");
+    await expect(createScheduledTaskRepository(db).getById("invalid-task")).resolves.toMatchObject({
+      schedule_value: "120",
+      revision: 0,
+    });
+    await expect(createAutomationStepContentRepository(db).getByTask("invalid-task")).resolves.toEqual([
+      expect.objectContaining({ content: definition().stepContent.agent.content }),
+    ]);
+  });
+
+  it("keeps ownership on the owner while allowing an admin editor and denying a member", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("ownership-task"),
+      brokerCapable: true,
+    });
+    const adminScheduler = schedulerFor("ownership-task", "owner-1");
+    const adminResult = await handleManageScheduledTasks(
+      { action: "update", task_id: "ownership-task", prompt: "Admin edit", expected_revision: 0 },
+      {
+        db,
+        scheduler: adminScheduler,
+        taskContext: { ...taskContextFor("ownership-task", "admin-1"), canManageAnyTask: true },
+      },
+    );
+    expect(adminResult.content[0].text).toContain("Automation updated:");
+    await expect(createScheduledTaskRepository(db).getById("ownership-task")).resolves.toMatchObject({
+      created_by: "owner-1",
+      last_edited_by: "admin-1",
+      revision: 1,
+    });
+
+    const memberResult = await handleManageScheduledTasks(
+      { action: "update", task_id: "ownership-task", prompt: "Member edit", expected_revision: 1 },
+      {
+        db,
+        scheduler: schedulerFor("ownership-task", "owner-1"),
+        taskContext: taskContextFor("ownership-task", "member-1"),
+      },
+    );
+    expect(memberResult.content[0].text).toContain("created by");
+    await expect(createScheduledTaskRepository(db).getById("ownership-task")).resolves.toMatchObject({
+      prompt: "Admin edit",
+      revision: 1,
+      last_edited_by: "admin-1",
+    });
+  });
+
+  it("uses the ambient builder revision for an implicit update", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("ambient-task"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("ambient-task");
+    const taskContext = taskContextFor("ambient-task", "owner-1", currentAutomationFor("ambient-task", 0));
+
+    const first = await handleManageScheduledTasks(
+      { action: "update", prompt: "Ambient edit" },
+      { db, scheduler, taskContext },
+    );
+    expect(first.content[0].text).toContain("Automation updated:");
+
+    const stale = await handleManageScheduledTasks(
+      { action: "update", prompt: "Stale ambient edit" },
+      { db, scheduler, taskContext },
+    );
+    expect(stale.content[0].text).toContain("revision conflict");
+  });
+});

--- a/packages/server/src/agent/tools/scheduled-tasks-slack-trigger.test.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks-slack-trigger.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createScheduledTaskRepository } from "../../db/repositories/scheduled-tasks";
+import { createTestDb } from "../../test-utils";
 import { handleManageScheduledTasks } from "./scheduled-tasks";
 
 const trigger = (channelId: string) => ({
@@ -22,6 +24,11 @@ const agent = {
 function makeDeps(overrides: Record<string, unknown> = {}) {
   const scheduler = {
     addTask: vi.fn().mockResolvedValue({ id: "task-1", status: "active", delivery: { mode: "silent" } }),
+    refreshTaskSchedule: vi.fn().mockImplementation(async (id: string) => ({
+      id,
+      status: "active",
+      delivery: { mode: "silent" },
+    })),
     getTaskById: vi.fn().mockResolvedValue({
       id: "task-1",
       platform: "slack",
@@ -55,17 +62,29 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
 }
 
 describe("manage_scheduled_tasks Slack channel trigger", () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
   it("infers the external Slack trigger schedule when adding a channel-message workflow", async () => {
-    const deps = makeDeps();
+    const deps = makeDeps({ db });
 
     await handleManageScheduledTasks(
       { action: "add", title: "Slack bug report", steps: [trigger("C1"), agent], output_mode: "silent" },
       deps as never,
     );
 
-    expect(deps.scheduler.addTask).toHaveBeenCalledWith(
-      expect.objectContaining({ scheduleType: "external", scheduleValue: "slack_channel_message" }),
-    );
+    expect(deps.scheduler.refreshTaskSchedule).toHaveBeenCalledOnce();
+    expect(deps.scheduler.addTask).not.toHaveBeenCalled();
+    await expect(createScheduledTaskRepository(db).listAll()).resolves.toEqual([
+      expect.objectContaining({ schedule_type: "external", schedule_value: "slack_channel_message" }),
+    ]);
   });
 
   it("rejects a blank Slack channel ID", async () => {

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -690,6 +690,14 @@ export async function handleManageScheduledTasks(
     return handleConfiguredChatAuthoring(params, deps);
   }
 
+  let brokerCapabilitySnapshot: boolean | undefined;
+  const getBrokerCapabilitySnapshot = async (): Promise<boolean> => {
+    if (brokerCapabilitySnapshot !== undefined) return brokerCapabilitySnapshot;
+    const provider = deps.loadIntegrationProvider ? await deps.loadIntegrationProvider() : null;
+    brokerCapabilitySnapshot = Boolean(provider?.isBrokerCapable());
+    return brokerCapabilitySnapshot;
+  };
+
   /** Returns an error response if any action step is present but no broker-capable
    *  provider is configured. Returns null when validation passes (no action steps,
    *  or a broker-capable provider exists). */
@@ -697,9 +705,7 @@ export async function handleManageScheduledTasks(
     candidateSteps: WorkflowStepInput[] | undefined,
   ): Promise<ReturnType<typeof text> | null> => {
     if (!candidateSteps?.some((s) => s.type === "action")) return null;
-    if (!deps.loadIntegrationProvider) return text(BROKER_REQUIRED_MSG);
-    const provider = await deps.loadIntegrationProvider();
-    if (!provider || !provider.isBrokerCapable()) return text(BROKER_REQUIRED_MSG);
+    if (!(await getBrokerCapabilitySnapshot())) return text(BROKER_REQUIRED_MSG);
     return null;
   };
 
@@ -940,7 +946,7 @@ export async function handleManageScheduledTasks(
             originProviderThreadId: ctx.origin?.providerThreadId ?? null,
             originMessageId: ctx.origin?.currentMessageId ?? null,
           },
-          brokerCapable: true,
+          brokerCapable: await getBrokerCapabilitySnapshot(),
         });
       } catch (error) {
         if (error instanceof AutomationValidationError) {
@@ -1005,7 +1011,7 @@ export async function handleManageScheduledTasks(
       const expectedRevision =
         params.expected_revision ??
         params.expectedRevision ??
-        (!explicitTaskId && currentAutomation?.taskId === task_id ? currentAutomation.revision : undefined);
+        (currentAutomation?.taskId === task_id ? currentAutomation.revision : undefined);
       const patch = definitionPatchFromParams(params, ctx);
       if (expectedRevision !== undefined) patch.expectedRevision = expectedRevision;
 
@@ -1019,7 +1025,7 @@ export async function handleManageScheduledTasks(
             userId: ctx.createdBy,
             canManageAnyTask: ctx.canManageAnyTask ?? false,
           },
-          brokerCapable: true,
+          brokerCapable: await getBrokerCapabilitySnapshot(),
         });
       } catch (error) {
         if (error instanceof AutomationValidationError) {
@@ -1165,7 +1171,7 @@ export async function handleManageScheduledTasks(
       const expectedRevision =
         params.expected_revision ??
         params.expectedRevision ??
-        (!explicitTaskId && currentAutomation?.taskId === task_id ? currentAutomation.revision : undefined);
+        (currentAutomation?.taskId === task_id ? currentAutomation.revision : undefined);
       let saved: Awaited<ReturnType<typeof updateAutomationDefinition>>;
       try {
         saved = await updateAutomationDefinition({
@@ -1185,7 +1191,7 @@ export async function handleManageScheduledTasks(
             userId: ctx.createdBy,
             canManageAnyTask: ctx.canManageAnyTask ?? false,
           },
-          brokerCapable: true,
+          brokerCapable: await getBrokerCapabilitySnapshot(),
         });
       } catch (error) {
         if (error instanceof AutomationValidationError) {

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -1,26 +1,26 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import type { Kysely } from "kysely";
 import { z } from "zod/v4";
 import { AutomationAuthoringValidationError } from "../../automation/authoring/service";
 import type { ChatAutomationAuthoring, ChatAutomationAuthoringResult } from "../../automation/chat-authoring";
+import { AutomationValidationError } from "../../automation/definition";
 import {
-  AutomationValidationError,
-  validateAutomationBuilderSaveRequest,
-  validateWorkflowGraph,
-} from "../../automation/definition";
+  type AutomationDefinitionPatch,
+  createAutomationDefinition,
+  getAutomationDefinition,
+  updateAutomationDefinition,
+} from "../../automation/persistence";
 import type { createAutomationRunsRepository } from "../../db/repositories/automation-runs";
 import type { createAutomationStepContentRepository } from "../../db/repositories/automation-step-content";
+import type { DB } from "../../db/schema";
 import type { IntegrationProvider } from "../../integrations/types";
 import { parseOnceSchedule } from "../../scheduler/parse-once";
 import { getActiveTaskContextQueueKey, getScheduledTaskQueueKey } from "../../scheduler/queue-key";
 import type { TaskScheduler } from "../../scheduler/service";
-import {
-  formatIntervalScheduleLabel,
-  normalizeScheduleTriggerSteps,
-  normalizeScheduleTriggerStepsJson,
-} from "../../scheduler/trigger-metadata";
+import { formatIntervalScheduleLabel, normalizeScheduleTriggerSteps } from "../../scheduler/trigger-metadata";
 import type { CurrentAutomation, ScheduledTask, TaskContext } from "../../scheduler/types";
-import type { WorkflowEdge, WorkflowStep } from "../../workflows/types";
+import type { WorkflowStep } from "../../workflows/types";
 import type { AutomationArtifactCollector, SearchableUserRepo } from "./types";
 
 const workflowStepSchema = z.object({
@@ -76,12 +76,13 @@ const deliverySchema = z.object({
 
 const manageScheduledTasksSchema = {
   action: z
-    .enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun", "share", "updateStepContent"])
+    .enum(["list", "add", "update", "remove", "pause", "resume", "run", "get", "getRun", "share", "updateStepContent"])
     .describe(
       `Action to perform.
 - 'add': create an automation (simple: prompt + schedule_type + schedule_value; multi-step: title + steps)
 - 'list': list automations in this context
-- 'update': modify an automation (requires task_id)
+- 'update': modify an automation (requires task_id unless the current builder automation is implicit)
+- 'get': inspect one complete automation definition, including step content and run history (requires task_id)
 - 'remove': delete an automation (requires task_id)
 - 'pause': pause an automation (requires task_id)
 - 'resume': resume a paused automation (requires task_id)
@@ -120,7 +121,7 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
     .string()
     .optional()
     .describe(
-      "ID of the task. Required for update unless the current builder automation is implicit; required for remove/pause/resume/run/getRun/share.",
+      "ID of the task. Required for update unless the current builder automation is implicit; required for get/remove/pause/resume/run/getRun/share/updateStepContent.",
     ),
   title: z.string().optional().describe("Human-readable name. Required for multi-step automations."),
   description: z.string().optional().describe("Description of what this automation does."),
@@ -144,6 +145,22 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
     .optional()
     .describe("Use 'silent' to record successful runs without sending final output to Slack or WhatsApp."),
   delivery: deliverySchema.optional().describe("Canonical final-output delivery destination for the workflow."),
+  status: z
+    .enum(["active", "paused", "completed"])
+    .optional()
+    .describe("Lifecycle status for a full definition update."),
+  expected_revision: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("Expected persisted revision for compare-and-swap writes. Stale revisions are rejected."),
+  expectedRevision: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("Alias for expected_revision when the caller uses the canonical camelCase field."),
   run_id: z.string().optional().describe("Run ID for getRun action. Omit for latest run."),
   step_id: z.string().optional().describe("Step ID for updateStepContent action."),
   step_content: z.string().optional().describe("New prompt or script content for updateStepContent action."),
@@ -151,10 +168,11 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
 };
 
 const authoredScheduledTasksSchema = {
-  action: z.enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun", "share"]).describe(
+  action: z.enum(["list", "add", "update", "remove", "pause", "resume", "run", "get", "getRun", "share"]).describe(
     `Action to perform.
 - 'add': create an automation from the user's natural-language request
 - 'update': edit an automation from the user's natural-language request (requires task_id)
+- 'get': inspect one complete automation definition, including step content and run history (requires task_id)
 - 'list': list automations in this context
 - 'remove': delete an automation (requires task_id)
 - 'pause': pause an automation (requires task_id)
@@ -173,7 +191,7 @@ const authoredScheduledTasksSchema = {
     .string()
     .optional()
     .describe(
-      "ID of the task. Required for update unless the current builder automation is implicit; required for remove/pause/resume/run/getRun/share.",
+      "ID of the task. Required for update unless the current builder automation is implicit; required for get/remove/pause/resume/run/getRun/share.",
     ),
   run_id: z.string().optional().describe("Run ID for getRun action. Omit for latest run."),
 };
@@ -181,7 +199,18 @@ const authoredScheduledTasksSchema = {
 export type WorkflowStepInput = z.infer<typeof workflowStepSchema>;
 
 type ManageScheduledTasksParams = {
-  action: "list" | "add" | "update" | "remove" | "pause" | "resume" | "run" | "getRun" | "share" | "updateStepContent";
+  action:
+    | "list"
+    | "add"
+    | "update"
+    | "remove"
+    | "pause"
+    | "resume"
+    | "run"
+    | "get"
+    | "getRun"
+    | "share"
+    | "updateStepContent";
   request?: string;
   prompt?: string;
   schedule_type?: "cron" | "interval" | "once" | "external";
@@ -197,6 +226,9 @@ type ManageScheduledTasksParams = {
   output_platform?: "slack" | "whatsapp";
   output_thread_ts?: string | null;
   output_mode?: "deliver" | "silent";
+  status?: "active" | "paused" | "completed";
+  expected_revision?: number;
+  expectedRevision?: number;
   delivery?: {
     platform?: "slack" | "whatsapp";
     targetType?: "dm" | "channel" | "group" | "thread";
@@ -223,6 +255,7 @@ export interface ManageScheduledTasksDeps {
   automationArtifactCollector?: AutomationArtifactCollector;
   chatAuthoring?: ChatAutomationAuthoring;
   currentAutomation?: CurrentAutomation;
+  db?: Kysely<DB>;
 }
 
 function stripContentFromSteps(steps: WorkflowStepInput[]): WorkflowStep[] {
@@ -237,15 +270,6 @@ function defaultEdgesForSteps(steps: WorkflowStep[]): { id: string; from: string
   }));
 }
 
-function formatGraphValidationError(
-  steps: WorkflowStep[],
-  edges: { id: string; from: string; to: string }[],
-): string | null {
-  const issues = validateWorkflowGraph(steps, edges);
-  if (issues.length === 0) return null;
-  return `Error: automation graph is invalid:\n${issues.map((issue) => `- ${issue.code}: ${issue.message}`).join("\n")}`;
-}
-
 function parseWorkflowStepsJson(value: string | null | undefined): WorkflowStep[] | null {
   if (!value) return null;
   try {
@@ -256,46 +280,15 @@ function parseWorkflowStepsJson(value: string | null | undefined): WorkflowStep[
   }
 }
 
-function parseWorkflowEdgesJson(value: string | null | undefined): WorkflowEdge[] | null {
-  if (!value) return null;
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    return Array.isArray(parsed) ? (parsed as WorkflowEdge[]) : null;
-  } catch {
-    return null;
-  }
-}
-
-function parseAppsJson(value: string | null | undefined): string[] | null {
-  if (!value) return null;
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : null;
-  } catch {
-    return null;
-  }
-}
-
-function stepContentForValidation(params: {
-  taskId: string;
-  steps: WorkflowStepInput[];
-  existingContent?: Awaited<ReturnType<NonNullable<ManageScheduledTasksDeps["stepContentRepo"]>["getByTask"]>>;
-}): AutomationBuilderSaveRequest["stepContent"] {
+function stepContentForDefinition(
+  taskId: string,
+  steps: WorkflowStepInput[],
+): AutomationBuilderSaveRequest["stepContent"] {
   const content: AutomationBuilderSaveRequest["stepContent"] = {};
-  for (const existing of params.existingContent ?? []) {
-    content[existing.step_id] = {
-      taskId: existing.task_id,
-      stepId: existing.step_id,
-      contentType: existing.content_type === "script" ? "script" : "prompt",
-      content: existing.content,
-      apps: parseAppsJson(existing.apps),
-      updatedAt: existing.updated_at,
-    };
-  }
-  for (const step of params.steps) {
+  for (const step of steps) {
     if (step.agentPrompt !== undefined) {
       content[step.id] = {
-        taskId: params.taskId,
+        taskId,
         stepId: step.id,
         contentType: "prompt",
         content: step.agentPrompt,
@@ -303,7 +296,7 @@ function stepContentForValidation(params: {
       };
     } else if (step.script !== undefined) {
       content[step.id] = {
-        taskId: params.taskId,
+        taskId,
         stepId: step.id,
         contentType: "script",
         content: step.script,
@@ -314,55 +307,84 @@ function stepContentForValidation(params: {
   return content;
 }
 
-function validateBuilderLikeDefinition(params: {
-  title: string | null;
-  description: string | null;
-  prompt: string;
-  scheduleType: "cron" | "interval" | "once" | "external";
-  scheduleValue: string;
-  timezone: string;
-  status: "active" | "paused" | "completed";
-  steps: WorkflowStep[];
-  edges: WorkflowEdge[];
-  outputPlatform: "slack" | "whatsapp";
-  outputTarget: string;
-  outputThreadTs: string | null;
-  outputMode: "deliver" | "silent";
-  stepContent: AutomationBuilderSaveRequest["stepContent"];
-}): string | null {
-  try {
-    validateAutomationBuilderSaveRequest({
-      request: {
-        expectedRevision: undefined,
-        title: params.title,
-        description: params.description,
-        prompt: params.prompt,
-        scheduleType: params.scheduleType,
-        scheduleValue: params.scheduleValue,
-        timezone: params.timezone,
-        status: params.status,
-        delivery: {
-          platform: params.outputPlatform,
-          targetType: "dm",
-          targetId: params.outputTarget,
-          threadTs: params.outputThreadTs,
-          mode: params.outputMode,
-        },
-        steps: params.steps,
-        edges: params.edges,
-        stepContent: params.stepContent,
-      },
-      brokerCapable: true,
-    });
-    return null;
-  } catch (err) {
-    if (err instanceof AutomationValidationError) {
-      return `Error: automation definition is invalid:\n${err.issues
-        .map((issue) => `- ${issue.code}: ${issue.message}`)
-        .join("\n")}`;
-    }
-    throw err;
+function stepContentPatchForSteps(steps: WorkflowStepInput[]): AutomationDefinitionPatch["stepContent"] {
+  const content: AutomationDefinitionPatch["stepContent"] = {};
+  for (const step of steps) {
+    const hasPrompt = hasOwn(step, "agentPrompt") && step.agentPrompt !== undefined;
+    const hasScript = hasOwn(step, "script") && step.script !== undefined;
+    const hasApps = hasOwn(step, "apps") && step.apps !== undefined;
+    if (!hasPrompt && !hasScript && !hasApps) continue;
+    content[step.id] = {
+      contentType: step.type === "action" ? "script" : "prompt",
+      ...(hasPrompt ? { content: step.agentPrompt } : {}),
+      ...(hasScript ? { content: step.script } : {}),
+      ...(hasApps ? { apps: step.apps ?? null } : {}),
+    };
   }
+  return content;
+}
+
+function definitionPatchFromParams(params: ManageScheduledTasksParams, ctx: TaskContext): AutomationDefinitionPatch {
+  const patch: AutomationDefinitionPatch = {};
+  if (params.prompt !== undefined) patch.prompt = params.prompt;
+  if (params.schedule_type !== undefined) patch.scheduleType = params.schedule_type;
+  if (params.schedule_value !== undefined) patch.scheduleValue = params.schedule_value;
+  if (params.timezone !== undefined) patch.timezone = params.timezone;
+  if (params.status !== undefined) patch.status = params.status;
+  if (params.title !== undefined) patch.title = params.title;
+  if (params.description !== undefined) patch.description = params.description;
+
+  const delivery: NonNullable<AutomationDefinitionPatch["delivery"]> = {};
+  if (params.output_platform !== undefined) delivery.platform = params.output_platform;
+  if (params.output_target !== undefined) delivery.targetId = params.output_target;
+  if (params.output_thread_ts !== undefined) delivery.threadTs = params.output_thread_ts;
+  if (params.output_mode !== undefined) delivery.mode = params.output_mode;
+  if (params.delivery) {
+    const hasExplicitThreadTs = hasOwn(params.delivery, "threadTs");
+    if (params.delivery.platform !== undefined) delivery.platform = params.delivery.platform;
+    if (params.delivery.targetType !== undefined) delivery.targetType = params.delivery.targetType;
+    if (params.delivery.targetId !== undefined) delivery.targetId = params.delivery.targetId;
+    if (hasExplicitThreadTs) delivery.threadTs = params.delivery.threadTs ?? null;
+    if (params.delivery.mode !== undefined) delivery.mode = params.delivery.mode;
+    if (params.delivery.targetType === "thread" && params.delivery.targetId === undefined) {
+      delivery.targetId = ctx.deliveryTarget;
+      delivery.platform ??= ctx.platform;
+      delivery.threadTs = ctx.threadTs ?? null;
+    } else if (
+      (params.delivery.targetType !== undefined && params.delivery.targetType !== "thread") ||
+      params.delivery.targetId !== undefined
+    ) {
+      delivery.threadTs = null;
+    }
+  }
+  if (Object.keys(delivery).length > 0) patch.delivery = delivery;
+
+  if (params.steps) {
+    const triggerStep = params.steps.find((step) => step.type === "trigger");
+    const steps = params.steps.map((step) => {
+      if (step.type !== "trigger" || !step.triggerConfig) return step;
+      if (step.triggerConfig.type !== "canvas") return step;
+      return {
+        ...step,
+        triggerConfig: {
+          ...step.triggerConfig,
+          status: step.triggerConfig.status ?? "pending_canvas_setup",
+        },
+      };
+    });
+    patch.steps = stripContentFromSteps(steps);
+    patch.stepContent = stepContentPatchForSteps(steps);
+    if (triggerStep?.triggerConfig?.type === "canvas") {
+      patch.scheduleType = "external";
+      patch.scheduleValue = "canvas";
+    }
+    if (triggerStep?.triggerConfig?.type === "slack_channel_message") {
+      patch.scheduleType = "external";
+      patch.scheduleValue = "slack_channel_message";
+    }
+  }
+  if (params.edges !== undefined) patch.edges = params.edges;
+  return patch;
 }
 
 function isLocalScheduleType(value: unknown): value is "cron" | "interval" | "once" {
@@ -414,7 +436,7 @@ function guardedActionLabel(action: ManageScheduledTasksParams["action"]): strin
   if (action === "resume") return "resume";
   if (action === "pause") return "pause";
   if (action === "run") return "run";
-  if (action === "getRun") return "inspect";
+  if (action === "getRun" || action === "get") return "inspect";
   if (action === "share") return "share";
   return "update";
 }
@@ -567,6 +589,9 @@ const LEGACY_AUTHORING_FIELDS = [
   "output_platform",
   "output_thread_ts",
   "output_mode",
+  "status",
+  "expected_revision",
+  "expectedRevision",
   "delivery",
   "step_id",
   "step_content",
@@ -651,7 +676,8 @@ export async function handleManageScheduledTasks(
   const ctx = deps.taskContext;
   const currentAutomation = deps.currentAutomation ?? ctx.currentAutomation;
   const explicitTaskId = params.task_id?.trim() || undefined;
-  const task_id = explicitTaskId ?? (action === "update" ? currentAutomation?.taskId : undefined);
+  const task_id =
+    explicitTaskId ?? (action === "update" || action === "updateStepContent" ? currentAutomation?.taskId : undefined);
 
   const text = (msg: string) => ({ content: [{ type: "text" as const, text: msg }] });
 
@@ -679,6 +705,7 @@ export async function handleManageScheduledTasks(
 
   const OWNERSHIP_GUARDED_ACTIONS = [
     "update",
+    "get",
     "remove",
     "pause",
     "resume",
@@ -853,6 +880,7 @@ export async function handleManageScheduledTasks(
       // Strip content from steps (stored separately in automation_step_content)
       const steps = params.steps as NonNullable<typeof params.steps>;
       const title = params.title as string;
+      const prompt = params.prompt ?? title;
       const scheduleType = params.schedule_type as NonNullable<typeof params.schedule_type>;
       const scheduleValue = params.schedule_value as string;
       let stepsForDb = stripContentFromSteps(steps);
@@ -868,80 +896,68 @@ export async function handleManageScheduledTasks(
       const outputTarget = deliveryFields.outputTarget ?? ctx.deliveryTarget;
       const outputThreadTs = deliveryFields.outputThreadTs ?? null;
       const outputMode = deliveryFields.outputMode ?? "deliver";
-      const builderError = validateBuilderLikeDefinition({
-        title,
-        description: params.description ?? null,
-        prompt: title,
-        scheduleType,
-        scheduleValue,
-        timezone: resolvedTimezone,
-        status: "active",
-        steps: stepsForDb,
-        edges: edgesForDb,
-        outputPlatform,
-        outputTarget,
-        outputThreadTs,
-        outputMode,
-        stepContent: stepContentForValidation({ taskId: "new-task", steps }),
-      });
-      if (builderError) return text(builderError);
-
-      // Guard against silently dropping step content if the repo wasn't plumbed
-      // through. Runs after input validation so user-input errors surface first.
-      // Without this guard, prompts/scripts vanish at creation time and the
-      // workflow fails at first run with 'has no prompt'.
-      if (!deps.stepContentRepo && steps.some((s) => s.agentPrompt || s.script)) {
-        return text(
-          "Error: step content storage is not available in this context. Multi-step automations with prompts or scripts cannot be created.",
-        );
+      if (!deps.db) {
+        return text("Error: canonical automation persistence is not available in this context. No changes were saved.");
       }
 
-      const task = await deps.scheduler.addTask({
-        platform: ctx.platform,
-        contextType: ctx.contextType,
-        deliveryTarget: ctx.deliveryTarget,
-        threadTs: ctx.threadTs ?? null,
-        prompt: title,
-        scheduleType,
-        scheduleValue,
-        timezone: resolvedTimezone,
-        sessionMode,
-        createdBy: ctx.createdBy,
-        title: params.title,
-        description: params.description,
-        steps: JSON.stringify(stepsForDb),
-        edges: JSON.stringify(edgesForDb),
-        outputTarget: deliveryFields.outputTarget,
-        outputPlatform: deliveryFields.outputPlatform,
-        outputThreadTs: deliveryFields.outputThreadTs,
-        outputMode: deliveryFields.outputMode,
-        originPlatform: ctx.origin?.platform ?? null,
-        originConversationId: ctx.origin?.conversationId ?? null,
-        originProviderThreadId: ctx.origin?.providerThreadId ?? null,
-        originMessageId: ctx.origin?.currentMessageId ?? null,
-      });
-
-      // Store step content
-      if (deps.stepContentRepo) {
-        for (const step of steps) {
-          if (step.agentPrompt) {
-            await deps.stepContentRepo.upsert({
-              taskId: task.id,
-              stepId: step.id,
-              contentType: "prompt",
-              content: step.agentPrompt,
-              apps: step.apps,
-            });
-          } else if (step.script) {
-            await deps.stepContentRepo.upsert({
-              taskId: task.id,
-              stepId: step.id,
-              contentType: "script",
-              content: step.script,
-              apps: step.apps,
-            });
-          }
+      let saved: Awaited<ReturnType<typeof createAutomationDefinition>>;
+      try {
+        saved = await createAutomationDefinition({
+          db: deps.db,
+          request: {
+            title,
+            description: params.description ?? null,
+            prompt,
+            scheduleType: scheduleType as "cron" | "interval" | "once" | "external",
+            scheduleValue,
+            timezone: resolvedTimezone,
+            status: "active",
+            delivery: {
+              platform: outputPlatform,
+              targetType:
+                params.delivery?.targetType ??
+                (deliveryFields.outputThreadTs
+                  ? "thread"
+                  : ctx.contextType === "channel"
+                    ? "channel"
+                    : ctx.contextType),
+              targetId: outputTarget,
+              threadTs: outputThreadTs,
+              mode: outputMode,
+            },
+            steps: stepsForDb,
+            edges: edgesForDb,
+            stepContent: stepContentForDefinition("new-task", steps),
+          },
+          context: {
+            platform: ctx.platform,
+            contextType: ctx.contextType,
+            deliveryTarget: ctx.deliveryTarget,
+            threadTs: ctx.threadTs ?? null,
+            createdBy: ctx.createdBy,
+            originPlatform: ctx.origin?.platform ?? null,
+            originConversationId: ctx.origin?.conversationId ?? null,
+            originProviderThreadId: ctx.origin?.providerThreadId ?? null,
+            originMessageId: ctx.origin?.currentMessageId ?? null,
+          },
+          brokerCapable: true,
+        });
+      } catch (error) {
+        if (error instanceof AutomationValidationError) {
+          return text(
+            `Error: automation definition is invalid:\n${error.issues.map((issue) => `- ${issue.code}: ${issue.message}`).join("\n")}`,
+          );
         }
+        throw error;
+      }
+
+      const task =
+        typeof deps.scheduler.refreshTaskSchedule === "function"
+          ? await deps.scheduler.refreshTaskSchedule(saved.row.id).catch(() => null)
+          : null;
+      const refreshedTask = task ?? (await deps.scheduler.getTaskById(saved.row.id));
+      if (!refreshedTask) {
+        return text("Error: automation was saved, but its scheduler state could not be refreshed.");
       }
 
       // Build webhook URL for webhook triggers
@@ -949,19 +965,19 @@ export async function handleManageScheduledTasks(
       let webhookUrl: string | undefined;
       if (triggerStep && deps.config) {
         const baseUrl = deps.config.BASE_URL ?? `http://localhost:${deps.config.PORT}`;
-        webhookUrl = `${baseUrl}/api/webhooks/wf/${task.id}`;
+        webhookUrl = `${baseUrl}/api/webhooks/wf/${refreshedTask.id}`;
       }
 
       collectAutomationArtifact({
         deps,
-        task,
+        task: refreshedTask,
         steps,
         scheduleType,
         scheduleValue,
         timezone: resolvedTimezone,
       });
 
-      const response: Record<string, unknown> = { ...task };
+      const response: Record<string, unknown> = { ...refreshedTask };
       if (webhookUrl) response.webhookUrl = webhookUrl;
       return text(`Automation created:\n${JSON.stringify(response, null, 2)}`);
     }
@@ -971,136 +987,8 @@ export async function handleManageScheduledTasks(
         return text("Error: task_id is required for update action.");
       }
 
-      // Build update fields for the scheduler
-      const updateFields: Record<string, string | null | undefined> = {};
-      if (params.prompt !== undefined) updateFields.prompt = params.prompt;
-      if (params.schedule_type !== undefined) updateFields.scheduleType = params.schedule_type;
-      if (params.schedule_value !== undefined) updateFields.scheduleValue = params.schedule_value;
-      if (params.timezone !== undefined) updateFields.timezone = params.timezone;
-      if (params.session_mode !== undefined) updateFields.sessionMode = params.session_mode;
-      if (params.title !== undefined) updateFields.title = params.title;
-      if (params.description !== undefined) updateFields.description = params.description;
-      if (params.output_target !== undefined) updateFields.outputTarget = params.output_target;
-      if (params.output_platform !== undefined) updateFields.outputPlatform = params.output_platform;
-      if (params.output_thread_ts !== undefined) updateFields.outputThreadTs = params.output_thread_ts;
-      if (params.output_mode !== undefined) updateFields.outputMode = params.output_mode;
-      if (params.delivery) {
-        const deliveryFields = buildDeliveryFields(params, ctx);
-        if (deliveryFields.outputTarget !== undefined) updateFields.outputTarget = deliveryFields.outputTarget;
-        if (deliveryFields.outputPlatform !== undefined) updateFields.outputPlatform = deliveryFields.outputPlatform;
-        if (deliveryFields.outputThreadTs !== undefined) updateFields.outputThreadTs = deliveryFields.outputThreadTs;
-        if (deliveryFields.outputMode !== undefined) updateFields.outputMode = deliveryFields.outputMode;
-      }
-
-      // Handle steps update
-      if (params.steps) {
-        const brokerError = await ensureBrokerForActionSteps(params.steps);
-        if (brokerError) return brokerError;
-
-        if (!deps.stepContentRepo && params.steps.some((s) => s.type !== "trigger")) {
-          return text(
-            "Error: step content storage is not available in this context. Multi-step automations cannot be updated safely.",
-          );
-        }
-        const existingContent = deps.stepContentRepo ? await deps.stepContentRepo.getByTask(task_id) : [];
-
-        const triggerStep = params.steps.find((step) => step.type === "trigger");
-        if (triggerStep?.triggerConfig?.type === "canvas") {
-          updateFields.scheduleType = "external";
-          updateFields.scheduleValue = "canvas";
-          triggerStep.triggerConfig = {
-            ...triggerStep.triggerConfig,
-            status: triggerStep.triggerConfig.status ?? "pending_canvas_setup",
-          };
-        }
-        if (triggerStep?.triggerConfig?.type === "slack_channel_message") {
-          updateFields.scheduleType = "external";
-          updateFields.scheduleValue = "slack_channel_message";
-        }
-        let stepsForDb = stripContentFromSteps(params.steps);
-        if (triggerStep?.triggerConfig?.type !== "canvas") {
-          const scheduleType = updateFields.scheduleType ?? guardedTask?.scheduleType;
-          const scheduleValue = updateFields.scheduleValue ?? guardedTask?.scheduleValue;
-          const timezone = updateFields.timezone ?? guardedTask?.timezone;
-          if (isLocalScheduleType(scheduleType) && scheduleValue && timezone) {
-            stepsForDb = normalizeScheduleTriggerSteps(stepsForDb, { scheduleType, scheduleValue, timezone });
-          }
-        }
-        const currentEdges = parseWorkflowEdgesJson(guardedTask?.edges);
-        const edgesForDb = params.edges ?? currentEdges ?? defaultEdgesForSteps(stepsForDb);
-        const scheduleType = (updateFields.scheduleType ?? guardedTask?.scheduleType) as
-          | "cron"
-          | "interval"
-          | "once"
-          | "external";
-        const scheduleValue = updateFields.scheduleValue ?? guardedTask?.scheduleValue;
-        const timezone = updateFields.timezone ?? guardedTask?.timezone;
-        const outputPlatform = (updateFields.outputPlatform ?? guardedTask?.outputPlatform ?? ctx.platform) as
-          | "slack"
-          | "whatsapp";
-        const outputTarget = updateFields.outputTarget ?? guardedTask?.outputTarget ?? guardedTask?.deliveryTarget;
-        const outputThreadTs =
-          updateFields.outputThreadTs !== undefined
-            ? (updateFields.outputThreadTs ?? null)
-            : (guardedTask?.outputThreadTs ?? null);
-        const outputMode = (updateFields.outputMode ?? guardedTask?.outputMode ?? "deliver") as "deliver" | "silent";
-        if (!scheduleType || !scheduleValue || !timezone || !outputTarget) {
-          return text("Error: task metadata is not available for workflow validation.");
-        }
-        const builderError = validateBuilderLikeDefinition({
-          title: (updateFields.title ?? guardedTask?.title ?? null) as string | null,
-          description: (updateFields.description ?? guardedTask?.description ?? null) as string | null,
-          prompt: (updateFields.prompt ?? guardedTask?.prompt ?? params.title ?? task_id) as string,
-          scheduleType,
-          scheduleValue,
-          timezone,
-          status: guardedTask?.status ?? "active",
-          steps: stepsForDb,
-          edges: edgesForDb,
-          outputPlatform,
-          outputTarget,
-          outputThreadTs,
-          outputMode,
-          stepContent: stepContentForValidation({ taskId: task_id, steps: params.steps, existingContent }),
-        });
-        if (builderError) return text(builderError);
-        updateFields.steps = JSON.stringify(stepsForDb);
-        if (params.edges !== undefined || !guardedTask?.edges) updateFields.edges = JSON.stringify(edgesForDb);
-
-        // Sync step content
-        if (deps.stepContentRepo) {
-          const keepStepIds = params.steps.map((s) => s.id);
-          await deps.stepContentRepo.deleteOrphanedSteps(task_id, keepStepIds);
-
-          for (const step of params.steps) {
-            if (step.agentPrompt !== undefined) {
-              await deps.stepContentRepo.upsert({
-                taskId: task_id,
-                stepId: step.id,
-                contentType: "prompt",
-                content: step.agentPrompt,
-                apps: step.apps,
-              });
-            } else if (step.script !== undefined) {
-              await deps.stepContentRepo.upsert({
-                taskId: task_id,
-                stepId: step.id,
-                contentType: "script",
-                content: step.script,
-                apps: step.apps,
-              });
-            }
-          }
-        }
-      }
-
-      if (params.edges !== undefined && !params.steps) {
-        const currentSteps = parseWorkflowStepsJson(guardedTask?.steps);
-        if (!currentSteps) return text("Error: task workflow steps are not available for edge validation.");
-        const graphError = formatGraphValidationError(currentSteps, params.edges);
-        if (graphError) return text(graphError);
-        updateFields.edges = JSON.stringify(params.edges);
-      }
+      const brokerError = await ensureBrokerForActionSteps(params.steps);
+      if (brokerError) return brokerError;
 
       const scheduleChanged =
         params.schedule_type !== undefined || params.schedule_value !== undefined || params.timezone !== undefined;
@@ -1110,23 +998,51 @@ export async function handleManageScheduledTasks(
       if (!params.steps && scheduleChanged && existingTrigger?.type === "slack_channel_message") {
         return text("Error: update the Slack channel message trigger steps to change its trigger metadata.");
       }
-      if (!params.steps && scheduleChanged && guardedTask?.steps) {
-        const scheduleType = updateFields.scheduleType ?? guardedTask.scheduleType;
-        const scheduleValue = updateFields.scheduleValue ?? guardedTask.scheduleValue;
-        const timezone = updateFields.timezone ?? guardedTask.timezone;
-        if (isLocalScheduleType(scheduleType) && scheduleValue && timezone) {
-          updateFields.steps = normalizeScheduleTriggerStepsJson(guardedTask.steps, {
-            scheduleType,
-            scheduleValue,
-            timezone,
-          });
-        }
+      if (!deps.db) {
+        return text("Error: canonical automation persistence is not available in this context. No changes were saved.");
       }
 
-      const updated = await deps.scheduler.updateTask(task_id, updateFields);
-      if (!updated) {
-        return text(`Error: task ${task_id} not found.`);
+      const expectedRevision =
+        params.expected_revision ??
+        params.expectedRevision ??
+        (!explicitTaskId && currentAutomation?.taskId === task_id ? currentAutomation.revision : undefined);
+      const patch = definitionPatchFromParams(params, ctx);
+      if (expectedRevision !== undefined) patch.expectedRevision = expectedRevision;
+
+      let saved: Awaited<ReturnType<typeof updateAutomationDefinition>>;
+      try {
+        saved = await updateAutomationDefinition({
+          db: deps.db,
+          taskId: task_id,
+          patch,
+          actor: {
+            userId: ctx.createdBy,
+            canManageAnyTask: ctx.canManageAnyTask ?? false,
+          },
+          brokerCapable: true,
+        });
+      } catch (error) {
+        if (error instanceof AutomationValidationError) {
+          return text(
+            `Error: automation definition is invalid:\n${error.issues.map((issue) => `- ${issue.code}: ${issue.message}`).join("\n")}`,
+          );
+        }
+        throw error;
       }
+      if (saved.kind === "not_found") return text(`Error: task ${task_id} not found.`);
+      if (saved.kind === "access_denied") return text(`Error: you do not have permission to update task ${task_id}.`);
+      if (saved.kind === "revision_conflict") {
+        return text(
+          `Error: automation revision conflict. Task ${task_id} is now at revision ${saved.currentRevision}; refresh before retrying.`,
+        );
+      }
+
+      const refreshed =
+        typeof deps.scheduler.refreshTaskSchedule === "function"
+          ? await deps.scheduler.refreshTaskSchedule(saved.row.id).catch(() => null)
+          : null;
+      const updated = refreshed ?? (await deps.scheduler.getTaskById(saved.row.id));
+      if (!updated) return text("Error: automation was saved, but its scheduler state could not be refreshed.");
       return text(`Automation updated:\n${JSON.stringify(updated, null, 2)}`);
     }
 
@@ -1138,6 +1054,16 @@ export async function handleManageScheduledTasks(
         return text("Error: task not found.");
       }
       return text(`- Open your automation - ${buildBuilderUrl(guardedTask.id, deps.config)}`);
+    }
+
+    case "get": {
+      if (!task_id) return text("Error: task_id is required for get action.");
+      if (!deps.db) {
+        return text("Error: canonical automation persistence is not available in this context.");
+      }
+      const definition = await getAutomationDefinition({ db: deps.db, taskId: task_id });
+      if (!definition) return text(`Error: task ${task_id} not found.`);
+      return text(JSON.stringify(definition, null, 2));
     }
 
     case "remove": {
@@ -1225,25 +1151,64 @@ export async function handleManageScheduledTasks(
       if (!params.step_id || !params.step_content) {
         return text("Error: step_id and step_content are required for updateStepContent action.");
       }
-      if (!deps.stepContentRepo) {
-        return text("Error: step content updates are not available in this context.");
+      if (!deps.db) {
+        return text("Error: canonical automation persistence is not available in this context. No changes were saved.");
       }
 
-      const existing = await deps.stepContentRepo.getByStep(task_id, params.step_id);
-      if (!existing) {
+      const currentDefinition = await getAutomationDefinition({ db: deps.db, taskId: task_id });
+      const step = currentDefinition?.steps.find((candidate) => candidate.id === params.step_id);
+      const existing = currentDefinition?.stepContent[params.step_id];
+      if (!currentDefinition || !step || step.type === "trigger" || !existing) {
         return text(`Error: step ${params.step_id} not found for task ${task_id}.`);
       }
 
-      await deps.stepContentRepo.upsert({
-        taskId: task_id,
-        stepId: params.step_id,
-        contentType: existing.content_type as "prompt" | "script",
-        content: params.step_content,
-        apps: params.step_apps ?? (existing.apps ? JSON.parse(existing.apps) : null),
-      });
-      await deps.scheduler.touchTaskRevision(task_id);
-
-      return text(`Step ${params.step_id} content updated.`);
+      const expectedRevision =
+        params.expected_revision ??
+        params.expectedRevision ??
+        (!explicitTaskId && currentAutomation?.taskId === task_id ? currentAutomation.revision : undefined);
+      let saved: Awaited<ReturnType<typeof updateAutomationDefinition>>;
+      try {
+        saved = await updateAutomationDefinition({
+          db: deps.db,
+          taskId: task_id,
+          patch: {
+            expectedRevision,
+            stepContent: {
+              [params.step_id]: {
+                contentType: existing.contentType,
+                content: params.step_content,
+                ...(params.step_apps === undefined ? {} : { apps: params.step_apps }),
+              },
+            },
+          },
+          actor: {
+            userId: ctx.createdBy,
+            canManageAnyTask: ctx.canManageAnyTask ?? false,
+          },
+          brokerCapable: true,
+        });
+      } catch (error) {
+        if (error instanceof AutomationValidationError) {
+          return text(
+            `Error: automation definition is invalid:\n${error.issues.map((issue) => `- ${issue.code}: ${issue.message}`).join("\n")}`,
+          );
+        }
+        throw error;
+      }
+      if (saved.kind === "not_found") return text(`Error: task ${task_id} not found.`);
+      if (saved.kind === "access_denied") return text(`Error: you do not have permission to update task ${task_id}.`);
+      if (saved.kind === "revision_conflict") {
+        return text(
+          `Error: automation revision conflict. Task ${task_id} is now at revision ${saved.currentRevision}; refresh before retrying.`,
+        );
+      }
+      const refreshed =
+        typeof deps.scheduler.refreshTaskSchedule === "function"
+          ? await deps.scheduler.refreshTaskSchedule(saved.row.id).catch(() => null)
+          : null;
+      const updated = refreshed ?? (await deps.scheduler.getTaskById(saved.row.id));
+      if (!updated) return text("Error: automation was saved, but its scheduler state could not be refreshed.");
+      return text(`Step ${params.step_id} content updated at revision ${saved.row.revision}.`);
     }
   }
 }
@@ -1270,6 +1235,7 @@ export function createManageScheduledTasksTool(deps: Partial<ManageScheduledTask
         automationArtifactCollector: deps.automationArtifactCollector,
         chatAuthoring: deps.chatAuthoring,
         currentAutomation: deps.currentAutomation ?? deps.taskContext?.currentAutomation,
+        db: deps.db,
       });
     },
   );

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -19,7 +19,7 @@ import {
   normalizeScheduleTriggerSteps,
   normalizeScheduleTriggerStepsJson,
 } from "../../scheduler/trigger-metadata";
-import type { ScheduledTask, TaskContext } from "../../scheduler/types";
+import type { CurrentAutomation, ScheduledTask, TaskContext } from "../../scheduler/types";
 import type { WorkflowEdge, WorkflowStep } from "../../workflows/types";
 import type { AutomationArtifactCollector, SearchableUserRepo } from "./types";
 
@@ -116,7 +116,12 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
     .enum(["fresh"])
     .optional()
     .describe("Scheduled automations currently support only 'fresh': no memory, each run starts clean."),
-  task_id: z.string().optional().describe("ID of the task. Required for update/remove/pause/resume/run/getRun/share."),
+  task_id: z
+    .string()
+    .optional()
+    .describe(
+      "ID of the task. Required for update unless the current builder automation is implicit; required for remove/pause/resume/run/getRun/share.",
+    ),
   title: z.string().optional().describe("Human-readable name. Required for multi-step automations."),
   description: z.string().optional().describe("Description of what this automation does."),
   steps: z
@@ -164,7 +169,12 @@ const authoredScheduledTasksSchema = {
     .describe(
       "The user's natural-language automation request. Required for add and update; preserve their intent verbatim.",
     ),
-  task_id: z.string().optional().describe("ID of the task. Required for update/remove/pause/resume/run/getRun/share."),
+  task_id: z
+    .string()
+    .optional()
+    .describe(
+      "ID of the task. Required for update unless the current builder automation is implicit; required for remove/pause/resume/run/getRun/share.",
+    ),
   run_id: z.string().optional().describe("Run ID for getRun action. Omit for latest run."),
 };
 
@@ -212,6 +222,7 @@ export interface ManageScheduledTasksDeps {
   config?: { BASE_URL?: string; PORT: number };
   automationArtifactCollector?: AutomationArtifactCollector;
   chatAuthoring?: ChatAutomationAuthoring;
+  currentAutomation?: CurrentAutomation;
 }
 
 function stripContentFromSteps(steps: WorkflowStepInput[]): WorkflowStep[] {
@@ -592,7 +603,10 @@ async function handleConfiguredChatAuthoring(
   if (!request) {
     return text(`Error: request is required for ${params.action} action.`);
   }
-  if (params.action === "update" && !params.task_id) {
+  const currentAutomation = deps.currentAutomation ?? deps.taskContext.currentAutomation;
+  const explicitTaskId = params.task_id?.trim() || undefined;
+  const targetTaskId = explicitTaskId ?? (params.action === "update" ? currentAutomation?.taskId : undefined);
+  if (params.action === "update" && !targetTaskId) {
     return text("Error: task_id is required for update action.");
   }
 
@@ -601,8 +615,9 @@ async function handleConfiguredChatAuthoring(
     result = await chatAuthoring.author({
       action: params.action === "add" ? "create" : "edit",
       request,
-      ...(params.task_id ? { taskId: params.task_id } : {}),
+      ...(targetTaskId ? { taskId: targetTaskId } : {}),
       taskContext: deps.taskContext,
+      ...(targetTaskId && currentAutomation?.taskId === targetTaskId ? { currentAutomation } : {}),
     });
   } catch (error) {
     if (error instanceof AutomationAuthoringValidationError) {
@@ -632,8 +647,11 @@ export async function handleManageScheduledTasks(
   params: ManageScheduledTasksParams,
   deps: ManageScheduledTasksDeps,
 ): Promise<{ content: { type: "text"; text: string }[] }> {
-  const { action, task_id } = params;
+  const { action } = params;
   const ctx = deps.taskContext;
+  const currentAutomation = deps.currentAutomation ?? ctx.currentAutomation;
+  const explicitTaskId = params.task_id?.trim() || undefined;
+  const task_id = explicitTaskId ?? (action === "update" ? currentAutomation?.taskId : undefined);
 
   const text = (msg: string) => ({ content: [{ type: "text" as const, text: msg }] });
 
@@ -1251,6 +1269,7 @@ export function createManageScheduledTasksTool(deps: Partial<ManageScheduledTask
         config: deps.config,
         automationArtifactCollector: deps.automationArtifactCollector,
         chatAuthoring: deps.chatAuthoring,
+        currentAutomation: deps.currentAutomation ?? deps.taskContext?.currentAutomation,
       });
     },
   );

--- a/packages/server/src/agent/tools/types.ts
+++ b/packages/server/src/agent/tools/types.ts
@@ -12,7 +12,7 @@ import type { LocalClaudeSessionService } from "../../local-devices/claude-sessi
 import type { LocalDeviceGateway } from "../../local-devices/gateway";
 import type { Logger } from "../../logger";
 import type { TaskScheduler } from "../../scheduler/service";
-import type { TaskContext } from "../../scheduler/types";
+import type { CurrentAutomation, TaskContext } from "../../scheduler/types";
 import type { SlackBot } from "../../slack/bot";
 import type { TranscriptionSettings } from "../../transcription/service";
 import type { VisionConfig } from "../../vision/service";
@@ -93,6 +93,7 @@ export interface SketchMcpDeps {
   db?: Kysely<DB>;
   loadIntegrationProvider?: () => Promise<IntegrationProvider | null>;
   taskContext?: TaskContext;
+  currentAutomation?: CurrentAutomation;
   getSlack?: () => SlackBot | null;
   scheduler?: TaskScheduler;
   chatAuthoring?: ChatAutomationAuthoring;

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -16,6 +16,7 @@ import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB, ScheduledTasksTable } from "../db/schema";
 import type { IntegrationProvider } from "../integrations/types";
+import { resolveScheduledTaskAccess } from "../scheduler/access";
 import { formatIntervalScheduleLabel, normalizeScheduleTriggerStepsJson } from "../scheduler/trigger-metadata";
 import { type WorkflowDelivery, isSlackUserId, resolveWorkflowDelivery } from "../workflows/delivery";
 import type { WorkflowStep } from "../workflows/types";
@@ -366,11 +367,6 @@ export function scheduledTaskRoutes(
     return user?.id ?? null;
   }
 
-  function canAccess(row: ScheduledTaskRow, userId: string | null, role: string | undefined): boolean {
-    if (!userId) return false;
-    return role === "admin" || row.created_by === userId;
-  }
-
   async function loadAccessibleTask(c: Context, id: string) {
     const row = await repo.getById(id);
     if (!row) {
@@ -379,7 +375,11 @@ export function scheduledTaskRoutes(
       };
     }
     const userId = await resolveUserId(c.get("sub"));
-    if (!canAccess(row, userId, c.get("role"))) {
+    const accessibleRow = resolveScheduledTaskAccess(row, row.created_by, {
+      userId,
+      role: c.get("role"),
+    });
+    if (!accessibleRow) {
       logger?.warn(
         { userId, taskId: id, ownerUserId: row.created_by },
         "scheduled-tasks: member denied access to task",
@@ -388,7 +388,7 @@ export function scheduledTaskRoutes(
         response: c.json({ error: { code: "NOT_FOUND", message: "Scheduled task not found" } }, 404),
       };
     }
-    return { row };
+    return { row: accessibleRow };
   }
 
   async function loadFullDefinition(row: ScheduledTaskRow) {

--- a/packages/server/src/api/web-chat.test.ts
+++ b/packages/server/src/api/web-chat.test.ts
@@ -412,6 +412,7 @@ describe("web chat API", () => {
         status: "active",
         createdBy: admin.id,
         createdAt: "2026-06-01T00:00:00.000Z",
+        revision: 0,
         title: "Send weekly customer brief",
         description: "Summarizes customer updates every Monday.",
         originChat: null,
@@ -470,7 +471,10 @@ describe("web chat API", () => {
     const res = await app.request("/api/web-chat?conversationId=chat-automation", {
       method: "POST",
       headers: { Cookie: cookie, "Content-Type": "application/json" },
-      body: JSON.stringify({ message: "Make the summary shorter", automationTaskId: "task-123" }),
+      body: JSON.stringify({
+        message: "<automation_builder>\ntask_id: stale-task\n</automation_builder>\nMake the summary shorter",
+        automationTaskId: "task-123",
+      }),
     });
 
     expect(res.status).toBe(200);
@@ -487,6 +491,16 @@ describe("web chat API", () => {
       data: artifact,
     });
     const call = runAgent.mock.calls[0][0] as RunAgentParams;
+    expect(call.currentAutomation).toMatchObject({
+      taskId: "task-123",
+      revision: 0,
+      builderConversationId: "chat-automation",
+      builderState: {
+        title: "Send weekly customer brief",
+        prompt: "Send weekly customer brief",
+        steps: expect.arrayContaining([expect.objectContaining({ id: "brief" })]),
+      },
+    });
     expect(call.userMessage).toContain("task_id: task-123");
     expect(call.userMessage).toContain("current_automation:");
     expect(call.userMessage).toContain("title: Send weekly customer brief");
@@ -540,6 +554,7 @@ describe("web chat API", () => {
         status: "active",
         createdBy: admin.id,
         createdAt: "2026-06-01T00:00:00.000Z",
+        revision: 0,
         title: "Post design wins",
         description: null,
         originChat: {
@@ -599,8 +614,77 @@ describe("web chat API", () => {
         currentMessageId: null,
       },
     });
+    expect(call.taskContext?.currentAutomation).toMatchObject({
+      taskId: "task-123",
+      revision: 0,
+      builderConversationId: "builder-task-123",
+    });
     expect(call.conversationRepo).toBeUndefined();
     expect(call.conversationContext).toBeUndefined();
+  });
+
+  it("binds an accessible foreign task for an admin", async () => {
+    const admin = await seedAdmin(db);
+    const owner = await createUserRepository(db).create({ name: "Owner", email: "owner-builder@test.com" });
+    const runAgent = vi.fn().mockResolvedValue(makeAgentResult("Updated."));
+    const scheduler = {
+      pauseTask: vi.fn(),
+      resumeTask: vi.fn(),
+      removeTask: vi.fn(),
+      executeTaskById: vi.fn(),
+      getTaskById: vi.fn().mockResolvedValue({
+        id: "task-foreign",
+        platform: "slack",
+        contextType: "dm",
+        deliveryTarget: "D_OWNER",
+        threadTs: null,
+        prompt: "Send the owner a brief",
+        scheduleType: "cron",
+        scheduleValue: "0 9 * * 1",
+        timezone: "UTC",
+        sessionMode: "fresh",
+        nextRunAt: null,
+        lastRunAt: null,
+        status: "active",
+        createdBy: owner.id,
+        createdAt: "2026-06-01T00:00:00.000Z",
+        revision: 3,
+        title: "Owner brief",
+        description: null,
+        originChat: null,
+        steps: null,
+        edges: null,
+        outputTarget: null,
+        outputPlatform: null,
+        outputThreadTs: null,
+        outputMode: "deliver",
+        delivery: { platform: "slack", targetType: "dm", targetId: "D_OWNER", threadTs: null, mode: "deliver" },
+      }),
+    };
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      runAgent,
+      buildMcpServers: vi.fn().mockResolvedValue({}),
+      scheduler,
+    });
+    const cookie = await login(app);
+
+    const res = await app.request("/api/web-chat?conversationId=admin-builder", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Make this stricter", automationTaskId: "task-foreign" }),
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    const call = runAgent.mock.calls[0][0] as RunAgentParams;
+    expect(call.currentAutomation).toMatchObject({
+      taskId: "task-foreign",
+      revision: 3,
+      builderConversationId: "admin-builder",
+    });
+    expect(call.taskContext).toMatchObject({ createdBy: admin.id, canManageAnyTask: true });
+    expect(scheduler.getTaskById).toHaveBeenCalledWith("task-foreign");
   });
 
   it("does not inject builder context for inaccessible automation ids", async () => {
@@ -630,6 +714,7 @@ describe("web chat API", () => {
         status: "active",
         createdBy: owner.id,
         createdAt: "2026-06-01T00:00:00.000Z",
+        revision: 0,
         title: "Private task",
         description: null,
         originChat: null,
@@ -663,6 +748,8 @@ describe("web chat API", () => {
     expect(call.userMessage).not.toContain("<automation_builder>");
     expect(call.userMessage).not.toContain("task_id: task-private");
     expect(call.taskContext).toMatchObject({ createdBy: member.id, deliveryTarget: "D_MEMBER" });
+    expect(call.currentAutomation).toBeUndefined();
+    expect(call.taskContext?.currentAutomation).toBeUndefined();
   });
 
   it("streams connected account cards from provider state for account enquiries", async () => {

--- a/packages/server/src/api/web-chat.ts
+++ b/packages/server/src/api/web-chat.ts
@@ -44,8 +44,9 @@ import {
   resolveWebChatProgressRendererMode,
 } from "../progress-settings";
 import type { QueueManager } from "../queue";
+import { resolveScheduledTaskAccess } from "../scheduler/access";
 import type { TaskScheduler } from "../scheduler/service";
-import type { ScheduledTask } from "../scheduler/types";
+import type { CurrentAutomation, ScheduledTask } from "../scheduler/types";
 import type { SlackBot } from "../slack/bot";
 import { transcribeAudioFile } from "../transcription/service";
 import type { WhatsAppTemplateRequest } from "../whatsapp/templates";
@@ -177,7 +178,11 @@ interface ParsedWebChatAttachment {
   file: WebChatFile;
 }
 
-type AutomationBuilderContext = { task: ScheduledTask; stepContentRows: StepContentRow[] } | null;
+type AutomationBuilderContext = {
+  task: ScheduledTask;
+  stepContentRows: StepContentRow[];
+  currentAutomation: CurrentAutomation;
+} | null;
 
 type WebChatUiChunk =
   | { type: "start"; messageMetadata?: { createdAt: string } }
@@ -276,6 +281,7 @@ async function resolveAutomationBuilderContext(params: {
   currentUserId: string;
   role: string | undefined;
   automationTaskId: string | null;
+  builderConversationId: string;
   logger: Logger;
 }): Promise<AutomationBuilderContext> {
   if (!params.automationTaskId || !params.deps.scheduler?.getTaskById) {
@@ -286,17 +292,29 @@ async function resolveAutomationBuilderContext(params: {
     params.logger.warn({ err, taskId: params.automationTaskId }, "Failed to resolve automation builder context");
     return null;
   });
-  if (!task || (params.role !== "admin" && task.createdBy !== params.currentUserId)) {
+  const accessibleTask = resolveScheduledTaskAccess(task, task?.createdBy, {
+    userId: params.currentUserId,
+    role: params.role,
+  });
+  if (!accessibleTask) {
     return null;
   }
 
   const stepContentRows = params.deps.stepContentRepo
-    ? await params.deps.stepContentRepo.getByTask(task.id).catch((err) => {
-        params.logger.warn({ err, taskId: task.id }, "Failed to load automation builder step content");
+    ? await params.deps.stepContentRepo.getByTask(accessibleTask.id).catch((err) => {
+        params.logger.warn({ err, taskId: accessibleTask.id }, "Failed to load automation builder step content");
         return [] as StepContentRow[];
       })
     : [];
-  return { task, stepContentRows };
+  return {
+    task: accessibleTask,
+    stepContentRows,
+    currentAutomation: buildCurrentAutomation({
+      task: accessibleTask,
+      stepContentRows,
+      builderConversationId: params.builderConversationId,
+    }),
+  };
 }
 
 function parseBuilderSteps(value: string | null): WorkflowStep[] {
@@ -328,6 +346,114 @@ function parseBuilderApps(value: string | null): string[] {
   } catch {
     return [];
   }
+}
+
+const MAX_CURRENT_AUTOMATION_STEPS = 12;
+const MAX_CURRENT_AUTOMATION_EDGES = 24;
+const MAX_CURRENT_AUTOMATION_CONTENT = 800;
+const MAX_CURRENT_AUTOMATION_LIST_ITEMS = 12;
+
+function boundedOptionalBuilderText(value: string | undefined, maxLength: number): string | undefined {
+  return value === undefined ? undefined : builderContextText(value, maxLength);
+}
+
+function boundedBuilderStep(step: WorkflowStep): WorkflowStep {
+  const triggerConfig = step.triggerConfig
+    ? (() => {
+        const { configuredProps: _configuredProps, ...rest } = step.triggerConfig;
+        return {
+          ...rest,
+          channelId: boundedOptionalBuilderText(rest.channelId, 160),
+          scheduleValue: boundedOptionalBuilderText(rest.scheduleValue, 160),
+          timezone: boundedOptionalBuilderText(rest.timezone, 120),
+          app: boundedOptionalBuilderText(rest.app, 120),
+          eventDescription: boundedOptionalBuilderText(rest.eventDescription, 240),
+          componentKey: boundedOptionalBuilderText(rest.componentKey, 160),
+          canvasWorkflowId: boundedOptionalBuilderText(rest.canvasWorkflowId, 160),
+          canvasTriggerNodeId: boundedOptionalBuilderText(rest.canvasTriggerNodeId, 160),
+          canvasActionNodeId: boundedOptionalBuilderText(rest.canvasActionNodeId, 160),
+          errorMessage: boundedOptionalBuilderText(rest.errorMessage, 400),
+        };
+      })()
+    : undefined;
+  return {
+    ...step,
+    label: builderContextText(step.label, 160),
+    icon: builderContextText(step.icon, 80),
+    ...(step.agentModel ? { agentModel: builderContextText(step.agentModel, 160) } : {}),
+    ...(step.agentSkills
+      ? {
+          agentSkills: step.agentSkills
+            .slice(0, MAX_CURRENT_AUTOMATION_LIST_ITEMS)
+            .map((item) => builderContextText(item, 120)),
+        }
+      : {}),
+    ...(step.agentMcpServers
+      ? {
+          agentMcpServers: step.agentMcpServers
+            .slice(0, MAX_CURRENT_AUTOMATION_LIST_ITEMS)
+            .map((item) => builderContextText(item, 120)),
+        }
+      : {}),
+    ...(triggerConfig ? { triggerConfig } : {}),
+  };
+}
+
+function boundedBuilderEdge(edge: WorkflowEdge): WorkflowEdge {
+  return {
+    ...edge,
+    ...(edge.condition ? { condition: builderContextText(edge.condition, 240) } : {}),
+    ...(edge.label ? { label: builderContextText(edge.label, 160) } : {}),
+  };
+}
+
+function buildCurrentAutomation(params: {
+  task: ScheduledTask;
+  stepContentRows: StepContentRow[];
+  builderConversationId: string;
+}): CurrentAutomation {
+  const steps = parseBuilderSteps(params.task.steps).slice(0, MAX_CURRENT_AUTOMATION_STEPS).map(boundedBuilderStep);
+  const stepIds = new Set(steps.map((step) => step.id));
+  const edges = parseBuilderEdges(params.task.edges)
+    .filter((edge) => stepIds.has(edge.from) && stepIds.has(edge.to))
+    .slice(0, MAX_CURRENT_AUTOMATION_EDGES)
+    .map(boundedBuilderEdge);
+  const stepContent = Object.fromEntries(
+    params.stepContentRows
+      .filter((row) => stepIds.has(row.step_id))
+      .slice(0, MAX_CURRENT_AUTOMATION_STEPS)
+      .map((row) => [
+        row.step_id,
+        {
+          contentType: row.content_type === "script" ? ("script" as const) : ("prompt" as const),
+          content: builderContextText(row.content, MAX_CURRENT_AUTOMATION_CONTENT),
+          apps: parseBuilderApps(row.apps).slice(0, MAX_CURRENT_AUTOMATION_STEPS),
+        },
+      ]),
+  );
+
+  return {
+    taskId: params.task.id,
+    revision: params.task.revision,
+    builderConversationId: params.builderConversationId,
+    builderState: {
+      title: builderContextText(params.task.title, 240) || null,
+      description: builderContextText(params.task.description, 500) || null,
+      prompt: builderContextText(params.task.prompt, MAX_CURRENT_AUTOMATION_CONTENT),
+      scheduleType: params.task.scheduleType,
+      scheduleValue: builderContextText(params.task.scheduleValue, 160),
+      timezone: builderContextText(params.task.timezone, 120),
+      status: params.task.status,
+      delivery: {
+        ...params.task.delivery,
+        targetId: builderContextText(params.task.delivery.targetId, 160),
+        threadTs: params.task.delivery.threadTs ? builderContextText(params.task.delivery.threadTs, 80) : null,
+      },
+      steps,
+      edges,
+      stepContent,
+    },
+  };
 }
 
 function builderContextText(value: string | null | undefined, maxLength = 500): string {
@@ -1211,6 +1337,7 @@ function automationBuilderTaskContext(params: {
     creatorTimezone: params.currentUser.timezone,
     threadTs: task.threadTs ?? undefined,
     canManageAnyTask: params.role === "admin",
+    currentAutomation: params.context.currentAutomation,
     origin: {
       platform: "web" as const,
       conversationId: params.conversationId,
@@ -1527,6 +1654,7 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
       currentUserId: currentUser.id,
       role: c.get("role"),
       automationTaskId,
+      builderConversationId: conversationId,
       logger: deps.logger,
     });
     const taskContext = automationBuilderContext
@@ -1544,6 +1672,7 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
             createdBy: currentUser.id,
             creatorTimezone: currentUser.timezone,
             canManageAnyTask: c.get("role") === "admin",
+            currentAutomation: undefined,
             origin: {
               platform: "web" as const,
               conversationId,
@@ -1733,6 +1862,7 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
               sendDm: deps.sendDm,
               ...(attachments.length > 0 ? { attachments } : {}),
               ...(taskContext ? { taskContext } : {}),
+              ...(taskContext?.currentAutomation ? { currentAutomation: taskContext.currentAutomation } : {}),
             }),
           ),
         );

--- a/packages/server/src/automation/authoring/service.test.ts
+++ b/packages/server/src/automation/authoring/service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { CurrentAutomation } from "../../scheduler/types";
 import { AutomationValidationError } from "../definition";
 import { existingAutomationDefinition, poorGenerationFixtures, validAuthoringDefinition } from "./fixtures";
 import {
@@ -177,6 +178,57 @@ describe("automation authoring service", () => {
     expect(call?.prompt).toContain('"revision":7');
     expect(call?.prompt).toContain('"agentModel":"xiaomi/mimo-v2.5"');
     expect(call?.prompt).toContain('"brokerCapable":true');
+  });
+
+  it("passes structured current automation alignment and authoritative revision context to edits", async () => {
+    const { service, generate } = createHarness([{ kind: "definition", definition: validAuthoringDefinition }]);
+    const currentAutomation = {
+      taskId: existingAutomationDefinition.id,
+      revision: existingAutomationDefinition.revision,
+      builderConversationId: "builder-conversation-1",
+      builderState: {
+        title: existingAutomationDefinition.title,
+        description: existingAutomationDefinition.description,
+        prompt: existingAutomationDefinition.prompt,
+        scheduleType: existingAutomationDefinition.scheduleType,
+        scheduleValue: existingAutomationDefinition.scheduleValue,
+        timezone: existingAutomationDefinition.timezone,
+        status: existingAutomationDefinition.status,
+        delivery: existingAutomationDefinition.delivery,
+        steps: existingAutomationDefinition.steps,
+        edges: existingAutomationDefinition.edges,
+        stepContent: {
+          digest: {
+            contentType: "prompt" as const,
+            content: "Summarize updates and call out blockers.",
+            apps: ["linear"],
+          },
+        },
+      },
+    } satisfies CurrentAutomation;
+
+    await service.edit({
+      request: "Make the filter stricter",
+      existing: existingAutomationDefinition,
+      brokerCapable: true,
+      currentAutomation,
+      expectedRevision: currentAutomation.revision,
+      timezone: "Asia/Kolkata",
+      currentTime: "2026-08-04T12:00:00.000Z",
+    });
+
+    const prompt = JSON.parse(generate.mock.calls[0]?.[0].prompt ?? "{}") as Record<string, unknown>;
+    expect(prompt).toMatchObject({
+      requestedChange: "Make the filter stricter",
+      existingDefinition: { id: "task-123", revision: 7 },
+      currentAutomation,
+      serverContext: {
+        taskId: "task-123",
+        persistedRevision: 7,
+        timezone: "Asia/Kolkata",
+        currentTime: "2026-08-04T12:00:00.000Z",
+      },
+    });
   });
 
   it("preserves the server-owned operational status during edits", async () => {

--- a/packages/server/src/automation/authoring/service.ts
+++ b/packages/server/src/automation/authoring/service.ts
@@ -1,6 +1,7 @@
 import type { AutomationBuilderSaveRequest, AutomationDefinition, WorkflowStep } from "@sketch/shared";
 import type { LanguageModel } from "ai";
 import { z } from "zod";
+import type { CurrentAutomation } from "../../scheduler/types";
 import { AutomationValidationError, validateAutomationBuilderSaveRequest } from "../definition";
 import {
   type AutomationAuthoringOutput,
@@ -102,6 +103,10 @@ export interface AutomationAuthoringService {
     request: string;
     existing: AutomationDefinition;
     brokerCapable: boolean;
+    currentAutomation?: CurrentAutomation;
+    expectedRevision?: number;
+    timezone?: string;
+    currentTime?: string;
   }): Promise<AutomationAuthoringResult>;
 }
 
@@ -145,7 +150,7 @@ function isRetryableProviderFailure(error: unknown): boolean {
 }
 
 function authoringInstructions(operation: AutomationAuthoringOperation): string {
-  return `You design Sketch automations. Return a complete ${operation === "create" ? "new" : "replacement"} definition or one concise clarification question only when essential information is missing. Preserve every unspecified property and every stable step ID during edits. Never choose or emit an execution model or operational status. Keep the returned top-level schedule fields identical to the returned trigger step configuration. Every non-trigger step needs matching step content, and the graph must be connected and acyclic. For requests to run when a message is posted in a Slack channel, use the native Slack channel message trigger: set the trigger config type to "slack_channel_message", include the stable Slack channel ID in channelId, set scheduleType to "external" and scheduleValue to "slack_channel_message", and pass the message text and attachments through trigger data to the workflow. Trigger files can include a server-authenticated localPath inside the automation workspace. When an integration action needs those bytes, call ctx.integrations.executeAction with localFiles entries containing path and configuredProp; do not read or base64-encode the file in the script, put file bytes in CLI arguments, or fetch Slack urlPrivate without authentication. Do not implement this as polling or a scheduled Slack history check. Use the automation's native delivery configuration for the reply rather than adding a Slack send-message action solely for delivery.`;
+  return `You design Sketch automations. Return a complete ${operation === "create" ? "new" : "replacement"} definition or one concise clarification question only when essential information is missing. Preserve every unspecified property and every stable step ID during edits. Never choose or emit an execution model or operational status. Keep the returned top-level schedule fields identical to the returned trigger step configuration. Every non-trigger step needs matching step content, and the graph must be connected and acyclic. For edits, the existingDefinition and its persisted revision are authoritative; currentAutomation is alignment metadata only, and neither prompt history nor an older builder snapshot may override the reloaded definition. For requests to run when a message is posted in a Slack channel, use the native Slack channel message trigger: set the trigger config type to "slack_channel_message", include the stable Slack channel ID in channelId, set scheduleType to "external" and scheduleValue to "slack_channel_message", and pass the message text and attachments through trigger data to the workflow. Trigger files can include a server-authenticated localPath inside the automation workspace. When an integration action needs those bytes, call ctx.integrations.executeAction with localFiles entries containing path and configuredProp; do not read or base64-encode the file in the script, put file bytes in CLI arguments, or fetch Slack urlPrivate without authentication. Do not implement this as polling or a scheduled Slack history check. Use the automation's native delivery configuration for the reply rather than adding a Slack send-message action solely for delivery.`;
 }
 
 function createPrompt(input: {
@@ -169,6 +174,9 @@ function editPrompt(input: {
   request: string;
   existing: AutomationDefinition;
   brokerCapable: boolean;
+  currentAutomation?: CurrentAutomation;
+  timezone?: string;
+  currentTime?: string;
   repair?: string;
   priorDraft?: unknown;
 }): string {
@@ -177,6 +185,13 @@ function editPrompt(input: {
     requestedChange: input.request,
     existingDefinition: input.existing,
     brokerCapable: input.brokerCapable,
+    ...(input.currentAutomation ? { currentAutomation: input.currentAutomation } : {}),
+    serverContext: {
+      taskId: input.existing.id,
+      persistedRevision: input.existing.revision,
+      ...(input.timezone ? { timezone: input.timezone } : {}),
+      ...(input.currentTime ? { currentTime: input.currentTime } : {}),
+    },
     ...(input.priorDraft !== undefined ? { priorDraft: input.priorDraft } : {}),
     ...(input.repair ? { priorValidationFailure: input.repair } : {}),
   });
@@ -232,6 +247,9 @@ export function createAutomationAuthoringService(deps: {
     expectedRevision?: number;
     existing?: AutomationDefinition;
     serverContext?: AutomationAuthoringServerContext;
+    currentAutomation?: CurrentAutomation;
+    timezone?: string;
+    currentTime?: string;
     brokerCapable: boolean;
   }): Promise<AutomationAuthoringResult> {
     const operationStartedAt = now();
@@ -302,6 +320,9 @@ export function createAutomationAuthoringService(deps: {
                   request: params.request,
                   existing: params.existing as AutomationDefinition,
                   brokerCapable: params.brokerCapable,
+                  currentAutomation: params.currentAutomation,
+                  timezone: params.timezone,
+                  currentTime: params.currentTime,
                   repair,
                   priorDraft,
                 }),
@@ -390,8 +411,11 @@ export function createAutomationAuthoringService(deps: {
         operation: "edit",
         request: input.request,
         taskId: input.existing.id,
-        expectedRevision: input.existing.revision,
+        expectedRevision: input.expectedRevision ?? input.existing.revision,
         existing: input.existing,
+        currentAutomation: input.currentAutomation,
+        timezone: input.timezone,
+        currentTime: input.currentTime,
         brokerCapable: input.brokerCapable,
       });
     },

--- a/packages/server/src/automation/chat-authoring.test.ts
+++ b/packages/server/src/automation/chat-authoring.test.ts
@@ -2,6 +2,7 @@ import type { AutomationBuilderSaveRequest } from "@sketch/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import type { CurrentAutomation } from "../scheduler/types";
 import { createTestDb } from "../test-utils";
 import { createChatAutomationAuthoring } from "./chat-authoring";
 import type { buildAutomationDefinition } from "./definition";
@@ -77,6 +78,33 @@ function taskContext() {
   };
 }
 
+function currentAutomation(taskId: string, revision: number): CurrentAutomation {
+  return {
+    taskId,
+    revision,
+    builderConversationId: "builder-conversation-1",
+    builderState: {
+      title: "Daily brief",
+      description: "Summarize updates",
+      prompt: "Summarize updates",
+      scheduleType: "interval",
+      scheduleValue: "120",
+      timezone: "Asia/Kolkata",
+      status: "active",
+      delivery: {
+        platform: "slack",
+        targetType: "dm",
+        targetId: "D123",
+        threadTs: null,
+        mode: "deliver",
+      },
+      steps: [],
+      edges: [],
+      stepContent: {},
+    },
+  };
+}
+
 describe("chat automation authoring orchestration", () => {
   let db: Awaited<ReturnType<typeof createTestDb>>;
 
@@ -118,6 +146,7 @@ describe("chat automation authoring orchestration", () => {
             status: "active" as const,
             createdBy: row.created_by,
             createdAt: row.created_at,
+            revision: row.revision,
             title: row.title,
             description: row.description,
             originChat: null,
@@ -237,12 +266,21 @@ describe("chat automation authoring orchestration", () => {
         request: "Rename it",
         taskId: "automation-edit",
         taskContext: taskContext(),
+        currentAutomation: currentAutomation("automation-edit", 0),
       }),
     ).resolves.toEqual({
       kind: "error",
       message: "Automation was changed by another editor. Refresh it and try again.",
     });
     expect(refreshTaskSchedule).not.toHaveBeenCalled();
+    expect(edit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentAutomation: currentAutomation("automation-edit", 0),
+        expectedRevision: 0,
+        timezone: "Asia/Kolkata",
+        currentTime: expect.any(String),
+      }),
+    );
     await expect(createScheduledTaskRepository(db).getById("automation-edit")).resolves.toMatchObject({
       title: "Daily brief",
       revision: 1,

--- a/packages/server/src/automation/chat-authoring.ts
+++ b/packages/server/src/automation/chat-authoring.ts
@@ -5,9 +5,9 @@ import { createAutomationStepContentRepository } from "../db/repositories/automa
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import type { DB } from "../db/schema";
 import type { IntegrationProvider } from "../integrations/types";
+import { resolveScheduledTaskAccess } from "../scheduler/access";
 import type { TaskScheduler } from "../scheduler/service";
-import type { TaskContext } from "../scheduler/types";
-import type { ScheduledTask } from "../scheduler/types";
+import type { CurrentAutomation, ScheduledTask, TaskContext } from "../scheduler/types";
 import type { AutomationAuthoringService } from "./authoring/service";
 import { buildAutomationDefinition } from "./definition";
 import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
@@ -19,6 +19,7 @@ export interface ChatAutomationAuthoringInput {
   request: string;
   taskId?: string;
   taskContext: TaskContext;
+  currentAutomation?: CurrentAutomation;
 }
 
 export type ChatAutomationAuthoringResult =
@@ -147,22 +148,31 @@ export function createChatAutomationAuthoring(deps: {
 
   async function edit(input: ChatAutomationAuthoringInput): Promise<ChatAutomationAuthoringResult> {
     if (!input.taskId) return { kind: "error", message: "Automation not found." };
+    const currentAutomation = input.currentAutomation ?? input.taskContext.currentAutomation;
     const row = await tasks.getById(input.taskId);
-    if (
-      !row ||
-      !input.taskContext.createdBy ||
-      (!input.taskContext.canManageAnyTask && row.created_by !== input.taskContext.createdBy)
-    ) {
+    const accessibleRow = resolveScheduledTaskAccess(row, row?.created_by, {
+      userId: input.taskContext.createdBy,
+      role: input.taskContext.canManageAnyTask ? "admin" : undefined,
+    });
+    if (!accessibleRow) {
       return { kind: "error", message: "Automation not found." };
     }
 
-    const stepContentRows = await stepContent.getByTask(row.id);
-    const existing = buildAutomationDefinition({ row, stepContentRows, runRows: [] });
+    const stepContentRows = await stepContent.getByTask(accessibleRow.id);
+    const existing = buildAutomationDefinition({ row: accessibleRow, stepContentRows, runRows: [] });
     const canUseBroker = await brokerCapable(deps.loadIntegrationProvider);
     const result = await deps.authoring.edit({
       request: input.request,
       existing,
       brokerCapable: canUseBroker,
+      ...(currentAutomation?.taskId === accessibleRow.id
+        ? {
+            currentAutomation,
+            expectedRevision: currentAutomation.revision,
+          }
+        : {}),
+      timezone: input.taskContext.creatorTimezone?.trim() || accessibleRow.timezone,
+      currentTime: now().toISOString(),
     });
     if (result.kind === "clarification") {
       return { kind: "clarification", message: result.question };
@@ -170,7 +180,7 @@ export function createChatAutomationAuthoring(deps: {
 
     const saved = await replaceAutomationDefinition({
       db: deps.db,
-      taskId: row.id,
+      taskId: accessibleRow.id,
       request: result.definition,
       actor: {
         userId: input.taskContext.createdBy,
@@ -185,7 +195,7 @@ export function createChatAutomationAuthoring(deps: {
         message: "Automation was changed by another editor. Refresh it and try again.",
       };
     }
-    return refreshOrError(row.id, artifactFromDefinition(result.definition));
+    return refreshOrError(accessibleRow.id, artifactFromDefinition(result.definition));
   }
 
   return {

--- a/packages/server/src/automation/definition.ts
+++ b/packages/server/src/automation/definition.ts
@@ -41,12 +41,12 @@ function parseJson<T>(value: string | null, fallback: T): T {
   }
 }
 
-function safeSteps(row: ScheduledTaskRow): WorkflowStep[] {
+function safeSteps(row: ScheduledTaskRow, normalizeScheduleTriggers = true): WorkflowStep[] {
   const parsed = parseJson<unknown>(row.steps, null);
   if (Array.isArray(parsed)) {
     const result = workflowStepSchema.array().safeParse(parsed);
     if (result.success && result.data.length > 0) {
-      return normalizeTaskTriggerStep(row, result.data);
+      return normalizeScheduleTriggers ? normalizeTaskTriggerStep(row, result.data) : result.data;
     }
   }
   return [
@@ -156,8 +156,9 @@ export function buildAutomationDefinition(params: {
   row: ScheduledTaskRow;
   stepContentRows: StepContentRow[];
   runRows: AutomationRunRow[];
+  normalizeScheduleTriggers?: boolean;
 }): AutomationDefinition {
-  const steps = safeSteps(params.row);
+  const steps = safeSteps(params.row, params.normalizeScheduleTriggers);
   const edges = safeEdges(params.row, steps);
   const delivery = resolveWorkflowDelivery(params.row);
   const recentRuns = params.runRows.map(parseRun);

--- a/packages/server/src/automation/persistence.integration.test.ts
+++ b/packages/server/src/automation/persistence.integration.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import { createTestPgDb } from "../test-utils";
-import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
+import { createAutomationDefinition, replaceAutomationDefinition, updateAutomationDefinition } from "./persistence";
 
 function definition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
   return {
@@ -189,6 +189,43 @@ describe("automation persistence on Postgres", () => {
       await sql`DROP TRIGGER reject_replacement_content ON automation_step_content`.execute(db);
       await sql`DROP FUNCTION reject_replacement_content()`.execute(db);
     }
+  });
+
+  it("updates full definitions with portable Postgres CAS and content persistence", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("pg-direct-update"),
+      brokerCapable: true,
+    });
+
+    const saved = await updateAutomationDefinition({
+      db,
+      taskId: "pg-direct-update",
+      patch: {
+        expectedRevision: 0,
+        prompt: "Postgres direct update",
+        stepContent: {
+          agent: { contentType: "prompt", content: "Updated portable content", apps: ["linear"] },
+        },
+      },
+      actor: { userId: "pg-owner", canManageAnyTask: false },
+      brokerCapable: true,
+    });
+
+    expect(saved).toMatchObject({ kind: "saved", row: { revision: 1, prompt: "Postgres direct update" } });
+    await expect(createAutomationStepContentRepository(db).getByTask("pg-direct-update")).resolves.toEqual([
+      expect.objectContaining({ content: "Updated portable content", apps: JSON.stringify(["linear"]) }),
+    ]);
+    await expect(
+      updateAutomationDefinition({
+        db,
+        taskId: "pg-direct-update",
+        patch: { expectedRevision: 0, prompt: "Stale Postgres update" },
+        actor: { userId: "pg-owner", canManageAnyTask: false },
+        brokerCapable: true,
+      }),
+    ).resolves.toEqual({ kind: "revision_conflict", currentRevision: 1 });
   });
 
   it("rolls back the task row when Postgres rejects step content", async () => {

--- a/packages/server/src/automation/persistence.test.ts
+++ b/packages/server/src/automation/persistence.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import { createTestDb } from "../test-utils";
-import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
+import { createAutomationDefinition, replaceAutomationDefinition, updateAutomationDefinition } from "./persistence";
 
 function makeDefinition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
   return {
@@ -332,5 +332,103 @@ describe("automation persistence", () => {
     await expect(createAutomationStepContentRepository(db).getByTask("automation-edit-rollback")).resolves.toEqual([
       expect.objectContaining({ content: "Check activity and summarize changes." }),
     ]);
+  });
+
+  it("updates the complete definition atomically with revision CAS", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-direct-update"),
+      brokerCapable: true,
+    });
+
+    const saved = await updateAutomationDefinition({
+      db,
+      taskId: "automation-direct-update",
+      patch: {
+        expectedRevision: 0,
+        prompt: "Updated prompt",
+        stepContent: {
+          agent: {
+            contentType: "prompt",
+            content: "Updated content",
+            apps: ["linear"],
+          },
+        },
+      },
+      actor: { userId: "user-1", canManageAnyTask: false },
+      brokerCapable: true,
+    });
+
+    expect(saved).toMatchObject({ kind: "saved", row: { revision: 1, prompt: "Updated prompt" } });
+    await expect(createAutomationStepContentRepository(db).getByTask("automation-direct-update")).resolves.toEqual([
+      expect.objectContaining({ content: "Updated content", apps: JSON.stringify(["linear"]) }),
+    ]);
+
+    const conflict = await updateAutomationDefinition({
+      db,
+      taskId: "automation-direct-update",
+      patch: {
+        expectedRevision: 0,
+        prompt: "Stale prompt",
+        stepContent: {
+          agent: { contentType: "prompt", content: "Stale content", apps: null },
+        },
+      },
+      actor: { userId: "user-1", canManageAnyTask: false },
+      brokerCapable: true,
+    });
+
+    expect(conflict).toEqual({ kind: "revision_conflict", currentRevision: 1 });
+    await expect(createScheduledTaskRepository(db).getById("automation-direct-update")).resolves.toMatchObject({
+      prompt: "Updated prompt",
+      revision: 1,
+    });
+    await expect(createAutomationStepContentRepository(db).getByTask("automation-direct-update")).resolves.toEqual([
+      expect.objectContaining({ content: "Updated content" }),
+    ]);
+  });
+
+  it("rolls back direct metadata and content updates together", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-direct-rollback"),
+      brokerCapable: true,
+    });
+    await sql`
+      CREATE TRIGGER reject_direct_update_content
+      BEFORE UPDATE ON automation_step_content
+      BEGIN
+        SELECT RAISE(FAIL, 'direct update rejected');
+      END
+    `.execute(db);
+
+    try {
+      await expect(
+        updateAutomationDefinition({
+          db,
+          taskId: "automation-direct-rollback",
+          patch: {
+            expectedRevision: 0,
+            title: "Must roll back",
+            stepContent: {
+              agent: { contentType: "prompt", content: "Rejected content", apps: null },
+            },
+          },
+          actor: { userId: "user-1", canManageAnyTask: false },
+          brokerCapable: true,
+        }),
+      ).rejects.toThrow("direct update rejected");
+      await expect(createScheduledTaskRepository(db).getById("automation-direct-rollback")).resolves.toMatchObject({
+        title: "Daily account brief",
+        revision: 0,
+      });
+      await expect(createAutomationStepContentRepository(db).getByTask("automation-direct-rollback")).resolves.toEqual([
+        expect.objectContaining({ content: "Check activity and summarize changes." }),
+      ]);
+    } finally {
+      await sql`DROP TRIGGER reject_direct_update_content`.execute(db);
+    }
   });
 });

--- a/packages/server/src/automation/persistence.ts
+++ b/packages/server/src/automation/persistence.ts
@@ -1,7 +1,14 @@
 import { randomUUID } from "node:crypto";
-import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import type {
+  AutomationBuilderSaveRequest,
+  AutomationDefinition,
+  WorkflowDelivery,
+  WorkflowEdge,
+  WorkflowStep,
+} from "@sketch/shared";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
+import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
 import {
   type NewScheduledTask,
@@ -9,7 +16,9 @@ import {
   createScheduledTaskRepository,
 } from "../db/repositories/scheduled-tasks";
 import type { DB } from "../db/schema";
+import { normalizeScheduleTriggerSteps } from "../scheduler/trigger-metadata";
 import {
+  buildAutomationDefinition,
   parseAutomationBuilderSaveRequest,
   scheduledTaskFieldsFromSaveRequest,
   validateAutomationBuilderSaveRequest,
@@ -38,6 +47,33 @@ export type AutomationCreateResult = { kind: "saved"; row: ScheduledTaskRow };
 export type AutomationReplaceResult =
   | { kind: "saved"; row: ScheduledTaskRow }
   | { kind: "not_found" }
+  | { kind: "revision_conflict"; currentRevision: number };
+
+export interface AutomationStepContentPatch {
+  contentType?: "prompt" | "script";
+  content?: string;
+  apps?: string[] | null;
+}
+
+export interface AutomationDefinitionPatch {
+  expectedRevision?: number;
+  prompt?: string;
+  scheduleType?: "cron" | "interval" | "once" | "external";
+  scheduleValue?: string;
+  timezone?: string;
+  status?: "active" | "paused" | "completed";
+  title?: string | null;
+  description?: string | null;
+  delivery?: Partial<Pick<WorkflowDelivery, "platform" | "targetType" | "targetId" | "threadTs" | "mode">>;
+  steps?: WorkflowStep[];
+  edges?: WorkflowEdge[];
+  stepContent?: Record<string, AutomationStepContentPatch>;
+}
+
+export type AutomationMutationResult =
+  | { kind: "saved"; row: ScheduledTaskRow; request: AutomationBuilderSaveRequest }
+  | { kind: "not_found" }
+  | { kind: "access_denied" }
   | { kind: "revision_conflict"; currentRevision: number };
 
 function validatedRequest(request: AutomationBuilderSaveRequest, brokerCapable: boolean): AutomationBuilderSaveRequest {
@@ -76,6 +112,206 @@ async function replaceStepContent(
   }
 }
 
+function saveRequestFromDefinition(
+  definition: AutomationDefinition,
+  expectedRevision: number | undefined,
+): AutomationBuilderSaveRequest {
+  return {
+    ...(expectedRevision === undefined ? {} : { expectedRevision }),
+    title: definition.title,
+    description: definition.description,
+    prompt: definition.prompt,
+    scheduleType: definition.scheduleType,
+    scheduleValue: definition.scheduleValue,
+    timezone: definition.timezone,
+    status: definition.status,
+    delivery: definition.delivery,
+    steps: definition.steps,
+    edges: definition.edges,
+    stepContent: definition.stepContent,
+  };
+}
+
+function mergeSteps(current: WorkflowStep[], requested: WorkflowStep[] | undefined): WorkflowStep[] {
+  if (!requested) return current;
+  const currentById = new Map(current.map((step) => [step.id, step]));
+  return requested.map((step) => {
+    const existing = currentById.get(step.id);
+    if (!existing) return step;
+    return {
+      ...existing,
+      ...step,
+      ...(step.triggerConfig === undefined ? { triggerConfig: existing.triggerConfig } : {}),
+    };
+  });
+}
+
+function contentTypeForStep(step: WorkflowStep | undefined): "prompt" | "script" {
+  return step?.type === "action" ? "script" : "prompt";
+}
+
+function mergeStepContent(
+  definition: AutomationDefinition,
+  steps: WorkflowStep[],
+  requested: Record<string, AutomationStepContentPatch> | undefined,
+): AutomationBuilderSaveRequest["stepContent"] {
+  const stepById = new Map(steps.map((step) => [step.id, step]));
+  const content = Object.fromEntries(
+    Object.entries(definition.stepContent).map(([stepId, value]) => [
+      stepId,
+      { ...value, taskId: definition.id, stepId },
+    ]),
+  ) as AutomationBuilderSaveRequest["stepContent"];
+
+  for (const [stepId, patch] of Object.entries(requested ?? {})) {
+    const current = content[stepId];
+    const step = stepById.get(stepId);
+    content[stepId] = {
+      taskId: definition.id,
+      stepId,
+      contentType: patch.contentType ?? current?.contentType ?? contentTypeForStep(step),
+      content: patch.content ?? current?.content ?? "",
+      apps: Object.prototype.hasOwnProperty.call(patch, "apps") ? (patch.apps ?? null) : (current?.apps ?? null),
+      ...(current?.updatedAt ? { updatedAt: current.updatedAt } : {}),
+    };
+  }
+
+  return content;
+}
+
+function applyDefinitionPatch(
+  definition: AutomationDefinition,
+  patch: AutomationDefinitionPatch,
+  expectedRevision: number,
+): AutomationBuilderSaveRequest {
+  let scheduleType = patch.scheduleType ?? definition.scheduleType;
+  let scheduleValue = patch.scheduleValue ?? definition.scheduleValue;
+  const timezone = patch.timezone ?? definition.timezone;
+  let steps = mergeSteps(definition.steps, patch.steps);
+  const trigger = steps.find((step) => step.type === "trigger")?.triggerConfig;
+
+  if (trigger?.type === "slack_channel_message") {
+    scheduleType = "external";
+    scheduleValue = "slack_channel_message";
+  } else if (trigger?.type === "canvas") {
+    scheduleType = "external";
+    scheduleValue = "canvas";
+  } else if (
+    (patch.scheduleType !== undefined || patch.scheduleValue !== undefined || patch.timezone !== undefined) &&
+    scheduleType !== "external" &&
+    trigger?.type === "schedule"
+  ) {
+    steps = normalizeScheduleTriggerSteps(steps, { scheduleType, scheduleValue, timezone });
+  }
+
+  const delivery = {
+    ...definition.delivery,
+    ...(patch.delivery?.platform === undefined ? {} : { platform: patch.delivery.platform }),
+    ...(patch.delivery?.targetType === undefined ? {} : { targetType: patch.delivery.targetType }),
+    ...(patch.delivery?.targetId === undefined ? {} : { targetId: patch.delivery.targetId }),
+    ...(Object.prototype.hasOwnProperty.call(patch.delivery ?? {}, "threadTs")
+      ? { threadTs: patch.delivery?.threadTs ?? null }
+      : {}),
+    ...(patch.delivery?.mode === undefined ? {} : { mode: patch.delivery.mode }),
+  };
+  const hasTitle = Object.prototype.hasOwnProperty.call(patch, "title");
+  const hasDescription = Object.prototype.hasOwnProperty.call(patch, "description");
+
+  return {
+    ...saveRequestFromDefinition(definition, expectedRevision),
+    expectedRevision,
+    title: hasTitle ? (patch.title ?? null) : definition.title,
+    description: hasDescription ? (patch.description ?? null) : definition.description,
+    prompt: patch.prompt ?? definition.prompt,
+    scheduleType,
+    scheduleValue,
+    timezone,
+    status: patch.status ?? definition.status,
+    delivery,
+    steps,
+    edges: patch.edges ?? definition.edges,
+    stepContent: mergeStepContent(definition, steps, patch.stepContent),
+  };
+}
+
+export async function getAutomationDefinition(params: {
+  db: Kysely<DB>;
+  taskId: string;
+}): Promise<AutomationDefinition | null> {
+  const row = await createScheduledTaskRepository(params.db).getById(params.taskId);
+  if (!row) return null;
+  const [stepContentRows, runRows] = await Promise.all([
+    createAutomationStepContentRepository(params.db).getByTask(params.taskId),
+    createAutomationRunsRepository(params.db).list(params.taskId),
+  ]);
+  return buildAutomationDefinition({ row, stepContentRows, runRows });
+}
+
+export async function updateAutomationDefinition(params: {
+  db: Kysely<DB>;
+  taskId: string;
+  patch: AutomationDefinitionPatch;
+  actor: AutomationEditActor;
+  brokerCapable: boolean;
+}): Promise<AutomationMutationResult> {
+  return params.db.transaction().execute(async (trx) => {
+    const current = await trx
+      .selectFrom("scheduled_tasks")
+      .selectAll()
+      .where("id", "=", params.taskId)
+      .executeTakeFirst();
+    if (!current) return { kind: "not_found" as const };
+    if (!params.actor.userId) return { kind: "access_denied" as const };
+    if (!params.actor.canManageAnyTask && current.created_by !== params.actor.userId) {
+      return { kind: "access_denied" as const };
+    }
+
+    const currentDefinition = buildAutomationDefinition({
+      row: current,
+      stepContentRows: await createAutomationStepContentRepository(trx).getByTask(params.taskId),
+      runRows: [],
+      normalizeScheduleTriggers: false,
+    });
+    const expectedRevision = params.patch.expectedRevision ?? current.revision;
+    if (current.revision !== expectedRevision) {
+      return { kind: "revision_conflict" as const, currentRevision: current.revision };
+    }
+    const request = validatedRequest(
+      applyDefinitionPatch(currentDefinition, params.patch, expectedRevision),
+      params.brokerCapable,
+    );
+
+    const updateResult = await trx
+      .updateTable("scheduled_tasks")
+      .set({
+        ...scheduledTaskFieldsFromSaveRequest(request),
+        revision: sql<number>`revision + 1`,
+        updated_at: sql<string>`CURRENT_TIMESTAMP`,
+        last_edited_by: params.actor.userId,
+      })
+      .where("id", "=", params.taskId)
+      .where("revision", "=", expectedRevision)
+      .executeTakeFirst();
+    if (Number(updateResult.numUpdatedRows ?? 0) === 0) {
+      const latest = await trx
+        .selectFrom("scheduled_tasks")
+        .select("revision")
+        .where("id", "=", params.taskId)
+        .executeTakeFirst();
+      if (!latest) return { kind: "not_found" as const };
+      return { kind: "revision_conflict" as const, currentRevision: latest.revision };
+    }
+
+    await replaceStepContent(trx, params.taskId, request);
+    const row = await trx
+      .selectFrom("scheduled_tasks")
+      .selectAll()
+      .where("id", "=", params.taskId)
+      .executeTakeFirstOrThrow();
+    return { kind: "saved" as const, row, request };
+  });
+}
+
 export async function createAutomationDefinition(params: {
   db: Kysely<DB>;
   request: AutomationBuilderSaveRequest;
@@ -94,8 +330,8 @@ export async function createAutomationDefinition(params: {
       delivery_target: params.context.deliveryTarget,
       thread_ts: params.context.threadTs,
       prompt: request.prompt,
-      schedule_type: request.scheduleType,
-      schedule_value: request.scheduleValue,
+      schedule_type: fields.schedule_type ?? request.scheduleType,
+      schedule_value: fields.schedule_value ?? request.scheduleValue,
       timezone: request.timezone,
       session_mode: "fresh",
       next_run_at: null,
@@ -142,7 +378,8 @@ export async function replaceAutomationDefinition(params: {
     if (!params.actor.userId || (!params.actor.canManageAnyTask && current.created_by !== params.actor.userId)) {
       return { kind: "not_found" as const };
     }
-    if (request.expectedRevision !== undefined && current.revision !== request.expectedRevision) {
+    const expectedRevision = request.expectedRevision ?? current.revision;
+    if (current.revision !== expectedRevision) {
       return { kind: "revision_conflict" as const, currentRevision: current.revision };
     }
 
@@ -155,9 +392,7 @@ export async function replaceAutomationDefinition(params: {
         last_edited_by: params.actor.userId,
       })
       .where("id", "=", params.taskId);
-    if (request.expectedRevision !== undefined) {
-      update = update.where("revision", "=", request.expectedRevision);
-    }
+    update = update.where("revision", "=", expectedRevision);
     const updateResult = await update.executeTakeFirst();
     if (Number(updateResult.numUpdatedRows ?? 0) === 0) {
       const latest = await trx

--- a/packages/server/src/scheduler/access.test.ts
+++ b/packages/server/src/scheduler/access.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { canAccessScheduledTask, resolveScheduledTaskAccess } from "./access";
+
+describe("scheduled task access", () => {
+  it("allows the owner and denies a different member", () => {
+    expect(canAccessScheduledTask("owner-1", { userId: "owner-1", role: "member" })).toBe(true);
+    expect(canAccessScheduledTask("owner-1", { userId: "member-1", role: "member" })).toBe(false);
+  });
+
+  it("allows an admin to resolve a foreign-owned task", () => {
+    const task = { id: "task-1", createdBy: "owner-1" };
+    expect(resolveScheduledTaskAccess(task, task.createdBy, { userId: "admin-1", role: "admin" })).toEqual(task);
+  });
+
+  it("fails closed for missing identity or task", () => {
+    const task = { id: "task-1", createdBy: "owner-1" };
+    expect(resolveScheduledTaskAccess(task, task.createdBy, { userId: null, role: "admin" })).toBeNull();
+    expect(resolveScheduledTaskAccess(null, null, { userId: "owner-1", role: "member" })).toBeNull();
+  });
+});

--- a/packages/server/src/scheduler/access.ts
+++ b/packages/server/src/scheduler/access.ts
@@ -1,0 +1,20 @@
+export interface ScheduledTaskAccessSubject {
+  userId: string | null;
+  role?: string;
+}
+
+export function canAccessScheduledTask(
+  ownerId: string | null | undefined,
+  subject: ScheduledTaskAccessSubject,
+): boolean {
+  if (!subject.userId) return false;
+  return subject.role === "admin" || ownerId === subject.userId;
+}
+
+export function resolveScheduledTaskAccess<T>(
+  task: T | null | undefined,
+  ownerId: string | null | undefined,
+  subject: ScheduledTaskAccessSubject,
+): T | null {
+  return task && canAccessScheduledTask(ownerId, subject) ? task : null;
+}

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -852,6 +852,7 @@ export class TaskScheduler {
       status: row.status as "active" | "paused" | "completed",
       createdBy: row.created_by,
       createdAt: row.created_at,
+      revision: row.revision,
       title: row.title,
       description: row.description,
       originChat:

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -373,7 +373,7 @@ describe("handleManageScheduledTasks — configured chat authoring", () => {
     expect(stepContentRepo.upsert).not.toHaveBeenCalled();
   });
 
-  it.each(["list", "remove", "pause", "resume", "run", "getRun", "share"] as const)(
+  it.each(["list", "get", "remove", "pause", "resume", "run", "getRun", "share"] as const)(
     "keeps %s deterministic without invoking the authorer",
     async (action) => {
       const scheduler = makeMockScheduler();
@@ -414,17 +414,6 @@ describe("handleManageScheduledTasks — configured chat authoring", () => {
     expect(result.content[0].text).toContain(expected);
     expect(automationArtifactCollector.collect).not.toHaveBeenCalled();
     expect(scheduler.addTask).not.toHaveBeenCalled();
-  });
-
-  it("preserves legacy add behavior when no authorer is configured", async () => {
-    const scheduler = makeMockScheduler();
-
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-
-    expect(scheduler.addTask).toHaveBeenCalledOnce();
   });
 });
 
@@ -509,403 +498,33 @@ describe("handleManageScheduledTasks — list", () => {
 });
 
 describe("handleManageScheduledTasks — add", () => {
-  it("returns error when prompt is missing", async () => {
+  it("returns an actionable error when prompt is missing", async () => {
     const scheduler = makeMockScheduler();
     const result = await handleManageScheduledTasks(
       { action: "add", schedule_type: "cron", schedule_value: "0 9 * * 1" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(result.content[0].text).toContain("Error:");
+    expect(result.content[0].text).toContain("prompt or steps are required");
     expect(scheduler.addTask).not.toHaveBeenCalled();
   });
 
-  it("returns error when schedule_type is missing", async () => {
-    const scheduler = makeMockScheduler();
-    const result = await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-    expect(result.content[0].text).toContain("Error:");
-  });
-
-  it("returns error when schedule_value is missing", async () => {
+  it("returns an actionable error when a schedule field is missing", async () => {
     const scheduler = makeMockScheduler();
     const result = await handleManageScheduledTasks(
       { action: "add", prompt: "Do it", schedule_type: "cron" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(result.content[0].text).toContain("Error:");
-  });
-
-  it("defaults session_mode to 'fresh' for DM context", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ sessionMode: "fresh" }));
-  });
-
-  it("defaults session_mode to 'fresh' for top-level channel context (no threadTs)", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: channelContext },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ sessionMode: "fresh" }));
-  });
-
-  it("defaults session_mode to 'fresh' for channel thread context", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ sessionMode: "fresh" }));
-  });
-
-  it("defaults session_mode to 'fresh' for WhatsApp group", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "interval", schedule_value: "3600" },
-      { scheduler, stepContentRepo, taskContext: whatsappGroupContext },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ sessionMode: "fresh" }));
-  });
-
-  it("uses creator's timezone when params.timezone is omitted", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      {
-        scheduler,
-        stepContentRepo,
-        taskContext: { ...dmContext, creatorTimezone: "Asia/Kolkata" },
-      },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ timezone: "Asia/Kolkata" }));
-  });
-
-  it("falls back to creator's timezone when params.timezone is an empty string", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1", timezone: "" },
-      {
-        scheduler,
-        stepContentRepo,
-        taskContext: { ...dmContext, creatorTimezone: "Asia/Kolkata" },
-      },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ timezone: "Asia/Kolkata" }));
-  });
-
-  it("falls back to UTC when both params.timezone and creatorTimezone are blank", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1", timezone: "   " },
-      {
-        scheduler,
-        stepContentRepo,
-        taskContext: { ...dmContext, creatorTimezone: "" },
-      },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ timezone: "UTC" }));
-  });
-
-  it("explicit params.timezone wins over creatorTimezone", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      {
-        action: "add",
-        prompt: "Do it",
-        schedule_type: "cron",
-        schedule_value: "0 9 * * 1",
-        timezone: "America/Los_Angeles",
-      },
-      {
-        scheduler,
-        stepContentRepo,
-        taskContext: { ...dmContext, creatorTimezone: "Asia/Kolkata" },
-      },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ timezone: "America/Los_Angeles" }));
-  });
-
-  it("rejects non-fresh session modes", async () => {
-    const scheduler = makeMockScheduler();
-    const result = await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1", session_mode: "chat" },
-      { scheduler, stepContentRepo, taskContext: channelContext },
-    );
-    expect(result.content[0].text).toContain("Error:");
-    expect(result.content[0].text).toContain("only 'fresh'");
+    expect(result.content[0].text).toContain("prompt, schedule_type, and schedule_value are required");
     expect(scheduler.addTask).not.toHaveBeenCalled();
   });
 
-  it("allows explicit 'fresh' session_mode for channel thread", async () => {
+  it("rejects non-fresh session modes before mutation", async () => {
     const scheduler = makeMockScheduler();
     const result = await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1", session_mode: "fresh" },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-    expect(result.content[0].text).not.toContain("Error:");
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ sessionMode: "fresh" }));
-  });
-
-  it("fills platform/contextType/deliveryTarget/createdBy from taskContext", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
+      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1", session_mode: "chat" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(scheduler.addTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        platform: "slack",
-        contextType: "dm",
-        deliveryTarget: "D123",
-        createdBy: "U123",
-      }),
-    );
-  });
-
-  it("passes threadTs from taskContext when in a thread", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ threadTs: "1234567890.123456" }));
-  });
-
-  it("does not default workflow delivery to the current Slack thread", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ outputThreadTs: undefined }));
-  });
-
-  it("supports explicit delivery to the current Slack thread", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      {
-        action: "add",
-        prompt: "Do it",
-        schedule_type: "cron",
-        schedule_value: "0 9 * * 1",
-        delivery: { targetType: "thread" },
-      },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ outputThreadTs: "1234567890.123456" }));
-  });
-
-  it("creates simple prompt automations as Sketch-mode agent steps", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-
-    const addTaskCall = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    const stepsJson = JSON.parse(addTaskCall.steps);
-    expect(stepsJson.find((step: { id: string }) => step.id === "step1")).toEqual(
-      expect.objectContaining({ type: "agent", agentMode: "sketch" }),
-    );
-  });
-
-  it("returns created task in response", async () => {
-    const task = makeTask({ id: "new-task" });
-    const scheduler = makeMockScheduler({ addTask: vi.fn().mockResolvedValue(task) });
-    const result = await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-    expect(result.content[0].text).toContain("new-task");
-    expect(result.content[0].text).toContain("Automation created:");
-  });
-
-  it("collects structured automation artifacts for successful adds", async () => {
-    const task = makeTask({ id: "new-task", title: "Daily account brief", prompt: "Daily account brief" });
-    const scheduler = makeMockScheduler({ addTask: vi.fn().mockResolvedValue(task) });
-    const automationArtifactCollector = {
-      collect: vi.fn(),
-      drain: vi.fn(),
-    } as unknown as NonNullable<Parameters<typeof handleManageScheduledTasks>[1]["automationArtifactCollector"]>;
-    const result = await handleManageScheduledTasks(
-      { action: "add", prompt: "Daily account brief", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      {
-        scheduler,
-        stepContentRepo,
-        taskContext: dmContext,
-        automationArtifactCollector,
-      },
-    );
-
-    expect(result.content[0].text).not.toContain("builderUrl");
-    expect(automationArtifactCollector.collect).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: "new-task",
-        title: "Daily account brief",
-        builderUrl: "http://localhost:3000/scheduled-tasks/new-task/edit",
-        status: "active",
-      }),
-    );
-  });
-
-  it("passes origin chat metadata when creating automations", async () => {
-    const scheduler = makeMockScheduler({ addTask: vi.fn().mockResolvedValue(makeTask({ id: "origin-task" })) });
-    await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it", schedule_type: "cron", schedule_value: "0 9 * * 1" },
-      {
-        scheduler,
-        stepContentRepo,
-        taskContext: {
-          ...dmContext,
-          origin: { platform: "web", conversationId: "chat-alpha", providerThreadId: null, currentMessageId: null },
-        },
-      },
-    );
-
-    expect(scheduler.addTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        originPlatform: "web",
-        originConversationId: "chat-alpha",
-        originProviderThreadId: null,
-      }),
-    );
-  });
-
-  it("persists agent step prompts via stepContentRepo for multi-step workflows", async () => {
-    const localRepo = makeMockStepContentRepo();
-    const scheduler = makeMockScheduler({ addTask: vi.fn().mockResolvedValue(makeTask({ id: "wf-1" })) });
-    const result = await handleManageScheduledTasks(
-      {
-        action: "add",
-        title: "Hourly summary",
-        schedule_type: "cron",
-        schedule_value: "0 * * * *",
-        steps: [
-          {
-            id: "trigger",
-            type: "trigger",
-            label: "Hourly",
-            icon: "clock",
-            position: { x: 0, y: 0 },
-            triggerConfig: { type: "schedule" },
-          },
-          {
-            id: "agent1",
-            type: "agent",
-            label: "Summarize",
-            icon: "sketch-ai",
-            position: { x: 0, y: 100 },
-            agentPrompt: "Summarize the previous step output into a digest.",
-          },
-        ],
-      },
-      { scheduler, stepContentRepo: localRepo, taskContext: dmContext },
-    );
-    expect(result.content[0].text).toContain("Automation created:");
-    expect(localRepo.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: "wf-1",
-        stepId: "agent1",
-        contentType: "prompt",
-        content: "Summarize the previous step output into a digest.",
-      }),
-    );
-    // Steps JSON passed to scheduler.addTask must not contain agentPrompt (stripped)
-    const addTaskCall = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    const stepsJson = JSON.parse(addTaskCall.steps);
-    const agentStep = stepsJson.find((s: { id: string }) => s.id === "agent1");
-    expect(agentStep.agentPrompt).toBeUndefined();
-  });
-
-  it("creates Canvas-managed trigger workflows without requiring a local schedule", async () => {
-    const localRepo = makeMockStepContentRepo();
-    const scheduler = makeMockScheduler({ addTask: vi.fn().mockResolvedValue(makeTask({ id: "wf-canvas" })) });
-    const result = await handleManageScheduledTasks(
-      {
-        action: "add",
-        title: "New ClickUp issues",
-        steps: [
-          {
-            id: "trigger",
-            type: "trigger",
-            label: "ClickUp issue created",
-            icon: "clickup",
-            position: { x: 0, y: 0 },
-            triggerConfig: {
-              type: "canvas",
-              app: "clickup",
-              eventDescription: "new issue created",
-              componentKey: "clickup.issue.created",
-            },
-          },
-          {
-            id: "agent1",
-            type: "agent",
-            label: "Handle issue",
-            icon: "sketch-ai",
-            position: { x: 0, y: 100 },
-            agentPrompt: "Handle the incoming issue.",
-          },
-        ],
-      },
-      { scheduler, stepContentRepo: localRepo, taskContext: dmContext },
-    );
-
-    expect(result.content[0].text).toContain("Automation created:");
-    expect(scheduler.addTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scheduleType: "external",
-        scheduleValue: "canvas",
-      }),
-    );
-    const addTaskCall = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    const stepsJson = JSON.parse(addTaskCall.steps);
-    expect(stepsJson[0].triggerConfig).toEqual(
-      expect.objectContaining({
-        type: "canvas",
-        status: "pending_canvas_setup",
-      }),
-    );
-  });
-
-  it("fails loudly when multi-step workflow is created without stepContentRepo", async () => {
-    const scheduler = makeMockScheduler();
-    const result = await handleManageScheduledTasks(
-      {
-        action: "add",
-        title: "No repo",
-        schedule_type: "cron",
-        schedule_value: "0 * * * *",
-        steps: [
-          {
-            id: "trigger",
-            type: "trigger",
-            label: "Hourly",
-            icon: "clock",
-            position: { x: 0, y: 0 },
-            triggerConfig: { type: "schedule" },
-          },
-          {
-            id: "agent1",
-            type: "agent",
-            label: "Summarize",
-            icon: "sketch-ai",
-            position: { x: 0, y: 100 },
-            agentPrompt: "Summarize.",
-          },
-        ],
-      },
-      { scheduler, taskContext: dmContext },
-    );
-    expect(result.content[0].text).toContain("Error: step content storage is not available");
+    expect(result.content[0].text).toContain("only 'fresh'");
     expect(scheduler.addTask).not.toHaveBeenCalled();
   });
 });
@@ -992,392 +611,39 @@ describe("handleManageScheduledTasks — broker-capability gate", () => {
     expect(localRepo.upsert).not.toHaveBeenCalled();
     expect(localRepo.deleteOrphanedSteps).not.toHaveBeenCalled();
   });
-
-  it("rejects workflow graphs with fan-out before creating a task", async () => {
-    const scheduler = makeMockScheduler();
-    const result = await handleManageScheduledTasks(
-      {
-        action: "add",
-        title: "Fan out",
-        schedule_type: "cron",
-        schedule_value: "0 9 * * 1",
-        steps: [
-          {
-            id: "trigger",
-            type: "trigger",
-            label: "Schedule",
-            icon: "clock",
-            position: { x: 0, y: 0 },
-            triggerConfig: { type: "schedule" },
-          },
-          {
-            id: "agent1",
-            type: "agent",
-            label: "First",
-            icon: "sketch-ai",
-            position: { x: 0, y: 100 },
-            agentPrompt: "First prompt.",
-          },
-          {
-            id: "agent2",
-            type: "agent",
-            label: "Second",
-            icon: "sketch-ai",
-            position: { x: 0, y: 200 },
-            agentPrompt: "Second prompt.",
-          },
-        ],
-        edges: [
-          { id: "trigger-agent1", from: "trigger", to: "agent1" },
-          { id: "trigger-agent2", from: "trigger", to: "agent2" },
-        ],
-      },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-
-    expect(result.content[0].text).toContain("FAN_OUT_UNSUPPORTED");
-    expect(scheduler.addTask).not.toHaveBeenCalled();
-  });
 });
 
 describe("handleManageScheduledTasks — update", () => {
-  it("returns error when task_id is missing", async () => {
+  it("returns an error when task_id is missing", async () => {
     const scheduler = makeMockScheduler();
     const result = await handleManageScheduledTasks(
       { action: "update", prompt: "New prompt" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(result.content[0].text).toContain("Error:");
+    expect(result.content[0].text).toContain("task_id is required");
     expect(scheduler.updateTask).not.toHaveBeenCalled();
   });
 
-  it("returns error when task not found", async () => {
-    const scheduler = makeMockScheduler({ updateTask: vi.fn().mockResolvedValue(null) });
+  it("returns a distinct not-found error before canonical mutation", async () => {
+    const scheduler = makeMockScheduler({ getTaskById: vi.fn().mockResolvedValue(null) });
     const result = await handleManageScheduledTasks(
       { action: "update", task_id: "nonexistent", prompt: "New prompt" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(result.content[0].text).toContain("Error:");
-    expect(result.content[0].text).toContain("nonexistent");
-  });
-
-  it("calls scheduler.updateTask with provided fields", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      { action: "update", task_id: "task-1", prompt: "Updated", schedule_value: "0 10 * * 1" },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-    expect(scheduler.updateTask).toHaveBeenCalledWith("task-1", {
-      prompt: "Updated",
-      scheduleType: undefined,
-      scheduleValue: "0 10 * * 1",
-      timezone: undefined,
-      sessionMode: undefined,
-    });
-  });
-
-  it("syncs stored schedule trigger metadata when only schedule fields are updated", async () => {
-    const scheduler = makeMockScheduler({
-      getTaskById: vi.fn().mockResolvedValue(
-        makeTask({
-          scheduleType: "cron",
-          scheduleValue: "*/5 * * * *",
-          timezone: "UTC",
-          steps: JSON.stringify([
-            {
-              id: "trigger",
-              type: "trigger",
-              label: "Every 5 minutes",
-              icon: "clock",
-              position: { x: 0, y: 0 },
-              triggerConfig: {
-                type: "schedule",
-                scheduleType: "cron",
-                scheduleValue: "*/5 * * * *",
-                timezone: "UTC",
-              },
-            },
-            {
-              id: "agent1",
-              type: "agent",
-              label: "Check inbox",
-              icon: "sketch-ai",
-              position: { x: 0, y: 100 },
-            },
-          ]),
-        }),
-      ),
-    });
-
-    await handleManageScheduledTasks(
-      { action: "update", task_id: "task-1", schedule_value: "*/10 * * * *" },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-
-    const updateFields = (scheduler.updateTask as ReturnType<typeof vi.fn>).mock.calls[0][1] as { steps: string };
-    const stepsJson = JSON.parse(updateFields.steps);
-    expect(stepsJson[0].label).toBe("Every 10 minutes");
-    expect(stepsJson[0].triggerConfig).toEqual(
-      expect.objectContaining({
-        type: "schedule",
-        scheduleType: "cron",
-        scheduleValue: "*/10 * * * *",
-        timezone: "UTC",
-      }),
-    );
-  });
-
-  it("can clear Slack thread delivery without changing the channel target", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      {
-        action: "update",
-        task_id: "task-1",
-        delivery: { platform: "slack", targetType: "channel", targetId: "C456", threadTs: null },
-      },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-
-    expect(scheduler.updateTask).toHaveBeenCalledWith(
-      "task-1",
-      expect.objectContaining({
-        outputPlatform: "slack",
-        outputTarget: "C456",
-        outputThreadTs: null,
-      }),
-    );
-  });
-
-  it("clears Slack thread delivery when retargeting to a channel", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      {
-        action: "update",
-        task_id: "task-1",
-        delivery: { platform: "slack", targetType: "channel", targetId: "COPS" },
-      },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-
-    expect(scheduler.updateTask).toHaveBeenCalledWith(
-      "task-1",
-      expect.objectContaining({
-        outputPlatform: "slack",
-        outputTarget: "COPS",
-        outputThreadTs: null,
-      }),
-    );
-  });
-
-  it("does not clear Slack thread delivery for mode-only delivery updates", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      {
-        action: "update",
-        task_id: "task-1",
-        delivery: { mode: "silent" },
-      },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-
-    expect(scheduler.updateTask).toHaveBeenCalledWith(
-      "task-1",
-      expect.objectContaining({
-        outputMode: "silent",
-      }),
-    );
-    expect((scheduler.updateTask as ReturnType<typeof vi.fn>).mock.calls[0][1]).not.toHaveProperty("outputThreadTs");
-  });
-
-  it("sets the current channel target when updating delivery to the current thread", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      {
-        action: "update",
-        task_id: "task-1",
-        delivery: { targetType: "thread" },
-      },
-      { scheduler, stepContentRepo, taskContext: channelThreadContext },
-    );
-
-    expect(scheduler.updateTask).toHaveBeenCalledWith(
-      "task-1",
-      expect.objectContaining({
-        outputPlatform: "slack",
-        outputTarget: "C456",
-        outputThreadTs: "1234567890.123456",
-      }),
-    );
-  });
-
-  it("normalizes schedule fields when updating steps to a Canvas-managed trigger", async () => {
-    const scheduler = makeMockScheduler();
-    await handleManageScheduledTasks(
-      {
-        action: "update",
-        task_id: "task-1",
-        steps: [
-          {
-            id: "trigger",
-            type: "trigger",
-            label: "Linear issue created",
-            icon: "linear",
-            position: { x: 0, y: 0 },
-            triggerConfig: {
-              type: "canvas",
-              app: "linear",
-              eventDescription: "new issue created",
-              componentKey: "linear.issue.created",
-            },
-          },
-          {
-            id: "agent1",
-            type: "agent",
-            label: "Handle issue",
-            icon: "sketch-ai",
-            position: { x: 0, y: 100 },
-            agentPrompt: "Handle the issue.",
-          },
-        ],
-      },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-
-    expect(scheduler.updateTask).toHaveBeenCalledWith(
-      "task-1",
-      expect.objectContaining({
-        scheduleType: "external",
-        scheduleValue: "canvas",
-      }),
-    );
-    const updateFields = (scheduler.updateTask as ReturnType<typeof vi.fn>).mock.calls[0][1] as { steps: string };
-    const stepsJson = JSON.parse(updateFields.steps);
-    expect(stepsJson[0].triggerConfig).toEqual(
-      expect.objectContaining({
-        type: "canvas",
-        status: "pending_canvas_setup",
-      }),
-    );
-  });
-
-  it("preserves existing edges and step content when updating step metadata only", async () => {
-    const existingSteps = [
-      {
-        id: "trigger",
-        type: "trigger" as const,
-        label: "Every weekday",
-        icon: "clock",
-        position: { x: 0, y: 0 },
-        triggerConfig: {
-          type: "schedule" as const,
-          scheduleType: "cron" as const,
-          scheduleValue: "0 9 * * 1-5",
-          timezone: "UTC",
-        },
-      },
-      {
-        id: "agent1",
-        type: "agent" as const,
-        label: "Check inbox",
-        icon: "sketch-ai",
-        position: { x: 260, y: 0 },
-      },
-    ];
-    const existingEdges = [{ id: "trigger-agent1", from: "trigger", to: "agent1" }];
-    const scheduler = makeMockScheduler({
-      getTaskById: vi.fn().mockResolvedValue(
-        makeTask({
-          steps: JSON.stringify(existingSteps),
-          edges: JSON.stringify(existingEdges),
-          outputPlatform: "slack",
-          outputTarget: "D123",
-        }),
-      ),
-    });
-    const localRepo = makeMockStepContentRepo();
-    vi.mocked(localRepo.getByTask).mockResolvedValue([
-      {
-        task_id: "task-1",
-        step_id: "agent1",
-        content_type: "prompt",
-        content: "Summarize the inbox",
-        apps: null,
-        updated_at: "2026-06-01T00:00:00.000Z",
-      },
-    ]);
-
-    await handleManageScheduledTasks(
-      {
-        action: "update",
-        task_id: "task-1",
-        steps: [
-          existingSteps[0],
-          {
-            ...existingSteps[1],
-            label: "Check priority inbox",
-            position: { x: 300, y: 20 },
-          },
-        ],
-      },
-      { scheduler, stepContentRepo: localRepo, taskContext: dmContext },
-    );
-
-    expect(localRepo.deleteOrphanedSteps).toHaveBeenCalledWith("task-1", ["trigger", "agent1"]);
-    expect(localRepo.upsert).not.toHaveBeenCalled();
-    expect(scheduler.updateTask).toHaveBeenCalledWith(
-      "task-1",
-      expect.not.objectContaining({
-        edges: expect.any(String),
-      }),
-    );
-    const updateFields = (scheduler.updateTask as ReturnType<typeof vi.fn>).mock.calls[0][1] as { steps: string };
-    expect(JSON.parse(updateFields.steps)[1]).toMatchObject({
-      id: "agent1",
-      label: "Check priority inbox",
-      position: { x: 300, y: 20 },
-    });
-  });
-
-  it("rejects step updates whose trigger metadata does not match the schedule", async () => {
-    const scheduler = makeMockScheduler();
-    const result = await handleManageScheduledTasks(
-      {
-        action: "update",
-        task_id: "task-1",
-        steps: [
-          {
-            id: "trigger",
-            type: "trigger",
-            label: "Webhook",
-            icon: "webhook",
-            position: { x: 0, y: 0 },
-            triggerConfig: { type: "webhook" },
-          },
-          {
-            id: "agent1",
-            type: "agent",
-            label: "Check inbox",
-            icon: "sketch-ai",
-            position: { x: 0, y: 100 },
-            agentPrompt: "Check inbox.",
-          },
-        ],
-      },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-
-    expect(result.content[0].text).toContain("TRIGGER_CONFIG_MISMATCH");
+    expect(result.content[0].text).toBe("Error: task not found.");
     expect(scheduler.updateTask).not.toHaveBeenCalled();
   });
+});
 
-  it("returns updated task in response", async () => {
-    const task = makeTask({ prompt: "Updated" });
-    const scheduler = makeMockScheduler({ updateTask: vi.fn().mockResolvedValue(task) });
+describe("handleManageScheduledTasks — updateStepContent", () => {
+  it("requires a task and step content", async () => {
+    const scheduler = makeMockScheduler();
     const result = await handleManageScheduledTasks(
-      { action: "update", task_id: "task-1", prompt: "Updated" },
+      { action: "updateStepContent", task_id: "task-1", step_id: "step1" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(result.content[0].text).toContain("Automation updated:");
+    expect(result.content[0].text).toContain("step_id and step_content are required");
+    expect(scheduler.touchTaskRevision).not.toHaveBeenCalled();
   });
 });
 
@@ -1454,36 +720,6 @@ describe("handleManageScheduledTasks — resume", () => {
     );
     expect(scheduler.resumeTask).toHaveBeenCalledWith("task-1");
     expect(result.content[0].text).toContain("resumed");
-  });
-});
-
-describe("handleManageScheduledTasks — updateStepContent", () => {
-  it("updates step content and bumps the task revision", async () => {
-    const scheduler = makeMockScheduler();
-    const localRepo = makeMockStepContentRepo();
-    vi.mocked(localRepo.getByStep).mockResolvedValue({
-      task_id: "task-1",
-      step_id: "step1",
-      content_type: "prompt",
-      content: "old prompt",
-      apps: null,
-      updated_at: "2026-06-01T00:00:00.000Z",
-    });
-
-    const result = await handleManageScheduledTasks(
-      { action: "updateStepContent", task_id: "task-1", step_id: "step1", step_content: "new prompt" },
-      { scheduler, stepContentRepo: localRepo, taskContext: dmContext },
-    );
-
-    expect(localRepo.upsert).toHaveBeenCalledWith({
-      taskId: "task-1",
-      stepId: "step1",
-      contentType: "prompt",
-      content: "new prompt",
-      apps: null,
-    });
-    expect(scheduler.touchTaskRevision).toHaveBeenCalledWith("task-1");
-    expect(result.content[0].text).toContain("content updated");
   });
 });
 
@@ -1598,19 +834,6 @@ describe("handleManageScheduledTasks — run history", () => {
 });
 
 describe("handleManageScheduledTasks — add with once schedule type", () => {
-  it("succeeds with a valid future ISO datetime", async () => {
-    const futureDate = new Date(Date.now() + 3_600_000).toISOString();
-    const task = makeTask({ scheduleType: "once", scheduleValue: futureDate });
-    const scheduler = makeMockScheduler({ addTask: vi.fn().mockResolvedValue(task) });
-    const result = await handleManageScheduledTasks(
-      { action: "add", prompt: "Do it once", schedule_type: "once", schedule_value: futureDate },
-      { scheduler, stepContentRepo, taskContext: dmContext },
-    );
-    expect(result.content[0].text).not.toContain("Error:");
-    expect(result.content[0].text).toContain("Automation created:");
-    expect(scheduler.addTask).toHaveBeenCalledWith(expect.objectContaining({ scheduleType: "once" }));
-  });
-
   it("returns validation error for a past datetime", async () => {
     const pastDate = new Date(Date.now() - 3_600_000).toISOString();
     const scheduler = makeMockScheduler();
@@ -1618,18 +841,16 @@ describe("handleManageScheduledTasks — add with once schedule type", () => {
       { action: "add", prompt: "Too late", schedule_type: "once", schedule_value: pastDate },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(result.content[0].text).toContain("Error:");
     expect(result.content[0].text).toContain("past");
     expect(scheduler.addTask).not.toHaveBeenCalled();
   });
 
-  it("returns validation error for an invalid (non-ISO) string", async () => {
+  it("returns validation error for an invalid datetime", async () => {
     const scheduler = makeMockScheduler();
     const result = await handleManageScheduledTasks(
       { action: "add", prompt: "Bad date", schedule_type: "once", schedule_value: "not-a-date" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(result.content[0].text).toContain("Error:");
     expect(result.content[0].text).toContain("ISO 8601");
     expect(scheduler.addTask).not.toHaveBeenCalled();
   });
@@ -1638,6 +859,7 @@ describe("handleManageScheduledTasks — add with once schedule type", () => {
 describe("handleManageScheduledTasks — ownership", () => {
   const GUARDED_ACTIONS = [
     "update",
+    "get",
     "remove",
     "pause",
     "resume",
@@ -1669,7 +891,7 @@ describe("handleManageScheduledTasks — ownership", () => {
       });
 
       expect(result.content[0].text).toBe(
-        `Error: You can't ${action === "remove" ? "delete" : action === "getRun" ? "inspect" : action === "updateStepContent" ? "update" : action} "Do a thing" because it was created by Roopak.`,
+        `Error: You can't ${action === "remove" ? "delete" : action === "getRun" || action === "get" ? "inspect" : action === "updateStepContent" ? "update" : action} "Do a thing" because it was created by Roopak.`,
       );
       expect(scheduler.updateTask).not.toHaveBeenCalled();
       expect(scheduler.removeTask).not.toHaveBeenCalled();
@@ -1692,21 +914,6 @@ describe("handleManageScheduledTasks — ownership", () => {
       expect(result.content[0].text).toBe("Error: task not found.");
     });
   }
-
-  it("allows guarded actions when the context can manage any task", async () => {
-    const otherUsersTask = makeTask({ createdBy: "U_OTHER" });
-    const scheduler = makeMockScheduler({
-      getTaskById: vi.fn().mockResolvedValue(otherUsersTask),
-    });
-
-    const result = await handleManageScheduledTasks(
-      { action: "update", task_id: "task-1", prompt: "Admin update" },
-      { scheduler, stepContentRepo, taskContext: { ...dmContext, canManageAnyTask: true } },
-    );
-
-    expect(scheduler.updateTask).toHaveBeenCalledWith("task-1", expect.objectContaining({ prompt: "Admin update" }));
-    expect(result.content[0].text).toContain("Automation updated:");
-  });
 
   it("returns the canonical URL for an automation the member owns", async () => {
     const scheduler = makeMockScheduler();

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -12,8 +12,7 @@ import {
   AutomationAuthoringValidationError,
 } from "../automation/authoring/service";
 import type { TaskScheduler } from "./service";
-import type { ScheduledTask } from "./types";
-import type { TaskContext } from "./types";
+import type { CurrentAutomation, ScheduledTask, TaskContext } from "./types";
 
 function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   return {
@@ -32,6 +31,7 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     status: "active",
     createdBy: "U123",
     createdAt: "2025-01-01T00:00:00.000Z",
+    revision: 0,
     title: null,
     description: null,
     originChat: null,
@@ -49,6 +49,29 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
       mode: "deliver",
     },
     ...overrides,
+  };
+}
+
+function makeCurrentAutomation(
+  overrides: Partial<Pick<CurrentAutomation, "taskId" | "revision">> = {},
+): CurrentAutomation {
+  return {
+    taskId: overrides.taskId ?? "task-1",
+    revision: overrides.revision ?? 4,
+    builderConversationId: "builder-1",
+    builderState: {
+      title: "Do a thing",
+      description: null,
+      prompt: "Do a thing",
+      scheduleType: "cron",
+      scheduleValue: "0 9 * * 1-5",
+      timezone: "UTC",
+      status: "active",
+      delivery: makeTask().delivery,
+      steps: [],
+      edges: [],
+      stepContent: {},
+    },
   };
 }
 
@@ -216,6 +239,48 @@ describe("handleManageScheduledTasks — configured chat authoring", () => {
       taskContext: dmContext,
     });
     expect(scheduler.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("uses the ambient current automation for an implicit natural-language edit", async () => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = {
+      author: vi.fn().mockResolvedValue({ kind: "clarification", message: "Which filter?" }),
+    };
+    const currentAutomation = makeCurrentAutomation();
+
+    await handleManageScheduledTasks(
+      { action: "update", request: "Make this stricter" },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring, currentAutomation },
+    );
+
+    expect(scheduler.getTaskById).not.toHaveBeenCalled();
+    expect(chatAuthoring.author).toHaveBeenCalledWith({
+      action: "edit",
+      request: "Make this stricter",
+      taskId: "task-1",
+      taskContext: dmContext,
+      currentAutomation,
+    });
+  });
+
+  it("lets an explicit accessible task override ambient builder context", async () => {
+    const scheduler = makeMockScheduler();
+    const chatAuthoring = {
+      author: vi.fn().mockResolvedValue({ kind: "clarification", message: "Which filter?" }),
+    };
+    const currentAutomation = makeCurrentAutomation();
+
+    await handleManageScheduledTasks(
+      { action: "update", task_id: "task-2", request: "Make the other one stricter" },
+      { scheduler, stepContentRepo, taskContext: dmContext, chatAuthoring, currentAutomation },
+    );
+
+    expect(chatAuthoring.author).toHaveBeenCalledWith({
+      action: "edit",
+      request: "Make the other one stricter",
+      taskId: "task-2",
+      taskContext: dmContext,
+    });
   });
 
   it("reports invalid generated output separately from provider unavailability", async () => {
@@ -404,6 +469,20 @@ describe("handleManageScheduledTasks — list", () => {
       { scheduler, stepContentRepo, taskContext: { ...dmContext, canManageAnyTask: true } },
     );
     expect(scheduler.listTasks).toHaveBeenCalledWith({ includeInactive: true });
+  });
+
+  it("keeps explicit list behavior when ambient builder context exists", async () => {
+    const scheduler = makeMockScheduler();
+    await handleManageScheduledTasks(
+      { action: "list" },
+      {
+        scheduler,
+        stepContentRepo,
+        taskContext: dmContext,
+        currentAutomation: makeCurrentAutomation(),
+      },
+    );
+    expect(scheduler.listTasks).toHaveBeenCalledWith({ createdBy: "U123" });
   });
 
   it("fails closed when listing without an authenticated creator", async () => {

--- a/packages/server/src/scheduler/types.ts
+++ b/packages/server/src/scheduler/types.ts
@@ -7,6 +7,7 @@
  * delivery metadata without requiring the agent to supply it explicitly.
  */
 
+import type { WorkflowEdge, WorkflowStep } from "@sketch/shared";
 import type { WorkflowDelivery } from "../workflows/delivery";
 
 export interface ScheduledTask {
@@ -25,6 +26,7 @@ export interface ScheduledTask {
   status: "active" | "paused" | "completed";
   createdBy: string | null;
   createdAt: string;
+  revision: number;
   title: string | null;
   description: string | null;
   originChat: TaskOriginChat | null;
@@ -35,6 +37,39 @@ export interface ScheduledTask {
   outputThreadTs: string | null;
   outputMode: "deliver" | "silent";
   delivery: WorkflowDelivery;
+}
+
+export interface CurrentAutomationBuilderState {
+  title: string | null;
+  description: string | null;
+  prompt: string;
+  scheduleType: ScheduledTask["scheduleType"];
+  scheduleValue: string;
+  timezone: string;
+  status: ScheduledTask["status"];
+  delivery: WorkflowDelivery;
+  steps: WorkflowStep[];
+  edges: WorkflowEdge[];
+  stepContent: Record<
+    string,
+    {
+      contentType: "prompt" | "script";
+      content: string;
+      apps: string[] | null;
+    }
+  >;
+}
+
+/**
+ * Request-scoped builder alignment created only after the current task passed
+ * the normal owner/admin access check. The builder state is deliberately
+ * bounded; persisted task data remains authoritative for edits.
+ */
+export interface CurrentAutomation {
+  taskId: string;
+  revision: number;
+  builderConversationId: string;
+  builderState: CurrentAutomationBuilderState;
 }
 
 export interface TaskOriginChat {
@@ -57,4 +92,5 @@ export interface TaskContext {
   threadTs?: string;
   origin?: TaskOriginChat;
   canManageAnyTask?: boolean;
+  currentAutomation?: CurrentAutomation;
 }

--- a/packages/server/src/workflows/delivery.ts
+++ b/packages/server/src/workflows/delivery.ts
@@ -38,7 +38,8 @@ function inferTargetType(
     return targetId.endsWith("@g.us") ? "group" : "dm";
   }
   if (threadTs) return "thread";
-  if (fallbackContextType === "dm" || isSlackDmChannelId(targetId) || isSlackUserId(targetId)) return "dm";
+  if (isSlackDmChannelId(targetId) || isSlackUserId(targetId)) return "dm";
+  if (fallbackContextType === "dm" && !targetId.startsWith("C")) return "dm";
   return "channel";
 }
 


### PR DESCRIPTION
## Summary

- bind automation edits to the current access-checked task with structured task, revision, conversation, time, and bounded builder context
- route configured authoring and direct structured mutations through the same canonical validation and persistence authority
- enforce expected-revision CAS, atomic task/step-content writes, broker capability, ownership checks, audit identity, and scheduler refresh

## Linear Scope

- [SKE-330: Bind current automation context and canonicalize mutations](https://linear.app/sketch-ai/issue/SKE-330/bind-current-automation-context-and-canonicalize-mutations)

## Stack

- 1 of 7 in the automation hardening stack
- base: `main`
- review and merge this PR first; the remaining PRs target the preceding feature branch through GitHub's stacked PR flow

## Implementation Details

- resolve the current automation once at the authenticated boundary and pass a structured, access-checked snapshot into direct and configured authoring paths
- keep `AUTOMATION_AUTHORING_MODEL` and its semantic-compiler role while hardening its handoff with revision, conversation identity, current time/timezone, and bounded state
- preserve explicit cross-automation targeting and list/search behavior without treating ambient context as hard scope
- canonicalize partial edits so omitted fields survive, task and step content commit atomically, stale writers fail with revision conflicts, and scheduler state refreshes only after persistence
- use the actual integration-broker capability for authoring and direct structured mutations

## Verification

- Node 24 `pnpm biome check .` — passed
- `pnpm typecheck` — passed
- `pnpm test` — passed; server 4,905 passed / 20 skipped, web 437 passed
- `pnpm build` — passed
- Node 24 pre-push gate — passed on the complete stack
- `git diff --check` and stacked ancestry checks — passed

## Risk / Rollout

- no provider removal, configuration change, feature-flag change, deployment, or release
- mutation conflicts now fail closed instead of allowing last-writer-wins updates
- server-side access, validation, and persistence remain authoritative; model-provided IDs and stale prompt snapshots are not trusted
