### PR TITLE
SKE-331: Persist task-scoped automation chat provenance

### DIFF
--- a/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
@@ -1,10 +1,15 @@
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
+import { sql } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAutomationDefinition, getAutomationDefinition } from "../../automation/persistence";
+import { createAutomationRunsRepository } from "../../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../../db/repositories/automation-step-content";
+import { createScheduledTaskConversationRepository } from "../../db/repositories/scheduled-task-conversations";
 import { createScheduledTaskRepository } from "../../db/repositories/scheduled-tasks";
+import type { TaskScheduler } from "../../scheduler/service";
 import { createTestDb } from "../../test-utils";
 import { handleManageScheduledTasks } from "./scheduled-tasks";
+import { AutomationArtifactCollector } from "./types";
 
 function definition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
   return {
@@ -142,6 +147,19 @@ function taskContextFor(
   };
 }
 
+function normalWebChatContext(conversationId: string, createdBy = "owner-1") {
+  return {
+    ...taskContextFor("web-chat-task", createdBy),
+    conversationKind: "web_chat" as const,
+    origin: {
+      platform: "web" as const,
+      conversationId,
+      providerThreadId: null,
+      currentMessageId: null,
+    },
+  };
+}
+
 function currentAutomationFor(taskId: string, revision: number) {
   const current = definition();
   return {
@@ -215,6 +233,8 @@ function schedulerFor(taskId: string, createdBy = "owner-1") {
   return {
     getTaskById: vi.fn().mockResolvedValue(task),
     refreshTaskSchedule: vi.fn().mockImplementation(async (id: string) => ({ ...task, id })),
+    removeTask: vi.fn(),
+    removeTaskRuntime: vi.fn().mockResolvedValue(true),
     addTask: vi.fn(),
     updateTask: vi.fn(),
   } as never;
@@ -1071,6 +1091,180 @@ describe("ManageScheduledTasks canonical structured mutations", () => {
     expect(stale.content[0].text).toContain("revision conflict");
   });
 
+  it("records normal web-chat create provenance and embeds the source conversation in the artifact URL", async () => {
+    const automationArtifactCollector = new AutomationArtifactCollector();
+    const collectArtifact = vi.spyOn(automationArtifactCollector, "collect");
+    const result = await handleManageScheduledTasks(
+      {
+        action: "add",
+        prompt: "Send a daily account brief",
+        schedule_type: "interval",
+        schedule_value: "120",
+      },
+      {
+        db,
+        scheduler: schedulerFor("created-task"),
+        taskContext: normalWebChatContext("normal-chat-1"),
+        config: { BASE_URL: "https://sketch.example", PORT: 3000 },
+        automationArtifactCollector,
+      },
+    );
+
+    expect(result.content[0].text).toContain("Automation created:");
+    const task = (await createScheduledTaskRepository(db).listAll())[0];
+    expect(task).toBeDefined();
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskAndTranscriptUser(task.id, "owner-1", {
+        kind: "web_chat",
+      }),
+    ).resolves.toEqual([expect.objectContaining({ conversation_id: "normal-chat-1", kind: "web_chat" })]);
+    expect(collectArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.id,
+        builderUrl: `https://sketch.example/scheduled-tasks/${task.id}/edit?conversationId=normal-chat-1`,
+      }),
+    );
+  });
+
+  it("retains many-to-many task/chat provenance across direct updates and step-content updates", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: { ...context("many-task-a"), originConversationId: "creation-chat" },
+      brokerCapable: true,
+    });
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: { ...context("many-task-b"), originConversationId: "creation-chat" },
+      brokerCapable: true,
+    });
+
+    await handleManageScheduledTasks(
+      { action: "update", task_id: "many-task-a", prompt: "First chat edit", expected_revision: 0 },
+      { db, scheduler: schedulerFor("many-task-a"), taskContext: normalWebChatContext("chat-one") },
+    );
+    await handleManageScheduledTasks(
+      { action: "update", task_id: "many-task-b", prompt: "First chat edit", expected_revision: 0 },
+      { db, scheduler: schedulerFor("many-task-b"), taskContext: normalWebChatContext("chat-one") },
+    );
+    await handleManageScheduledTasks(
+      { action: "update", task_id: "many-task-a", prompt: "Second chat edit", expected_revision: 1 },
+      { db, scheduler: schedulerFor("many-task-a"), taskContext: normalWebChatContext("chat-two") },
+    );
+    await handleManageScheduledTasks(
+      { action: "update", task_id: "many-task-a", prompt: "Repeat first chat edit", expected_revision: 2 },
+      { db, scheduler: schedulerFor("many-task-a"), taskContext: normalWebChatContext("chat-one") },
+    );
+    await handleManageScheduledTasks(
+      {
+        action: "updateStepContent",
+        task_id: "many-task-a",
+        step_id: "agent",
+        step_content: "Apply the third chat's wording.",
+        expected_revision: 3,
+      },
+      { db, scheduler: schedulerFor("many-task-a"), taskContext: normalWebChatContext("chat-three") },
+    );
+
+    const conversations = createScheduledTaskConversationRepository(db);
+    await expect(
+      conversations.listByTaskAndTranscriptUser("many-task-a", "owner-1", { kind: "web_chat" }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ conversation_id: "chat-one" }),
+        expect.objectContaining({ conversation_id: "chat-two" }),
+        expect.objectContaining({ conversation_id: "chat-three" }),
+      ]),
+    );
+    await expect(
+      conversations.listByTaskAndTranscriptUser("many-task-a", "owner-1", { kind: "web_chat" }),
+    ).resolves.toHaveLength(3);
+    await expect(
+      conversations.listByTaskAndTranscriptUser("many-task-b", "owner-1", { kind: "web_chat" }),
+    ).resolves.toEqual([expect.objectContaining({ conversation_id: "chat-one" })]);
+    await expect(createScheduledTaskRepository(db).getById("many-task-a")).resolves.toMatchObject({
+      origin_conversation_id: "creation-chat",
+      revision: 4,
+    });
+  });
+
+  it("does not associate validation, access, or revision failures", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("failure-task"),
+      brokerCapable: true,
+    });
+
+    const invalid = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "failure-task",
+        schedule_type: "interval",
+        schedule_value: "30",
+        expected_revision: 0,
+      },
+      { db, scheduler: schedulerFor("failure-task"), taskContext: normalWebChatContext("invalid-chat") },
+    );
+    expect(invalid.content[0].text).toContain("automation definition is invalid");
+
+    const denied = await handleManageScheduledTasks(
+      { action: "update", task_id: "failure-task", prompt: "Denied", expected_revision: 0 },
+      {
+        db,
+        scheduler: schedulerFor("failure-task"),
+        taskContext: normalWebChatContext("denied-chat", "member-1"),
+      },
+    );
+    expect(denied.content[0].text).toContain("created by");
+
+    const saved = await handleManageScheduledTasks(
+      { action: "update", task_id: "failure-task", prompt: "First edit", expected_revision: 0 },
+      { db, scheduler: schedulerFor("failure-task"), taskContext: normalWebChatContext("successful-chat") },
+    );
+    expect(saved.content[0].text).toContain("Automation updated:");
+    const conflict = await handleManageScheduledTasks(
+      { action: "update", task_id: "failure-task", prompt: "Stale edit", expected_revision: 0 },
+      { db, scheduler: schedulerFor("failure-task"), taskContext: normalWebChatContext("stale-chat") },
+    );
+    expect(conflict.content[0].text).toContain("revision conflict");
+
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskAndTranscriptUser("failure-task", "owner-1", {
+        kind: "web_chat",
+      }),
+    ).resolves.toEqual([expect.objectContaining({ conversation_id: "successful-chat" })]);
+  });
+
+  it("rolls back the canonical mutation and emits no artifact when provenance persistence fails", async () => {
+    await sql`
+      CREATE TRIGGER reject_web_chat_provenance
+      BEFORE INSERT ON scheduled_task_conversations
+      WHEN NEW.conversation_id = 'failing-chat'
+      BEGIN
+        SELECT RAISE(FAIL, 'provenance rejected');
+      END
+    `.execute(db);
+
+    const automationArtifactCollector = new AutomationArtifactCollector();
+    const collectArtifact = vi.spyOn(automationArtifactCollector, "collect");
+    await expect(
+      handleManageScheduledTasks(
+        { action: "add", prompt: "This must not partially save", schedule_type: "interval", schedule_value: "120" },
+        {
+          db,
+          scheduler: schedulerFor("failed-provenance-task"),
+          taskContext: normalWebChatContext("failing-chat"),
+          automationArtifactCollector,
+        },
+      ),
+    ).rejects.toThrow("provenance rejected");
+
+    await expect(createScheduledTaskRepository(db).listAll()).resolves.toEqual([]);
+    expect(collectArtifact).not.toHaveBeenCalled();
+  });
+
   it("uses the ambient revision for an explicit same-task update and rejects a stale race", async () => {
     await createAutomationDefinition({
       db,
@@ -1238,5 +1432,60 @@ describe("ManageScheduledTasks canonical structured mutations", () => {
       prompt: "Second explicit edit",
       revision: 2,
     });
+  });
+
+  it("deletes task data through the canonical service and only removes runtime state after commit", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("remove-task"),
+      brokerCapable: true,
+    });
+    const runId = await createAutomationRunsRepository(db).create({ taskId: "remove-task" });
+    await createScheduledTaskConversationRepository(db).upsert({
+      taskId: "remove-task",
+      conversationId: "builder-remove",
+      transcriptUserId: "owner-1",
+      kind: "builder",
+    });
+    const scheduler = schedulerFor("remove-task");
+
+    const result = await handleManageScheduledTasks(
+      { action: "remove", task_id: "remove-task" },
+      { db, scheduler, taskContext: taskContextFor("remove-task") },
+    );
+
+    expect(result.content[0].text).toBe("Automation remove-task removed.");
+    await expect(createScheduledTaskRepository(db).getById("remove-task")).resolves.toBeUndefined();
+    await expect(createAutomationStepContentRepository(db).getByTask("remove-task")).resolves.toEqual([]);
+    await expect(createAutomationRunsRepository(db).getById(runId)).resolves.toBeUndefined();
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskConversation("remove-task", "builder-remove"),
+    ).resolves.toEqual([]);
+    expect((scheduler as { removeTask: ReturnType<typeof vi.fn> }).removeTask).not.toHaveBeenCalled();
+    expect((scheduler as { removeTaskRuntime: ReturnType<typeof vi.fn> }).removeTaskRuntime).toHaveBeenCalledWith(
+      "remove-task",
+    );
+  });
+
+  it("reports runtime cleanup failure after structured deletion commits", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("remove-runtime-failure"),
+      brokerCapable: true,
+    });
+    const removeTaskRuntime = vi.fn().mockResolvedValue(false);
+    const scheduler = schedulerFor("remove-runtime-failure") as unknown as TaskScheduler;
+    (scheduler as unknown as { removeTaskRuntime: ReturnType<typeof vi.fn> }).removeTaskRuntime = removeTaskRuntime;
+
+    const result = await handleManageScheduledTasks(
+      { action: "remove", task_id: "remove-runtime-failure" },
+      { db, scheduler, taskContext: taskContextFor("remove-runtime-failure") },
+    );
+
+    expect(result.content[0].text).toContain("Runtime state is inconsistent");
+    await expect(createScheduledTaskRepository(db).getById("remove-runtime-failure")).resolves.toBeUndefined();
+    expect(removeTaskRuntime).toHaveBeenCalledWith("remove-runtime-failure");
   });
 });

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -8,9 +8,11 @@ import { AutomationValidationError } from "../../automation/definition";
 import {
   type AutomationDefinitionPatch,
   createAutomationDefinition,
+  deleteAutomation,
   getAutomationDefinition,
   updateAutomationDefinition,
 } from "../../automation/persistence";
+import { webChatTaskConversationAssociation } from "../../automation/task-conversations";
 import type { createAutomationRunsRepository } from "../../db/repositories/automation-runs";
 import type { createAutomationStepContentRepository } from "../../db/repositories/automation-step-content";
 import type { DB } from "../../db/schema";
@@ -503,10 +505,13 @@ function displayPlatform(value: string): string {
   return value === "whatsapp" ? "WhatsApp" : "Slack";
 }
 
-function buildBuilderUrl(taskId: string, config: ManageScheduledTasksDeps["config"]): string {
+function buildBuilderUrl(taskId: string, config: ManageScheduledTasksDeps["config"], conversationId?: string): string {
   const path = `/scheduled-tasks/${encodeURIComponent(taskId)}/edit`;
   const base = config?.BASE_URL?.replace(/\/$/, "") ?? `http://localhost:${config?.PORT ?? 3000}`;
-  return `${base}${path}`;
+  const conversationQuery = conversationId?.trim()
+    ? `?conversationId=${encodeURIComponent(conversationId.trim())}`
+    : "";
+  return `${base}${path}${conversationQuery}`;
 }
 
 /**
@@ -568,7 +573,9 @@ function collectAutomationArtifact(params: {
   scheduleValue: string;
   timezone: string;
 }): string {
-  const builderUrl = buildBuilderUrl(params.task.id, params.deps.config);
+  const sourceConversationId =
+    params.deps.taskContext.origin?.platform === "web" ? params.deps.taskContext.origin.conversationId : undefined;
+  const builderUrl = buildBuilderUrl(params.task.id, params.deps.config, sourceConversationId);
   const delivery = params.task.delivery;
   const deliveryLabel =
     delivery.mode === "silent"
@@ -693,6 +700,7 @@ export async function handleManageScheduledTasks(
   const { action } = params;
   const ctx = deps.taskContext;
   const currentAutomation = deps.currentAutomation ?? ctx.currentAutomation;
+  const taskConversationAssociation = webChatTaskConversationAssociation(ctx);
   const explicitTaskId = params.task_id?.trim() || undefined;
   const task_id =
     explicitTaskId ?? (action === "update" || action === "updateStepContent" ? currentAutomation?.taskId : undefined);
@@ -965,6 +973,7 @@ export async function handleManageScheduledTasks(
             originMessageId: ctx.origin?.currentMessageId ?? null,
           },
           brokerCapable: await getBrokerCapabilitySnapshot(),
+          ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
         });
       } catch (error) {
         if (error instanceof AutomationValidationError) {
@@ -1043,6 +1052,7 @@ export async function handleManageScheduledTasks(
             canManageAnyTask: ctx.canManageAnyTask ?? false,
           },
           brokerCapable: await getBrokerCapabilitySnapshot(),
+          ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
         });
       } catch (error) {
         if (error instanceof AutomationValidationError) {
@@ -1090,13 +1100,25 @@ export async function handleManageScheduledTasks(
       if (!task_id) {
         return text("Error: task_id is required for remove action.");
       }
-      // Cascade delete step content and runs
-      if (deps.stepContentRepo) await deps.stepContentRepo.deleteByTaskId(task_id);
-      if (deps.automationRunsRepo) await deps.automationRunsRepo.deleteByTaskId(task_id);
-
-      const removed = await deps.scheduler.removeTask(task_id);
-      if (!removed) {
-        return text(`Error: task ${task_id} not found.`);
+      if (!deps.db) {
+        return text("Error: canonical automation persistence is not available in this context. No changes were saved.");
+      }
+      const deletion = await deleteAutomation({
+        db: deps.db,
+        taskId: task_id,
+        actor: {
+          userId: ctx.createdBy,
+          canManageAnyTask: ctx.canManageAnyTask ?? false,
+        },
+        scheduler: { removeTaskRuntime: (id) => deps.scheduler.removeTaskRuntime(id) },
+      });
+      if (deletion.kind === "not_found") return text(`Error: task ${task_id} not found.`);
+      if (deletion.kind === "access_denied")
+        return text(`Error: you do not have permission to delete task ${task_id}.`);
+      if (deletion.kind === "scheduler_failure") {
+        return text(
+          `Error: automation ${task_id} was deleted, but scheduler cleanup failed. Runtime state is inconsistent.`,
+        );
       }
       return text(`Automation ${task_id} removed.`);
     }
@@ -1206,6 +1228,7 @@ export async function handleManageScheduledTasks(
             canManageAnyTask: ctx.canManageAnyTask ?? false,
           },
           brokerCapable: await getBrokerCapabilitySnapshot(),
+          ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
         });
       } catch (error) {
         if (error instanceof AutomationValidationError) {

--- a/packages/server/src/api/scheduled-task-conversations.test.ts
+++ b/packages/server/src/api/scheduled-task-conversations.test.ts
@@ -1,0 +1,227 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { signJwt } from "../auth/jwt";
+import { hashPassword } from "../auth/password";
+import { createAutomationTaskConversationService } from "../automation/task-conversations";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestDb } from "../test-utils";
+
+const config = createTestConfig();
+
+async function seedAdmin(db: Kysely<DB>) {
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  await settings.create();
+  const admin = await users.create({
+    name: "Admin",
+    email: "admin-conversations@test.com",
+    emailVerified: true,
+    passwordHash: await hashPassword("testpassword123"),
+    authRole: "admin",
+  });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+  return admin;
+}
+
+async function loginAdmin(app: ReturnType<typeof createApp>): Promise<string> {
+  const response = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "admin-conversations@test.com", password: "testpassword123" }),
+  });
+  return response.headers.get("set-cookie") ?? "";
+}
+
+async function memberCookie(db: Kysely<DB>, userId: string): Promise<string> {
+  const settings = createSettingsRepository(db);
+  const row = await settings.get();
+  if (!row?.jwt_secret) throw new Error("JWT secret not found");
+  return `sketch_session=${await signJwt(userId, "member", row.jwt_secret)}`;
+}
+
+async function seedTask(db: Kysely<DB>, id: string, createdBy: string) {
+  await createScheduledTaskRepository(db).add({
+    id,
+    platform: "slack",
+    context_type: "dm",
+    delivery_target: "D123",
+    thread_ts: null,
+    prompt: "Summarize the task",
+    schedule_type: "cron",
+    schedule_value: "0 9 * * *",
+    timezone: "UTC",
+    session_mode: "fresh",
+    created_by: createdBy,
+    status: "active",
+    next_run_at: null,
+  });
+}
+
+describe("scheduled task conversation API", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("creates one stable builder association, supports new chats, and archives without deleting", async () => {
+    const admin = await seedAdmin(db);
+    const member = await createUserRepository(db).create({ name: "Member", email: "member-conversations@test.com" });
+    await seedTask(db, "task-conversations", member.id);
+
+    const app = createApp(db, config, {
+      scheduler: {
+        pauseTask: vi.fn(),
+        resumeTask: vi.fn(),
+        removeTask: vi.fn(),
+        executeTaskById: vi.fn(),
+      },
+    });
+    const cookie = await memberCookie(db, member.id);
+
+    const first = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
+      method: "POST",
+      headers: { Cookie: cookie },
+    });
+    expect(first.status).toBe(201);
+    const firstBody = await first.json();
+    const firstConversationId = firstBody.conversation.conversationId;
+    expect(firstConversationId).toMatch(/^builder-/);
+
+    const refresh = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
+      method: "POST",
+      headers: { Cookie: cookie },
+    });
+    expect(refresh.status).toBe(200);
+    expect((await refresh.json()).conversation.conversationId).toBe(firstConversationId);
+
+    const second = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ createNew: true }),
+    });
+    expect(second.status).toBe(201);
+    const secondConversationId = (await second.json()).conversation.conversationId;
+    expect(secondConversationId).not.toBe(firstConversationId);
+
+    const list = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
+      headers: { Cookie: cookie },
+    });
+    expect(list.status).toBe(200);
+    expect((await list.json()).conversations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ conversationId: firstConversationId, state: "active" }),
+        expect.objectContaining({ conversationId: secondConversationId, state: "active" }),
+      ]),
+    );
+
+    const archive = await app.request(`/api/scheduled-tasks/task-conversations/conversations/${firstConversationId}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: true }),
+    });
+    expect(archive.status).toBe(200);
+    expect((await archive.json()).conversation).toMatchObject({
+      conversationId: firstConversationId,
+      state: "archived",
+    });
+
+    const activeList = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
+      headers: { Cookie: cookie },
+    });
+    expect((await activeList.json()).conversations).toEqual([
+      expect.objectContaining({ conversationId: secondConversationId, state: "active" }),
+    ]);
+
+    const historicalList = await app.request(
+      "/api/scheduled-tasks/task-conversations/conversations?includeArchived=true",
+      { headers: { Cookie: cookie } },
+    );
+    expect((await historicalList.json()).conversations).toEqual(
+      expect.arrayContaining([expect.objectContaining({ conversationId: firstConversationId, state: "archived" })]),
+    );
+
+    await expect(
+      db.selectFrom("scheduled_task_conversations").selectAll().where("task_id", "=", "task-conversations").execute(),
+    ).resolves.toHaveLength(2);
+    expect(admin.id).not.toBe(member.id);
+  });
+
+  it("keeps foreign-owner transcripts out of admin task navigation", async () => {
+    const admin = await seedAdmin(db);
+    const owner = await createUserRepository(db).create({ name: "Owner", email: "owner-conversations@test.com" });
+    const member = await createUserRepository(db).create({ name: "Member", email: "member-two@test.com" });
+    await seedTask(db, "foreign-task", owner.id);
+    await createAutomationTaskConversationService(db).associate({
+      taskId: "foreign-task",
+      conversationId: "owner-private-chat",
+      transcriptUserId: owner.id,
+      kind: "builder",
+    });
+
+    const app = createApp(db, config, {
+      scheduler: {
+        pauseTask: vi.fn(),
+        resumeTask: vi.fn(),
+        removeTask: vi.fn(),
+        executeTaskById: vi.fn(),
+      },
+    });
+    const adminCookie = await loginAdmin(app);
+    const adminList = await app.request("/api/scheduled-tasks/foreign-task/conversations", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(adminList.status).toBe(200);
+    await expect(adminList.json()).resolves.toMatchObject({ conversations: [], transcriptAccess: "viewer" });
+
+    const adminDetail = await app.request("/api/scheduled-tasks/foreign-task/conversations/owner-private-chat", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(adminDetail.status).toBe(404);
+    await expect(adminDetail.json()).resolves.toMatchObject({
+      error: { code: "CONVERSATION_NOT_FOUND" },
+    });
+
+    const memberResponse = await app.request("/api/scheduled-tasks/foreign-task/conversations", {
+      headers: { Cookie: await memberCookie(db, member.id) },
+    });
+    expect(memberResponse.status).toBe(404);
+    expect(admin.id).not.toBe(owner.id);
+  });
+
+  it("rejects unrelated or malformed selections without creating associations", async () => {
+    const admin = await seedAdmin(db);
+    await seedTask(db, "safe-task", admin.id);
+    const app = createApp(db, config, {
+      scheduler: {
+        pauseTask: vi.fn(),
+        resumeTask: vi.fn(),
+        removeTask: vi.fn(),
+        executeTaskById: vi.fn(),
+      },
+    });
+    const cookie = await loginAdmin(app);
+
+    const malformed = await app.request("/api/scheduled-tasks/safe-task/conversations/has%20space", {
+      headers: { Cookie: cookie },
+    });
+    expect(malformed.status).toBe(400);
+
+    const unrelated = await app.request("/api/scheduled-tasks/safe-task/conversations/not-associated", {
+      headers: { Cookie: cookie },
+    });
+    expect(unrelated.status).toBe(404);
+
+    await expect(
+      db.selectFrom("scheduled_task_conversations").selectAll().where("task_id", "=", "safe-task").execute(),
+    ).resolves.toEqual([]);
+  });
+});

--- a/packages/server/src/api/scheduled-task-conversations.ts
+++ b/packages/server/src/api/scheduled-task-conversations.ts
@@ -1,0 +1,222 @@
+import type { Context } from "hono";
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import type { Logger } from "pino";
+import { createAutomationTaskConversationService } from "../automation/task-conversations";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { resolveScheduledTaskAccess } from "../scheduler/access";
+
+const CONVERSATION_ID_RE = /^[A-Za-z0-9_-]{1,80}$/;
+const CONVERSATION_KINDS = new Set(["builder", "web_chat"]);
+
+interface ScheduledTaskConversationRouteOptions {
+  logger?: Logger;
+}
+
+function errorResponse(c: Context, code: string, message: string, status: 400 | 403 | 404 | 409) {
+  return c.json({ error: { code, message } }, status);
+}
+
+function parseConversationId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const conversationId = value.trim();
+  return CONVERSATION_ID_RE.test(conversationId) ? conversationId : null;
+}
+
+function parseKind(value: unknown): "builder" | "web_chat" | null {
+  if (typeof value !== "string" || !CONVERSATION_KINDS.has(value)) return null;
+  return value as "builder" | "web_chat";
+}
+
+async function resolveUserId(db: Kysely<DB>, subject: string | undefined): Promise<string | null> {
+  if (!subject) return null;
+  const users = createUserRepository(db);
+  if (subject.includes("@")) {
+    const user = await users.findByEmail(subject);
+    return user?.id ?? null;
+  }
+  const user = await users.findById(subject);
+  return user?.id ?? null;
+}
+
+/**
+ * Exposes task-scoped conversation association metadata without exposing
+ * transcript content. Clients must use the returned conversation ID with the
+ * existing viewer-scoped web-chat transcript endpoint.
+ */
+export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: ScheduledTaskConversationRouteOptions = {}) {
+  const routes = new Hono();
+  const tasks = createScheduledTaskRepository(db);
+  const conversations = createAutomationTaskConversationService(db);
+
+  async function loadAccessibleTask(c: Context, taskId: string) {
+    const row = await tasks.getById(taskId);
+    if (!row) {
+      return { response: errorResponse(c, "NOT_FOUND", "Scheduled task not found", 404) };
+    }
+
+    const userId = await resolveUserId(db, c.get("sub"));
+    const accessibleTask = resolveScheduledTaskAccess(row, row.created_by, {
+      userId,
+      role: c.get("role"),
+    });
+    if (!accessibleTask) {
+      options.logger?.warn({ taskId, userId, ownerUserId: row.created_by }, "task-conversations: task access denied");
+      return { response: errorResponse(c, "NOT_FOUND", "Scheduled task not found", 404) };
+    }
+
+    return { row: accessibleTask, userId };
+  }
+
+  async function readBody(c: Context): Promise<Record<string, unknown>> {
+    const body = await c.req.json().catch(() => ({}));
+    return typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
+  }
+
+  routes.get("/:id/conversations", async (c) => {
+    const taskId = c.req.param("id");
+    const access = await loadAccessibleTask(c, taskId);
+    if ("response" in access) return access.response;
+    if (!access.userId) return errorResponse(c, "TRANSCRIPT_ACCESS_DENIED", "Transcript access is viewer-scoped", 403);
+
+    const includeArchived = c.req.query("includeArchived") === "true";
+    const taskConversations = await conversations.listForTranscriptUser(taskId, access.userId, { includeArchived });
+    return c.json({ taskId, conversations: taskConversations, transcriptAccess: "viewer" as const });
+  });
+
+  routes.post("/:id/conversations", async (c) => {
+    const taskId = c.req.param("id");
+    const access = await loadAccessibleTask(c, taskId);
+    if ("response" in access) return access.response;
+    if (!access.userId) return errorResponse(c, "TRANSCRIPT_ACCESS_DENIED", "Transcript access is viewer-scoped", 403);
+
+    const body = await readBody(c);
+    const requestedConversationId =
+      body.conversationId === undefined ? undefined : parseConversationId(body.conversationId);
+    if (requestedConversationId === null) {
+      return errorResponse(c, "VALIDATION_ERROR", "Conversation id is invalid", 400);
+    }
+    const kind = body.kind === undefined ? "builder" : parseKind(body.kind);
+    if (!kind) return errorResponse(c, "VALIDATION_ERROR", "Conversation kind is invalid", 400);
+
+    if (kind === "web_chat" && !requestedConversationId) {
+      return errorResponse(c, "VALIDATION_ERROR", "A web chat conversation id is required", 400);
+    }
+
+    let result: { association: Awaited<ReturnType<typeof conversations.associate>>; created: boolean };
+    if (kind === "builder" && !requestedConversationId && body.createNew !== true) {
+      result = await conversations.getOrCreateBuilderConversation(taskId, access.userId);
+    } else if (kind === "builder") {
+      const existing = requestedConversationId
+        ? await conversations.getForTranscriptUser(taskId, requestedConversationId, access.userId, {
+            includeArchived: true,
+          })
+        : undefined;
+      result = await conversations.createBuilderConversation(taskId, access.userId, requestedConversationId);
+      result.created = !existing;
+    } else {
+      const existing = await conversations.getForTranscriptUser(
+        taskId,
+        requestedConversationId as string,
+        access.userId,
+        {
+          includeArchived: true,
+        },
+      );
+      result = {
+        association: await conversations.associate({
+          taskId,
+          conversationId: requestedConversationId as string,
+          transcriptUserId: access.userId,
+          kind,
+        }),
+        created: !existing,
+      };
+    }
+
+    const summary = await conversations.getForTranscriptUser(
+      taskId,
+      result.association.conversation_id,
+      access.userId,
+      { includeArchived: true },
+    );
+    if (!summary) {
+      return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation association was not persisted", 409);
+    }
+
+    const response = { conversation: summary, created: result.created };
+    return result.created ? c.json(response, 201) : c.json(response);
+  });
+
+  routes.get("/:id/conversations/:conversationId", async (c) => {
+    const taskId = c.req.param("id");
+    const conversationId = parseConversationId(c.req.param("conversationId"));
+    if (!conversationId) return errorResponse(c, "VALIDATION_ERROR", "Conversation id is invalid", 400);
+
+    const access = await loadAccessibleTask(c, taskId);
+    if ("response" in access) return access.response;
+    if (!access.userId) return errorResponse(c, "TRANSCRIPT_ACCESS_DENIED", "Transcript access is viewer-scoped", 403);
+
+    const summary = await conversations.getForTranscriptUser(taskId, conversationId, access.userId, {
+      includeArchived: true,
+    });
+    if (!summary)
+      return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation is not associated with this task", 404);
+    return c.json({ conversation: summary });
+  });
+
+  routes.put("/:id/conversations/:conversationId", async (c) => {
+    const taskId = c.req.param("id");
+    const conversationId = parseConversationId(c.req.param("conversationId"));
+    if (!conversationId) return errorResponse(c, "VALIDATION_ERROR", "Conversation id is invalid", 400);
+
+    const access = await loadAccessibleTask(c, taskId);
+    if ("response" in access) return access.response;
+    if (!access.userId) return errorResponse(c, "TRANSCRIPT_ACCESS_DENIED", "Transcript access is viewer-scoped", 403);
+
+    const body = await readBody(c);
+    const kind = body.kind === undefined ? "builder" : parseKind(body.kind);
+    if (!kind) return errorResponse(c, "VALIDATION_ERROR", "Conversation kind is invalid", 400);
+
+    const existing = await conversations.getForTranscriptUser(taskId, conversationId, access.userId, {
+      includeArchived: true,
+    });
+    await conversations.associate({
+      taskId,
+      conversationId,
+      transcriptUserId: access.userId,
+      kind,
+    });
+    const summary = await conversations.getForTranscriptUser(taskId, conversationId, access.userId, {
+      includeArchived: true,
+    });
+    if (!summary) return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation association was not persisted", 409);
+
+    const response = { conversation: summary, created: !existing };
+    return existing ? c.json(response) : c.json(response, 201);
+  });
+
+  routes.patch("/:id/conversations/:conversationId", async (c) => {
+    const taskId = c.req.param("id");
+    const conversationId = parseConversationId(c.req.param("conversationId"));
+    if (!conversationId) return errorResponse(c, "VALIDATION_ERROR", "Conversation id is invalid", 400);
+
+    const access = await loadAccessibleTask(c, taskId);
+    if ("response" in access) return access.response;
+    if (!access.userId) return errorResponse(c, "TRANSCRIPT_ACCESS_DENIED", "Transcript access is viewer-scoped", 403);
+
+    const body = await readBody(c);
+    if (typeof body.archived !== "boolean") {
+      return errorResponse(c, "VALIDATION_ERROR", "archived must be a boolean", 400);
+    }
+
+    const summary = await conversations.archiveForTranscriptUser(taskId, conversationId, access.userId, body.archived);
+    if (!summary)
+      return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation is not associated with this task", 404);
+    return c.json({ conversation: summary });
+  });
+
+  return routes;
+}

--- a/packages/server/src/api/scheduled-tasks.test.ts
+++ b/packages/server/src/api/scheduled-tasks.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { signJwt } from "../auth/jwt";
 import { hashPassword } from "../auth/password";
 import * as automationRunsModule from "../db/repositories/automation-runs";
+import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
 import { createConversationRepository } from "../db/repositories/conversations";
+import { createScheduledTaskConversationRepository } from "../db/repositories/scheduled-task-conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
@@ -1201,11 +1203,19 @@ describe("Scheduled Tasks API", () => {
       status: "active",
       next_run_at: null,
     });
+    await createAutomationRunsRepository(db).create({ taskId: "task-delete" });
+    await createScheduledTaskConversationRepository(db).upsert({
+      taskId: "task-delete",
+      conversationId: "builder-delete",
+      transcriptUserId: alice.id,
+      kind: "builder",
+    });
 
     const scheduler = {
       pauseTask: vi.fn(),
       resumeTask: vi.fn(),
-      removeTask: vi.fn(async (id: string) => tasks.remove(id)),
+      removeTask: vi.fn(),
+      removeTaskRuntime: vi.fn().mockResolvedValue(true),
       executeTaskById: vi.fn(),
     };
     const app = createApp(db, config, { scheduler });
@@ -1218,5 +1228,64 @@ describe("Scheduled Tasks API", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
     await expect(tasks.getById("task-delete")).resolves.toBeUndefined();
+    await expect(createAutomationRunsRepository(db).list("task-delete")).resolves.toEqual([]);
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskConversation("task-delete", "builder-delete"),
+    ).resolves.toEqual([]);
+    expect(scheduler.removeTaskRuntime).toHaveBeenCalledWith("task-delete");
+  });
+
+  it("surfaces runtime cleanup failure after committing API deletion", async () => {
+    await seedAdmin(db);
+    const users = createUserRepository(db);
+    const tasks = createScheduledTaskRepository(db);
+    const alice = await users.create({ name: "Alice", email: "alice@test.com" });
+    for (const id of ["task-delete-false", "task-delete-throw"]) {
+      await tasks.add({
+        id,
+        platform: "whatsapp",
+        context_type: "dm",
+        delivery_target: "alice@s.whatsapp.net",
+        thread_ts: null,
+        prompt: "Delete me",
+        schedule_type: "interval",
+        schedule_value: "3600",
+        timezone: "UTC",
+        session_mode: "fresh",
+        created_by: alice.id,
+        status: "active",
+        next_run_at: null,
+      });
+    }
+
+    const scheduler = {
+      pauseTask: vi.fn(),
+      resumeTask: vi.fn(),
+      removeTask: vi.fn(),
+      removeTaskRuntime: vi.fn().mockResolvedValueOnce(false).mockRejectedValueOnce(new Error("runtime unavailable")),
+      executeTaskById: vi.fn(),
+    };
+    const app = createApp(db, config, { scheduler });
+    const cookie = await loginAdmin(app);
+
+    const falseResponse = await app.request("/api/scheduled-tasks/task-delete-false", {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+    expect(falseResponse.status).toBe(503);
+    await expect(falseResponse.json()).resolves.toMatchObject({
+      error: { code: "SCHEDULER_INCONSISTENT" },
+    });
+    await expect(tasks.getById("task-delete-false")).resolves.toBeUndefined();
+
+    const thrownResponse = await app.request("/api/scheduled-tasks/task-delete-throw", {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+    expect(thrownResponse.status).toBe(503);
+    await expect(thrownResponse.json()).resolves.toMatchObject({
+      error: { code: "SCHEDULER_INCONSISTENT" },
+    });
+    await expect(tasks.getById("task-delete-throw")).resolves.toBeUndefined();
   });
 });

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -6,7 +6,7 @@ import {
   buildAutomationDefinition,
   parseAutomationBuilderSaveRequest,
 } from "../automation/definition";
-import { replaceAutomationDefinition } from "../automation/persistence";
+import { deleteAutomation, replaceAutomationDefinition } from "../automation/persistence";
 import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
 import { createChannelRepository } from "../db/repositories/channels";
@@ -28,6 +28,7 @@ interface ScheduledTaskMutationDeps {
   pauseTask: (id: string) => Promise<void>;
   resumeTask: (id: string) => Promise<void>;
   removeTask: (id: string) => Promise<boolean>;
+  removeTaskRuntime?: (id: string) => Promise<boolean>;
   executeTaskById: (id: string) => Promise<unknown>;
   refreshTaskSchedule?: (id: string) => Promise<unknown>;
   executeStepById?: (
@@ -595,16 +596,39 @@ export function scheduledTaskRoutes(
 
   routes.delete("/:id", async (c) => {
     const id = c.req.param("id");
-    const result = await loadAccessibleTask(c, id);
-    if ("response" in result) return result.response;
-
-    // Cascade delete runs and step content
-    const runsRepo2 = createAutomationRunsRepository(db);
-    const stepContentRepo = createAutomationStepContentRepository(db);
-    await runsRepo2.deleteByTaskId(id);
-    await stepContentRepo.deleteByTaskId(id);
-
-    await scheduler.removeTask(id);
+    const access = await loadAccessibleTask(c, id);
+    if ("response" in access) return access.response;
+    if (!scheduler.removeTaskRuntime) {
+      return c.json(
+        { error: { code: "SCHEDULER_UNAVAILABLE", message: "Scheduler runtime cleanup is unavailable" } },
+        503,
+      );
+    }
+    const userId = await resolveUserId(c.get("sub"));
+    const deletion = await deleteAutomation({
+      db,
+      taskId: id,
+      actor: { userId, canManageAnyTask: c.get("role") === "admin" },
+      scheduler: { removeTaskRuntime: scheduler.removeTaskRuntime },
+    });
+    if (deletion.kind === "not_found" || deletion.kind === "access_denied") {
+      return c.json({ error: { code: "NOT_FOUND", message: "Scheduled task not found" } }, 404);
+    }
+    if (deletion.kind === "scheduler_failure") {
+      logger?.error(
+        { err: deletion.error, taskId: id },
+        "scheduled-tasks: database deletion committed before scheduler failure",
+      );
+      return c.json(
+        {
+          error: {
+            code: "SCHEDULER_INCONSISTENT",
+            message: "Automation was deleted from the database, but scheduler cleanup failed.",
+          },
+        },
+        503,
+      );
+    }
     return c.json({ success: true });
   });
 

--- a/packages/server/src/api/web-chat.test.ts
+++ b/packages/server/src/api/web-chat.test.ts
@@ -2,12 +2,14 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Kysely } from "kysely";
+import { sql } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RunAgentParams } from "../agent/runner";
 import { getSessionId, saveSessionId } from "../agent/sessions";
 import { signJwt } from "../auth/jwt";
 import { hashPassword } from "../auth/password";
 import { createConversationRepository } from "../db/repositories/conversations";
+import { createScheduledTaskConversationRepository } from "../db/repositories/scheduled-task-conversations";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
@@ -89,6 +91,43 @@ async function getMemberCookie(db: Kysely<DB>, userId: string): Promise<string> 
 
 function webChatTranscriptPath(dataDir: string, userId: string, conversationId = "default") {
   return join(dataDir, "web-chat", userId, `${conversationId}.json`);
+}
+
+function makeBuilderScheduler(taskId: string, createdBy: string) {
+  return {
+    pauseTask: vi.fn(),
+    resumeTask: vi.fn(),
+    removeTask: vi.fn(),
+    executeTaskById: vi.fn(),
+    getTaskById: vi.fn().mockResolvedValue({
+      id: taskId,
+      platform: "slack",
+      contextType: "dm",
+      deliveryTarget: "D_BUILDER",
+      threadTs: null,
+      prompt: "Send a builder brief",
+      scheduleType: "cron",
+      scheduleValue: "0 9 * * 1",
+      timezone: "UTC",
+      sessionMode: "fresh",
+      nextRunAt: null,
+      lastRunAt: null,
+      status: "active",
+      createdBy,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      revision: 0,
+      title: "Builder brief",
+      description: null,
+      originChat: null,
+      steps: null,
+      edges: null,
+      outputTarget: null,
+      outputPlatform: null,
+      outputThreadTs: null,
+      outputMode: "deliver",
+      delivery: { platform: "slack", targetType: "dm", targetId: "D_BUILDER", threadTs: null, mode: "deliver" },
+    }),
+  } as never;
 }
 
 function webChatStreamChunks(text: string): Array<{ type?: string; data?: unknown }> {
@@ -364,6 +403,12 @@ describe("web chat API", () => {
 
   it("streams automation cards and includes builder context when a builder reply updates an automation", async () => {
     const admin = await seedAdmin(db);
+    await createScheduledTaskConversationRepository(db).upsert({
+      taskId: "task-123",
+      conversationId: "chat-automation",
+      transcriptUserId: admin.id,
+      kind: "builder",
+    });
     const artifact = {
       taskId: "task-123",
       kind: "New automation",
@@ -518,8 +563,271 @@ describe("web chat API", () => {
     });
   });
 
+  it("rejects a guessed builder conversation before agent or transcript execution", async () => {
+    const admin = await seedAdmin(db);
+    const legacyTranscriptPath = join(dataDir, "workspaces", admin.id, "web-chat", "guessed-builder.json");
+    await mkdir(join(dataDir, "workspaces", admin.id, "web-chat"), { recursive: true });
+    await writeFile(
+      legacyTranscriptPath,
+      JSON.stringify({ messages: [{ id: "legacy", role: "user", parts: [{ type: "text", text: "Keep me" }] }] }),
+    );
+    const runAgent = vi.fn().mockResolvedValue(makeAgentResult("Should not run."));
+    const scheduler = makeBuilderScheduler("task-guessed", admin.id);
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      runAgent,
+      buildMcpServers: vi.fn().mockResolvedValue({}),
+      scheduler,
+    });
+    const cookie = await login(app);
+
+    const res = await app.request("/api/web-chat?conversationId=guessed-builder", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Run this guessed conversation", automationTaskId: "task-guessed" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: { code: "CONVERSATION_NOT_FOUND" } });
+    expect(runAgent).not.toHaveBeenCalled();
+    await expect(readFile(webChatTranscriptPath(dataDir, admin.id, "guessed-builder"), "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(legacyTranscriptPath, "utf-8")).resolves.toContain("Keep me");
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskConversationForTranscriptUser(
+        "task-guessed",
+        "guessed-builder",
+        admin.id,
+        { includeArchived: true },
+      ),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("rejects an archived builder conversation without reviving it", async () => {
+    const admin = await seedAdmin(db);
+    const conversations = createScheduledTaskConversationRepository(db);
+    await conversations.upsert({
+      taskId: "task-archived",
+      conversationId: "archived-builder",
+      transcriptUserId: admin.id,
+      kind: "builder",
+    });
+    await conversations.setArchivedForTaskConversation("task-archived", "archived-builder", admin.id, true);
+    const runAgent = vi.fn().mockResolvedValue(makeAgentResult("Should not run."));
+    const scheduler = makeBuilderScheduler("task-archived", admin.id);
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      runAgent,
+      buildMcpServers: vi.fn().mockResolvedValue({}),
+      scheduler,
+    });
+    const cookie = await login(app);
+
+    const res = await app.request("/api/web-chat?conversationId=archived-builder", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Run this archived conversation", automationTaskId: "task-archived" }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: { code: "CONVERSATION_ARCHIVED" } });
+    expect(runAgent).not.toHaveBeenCalled();
+    await expect(readFile(webChatTranscriptPath(dataDir, admin.id, "archived-builder"), "utf-8")).rejects.toMatchObject(
+      { code: "ENOENT" },
+    );
+    await expect(
+      conversations.listByTaskConversationForTranscriptUser("task-archived", "archived-builder", admin.id, {
+        includeArchived: true,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ kind: "builder", archived_at: expect.any(String) })]);
+  });
+
+  it("allows an active source-chat association without manufacturing a builder association", async () => {
+    const admin = await seedAdmin(db);
+    const conversations = createScheduledTaskConversationRepository(db);
+    await conversations.upsert({
+      taskId: "task-source",
+      conversationId: "source-chat",
+      transcriptUserId: admin.id,
+      kind: "web_chat",
+    });
+    await db
+      .updateTable("scheduled_task_conversations")
+      .set({ updated_at: "2000-01-01 00:00:00", last_active_at: "2000-01-01 00:00:00" })
+      .where("task_id", "=", "task-source")
+      .where("conversation_id", "=", "source-chat")
+      .where("transcript_user_id", "=", admin.id)
+      .where("kind", "=", "web_chat")
+      .execute();
+    const runAgent = vi.fn().mockResolvedValue(makeAgentResult("Updated from the source chat."));
+    const scheduler = makeBuilderScheduler("task-source", admin.id);
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      runAgent,
+      buildMcpServers: vi.fn().mockResolvedValue({}),
+      scheduler,
+    });
+    const cookie = await login(app);
+
+    const res = await app.request("/api/web-chat?conversationId=source-chat", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Continue from the source chat", automationTaskId: "task-source" }),
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(runAgent).toHaveBeenCalledOnce();
+    const sourceAssociation = await conversations.listByTaskConversationForTranscriptUser(
+      "task-source",
+      "source-chat",
+      admin.id,
+      { includeArchived: true },
+    );
+    expect(sourceAssociation).toEqual([expect.objectContaining({ kind: "web_chat", archived_at: null })]);
+    expect(sourceAssociation[0]?.updated_at).not.toBe("2000-01-01 00:00:00");
+    expect(sourceAssociation[0]?.last_active_at).not.toBe("2000-01-01 00:00:00");
+  });
+
+  it("does not revive an archived builder kind when an active source-chat association opens the task", async () => {
+    const admin = await seedAdmin(db);
+    const conversations = createScheduledTaskConversationRepository(db);
+    await conversations.upsert({
+      taskId: "task-archived-builder",
+      conversationId: "source-with-archived-builder",
+      transcriptUserId: admin.id,
+      kind: "web_chat",
+    });
+    await conversations.upsert({
+      taskId: "task-archived-builder",
+      conversationId: "source-with-archived-builder",
+      transcriptUserId: admin.id,
+      kind: "builder",
+    });
+    await conversations.setArchivedForTaskConversation(
+      "task-archived-builder",
+      "source-with-archived-builder",
+      admin.id,
+      true,
+    );
+    await conversations.upsert({
+      taskId: "task-archived-builder",
+      conversationId: "source-with-archived-builder",
+      transcriptUserId: admin.id,
+      kind: "web_chat",
+    });
+    const runAgent = vi.fn().mockResolvedValue(makeAgentResult("Updated from the source chat."));
+    const scheduler = makeBuilderScheduler("task-archived-builder", admin.id);
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      runAgent,
+      buildMcpServers: vi.fn().mockResolvedValue({}),
+      scheduler,
+    });
+    const cookie = await login(app);
+
+    const res = await app.request("/api/web-chat?conversationId=source-with-archived-builder", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Continue from the source chat", automationTaskId: "task-archived-builder" }),
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(runAgent).toHaveBeenCalledOnce();
+    await expect(
+      conversations.listByTaskConversationForTranscriptUser(
+        "task-archived-builder",
+        "source-with-archived-builder",
+        admin.id,
+        { includeArchived: true },
+      ),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "builder", archived_at: expect.any(String) }),
+        expect.objectContaining({ kind: "web_chat", archived_at: null }),
+      ]),
+    );
+  });
+
+  it("does not run or append a transcript when an existing builder touch fails", async () => {
+    const admin = await seedAdmin(db);
+    const conversations = createScheduledTaskConversationRepository(db);
+    await conversations.upsert({
+      taskId: "task-builder-association-failure",
+      conversationId: "source-chat-association-failure",
+      transcriptUserId: admin.id,
+      kind: "web_chat",
+    });
+    await conversations.upsert({
+      taskId: "task-builder-association-failure",
+      conversationId: "source-chat-association-failure",
+      transcriptUserId: admin.id,
+      kind: "builder",
+    });
+    await sql`
+      CREATE TRIGGER reject_builder_touch
+      BEFORE UPDATE OF last_active_at ON scheduled_task_conversations
+      WHEN OLD.kind = 'builder'
+      BEGIN
+        SELECT RAISE(FAIL, 'builder touch rejected');
+      END
+    `.execute(db);
+    const runAgent = vi.fn().mockResolvedValue(makeAgentResult("Should not run."));
+    const scheduler = makeBuilderScheduler("task-builder-association-failure", admin.id);
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger: createTestLogger(),
+      runAgent,
+      buildMcpServers: vi.fn().mockResolvedValue({}),
+      scheduler,
+    });
+    const cookie = await login(app);
+
+    const res = await app.request("/api/web-chat?conversationId=source-chat-association-failure", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "Continue from the source chat",
+        automationTaskId: "task-builder-association-failure",
+      }),
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: { code: "CONVERSATION_UNAVAILABLE" } });
+    expect(runAgent).not.toHaveBeenCalled();
+    await expect(
+      readFile(webChatTranscriptPath(dataDir, admin.id, "source-chat-association-failure"), "utf-8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      conversations.listByTaskConversationForTranscriptUser(
+        "task-builder-association-failure",
+        "source-chat-association-failure",
+        admin.id,
+        { includeArchived: true },
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({ kind: "builder", archived_at: null }),
+      expect.objectContaining({ kind: "web_chat", archived_at: null }),
+    ]);
+  });
+
   it("starts builder replies without originating Slack conversation context", async () => {
     const admin = await seedAdmin(db);
+    await createScheduledTaskConversationRepository(db).upsert({
+      taskId: "task-123",
+      conversationId: "builder-task-123",
+      transcriptUserId: admin.id,
+      kind: "builder",
+    });
+    await db
+      .updateTable("scheduled_task_conversations")
+      .set({ updated_at: "2000-01-01 00:00:00", last_active_at: "2000-01-01 00:00:00" })
+      .where("task_id", "=", "task-123")
+      .where("conversation_id", "=", "builder-task-123")
+      .where("transcript_user_id", "=", admin.id)
+      .where("kind", "=", "builder")
+      .execute();
     const conversations = createConversationRepository(db);
     const conversation = await conversations.getOrCreate(
       { platform: "slack", kind: "channel", providerConversationId: "C123" },
@@ -621,11 +929,24 @@ describe("web chat API", () => {
     });
     expect(call.conversationRepo).toBeUndefined();
     expect(call.conversationContext).toBeUndefined();
+    const builderAssociation = await createScheduledTaskConversationRepository(
+      db,
+    ).listByTaskConversationForTranscriptUser("task-123", "builder-task-123", admin.id);
+    expect(builderAssociation).toEqual([expect.objectContaining({ kind: "builder", archived_at: null })]);
+    expect(builderAssociation[0]?.updated_at).not.toBe("2000-01-01 00:00:00");
+    expect(builderAssociation[0]?.last_active_at).not.toBe("2000-01-01 00:00:00");
   });
 
-  it("binds an accessible foreign task for an admin", async () => {
+  it("does not grant an admin access to the owner transcript", async () => {
     const admin = await seedAdmin(db);
     const owner = await createUserRepository(db).create({ name: "Owner", email: "owner-builder@test.com" });
+    const conversations = createScheduledTaskConversationRepository(db);
+    await conversations.upsert({
+      taskId: "task-foreign",
+      conversationId: "owner-builder",
+      transcriptUserId: owner.id,
+      kind: "builder",
+    });
     const runAgent = vi.fn().mockResolvedValue(makeAgentResult("Updated."));
     const scheduler = {
       pauseTask: vi.fn(),
@@ -669,25 +990,28 @@ describe("web chat API", () => {
     });
     const cookie = await login(app);
 
-    const res = await app.request("/api/web-chat?conversationId=admin-builder", {
+    const res = await app.request("/api/web-chat?conversationId=owner-builder", {
       method: "POST",
       headers: { Cookie: cookie, "Content-Type": "application/json" },
       body: JSON.stringify({ message: "Make this stricter", automationTaskId: "task-foreign" }),
     });
 
-    expect(res.status).toBe(200);
-    await res.text();
-    const call = runAgent.mock.calls[0][0] as RunAgentParams;
-    expect(call.currentAutomation).toMatchObject({
-      taskId: "task-foreign",
-      revision: 3,
-      builderConversationId: "admin-builder",
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: { code: "CONVERSATION_NOT_FOUND" } });
+    expect(runAgent).not.toHaveBeenCalled();
+    await expect(readFile(webChatTranscriptPath(dataDir, admin.id, "owner-builder"), "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
     });
-    expect(call.taskContext).toMatchObject({ createdBy: admin.id, canManageAnyTask: true });
+    await expect(
+      conversations.listByTaskConversationForTranscriptUser("task-foreign", "owner-builder", owner.id),
+    ).resolves.toHaveLength(1);
+    await expect(
+      conversations.listByTaskConversationForTranscriptUser("task-foreign", "owner-builder", admin.id),
+    ).resolves.toHaveLength(0);
     expect(scheduler.getTaskById).toHaveBeenCalledWith("task-foreign");
   });
 
-  it("does not inject builder context for inaccessible automation ids", async () => {
+  it("rejects inaccessible automation ids before running or mutating the transcript", async () => {
     await seedAdmin(db);
     const users = createUserRepository(db);
     const owner = await users.create({ name: "Owner", email: "owner@test.com" });
@@ -742,14 +1066,12 @@ describe("web chat API", () => {
       body: JSON.stringify({ message: "Update it", automationTaskId: "task-private" }),
     });
 
-    expect(res.status).toBe(200);
-    await res.text();
-    const call = runAgent.mock.calls[0][0] as RunAgentParams;
-    expect(call.userMessage).not.toContain("<automation_builder>");
-    expect(call.userMessage).not.toContain("task_id: task-private");
-    expect(call.taskContext).toMatchObject({ createdBy: member.id, deliveryTarget: "D_MEMBER" });
-    expect(call.currentAutomation).toBeUndefined();
-    expect(call.taskContext?.currentAutomation).toBeUndefined();
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: { code: "AUTOMATION_NOT_FOUND" } });
+    expect(runAgent).not.toHaveBeenCalled();
+    await expect(readFile(webChatTranscriptPath(dataDir, member.id, "chat-private"), "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("streams connected account cards from provider state for account enquiries", async () => {

--- a/packages/server/src/api/web-chat.ts
+++ b/packages/server/src/api/web-chat.ts
@@ -19,7 +19,10 @@ import type { McpServerConfig, ProgressEvent, RunAgentParams, RunAgentResult } f
 import { archiveRuntimeSessions } from "../agent/sessions";
 import { createProgressRenderer, createWebProgressData } from "../agent/tool-progress";
 import { ensureWorkspace } from "../agent/workspace";
-import { upsertAutomationTaskConversationAssociation } from "../automation/task-conversations";
+import {
+  createAutomationTaskConversationService,
+  touchActiveAutomationTaskConversationAssociations,
+} from "../automation/task-conversations";
 import { TOOL_PROGRESS_OPTIONS, type ToolProgressCommand } from "../commands";
 import type { Config } from "../config";
 import type { createAutomationRunsRepository } from "../db/repositories/automation-runs";
@@ -316,6 +319,74 @@ async function resolveAutomationBuilderContext(params: {
       builderConversationId: params.builderConversationId,
     }),
   };
+}
+
+type AutomationBuilderConversationAccess =
+  | { kind: "active" }
+  | { kind: "not_found" }
+  | { kind: "archived" }
+  | { kind: "error" };
+
+async function resolveAutomationBuilderConversationAccess(params: {
+  deps: WebChatRouteDeps;
+  taskId: string;
+  conversationId: string;
+  transcriptUserId: string;
+  logger: Logger;
+}): Promise<AutomationBuilderConversationAccess> {
+  try {
+    return await params.deps.db.transaction().execute(async (trx) => {
+      const conversationService = createAutomationTaskConversationService(trx);
+      const existing = await conversationService.getForTranscriptUser(
+        params.taskId,
+        params.conversationId,
+        params.transcriptUserId,
+        { includeArchived: true },
+      );
+      if (!existing) return { kind: "not_found" as const };
+
+      const active = await conversationService.getForTranscriptUser(
+        params.taskId,
+        params.conversationId,
+        params.transcriptUserId,
+      );
+      if (!active) return { kind: "archived" as const };
+
+      const touchedRows = await touchActiveAutomationTaskConversationAssociations(trx, {
+        taskId: params.taskId,
+        conversationId: params.conversationId,
+        transcriptUserId: params.transcriptUserId,
+      });
+      if (touchedRows === 0) {
+        const latest = await conversationService.getForTranscriptUser(
+          params.taskId,
+          params.conversationId,
+          params.transcriptUserId,
+          { includeArchived: true },
+        );
+        if (!latest) return { kind: "not_found" as const };
+        const latestActive = await conversationService.getForTranscriptUser(
+          params.taskId,
+          params.conversationId,
+          params.transcriptUserId,
+        );
+        if (!latestActive) return { kind: "archived" as const };
+        return { kind: "error" as const };
+      }
+      return { kind: "active" as const };
+    });
+  } catch (err) {
+    params.logger.warn(
+      {
+        errorType: err instanceof Error ? err.name : "unknown",
+        taskId: params.taskId,
+        conversationId: params.conversationId,
+        transcriptUserId: params.transcriptUserId,
+      },
+      "Failed to resolve automation builder conversation access",
+    );
+    return { kind: "error" };
+  }
 }
 
 function parseBuilderSteps(value: string | null): WorkflowStep[] {
@@ -1335,6 +1406,7 @@ function automationBuilderTaskContext(params: {
     contextType: task.contextType,
     deliveryTarget: task.deliveryTarget,
     createdBy: params.currentUser.id,
+    conversationKind: "builder" as const,
     creatorTimezone: params.currentUser.timezone,
     threadTs: task.threadTs ?? undefined,
     canManageAnyTask: params.role === "admin",
@@ -1648,8 +1720,6 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
       id: `attachment-${index}`,
       data: item.file,
     }));
-    await migrateLegacyWebChatTranscripts(deps.config, workspaceDir, currentUser.id, deps.logger);
-    const dmContext = await resolveWebChatDmContext(deps, currentUser, settingsRow);
     const automationBuilderContext = await resolveAutomationBuilderContext({
       deps,
       currentUserId: currentUser.id,
@@ -1658,19 +1728,33 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
       builderConversationId: conversationId,
       logger: deps.logger,
     });
+    if (automationTaskId && !automationBuilderContext) {
+      return c.json(badRequest("AUTOMATION_NOT_FOUND", "Automation not found"), 404);
+    }
+
     if (automationBuilderContext) {
-      await upsertAutomationTaskConversationAssociation(deps.db, {
+      const conversationAccess = await resolveAutomationBuilderConversationAccess({
+        deps,
         taskId: automationBuilderContext.task.id,
         conversationId,
         transcriptUserId: currentUser.id,
-        kind: "builder",
-      }).catch((err: unknown) => {
-        deps.logger.warn(
-          { err, taskId: automationBuilderContext.task.id, conversationId },
-          "Failed to associate builder chat",
-        );
+        logger: deps.logger,
       });
+      if (conversationAccess.kind === "not_found") {
+        return c.json(badRequest("CONVERSATION_NOT_FOUND", "Conversation is not associated with this task"), 404);
+      }
+      if (conversationAccess.kind === "archived") {
+        return c.json(
+          badRequest("CONVERSATION_ARCHIVED", "Conversation is archived; restore it before selecting"),
+          409,
+        );
+      }
+      if (conversationAccess.kind === "error") {
+        return c.json(badRequest("CONVERSATION_UNAVAILABLE", "Conversation is temporarily unavailable"), 503);
+      }
     }
+    await migrateLegacyWebChatTranscripts(deps.config, workspaceDir, currentUser.id, deps.logger);
+    const dmContext = await resolveWebChatDmContext(deps, currentUser, settingsRow);
     const taskContext = automationBuilderContext
       ? automationBuilderTaskContext({
           context: automationBuilderContext,
@@ -1684,6 +1768,7 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
             contextType: "dm" as const,
             deliveryTarget: dmContext.deliveryTarget,
             createdBy: currentUser.id,
+            conversationKind: "web_chat" as const,
             creatorTimezone: currentUser.timezone,
             canManageAnyTask: c.get("role") === "admin",
             currentAutomation: undefined,

--- a/packages/server/src/api/web-chat.ts
+++ b/packages/server/src/api/web-chat.ts
@@ -19,6 +19,7 @@ import type { McpServerConfig, ProgressEvent, RunAgentParams, RunAgentResult } f
 import { archiveRuntimeSessions } from "../agent/sessions";
 import { createProgressRenderer, createWebProgressData } from "../agent/tool-progress";
 import { ensureWorkspace } from "../agent/workspace";
+import { upsertAutomationTaskConversationAssociation } from "../automation/task-conversations";
 import { TOOL_PROGRESS_OPTIONS, type ToolProgressCommand } from "../commands";
 import type { Config } from "../config";
 import type { createAutomationRunsRepository } from "../db/repositories/automation-runs";
@@ -1657,6 +1658,19 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
       builderConversationId: conversationId,
       logger: deps.logger,
     });
+    if (automationBuilderContext) {
+      await upsertAutomationTaskConversationAssociation(deps.db, {
+        taskId: automationBuilderContext.task.id,
+        conversationId,
+        transcriptUserId: currentUser.id,
+        kind: "builder",
+      }).catch((err: unknown) => {
+        deps.logger.warn(
+          { err, taskId: automationBuilderContext.task.id, conversationId },
+          "Failed to associate builder chat",
+        );
+      });
+    }
     const taskContext = automationBuilderContext
       ? automationBuilderTaskContext({
           context: automationBuilderContext,

--- a/packages/server/src/automation/chat-authoring.test.ts
+++ b/packages/server/src/automation/chat-authoring.test.ts
@@ -1,6 +1,7 @@
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskConversationRepository } from "../db/repositories/scheduled-task-conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import type { CurrentAutomation } from "../scheduler/types";
 import { createTestDb } from "../test-utils";
@@ -199,6 +200,11 @@ describe("chat automation authoring orchestration", () => {
       task: { id: "automation-created" },
       artifact: { scheduleType: "interval", steps: [expect.anything(), expect.objectContaining({ apps: ["linear"] })] },
     });
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskAndTranscriptUser("automation-created", "user-1", {
+        kind: "web_chat",
+      }),
+    ).resolves.toEqual([expect.objectContaining({ conversation_id: "conversation-1", kind: "web_chat" })]);
   });
 
   it("returns a clarification without persisting or refreshing", async () => {
@@ -322,5 +328,116 @@ describe("chat automation authoring orchestration", () => {
       }),
     ).resolves.toEqual({ kind: "error", message: "Automation not found." });
     expect(edit).not.toHaveBeenCalled();
+  });
+
+  it("lets an admin edit a foreign-owned task without changing its owner", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: {
+        id: "foreign-admin-edit",
+        platform: "slack",
+        contextType: "dm",
+        deliveryTarget: "D123",
+        threadTs: null,
+        createdBy: "owner-id",
+        originPlatform: null,
+        originConversationId: null,
+        originProviderThreadId: null,
+        originMessageId: null,
+      },
+      brokerCapable: true,
+    });
+
+    const current = currentAutomation("foreign-admin-edit", 0);
+    const edit = vi.fn().mockResolvedValue({
+      kind: "definition" as const,
+      definition: definition({ expectedRevision: 0, title: "Admin-edited brief" }),
+    });
+    const service = createChatAutomationAuthoring({
+      db,
+      authoring: { create: vi.fn(), edit },
+      scheduler: {
+        refreshTaskSchedule: vi.fn().mockResolvedValue({ id: "foreign-admin-edit" }),
+        getTaskById: vi.fn(),
+      },
+      loadIntegrationProvider: async () => null,
+    });
+
+    await expect(
+      service.author({
+        action: "edit",
+        request: "Rename the brief",
+        taskId: "foreign-admin-edit",
+        taskContext: { ...taskContext(), createdBy: "admin-id", canManageAnyTask: true },
+        currentAutomation: current,
+      }),
+    ).resolves.toMatchObject({ kind: "saved", task: { id: "foreign-admin-edit" } });
+
+    expect(edit).toHaveBeenCalledWith(expect.objectContaining({ currentAutomation: current, expectedRevision: 0 }));
+    await expect(createScheduledTaskRepository(db).getById("foreign-admin-edit")).resolves.toMatchObject({
+      created_by: "owner-id",
+      last_edited_by: "admin-id",
+      title: "Admin-edited brief",
+      revision: 1,
+    });
+  });
+
+  it("associates a configured edit with its normal web chat without rewriting origin provenance", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: {
+        id: "configured-edit-provenance",
+        platform: "slack",
+        contextType: "dm",
+        deliveryTarget: "D123",
+        threadTs: null,
+        createdBy: "user-1",
+        originPlatform: "web",
+        originConversationId: "creation-chat",
+        originProviderThreadId: null,
+        originMessageId: 42,
+      },
+      brokerCapable: true,
+    });
+
+    const service = createChatAutomationAuthoring({
+      db,
+      authoring: {
+        create: vi.fn(),
+        edit: vi.fn().mockResolvedValue({
+          kind: "definition" as const,
+          definition: definition({ expectedRevision: 0, title: "Edited brief" }),
+        }),
+      },
+      scheduler: {
+        refreshTaskSchedule: vi.fn().mockResolvedValue({ id: "configured-edit-provenance" }),
+        getTaskById: vi.fn(),
+      },
+      loadIntegrationProvider: async () => null,
+    });
+
+    await expect(
+      service.author({
+        action: "edit",
+        request: "Rename the brief",
+        taskId: "configured-edit-provenance",
+        taskContext: { ...taskContext(), origin: { ...taskContext().origin, conversationId: "edit-chat" } },
+      }),
+    ).resolves.toMatchObject({ kind: "saved", task: { id: "configured-edit-provenance" } });
+
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskAndTranscriptUser(
+        "configured-edit-provenance",
+        "user-1",
+        { kind: "web_chat" },
+      ),
+    ).resolves.toEqual([expect.objectContaining({ conversation_id: "edit-chat", kind: "web_chat" })]);
+    await expect(createScheduledTaskRepository(db).getById("configured-edit-provenance")).resolves.toMatchObject({
+      origin_conversation_id: "creation-chat",
+      revision: 1,
+      title: "Edited brief",
+    });
   });
 });

--- a/packages/server/src/automation/chat-authoring.ts
+++ b/packages/server/src/automation/chat-authoring.ts
@@ -11,6 +11,7 @@ import type { CurrentAutomation, ScheduledTask, TaskContext } from "../scheduler
 import type { AutomationAuthoringService } from "./authoring/service";
 import { buildAutomationDefinition } from "./definition";
 import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
+import { webChatTaskConversationAssociation } from "./task-conversations";
 
 type AuthoringScheduler = Pick<TaskScheduler, "getTaskById" | "refreshTaskSchedule">;
 
@@ -103,6 +104,7 @@ export function createChatAutomationAuthoring(deps: {
       return { kind: "error", message: "Automation creator is not available in this context." };
     }
     const taskId = createId();
+    const taskConversationAssociation = webChatTaskConversationAssociation(input.taskContext);
     const canUseBroker = await brokerCapable(deps.loadIntegrationProvider);
     const result = await deps.authoring.create({
       request: input.request,
@@ -142,6 +144,7 @@ export function createChatAutomationAuthoring(deps: {
         originMessageId: input.taskContext.origin?.currentMessageId ?? null,
       },
       brokerCapable: canUseBroker,
+      ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
     });
     return refreshOrError(taskId, artifactFromDefinition(result.definition));
   }
@@ -149,6 +152,7 @@ export function createChatAutomationAuthoring(deps: {
   async function edit(input: ChatAutomationAuthoringInput): Promise<ChatAutomationAuthoringResult> {
     if (!input.taskId) return { kind: "error", message: "Automation not found." };
     const currentAutomation = input.currentAutomation ?? input.taskContext.currentAutomation;
+    const taskConversationAssociation = webChatTaskConversationAssociation(input.taskContext);
     const row = await tasks.getById(input.taskId);
     const accessibleRow = resolveScheduledTaskAccess(row, row?.created_by, {
       userId: input.taskContext.createdBy,
@@ -187,6 +191,7 @@ export function createChatAutomationAuthoring(deps: {
         canManageAnyTask: input.taskContext.canManageAnyTask ?? false,
       },
       brokerCapable: canUseBroker,
+      ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
     });
     if (saved.kind === "not_found") return { kind: "error", message: "Automation not found." };
     if (saved.kind === "revision_conflict") {

--- a/packages/server/src/automation/persistence.integration.test.ts
+++ b/packages/server/src/automation/persistence.integration.test.ts
@@ -1,10 +1,17 @@
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
 import { sql } from "kysely";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskConversationRepository } from "../db/repositories/scheduled-task-conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import { createTestPgDb } from "../test-utils";
-import { createAutomationDefinition, replaceAutomationDefinition, updateAutomationDefinition } from "./persistence";
+import {
+  createAutomationDefinition,
+  deleteAutomation,
+  replaceAutomationDefinition,
+  updateAutomationDefinition,
+} from "./persistence";
 
 function definition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
   return {
@@ -256,5 +263,42 @@ describe("automation persistence on Postgres", () => {
       await sql`DROP TRIGGER reject_automation_content ON automation_step_content`.execute(db);
       await sql`DROP FUNCTION reject_automation_content()`.execute(db);
     }
+  });
+
+  it("deletes task content, runs, and chat associations in one Postgres transaction", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("pg-delete"),
+      brokerCapable: true,
+    });
+    const runId = await createAutomationRunsRepository(db).create({ taskId: "pg-delete" });
+    await createScheduledTaskConversationRepository(db).upsert({
+      taskId: "pg-delete",
+      conversationId: "pg-builder-delete",
+      transcriptUserId: "pg-owner",
+      kind: "builder",
+    });
+    let taskVisibleAtRuntimeCleanup: boolean | undefined;
+    const result = await deleteAutomation({
+      db,
+      taskId: "pg-delete",
+      actor: { userId: "pg-owner", canManageAnyTask: false },
+      scheduler: {
+        removeTaskRuntime: async (taskId) => {
+          taskVisibleAtRuntimeCleanup = Boolean(await createScheduledTaskRepository(db).getById(taskId));
+          return true;
+        },
+      },
+    });
+
+    expect(result).toEqual({ kind: "deleted" });
+    expect(taskVisibleAtRuntimeCleanup).toBe(false);
+    await expect(createScheduledTaskRepository(db).getById("pg-delete")).resolves.toBeUndefined();
+    await expect(createAutomationStepContentRepository(db).getByTask("pg-delete")).resolves.toEqual([]);
+    await expect(createAutomationRunsRepository(db).getById(runId)).resolves.toBeUndefined();
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskConversation("pg-delete", "pg-builder-delete"),
+    ).resolves.toEqual([]);
   });
 });

--- a/packages/server/src/automation/persistence.test.ts
+++ b/packages/server/src/automation/persistence.test.ts
@@ -1,10 +1,17 @@
 import type { AutomationBuilderSaveRequest } from "@sketch/shared";
 import { sql } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskConversationRepository } from "../db/repositories/scheduled-task-conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import { createTestDb } from "../test-utils";
-import { createAutomationDefinition, replaceAutomationDefinition, updateAutomationDefinition } from "./persistence";
+import {
+  createAutomationDefinition,
+  deleteAutomation,
+  replaceAutomationDefinition,
+  updateAutomationDefinition,
+} from "./persistence";
 
 function makeDefinition(overrides: Partial<AutomationBuilderSaveRequest> = {}): AutomationBuilderSaveRequest {
   return {
@@ -430,5 +437,208 @@ describe("automation persistence", () => {
     } finally {
       await sql`DROP TRIGGER reject_direct_update_content`.execute(db);
     }
+  });
+
+  it("deletes all task-owned rows and invokes runtime cleanup after commit", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-delete"),
+      brokerCapable: true,
+    });
+    const runId = await createAutomationRunsRepository(db).create({
+      taskId: "automation-delete",
+      triggerData: { source: "test" },
+    });
+    await createScheduledTaskConversationRepository(db).upsert({
+      taskId: "automation-delete",
+      conversationId: "builder-delete",
+      transcriptUserId: "user-1",
+      kind: "builder",
+    });
+
+    let taskVisibleAtRuntimeCleanup: boolean | undefined;
+    const removeTaskRuntime = vi.fn(async (taskId: string) => {
+      taskVisibleAtRuntimeCleanup = Boolean(await createScheduledTaskRepository(db).getById(taskId));
+      return true;
+    });
+    const result = await deleteAutomation({
+      db,
+      taskId: "automation-delete",
+      actor: { userId: "user-1", canManageAnyTask: false },
+      scheduler: { removeTaskRuntime },
+    });
+
+    expect(result).toEqual({ kind: "deleted" });
+    expect(taskVisibleAtRuntimeCleanup).toBe(false);
+    expect(removeTaskRuntime).toHaveBeenCalledWith("automation-delete");
+    await expect(createScheduledTaskRepository(db).getById("automation-delete")).resolves.toBeUndefined();
+    await expect(createAutomationStepContentRepository(db).getByTask("automation-delete")).resolves.toEqual([]);
+    await expect(createAutomationRunsRepository(db).getById(runId)).resolves.toBeUndefined();
+    await expect(
+      createScheduledTaskConversationRepository(db).listByTaskConversation("automation-delete", "builder-delete"),
+    ).resolves.toEqual([]);
+  });
+
+  it("rolls back every dependent deletion when the database rejects a child delete", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-delete-rollback"),
+      brokerCapable: true,
+    });
+    await createAutomationRunsRepository(db).create({ taskId: "automation-delete-rollback" });
+    await createScheduledTaskConversationRepository(db).upsert({
+      taskId: "automation-delete-rollback",
+      conversationId: "builder-delete-rollback",
+      transcriptUserId: "user-1",
+      kind: "builder",
+    });
+    await sql`
+      CREATE TRIGGER reject_automation_run_delete
+      BEFORE DELETE ON automation_runs
+      BEGIN
+        SELECT RAISE(FAIL, 'run deletion rejected');
+      END
+    `.execute(db);
+    const removeTaskRuntime = vi.fn().mockResolvedValue(true);
+
+    try {
+      await expect(
+        deleteAutomation({
+          db,
+          taskId: "automation-delete-rollback",
+          actor: { userId: "user-1", canManageAnyTask: false },
+          scheduler: { removeTaskRuntime },
+        }),
+      ).rejects.toThrow("run deletion rejected");
+      await expect(createScheduledTaskRepository(db).getById("automation-delete-rollback")).resolves.toBeDefined();
+      await expect(
+        createAutomationStepContentRepository(db).getByTask("automation-delete-rollback"),
+      ).resolves.toHaveLength(1);
+      await expect(createAutomationRunsRepository(db).list("automation-delete-rollback")).resolves.toHaveLength(1);
+      await expect(
+        createScheduledTaskConversationRepository(db).listByTaskConversation(
+          "automation-delete-rollback",
+          "builder-delete-rollback",
+        ),
+      ).resolves.toHaveLength(1);
+      expect(removeTaskRuntime).not.toHaveBeenCalled();
+    } finally {
+      await sql`DROP TRIGGER reject_automation_run_delete`.execute(db);
+    }
+  });
+
+  it("surfaces false and thrown runtime cleanup without claiming a clean delete", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-delete-false"),
+      brokerCapable: true,
+    });
+    const falseCleanup = vi.fn().mockResolvedValue(false);
+    const falseResult = await deleteAutomation({
+      db,
+      taskId: "automation-delete-false",
+      actor: { userId: "user-1", canManageAnyTask: false },
+      scheduler: { removeTaskRuntime: falseCleanup },
+    });
+    expect(falseResult.kind).toBe("scheduler_failure");
+    await expect(createScheduledTaskRepository(db).getById("automation-delete-false")).resolves.toBeUndefined();
+
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-delete-throw"),
+      brokerCapable: true,
+    });
+    const thrownCleanup = vi.fn().mockRejectedValue(new Error("runtime unavailable"));
+    const thrownResult = await deleteAutomation({
+      db,
+      taskId: "automation-delete-throw",
+      actor: { userId: "user-1", canManageAnyTask: false },
+      scheduler: { removeTaskRuntime: thrownCleanup },
+    });
+    expect(thrownResult).toMatchObject({ kind: "scheduler_failure", error: new Error("runtime unavailable") });
+    await expect(createScheduledTaskRepository(db).getById("automation-delete-throw")).resolves.toBeUndefined();
+  });
+
+  it("preserves owner/admin access semantics and returns not-found for repeat deletes", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-delete-access"),
+      brokerCapable: true,
+    });
+    const removeTaskRuntime = vi.fn().mockResolvedValue(true);
+    await expect(
+      deleteAutomation({
+        db,
+        taskId: "automation-delete-access",
+        actor: { userId: "user-2", canManageAnyTask: false },
+        scheduler: { removeTaskRuntime },
+      }),
+    ).resolves.toEqual({ kind: "access_denied" });
+    await expect(createScheduledTaskRepository(db).getById("automation-delete-access")).resolves.toBeDefined();
+
+    await expect(
+      deleteAutomation({
+        db,
+        taskId: "automation-delete-access",
+        actor: { userId: "admin-1", canManageAnyTask: true },
+        scheduler: { removeTaskRuntime },
+      }),
+    ).resolves.toEqual({ kind: "deleted" });
+    await expect(
+      deleteAutomation({
+        db,
+        taskId: "automation-delete-access",
+        actor: { userId: "admin-1", canManageAnyTask: true },
+        scheduler: { removeTaskRuntime },
+      }),
+    ).resolves.toEqual({ kind: "not_found" });
+    expect(removeTaskRuntime).toHaveBeenCalledOnce();
+  });
+
+  it("returns not-found for a concurrent delete that arrives during runtime cleanup", async () => {
+    await createAutomationDefinition({
+      db,
+      request: makeDefinition(),
+      context: createContext("automation-delete-race"),
+      brokerCapable: true,
+    });
+    let markCleanupStarted!: () => void;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      markCleanupStarted = resolve;
+    });
+    let releaseCleanup!: () => void;
+    const cleanupReleased = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const firstCleanup = vi.fn(async () => {
+      markCleanupStarted();
+      await cleanupReleased;
+      return true;
+    });
+    const firstDelete = deleteAutomation({
+      db,
+      taskId: "automation-delete-race",
+      actor: { userId: "user-1", canManageAnyTask: false },
+      scheduler: { removeTaskRuntime: firstCleanup },
+    });
+    await cleanupStarted;
+
+    const secondCleanup = vi.fn().mockResolvedValue(true);
+    await expect(
+      deleteAutomation({
+        db,
+        taskId: "automation-delete-race",
+        actor: { userId: "user-1", canManageAnyTask: false },
+        scheduler: { removeTaskRuntime: secondCleanup },
+      }),
+    ).resolves.toEqual({ kind: "not_found" });
+    releaseCleanup();
+    await expect(firstDelete).resolves.toEqual({ kind: "deleted" });
+    expect(secondCleanup).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/automation/persistence.ts
+++ b/packages/server/src/automation/persistence.ts
@@ -23,6 +23,10 @@ import {
   scheduledTaskFieldsFromSaveRequest,
   validateAutomationBuilderSaveRequest,
 } from "./definition";
+import {
+  type AutomationTaskConversationAssociation,
+  upsertAutomationTaskConversationAssociation,
+} from "./task-conversations";
 
 export interface AutomationCreateContext {
   id?: string;
@@ -301,6 +305,7 @@ export async function updateAutomationDefinition(params: {
   patch: AutomationDefinitionPatch;
   actor: AutomationEditActor;
   brokerCapable: boolean;
+  taskConversationAssociation?: AutomationTaskConversationAssociation;
 }): Promise<AutomationMutationResult> {
   return params.db.transaction().execute(async (trx) => {
     const current = await trx
@@ -351,6 +356,12 @@ export async function updateAutomationDefinition(params: {
     }
 
     await replaceStepContent(trx, params.taskId, request);
+    if (params.taskConversationAssociation) {
+      await upsertAutomationTaskConversationAssociation(trx, {
+        taskId: params.taskId,
+        ...params.taskConversationAssociation,
+      });
+    }
     const row = await trx
       .selectFrom("scheduled_tasks")
       .selectAll()
@@ -365,6 +376,7 @@ export async function createAutomationDefinition(params: {
   request: AutomationBuilderSaveRequest;
   context: AutomationCreateContext;
   brokerCapable: boolean;
+  taskConversationAssociation?: AutomationTaskConversationAssociation;
 }): Promise<AutomationCreateResult> {
   const request = validatedRequest(params.request, params.brokerCapable);
   const id = params.context.id ?? randomUUID();
@@ -401,6 +413,12 @@ export async function createAutomationDefinition(params: {
     };
     const created = await createScheduledTaskRepository(trx).add(task);
     await replaceStepContent(trx, id, request);
+    if (params.taskConversationAssociation) {
+      await upsertAutomationTaskConversationAssociation(trx, {
+        taskId: id,
+        ...params.taskConversationAssociation,
+      });
+    }
     return created;
   });
 
@@ -413,6 +431,7 @@ export async function replaceAutomationDefinition(params: {
   request: AutomationBuilderSaveRequest;
   actor: AutomationEditActor;
   brokerCapable: boolean;
+  taskConversationAssociation?: AutomationTaskConversationAssociation;
 }): Promise<AutomationReplaceResult> {
   const request = validatedRequest(params.request, params.brokerCapable);
 
@@ -453,6 +472,12 @@ export async function replaceAutomationDefinition(params: {
     }
 
     await replaceStepContent(trx, params.taskId, request);
+    if (params.taskConversationAssociation) {
+      await upsertAutomationTaskConversationAssociation(trx, {
+        taskId: params.taskId,
+        ...params.taskConversationAssociation,
+      });
+    }
     const row = await trx
       .selectFrom("scheduled_tasks")
       .selectAll()

--- a/packages/server/src/automation/persistence.ts
+++ b/packages/server/src/automation/persistence.ts
@@ -10,6 +10,7 @@ import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import { createAutomationRunsRepository } from "../db/repositories/automation-runs";
 import { createAutomationStepContentRepository } from "../db/repositories/automation-step-content";
+import { createScheduledTaskConversationRepository } from "../db/repositories/scheduled-task-conversations";
 import {
   type NewScheduledTask,
   type ScheduledTaskRow,
@@ -79,6 +80,22 @@ export type AutomationMutationResult =
   | { kind: "not_found" }
   | { kind: "access_denied" }
   | { kind: "revision_conflict"; currentRevision: number };
+
+export interface AutomationDeletionScheduler {
+  removeTaskRuntime(taskId: string): Promise<boolean>;
+}
+
+export type AutomationDeletionResult =
+  | { kind: "deleted" }
+  | { kind: "not_found" }
+  | { kind: "access_denied" }
+  | { kind: "scheduler_failure"; error: unknown };
+
+class AutomationDeletionRaceError extends Error {
+  constructor() {
+    super("Automation was deleted concurrently");
+  }
+}
 
 function validatedRequest(request: AutomationBuilderSaveRequest, brokerCapable: boolean): AutomationBuilderSaveRequest {
   const parsed = parseAutomationBuilderSaveRequest(request);
@@ -297,6 +314,62 @@ export async function getAutomationDefinition(params: {
     createAutomationRunsRepository(params.db).list(params.taskId),
   ]);
   return buildAutomationDefinition({ row, stepContentRows, runRows });
+}
+
+/**
+ * Deletes an automation and every persisted task-owned row in one transaction.
+ * The legacy automation tables do not declare task foreign keys, so the dependent
+ * rows are removed explicitly before the task row. Scheduler cleanup is deliberately
+ * post-commit: a scheduler failure is returned as inconsistent runtime state because
+ * the committed database deletion cannot be rolled back. Transcript files are not
+ * part of this operation. A missing task is a deterministic not-found result, so a
+ * retry after a successful delete does not perform another scheduler mutation.
+ */
+export async function deleteAutomation(params: {
+  db: Kysely<DB>;
+  taskId: string;
+  actor: AutomationEditActor;
+  scheduler: AutomationDeletionScheduler;
+}): Promise<AutomationDeletionResult> {
+  let databaseResult: Extract<AutomationDeletionResult, { kind: "deleted" | "not_found" | "access_denied" }>;
+  try {
+    databaseResult = await params.db.transaction().execute(async (trx) => {
+      const current = await trx
+        .selectFrom("scheduled_tasks")
+        .select(["id", "created_by"])
+        .where("id", "=", params.taskId)
+        .executeTakeFirst();
+
+      if (!current) return { kind: "not_found" as const };
+      if (!params.actor.userId || (!params.actor.canManageAnyTask && current.created_by !== params.actor.userId)) {
+        return { kind: "access_denied" as const };
+      }
+
+      await createScheduledTaskConversationRepository(trx).deleteByTaskId(params.taskId);
+      await createAutomationStepContentRepository(trx).deleteByTaskId(params.taskId);
+      await createAutomationRunsRepository(trx).deleteByTaskId(params.taskId);
+
+      const deleted = await trx.deleteFrom("scheduled_tasks").where("id", "=", params.taskId).executeTakeFirst();
+      if (Number(deleted.numDeletedRows ?? 0) === 0) throw new AutomationDeletionRaceError();
+
+      return { kind: "deleted" as const };
+    });
+  } catch (error) {
+    if (error instanceof AutomationDeletionRaceError) return { kind: "not_found" };
+    throw error;
+  }
+
+  if (databaseResult.kind !== "deleted") return databaseResult;
+
+  try {
+    if (!(await params.scheduler.removeTaskRuntime(params.taskId))) {
+      return { kind: "scheduler_failure", error: new Error("Scheduler removal returned false") };
+    }
+  } catch (error) {
+    return { kind: "scheduler_failure", error };
+  }
+
+  return databaseResult;
 }
 
 export async function updateAutomationDefinition(params: {

--- a/packages/server/src/automation/task-conversations.test.ts
+++ b/packages/server/src/automation/task-conversations.test.ts
@@ -1,0 +1,63 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createScheduledTaskConversationRepository } from "../db/repositories/scheduled-task-conversations";
+import type { DB } from "../db/schema";
+import { createTestDb } from "../test-utils";
+import { touchActiveAutomationTaskConversationAssociations } from "./task-conversations";
+
+describe("automation task conversation touch", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("conditionally touches active rows without creating or reviving associations", async () => {
+    const repo = createScheduledTaskConversationRepository(db);
+    const input = {
+      taskId: "task-touch",
+      conversationId: "conversation-touch",
+      transcriptUserId: "user-touch",
+    };
+
+    await expect(touchActiveAutomationTaskConversationAssociations(db, input)).resolves.toBe(0);
+    await expect(
+      repo.listByTaskConversationForTranscriptUser(input.taskId, input.conversationId, input.transcriptUserId, {
+        includeArchived: true,
+      }),
+    ).resolves.toHaveLength(0);
+
+    await repo.upsert({ ...input, kind: "builder" });
+    await repo.setArchivedForTaskConversation(input.taskId, input.conversationId, input.transcriptUserId, true);
+    await repo.upsert({ ...input, kind: "web_chat" });
+    await db
+      .updateTable("scheduled_task_conversations")
+      .set({ updated_at: "2000-01-01 00:00:00", last_active_at: "2000-01-01 00:00:00" })
+      .where("task_id", "=", input.taskId)
+      .where("conversation_id", "=", input.conversationId)
+      .where("transcript_user_id", "=", input.transcriptUserId)
+      .execute();
+
+    await expect(touchActiveAutomationTaskConversationAssociations(db, input)).resolves.toBe(1);
+    const rows = await repo.listByTaskConversationForTranscriptUser(
+      input.taskId,
+      input.conversationId,
+      input.transcriptUserId,
+      { includeArchived: true },
+    );
+    const archivedBuilder = rows.find((row) => row.kind === "builder");
+    const activeSource = rows.find((row) => row.kind === "web_chat");
+    expect(archivedBuilder).toMatchObject({
+      archived_at: expect.any(String),
+      updated_at: "2000-01-01 00:00:00",
+      last_active_at: "2000-01-01 00:00:00",
+    });
+    expect(activeSource).toMatchObject({ archived_at: null });
+    expect(activeSource?.updated_at).not.toBe("2000-01-01 00:00:00");
+    expect(activeSource?.last_active_at).not.toBe("2000-01-01 00:00:00");
+  });
+});

--- a/packages/server/src/automation/task-conversations.ts
+++ b/packages/server/src/automation/task-conversations.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 import {
   type ScheduledTaskConversationKind,
   type ScheduledTaskConversationRow,
@@ -7,6 +7,7 @@ import {
   createScheduledTaskConversationRepository,
 } from "../db/repositories/scheduled-task-conversations";
 import type { DB } from "../db/schema";
+import type { TaskContext } from "../scheduler/types";
 
 export type { ScheduledTaskConversationKind } from "../db/repositories/scheduled-task-conversations";
 
@@ -25,6 +26,20 @@ export interface UpsertAutomationTaskConversationAssociationInput {
   conversationId: string;
   transcriptUserId: string;
   kind: ScheduledTaskConversationKind;
+}
+
+export type AutomationTaskConversationAssociation = Omit<UpsertAutomationTaskConversationAssociationInput, "taskId">;
+
+export function webChatTaskConversationAssociation(
+  context: Pick<TaskContext, "conversationKind" | "createdBy" | "currentAutomation" | "origin">,
+): AutomationTaskConversationAssociation | undefined {
+  const conversationKind =
+    context.conversationKind ??
+    (context.origin?.platform === "web" && !context.currentAutomation ? ("web_chat" as const) : undefined);
+  const conversationId = context.origin?.platform === "web" ? context.origin.conversationId.trim() : "";
+  const transcriptUserId = context.createdBy?.trim() ?? "";
+  if (conversationKind !== "web_chat" || !conversationId || !transcriptUserId) return undefined;
+  return { conversationId, transcriptUserId, kind: "web_chat" };
 }
 
 function earlier(left: string, right: string): string {
@@ -183,4 +198,23 @@ export async function upsertAutomationTaskConversationAssociation(
   input: UpsertAutomationTaskConversationAssociationInput,
 ): Promise<ScheduledTaskConversationRow> {
   return createAutomationTaskConversationService(db).associate(input);
+}
+
+export async function touchActiveAutomationTaskConversationAssociations(
+  db: Kysely<DB>,
+  input: Pick<UpsertAutomationTaskConversationAssociationInput, "taskId" | "conversationId" | "transcriptUserId">,
+): Promise<number> {
+  const result = await db
+    .updateTable("scheduled_task_conversations")
+    .set({
+      updated_at: sql<string>`CURRENT_TIMESTAMP`,
+      last_active_at: sql<string>`CURRENT_TIMESTAMP`,
+    })
+    .where("task_id", "=", input.taskId)
+    .where("conversation_id", "=", input.conversationId)
+    .where("transcript_user_id", "=", input.transcriptUserId)
+    .where("archived_at", "is", null)
+    .executeTakeFirst();
+
+  return Number(result.numUpdatedRows ?? 0);
 }

--- a/packages/server/src/automation/task-conversations.ts
+++ b/packages/server/src/automation/task-conversations.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely } from "kysely";
+import {
+  type ScheduledTaskConversationKind,
+  type ScheduledTaskConversationRow,
+  type UpsertScheduledTaskConversationInput,
+  createScheduledTaskConversationRepository,
+} from "../db/repositories/scheduled-task-conversations";
+import type { DB } from "../db/schema";
+
+export type { ScheduledTaskConversationKind } from "../db/repositories/scheduled-task-conversations";
+
+export interface AutomationTaskConversationSummary {
+  conversationId: string;
+  kinds: ScheduledTaskConversationKind[];
+  createdAt: string;
+  updatedAt: string;
+  lastActiveAt: string;
+  archivedAt: string | null;
+  state: "active" | "archived";
+}
+
+export interface UpsertAutomationTaskConversationAssociationInput {
+  taskId: string;
+  conversationId: string;
+  transcriptUserId: string;
+  kind: ScheduledTaskConversationKind;
+}
+
+function earlier(left: string, right: string): string {
+  return Date.parse(left) <= Date.parse(right) ? left : right;
+}
+
+function later(left: string, right: string): string {
+  return Date.parse(left) >= Date.parse(right) ? left : right;
+}
+
+function summarizeRows(rows: ScheduledTaskConversationRow[]): AutomationTaskConversationSummary | undefined {
+  if (rows.length === 0) return undefined;
+
+  const kinds = [...new Set(rows.map((row) => row.kind as ScheduledTaskConversationKind))].sort();
+  const createdAt = rows.slice(1).reduce((value, row) => earlier(value, row.created_at), rows[0].created_at);
+  const updatedAt = rows.slice(1).reduce((value, row) => later(value, row.updated_at), rows[0].updated_at);
+  const lastActiveAt = rows.slice(1).reduce((value, row) => later(value, row.last_active_at), rows[0].last_active_at);
+  const activeRows = rows.filter((row) => row.archived_at === null);
+  const archivedTimes = rows.flatMap((row) => (row.archived_at === null ? [] : [row.archived_at]));
+  const archivedAt =
+    activeRows.length > 0
+      ? null
+      : archivedTimes.reduce<string | null>(
+          (value, timestamp) => (value === null ? timestamp : later(value, timestamp)),
+          null,
+        );
+
+  return {
+    conversationId: rows[0].conversation_id,
+    kinds,
+    createdAt,
+    updatedAt,
+    lastActiveAt,
+    archivedAt,
+    state: activeRows.length > 0 ? "active" : "archived",
+  };
+}
+
+function groupSummaries(rows: ScheduledTaskConversationRow[]): AutomationTaskConversationSummary[] {
+  const grouped = new Map<string, ScheduledTaskConversationRow[]>();
+  for (const row of rows) {
+    const group = grouped.get(row.conversation_id) ?? [];
+    group.push(row);
+    grouped.set(row.conversation_id, group);
+  }
+
+  return [...grouped.values()]
+    .map((group) => summarizeRows(group))
+    .filter((summary): summary is AutomationTaskConversationSummary => Boolean(summary))
+    .sort((left, right) => {
+      const activeSort = Number(left.state === "archived") - Number(right.state === "archived");
+      if (activeSort !== 0) return activeSort;
+      const lastActiveSort = Date.parse(right.lastActiveAt) - Date.parse(left.lastActiveAt);
+      if (lastActiveSort !== 0) return lastActiveSort;
+      return left.conversationId.localeCompare(right.conversationId);
+    });
+}
+
+function generatedBuilderConversationId(): string {
+  return `builder-${randomUUID()}`;
+}
+
+export function createAutomationTaskConversationService(db: Kysely<DB>) {
+  const repo = createScheduledTaskConversationRepository(db);
+
+  return {
+    async associate(input: UpsertAutomationTaskConversationAssociationInput) {
+      return repo.upsert(input);
+    },
+
+    async listForTranscriptUser(
+      taskId: string,
+      transcriptUserId: string,
+      options: { includeArchived?: boolean; kind?: ScheduledTaskConversationKind } = {},
+    ): Promise<AutomationTaskConversationSummary[]> {
+      const rows = await repo.listByTaskAndTranscriptUser(taskId, transcriptUserId, options);
+      return groupSummaries(rows);
+    },
+
+    async getForTranscriptUser(
+      taskId: string,
+      conversationId: string,
+      transcriptUserId: string,
+      options: { includeArchived?: boolean } = {},
+    ): Promise<AutomationTaskConversationSummary | undefined> {
+      const rows = await repo.listByTaskConversationForTranscriptUser(
+        taskId,
+        conversationId,
+        transcriptUserId,
+        options,
+      );
+      return summarizeRows(rows);
+    },
+
+    async hasAnyAssociation(taskId: string, conversationId: string): Promise<boolean> {
+      return (await repo.listByTaskConversation(taskId, conversationId)).length > 0;
+    },
+
+    async archiveForTranscriptUser(
+      taskId: string,
+      conversationId: string,
+      transcriptUserId: string,
+      archived: boolean,
+    ): Promise<AutomationTaskConversationSummary | undefined> {
+      const changed = await repo.setArchivedForTaskConversation(taskId, conversationId, transcriptUserId, archived);
+      if (!changed) return undefined;
+      return this.getForTranscriptUser(taskId, conversationId, transcriptUserId, { includeArchived: true });
+    },
+
+    async getOrCreateBuilderConversation(taskId: string, transcriptUserId: string) {
+      const existing = await repo.listByTaskAndTranscriptUser(taskId, transcriptUserId, {
+        kind: "builder",
+      });
+      if (existing.length > 0) {
+        const association = await repo.upsert({
+          taskId,
+          conversationId: existing[0].conversation_id,
+          transcriptUserId,
+          kind: "builder",
+        });
+        return { association, created: false };
+      }
+
+      const association = await repo.upsert({
+        taskId,
+        conversationId: generatedBuilderConversationId(),
+        transcriptUserId,
+        kind: "builder",
+      });
+      return { association, created: true };
+    },
+
+    async createBuilderConversation(taskId: string, transcriptUserId: string, conversationId?: string) {
+      const association = await repo.upsert({
+        taskId,
+        conversationId: conversationId ?? generatedBuilderConversationId(),
+        transcriptUserId,
+        kind: "builder",
+      });
+      return { association, created: true };
+    },
+  };
+}
+
+/**
+ * Idempotently records task/chat provenance or builder navigation.
+ *
+ * The normal web-chat provenance worker should call this once per canonical
+ * create or update with kind `web_chat`, the task ID, conversation ID, and
+ * authenticated transcript user ID. Transcript user scope must remain
+ * separate from task ownership because admins can access foreign-owned tasks
+ * without receiving the owner's transcript content.
+ */
+export async function upsertAutomationTaskConversationAssociation(
+  db: Kysely<DB>,
+  input: UpsertAutomationTaskConversationAssociationInput,
+): Promise<ScheduledTaskConversationRow> {
+  return createAutomationTaskConversationService(db).associate(input);
+}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -158,6 +158,7 @@ import * as m155 from "./migrations/155-requeue-kept-slice-reemission";
 import * as m156 from "./migrations/156-operational-alerts";
 import * as m157 from "./migrations/157-task-activity-events";
 import * as m158 from "./migrations/158-slack-channel-participants";
+import * as m159 from "./migrations/159-scheduled-task-conversations";
 import type { DB } from "./schema";
 
 /**
@@ -325,6 +326,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "156-operational-alerts": m156,
           "157-task-activity-events": m157,
           "158-slack-channel-participants": m158,
+          "159-scheduled-task-conversations": m159,
         };
       },
     },

--- a/packages/server/src/db/migrations/159-scheduled-task-conversations.ts
+++ b/packages/server/src/db/migrations/159-scheduled-task-conversations.ts
@@ -1,0 +1,66 @@
+import { type Kysely, sql } from "kysely";
+
+const TABLE = "scheduled_task_conversations";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable(TABLE)
+    .addColumn("task_id", "text", (col) => col.notNull())
+    .addColumn("conversation_id", "text", (col) => col.notNull())
+    .addColumn("transcript_user_id", "text", (col) => col.notNull())
+    .addColumn("kind", "text", (col) => col.notNull().defaultTo("builder"))
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("updated_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("last_active_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("archived_at", "text")
+    .addPrimaryKeyConstraint("scheduled_task_conversations_pkey", [
+      "task_id",
+      "conversation_id",
+      "transcript_user_id",
+      "kind",
+    ])
+    .execute();
+
+  await db.schema
+    .createIndex("idx_scheduled_task_conversations_task_user_active")
+    .on(TABLE)
+    .columns(["task_id", "transcript_user_id", "archived_at", "last_active_at"])
+    .execute();
+
+  await db.schema
+    .createIndex("idx_scheduled_task_conversations_conversation_user")
+    .on(TABLE)
+    .columns(["conversation_id", "transcript_user_id", "task_id"])
+    .execute();
+
+  await sql`
+    INSERT INTO scheduled_task_conversations (
+      task_id,
+      conversation_id,
+      transcript_user_id,
+      kind,
+      created_at,
+      updated_at,
+      last_active_at
+    )
+    SELECT
+      id,
+      origin_conversation_id,
+      created_by,
+      'web_chat',
+      created_at,
+      updated_at,
+      updated_at
+    FROM scheduled_tasks
+    WHERE origin_platform = 'web'
+      AND origin_conversation_id IS NOT NULL
+      AND created_by IS NOT NULL
+    ON CONFLICT (task_id, conversation_id, transcript_user_id, kind) DO NOTHING
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_scheduled_task_conversations_conversation_user`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_scheduled_task_conversations_task_user_active`.execute(db);
+  await db.schema.dropTable(TABLE).execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -20,7 +20,7 @@ import type { DB } from "../schema";
 import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
 
-const EXPECTED_MIGRATION_COUNT = 154;
+const EXPECTED_MIGRATION_COUNT = 155;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -189,6 +189,17 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[151]).toBe("156-operational-alerts");
     expect(names[152]).toBe("157-task-activity-events");
     expect(names[153]).toBe("158-slack-channel-participants");
+    expect(names[154]).toBe("159-scheduled-task-conversations");
+  });
+
+  it("creates the task conversation association table", async () => {
+    const rows = await sql<{ relname: string }>`
+      SELECT relname
+      FROM pg_class
+      WHERE relname = 'scheduled_task_conversations'
+    `.execute(db);
+
+    expect(rows.rows).toEqual([{ relname: "scheduled_task_conversations" }]);
   });
 
   it("creates the bounded open-materializable partial index", async () => {

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -25,7 +25,7 @@ import * as chatSessionRuntimeMigration from "./133-chat-session-runtime";
 import * as chatSessionArchiveMigration from "./134-chat-session-archived-at";
 import * as combinedDurabilityReseedMigration from "./152-reseed-combined-durability-routes";
 
-const EXPECTED_MIGRATION_COUNT = 154;
+const EXPECTED_MIGRATION_COUNT = 155;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -223,6 +223,61 @@ describe("runMigrations — full sequence", () => {
     expect(names[151]).toBe("156-operational-alerts");
     expect(names[152]).toBe("157-task-activity-events");
     expect(names[153]).toBe("158-slack-channel-participants");
+    expect(names[154]).toBe("159-scheduled-task-conversations");
+  });
+
+  it("backfills only exact web origin task conversations", async () => {
+    const migrator = createMigrator(db);
+    await migrator.migrateTo("158-slack-channel-participants");
+
+    await db
+      .insertInto("scheduled_tasks")
+      .values([
+        {
+          id: "task-origin-backfill",
+          platform: "slack",
+          context_type: "dm",
+          delivery_target: "D123",
+          prompt: "Use the exact origin",
+          schedule_type: "cron",
+          schedule_value: "0 9 * * *",
+          created_by: "origin-owner",
+          origin_platform: "web",
+          origin_conversation_id: "normal-chat-1",
+          created_at: "2026-08-01T00:00:00.000Z",
+          updated_at: "2026-08-01T00:00:00.000Z",
+        },
+        {
+          id: "task-without-origin",
+          platform: "slack",
+          context_type: "dm",
+          delivery_target: "D123",
+          prompt: "Do not infer a relationship",
+          schedule_type: "cron",
+          schedule_value: "0 10 * * *",
+          created_by: "origin-owner",
+          created_at: "2026-08-01T00:00:00.000Z",
+          updated_at: "2026-08-01T00:00:00.000Z",
+        },
+      ])
+      .execute();
+
+    await migrator.migrateToLatest();
+
+    await expect(
+      db
+        .selectFrom("scheduled_task_conversations")
+        .select(["task_id", "conversation_id", "transcript_user_id", "kind"])
+        .orderBy("task_id", "asc")
+        .execute(),
+    ).resolves.toEqual([
+      {
+        task_id: "task-origin-backfill",
+        conversation_id: "normal-chat-1",
+        transcript_user_id: "origin-owner",
+        kind: "web_chat",
+      },
+    ]);
   });
 
   it("resets reviewed combined durability routes for member-source reseeding", async () => {

--- a/packages/server/src/db/repositories/scheduled-task-conversations.integration.test.ts
+++ b/packages/server/src/db/repositories/scheduled-task-conversations.integration.test.ts
@@ -1,0 +1,43 @@
+import { type Kysely, sql } from "kysely";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getSharedPgDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createScheduledTaskConversationRepository } from "./scheduled-task-conversations";
+
+describe("scheduled task conversation repository on Postgres", () => {
+  let db: Kysely<DB>;
+
+  beforeAll(async () => {
+    db = await getSharedPgDb();
+  }, 30000);
+
+  beforeEach(async () => {
+    await sql`BEGIN`.execute(db);
+  });
+
+  afterEach(async () => {
+    await sql`ROLLBACK`.execute(db);
+  });
+
+  it("uses the portable composite key and preserves archived associations", async () => {
+    const repo = createScheduledTaskConversationRepository(db);
+    const input = {
+      taskId: "pg-task-a",
+      conversationId: "pg-shared-chat",
+      transcriptUserId: "pg-owner",
+      kind: "builder" as const,
+    };
+
+    await repo.upsert(input);
+    await repo.upsert(input);
+    await repo.upsert({ ...input, kind: "web_chat" });
+    await expect(
+      repo.setArchivedForTaskConversation(input.taskId, input.conversationId, input.transcriptUserId, true),
+    ).resolves.toBe(true);
+
+    await expect(repo.listByTaskAndTranscriptUser(input.taskId, input.transcriptUserId)).resolves.toEqual([]);
+    await expect(
+      repo.listByTaskAndTranscriptUser(input.taskId, input.transcriptUserId, { includeArchived: true }),
+    ).resolves.toHaveLength(2);
+  });
+});

--- a/packages/server/src/db/repositories/scheduled-task-conversations.test.ts
+++ b/packages/server/src/db/repositories/scheduled-task-conversations.test.ts
@@ -1,0 +1,107 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAutomationTaskConversationService } from "../../automation/task-conversations";
+import { createTestDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { createScheduledTaskConversationRepository } from "./scheduled-task-conversations";
+
+describe("scheduled task conversation repository", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("supports many-to-many links, idempotent upserts, grouped kinds, and archival without deletion", async () => {
+    const repo = createScheduledTaskConversationRepository(db);
+
+    await repo.upsert({
+      taskId: "task-a",
+      conversationId: "shared-chat",
+      transcriptUserId: "owner-a",
+      kind: "builder",
+    });
+    await repo.upsert({
+      taskId: "task-a",
+      conversationId: "shared-chat",
+      transcriptUserId: "owner-a",
+      kind: "builder",
+    });
+    await repo.upsert({
+      taskId: "task-a",
+      conversationId: "shared-chat",
+      transcriptUserId: "owner-a",
+      kind: "web_chat",
+    });
+    await repo.upsert({
+      taskId: "task-a",
+      conversationId: "builder-chat",
+      transcriptUserId: "owner-a",
+      kind: "builder",
+    });
+    await repo.upsert({
+      taskId: "task-b",
+      conversationId: "shared-chat",
+      transcriptUserId: "owner-a",
+      kind: "web_chat",
+    });
+
+    const service = createAutomationTaskConversationService(db);
+    await expect(service.listForTranscriptUser("task-a", "owner-a")).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          conversationId: "shared-chat",
+          kinds: ["builder", "web_chat"],
+          state: "active",
+        }),
+        expect.objectContaining({ conversationId: "builder-chat", kinds: ["builder"], state: "active" }),
+      ]),
+    );
+    await expect(service.listForTranscriptUser("task-b", "owner-a")).resolves.toEqual([
+      expect.objectContaining({ conversationId: "shared-chat", kinds: ["web_chat"] }),
+    ]);
+
+    await expect(service.archiveForTranscriptUser("task-a", "shared-chat", "owner-a", true)).resolves.toMatchObject({
+      conversationId: "shared-chat",
+      state: "archived",
+      kinds: ["builder", "web_chat"],
+    });
+    await expect(service.listForTranscriptUser("task-a", "owner-a")).resolves.toEqual([
+      expect.objectContaining({ conversationId: "builder-chat" }),
+    ]);
+    await expect(service.listForTranscriptUser("task-a", "owner-a", { includeArchived: true })).resolves.toEqual([
+      expect.objectContaining({ conversationId: "builder-chat", state: "active" }),
+      expect.objectContaining({ conversationId: "shared-chat", state: "archived" }),
+    ]);
+
+    await expect(
+      db
+        .selectFrom("scheduled_task_conversations")
+        .select(({ fn }) => fn.countAll<number>().as("count"))
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ count: 4 });
+  });
+
+  it("reuses the active builder association and creates a new one after archival", async () => {
+    const service = createAutomationTaskConversationService(db);
+    const first = await service.getOrCreateBuilderConversation("task-reuse", "owner-reuse");
+    const reused = await service.getOrCreateBuilderConversation("task-reuse", "owner-reuse");
+
+    expect(first.created).toBe(true);
+    expect(reused.created).toBe(false);
+    expect(reused.association.conversation_id).toBe(first.association.conversation_id);
+
+    await service.archiveForTranscriptUser("task-reuse", first.association.conversation_id, "owner-reuse", true);
+    const replacement = await service.getOrCreateBuilderConversation("task-reuse", "owner-reuse");
+
+    expect(replacement.created).toBe(true);
+    expect(replacement.association.conversation_id).not.toBe(first.association.conversation_id);
+    await expect(
+      service.listForTranscriptUser("task-reuse", "owner-reuse", { includeArchived: true }),
+    ).resolves.toHaveLength(2);
+  });
+});

--- a/packages/server/src/db/repositories/scheduled-task-conversations.ts
+++ b/packages/server/src/db/repositories/scheduled-task-conversations.ts
@@ -1,0 +1,120 @@
+import type { Insertable, Kysely, Selectable } from "kysely";
+import { sql } from "kysely";
+import type { DB, ScheduledTaskConversationsTable } from "../schema";
+
+export type ScheduledTaskConversationRow = Selectable<ScheduledTaskConversationsTable>;
+
+export type ScheduledTaskConversationKind = "builder" | "web_chat";
+
+export interface UpsertScheduledTaskConversationInput {
+  taskId: string;
+  conversationId: string;
+  transcriptUserId: string;
+  kind: ScheduledTaskConversationKind;
+}
+
+export interface ListScheduledTaskConversationOptions {
+  includeArchived?: boolean;
+  kind?: ScheduledTaskConversationKind;
+}
+
+export function createScheduledTaskConversationRepository(db: Kysely<DB>) {
+  return {
+    async upsert(input: UpsertScheduledTaskConversationInput): Promise<ScheduledTaskConversationRow> {
+      const values: Insertable<ScheduledTaskConversationsTable> = {
+        task_id: input.taskId,
+        conversation_id: input.conversationId,
+        transcript_user_id: input.transcriptUserId,
+        kind: input.kind,
+      };
+
+      await db
+        .insertInto("scheduled_task_conversations")
+        .values(values)
+        .onConflict((oc) =>
+          oc.columns(["task_id", "conversation_id", "transcript_user_id", "kind"]).doUpdateSet({
+            updated_at: sql<string>`CURRENT_TIMESTAMP`,
+            last_active_at: sql<string>`CURRENT_TIMESTAMP`,
+            archived_at: null,
+          }),
+        )
+        .execute();
+
+      return db
+        .selectFrom("scheduled_task_conversations")
+        .selectAll()
+        .where("task_id", "=", input.taskId)
+        .where("conversation_id", "=", input.conversationId)
+        .where("transcript_user_id", "=", input.transcriptUserId)
+        .where("kind", "=", input.kind)
+        .executeTakeFirstOrThrow();
+    },
+
+    async listByTaskAndTranscriptUser(
+      taskId: string,
+      transcriptUserId: string,
+      options: ListScheduledTaskConversationOptions = {},
+    ): Promise<ScheduledTaskConversationRow[]> {
+      let query = db
+        .selectFrom("scheduled_task_conversations")
+        .selectAll()
+        .where("task_id", "=", taskId)
+        .where("transcript_user_id", "=", transcriptUserId);
+
+      if (!options.includeArchived) query = query.where("archived_at", "is", null);
+      if (options.kind) query = query.where("kind", "=", options.kind);
+
+      return query.orderBy("last_active_at", "desc").orderBy("created_at", "desc").orderBy("kind", "asc").execute();
+    },
+
+    async listByTaskConversation(taskId: string, conversationId: string): Promise<ScheduledTaskConversationRow[]> {
+      return db
+        .selectFrom("scheduled_task_conversations")
+        .selectAll()
+        .where("task_id", "=", taskId)
+        .where("conversation_id", "=", conversationId)
+        .orderBy("transcript_user_id", "asc")
+        .orderBy("kind", "asc")
+        .execute();
+    },
+
+    async listByTaskConversationForTranscriptUser(
+      taskId: string,
+      conversationId: string,
+      transcriptUserId: string,
+      options: { includeArchived?: boolean } = {},
+    ): Promise<ScheduledTaskConversationRow[]> {
+      let query = db
+        .selectFrom("scheduled_task_conversations")
+        .selectAll()
+        .where("task_id", "=", taskId)
+        .where("conversation_id", "=", conversationId)
+        .where("transcript_user_id", "=", transcriptUserId);
+
+      if (!options.includeArchived) query = query.where("archived_at", "is", null);
+
+      return query.orderBy("kind", "asc").execute();
+    },
+
+    async setArchivedForTaskConversation(
+      taskId: string,
+      conversationId: string,
+      transcriptUserId: string,
+      archived: boolean,
+    ): Promise<boolean> {
+      const result = await db
+        .updateTable("scheduled_task_conversations")
+        .set({
+          archived_at: archived ? sql<string>`CURRENT_TIMESTAMP` : null,
+          updated_at: sql<string>`CURRENT_TIMESTAMP`,
+          ...(archived ? {} : { last_active_at: sql<string>`CURRENT_TIMESTAMP` }),
+        })
+        .where("task_id", "=", taskId)
+        .where("conversation_id", "=", conversationId)
+        .where("transcript_user_id", "=", transcriptUserId)
+        .executeTakeFirst();
+
+      return (result.numUpdatedRows ?? 0n) > 0n;
+    },
+  };
+}

--- a/packages/server/src/db/repositories/scheduled-task-conversations.ts
+++ b/packages/server/src/db/repositories/scheduled-task-conversations.ts
@@ -116,5 +116,9 @@ export function createScheduledTaskConversationRepository(db: Kysely<DB>) {
 
       return (result.numUpdatedRows ?? 0n) > 0n;
     },
+
+    async deleteByTaskId(taskId: string): Promise<void> {
+      await db.deleteFrom("scheduled_task_conversations").where("task_id", "=", taskId).execute();
+    },
   };
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -768,6 +768,17 @@ export interface AutomationStepContentTable {
   updated_at: Generated<string>;
 }
 
+export interface ScheduledTaskConversationsTable {
+  task_id: string;
+  conversation_id: string;
+  transcript_user_id: string;
+  kind: Generated<string>;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+  last_active_at: Generated<string>;
+  archived_at: string | null;
+}
+
 export interface AgentOutputsTable {
   id: string;
   agent_key: string;
@@ -1443,6 +1454,7 @@ export interface DB {
   scheduled_tasks: ScheduledTasksTable;
   automation_runs: AutomationRunsTable;
   automation_step_content: AutomationStepContentTable;
+  scheduled_task_conversations: ScheduledTaskConversationsTable;
   agent_outputs: AgentOutputsTable;
   agent_output_items: AgentOutputItemsTable;
   agent_output_deliveries: AgentOutputDeliveriesTable;

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -29,6 +29,7 @@ import { createAuthMiddleware } from "./api/middleware";
 import { productRoutes } from "./api/products";
 import { createProjectRoutes } from "./api/projects";
 import { providerIdentityRoutes } from "./api/provider-identities";
+import { scheduledTaskConversationRoutes } from "./api/scheduled-task-conversations";
 import { scheduledTaskRoutes } from "./api/scheduled-tasks";
 import { settingsRoutes } from "./api/settings";
 import { setupRoutes } from "./api/setup";
@@ -544,6 +545,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       }),
     );
   }
+  app.route("/api/scheduled-tasks", scheduledTaskConversationRoutes(db, { logger }));
   app.route(
     "/api/channels",
     channelRoutes({

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -115,6 +115,7 @@ interface AppDeps {
   onLlmSettingsUpdated?: () => Promise<void>;
   onSmtpUpdated?: () => Promise<void>;
   scheduler?: Pick<TaskScheduler, "pauseTask" | "resumeTask" | "removeTask" | "executeTaskById"> &
+    Partial<Pick<TaskScheduler, "removeTaskRuntime">> &
     Partial<Pick<TaskScheduler, "refreshTaskSchedule" | "executeStepById" | "getTaskById">>;
   runAgent?: (params: RunAgentParams) => Promise<RunAgentResult>;
   buildMcpServers?: (email: string | null) => Promise<Record<string, McpServerConfig>>;

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -367,6 +367,29 @@ describe("removeTask()", () => {
     const dbRow = await repo.getById(task.id);
     expect(dbRow).toBeUndefined();
   });
+
+  it("removes only runtime schedule state after canonical database deletion", async () => {
+    const deps = buildDeps(db);
+    const scheduler = new TaskScheduler(deps as never);
+    const task = await scheduler.addTask({
+      platform: "slack",
+      contextType: "dm",
+      deliveryTarget: "U_USER1",
+      prompt: "Runtime-only cleanup",
+      scheduleType: "cron",
+      scheduleValue: "0 9 * * 1",
+      createdBy: "U_USER1",
+    });
+    const row = await repo.getById(task.id);
+    if (!row) throw new Error("Expected task row");
+    await scheduler.scheduleTask(row);
+
+    const removed = await scheduler.removeTaskRuntime(task.id);
+
+    expect(removed).toBe(true);
+    await expect(repo.getById(task.id)).resolves.toBeDefined();
+    expect(mockCronInstances.at(-1)?.stopped).toBe(true);
+  });
 });
 
 describe("pauseTask()", () => {

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -802,6 +802,11 @@ export class TaskScheduler {
     return this.repo.remove(id);
   }
 
+  async removeTaskRuntime(id: string): Promise<boolean> {
+    this.unscheduleTask(id);
+    return !this.cronInstances.has(id);
+  }
+
   async pauseTask(id: string): Promise<void> {
     this.unscheduleTask(id);
     await this.repo.updateStatus(id, "paused", { incrementRevision: true });

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -84,6 +84,7 @@ function makeMockScheduler(overrides: Partial<TaskScheduler> = {}): TaskSchedule
     addTask: vi.fn().mockResolvedValue(makeTask()),
     updateTask: vi.fn().mockResolvedValue(makeTask()),
     removeTask: vi.fn().mockResolvedValue(true),
+    removeTaskRuntime: vi.fn().mockResolvedValue(true),
     pauseTask: vi.fn().mockResolvedValue(undefined),
     resumeTask: vi.fn().mockResolvedValue(undefined),
     executeTaskById: vi.fn().mockResolvedValue(undefined),
@@ -667,15 +668,15 @@ describe("handleManageScheduledTasks — remove", () => {
     expect(result.content[0].text).toContain("Error:");
   });
 
-  it("calls scheduler.removeTask and confirms removal", async () => {
+  it("requires canonical persistence before runtime cleanup", async () => {
     const scheduler = makeMockScheduler({ removeTask: vi.fn().mockResolvedValue(true) });
     const result = await handleManageScheduledTasks(
       { action: "remove", task_id: "task-1" },
       { scheduler, stepContentRepo, taskContext: dmContext },
     );
-    expect(scheduler.removeTask).toHaveBeenCalledWith("task-1");
-    expect(result.content[0].text).toContain("task-1");
-    expect(result.content[0].text).toContain("removed");
+    expect(scheduler.removeTask).not.toHaveBeenCalled();
+    expect(scheduler.removeTaskRuntime).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain("canonical automation persistence is not available");
   });
 });
 

--- a/packages/server/src/scheduler/types.ts
+++ b/packages/server/src/scheduler/types.ts
@@ -84,6 +84,7 @@ export interface TaskContext {
   contextType: "dm" | "channel" | "group";
   deliveryTarget: string;
   createdBy: string | null;
+  conversationKind?: "web_chat" | "builder";
   /**
    * Creator's IANA timezone, used as the default for new scheduled tasks when
    * the agent doesn't pass `timezone` explicitly. Null means "fall through to UTC".

--- a/packages/web/src/components/sketch/automation-artifact-card.isolated.test.tsx
+++ b/packages/web/src/components/sketch/automation-artifact-card.isolated.test.tsx
@@ -36,9 +36,9 @@ describe("AutomationArtifactCard", () => {
 
     expect(screen.getByText("Daily account brief")).toBeInTheDocument();
     expect(screen.getByText("ClickUp")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open automation" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue in builder" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Open automation" }));
+    await user.click(screen.getByRole("button", { name: "Continue in builder" }));
     expect(mocks.navigate).toHaveBeenCalledWith({
       to: "/scheduled-tasks/$taskId/edit",
       params: { taskId: "task-123" },
@@ -47,5 +47,22 @@ describe("AutomationArtifactCard", () => {
 
     await user.click(screen.getByRole("button", { name: "Save as-is" }));
     expect(mocks.navigate).toHaveBeenLastCalledWith({ to: "/scheduled-tasks" });
+  });
+
+  it("uses the exact conversation embedded in the artifact URL when no prop is supplied", async () => {
+    const user = userEvent.setup();
+    render(
+      <AutomationArtifactCard
+        artifact={{ ...artifact, builderUrl: "/scheduled-tasks/task-123/edit?conversationId=source-chat" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Continue in builder" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: "/scheduled-tasks/$taskId/edit",
+      params: { taskId: "task-123" },
+      search: { conversationId: "source-chat" },
+    });
   });
 });

--- a/packages/web/src/components/sketch/automation-artifact-card.tsx
+++ b/packages/web/src/components/sketch/automation-artifact-card.tsx
@@ -4,6 +4,15 @@ import { Button } from "@sketch/ui/components/button";
 import { cn } from "@sketch/ui/lib/utils";
 import { useNavigate } from "@tanstack/react-router";
 
+function conversationIdFromBuilderUrl(builderUrl: string): string | undefined {
+  try {
+    const value = new URL(builderUrl, "http://sketch.local").searchParams.get("conversationId")?.trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function AutomationArtifactCard({
   artifact,
   conversationId,
@@ -15,12 +24,13 @@ export function AutomationArtifactCard({
 }) {
   const navigate = useNavigate();
   const tags = Array.from(new Set(artifact.tags));
+  const continuationConversationId = conversationIdFromBuilderUrl(artifact.builderUrl) ?? conversationId;
 
   const openBuilder = () => {
     void navigate({
       to: "/scheduled-tasks/$taskId/edit",
       params: { taskId: artifact.taskId },
-      search: conversationId ? { conversationId } : {},
+      search: continuationConversationId ? { conversationId: continuationConversationId } : {},
     });
   };
 
@@ -65,7 +75,7 @@ export function AutomationArtifactCard({
           className="h-9 rounded-[8px] bg-brand-accent px-4 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-[#161300] shadow-none hover:bg-brand-accent/90 sm:px-5"
           onClick={openBuilder}
         >
-          Open automation
+          {continuationConversationId ? "Continue in builder" : "Open automation"}
         </Button>
         <Button
           type="button"


### PR DESCRIPTION
## Summary

- persist durable many-to-many associations between automations and the web chats that create or edit them
- expose task-scoped conversation APIs with strict viewer, archive, and ownership boundaries
- make automation deletion failure-safe across persistence, scheduler state, step content, and chat associations

## Linear Scope

- [SKE-331: Persist task-scoped automation chat provenance](https://linear.app/sketch-ai/issue/SKE-331/persist-task-scoped-automation-chat-provenance)

## Stack

- 3 of 7 in the automation hardening stack
- depends on [#446](https://github.com/canvasxai/sketch/pull/446)
- GitHub base: `fix/ske-347-automation-hardening`

## Implementation Details

- add an additive, SQLite/Postgres-compatible scheduled-task conversation association schema and repository
- separate conversation identity from current task identity so one chat may affect multiple automations and one automation may retain multiple chats
- record every canonical create/update against its source web chat without rewriting creation-only `originChat` provenance
- require an existing viewer-scoped transcript before selecting or associating a supplied conversation ID; archived associations remain archived until explicitly restored
- retain detached transcripts and expose only provable task associations
- delete task state transactionally where possible and preserve retriable database state when scheduler cleanup fails

## Verification

- Node 24 `pnpm biome check .` — passed; 1,313 files
- `pnpm typecheck` — passed
- `pnpm test` — passed; server 4,935 passed / 20 skipped, web 437 passed
- `pnpm build` — passed
- migration sequence, SQLite repository, PGlite/Postgres persistence, API authorization, provenance, and deletion coverage passed
- Node 24 pre-push gate — passed on the complete stack

## Risk / Rollout

- adds migration `159-scheduled-task-conversations`; it is additive and portable across SQLite and Postgres
- no transcript content is copied into the association table
- admin task access does not grant foreign-owner transcript access
- no deployment or release is included
