### PR TITLE
SKE-332: Add durable automation chat navigation

### DIFF
--- a/packages/server/src/api/scheduled-task-conversations.test.ts
+++ b/packages/server/src/api/scheduled-task-conversations.test.ts
@@ -89,7 +89,8 @@ describe("scheduled task conversation API", () => {
 
     const first = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
       method: "POST",
-      headers: { Cookie: cookie },
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ createNew: true }),
     });
     expect(first.status).toBe(201);
     const firstBody = await first.json();
@@ -133,6 +134,26 @@ describe("scheduled task conversation API", () => {
       conversationId: firstConversationId,
       state: "archived",
     });
+
+    const selectArchived = await app.request(
+      `/api/scheduled-tasks/task-conversations/conversations/${firstConversationId}`,
+      {
+        method: "PUT",
+        headers: { Cookie: cookie, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(selectArchived.status).toBe(409);
+    await expect(selectArchived.json()).resolves.toMatchObject({
+      error: { code: "CONVERSATION_ARCHIVED" },
+    });
+    const archivedRows = await db
+      .selectFrom("scheduled_task_conversations")
+      .select(["archived_at"])
+      .where("task_id", "=", "task-conversations")
+      .where("conversation_id", "=", firstConversationId)
+      .execute();
+    expect(archivedRows.every((row) => row.archived_at !== null)).toBe(true);
 
     const activeList = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
       headers: { Cookie: cookie },
@@ -219,6 +240,26 @@ describe("scheduled task conversation API", () => {
       headers: { Cookie: cookie },
     });
     expect(unrelated.status).toBe(404);
+
+    const putUnrelated = await app.request("/api/scheduled-tasks/safe-task/conversations/not-associated", {
+      method: "PUT",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(putUnrelated.status).toBe(404);
+    await expect(putUnrelated.json()).resolves.toMatchObject({
+      error: { code: "CONVERSATION_NOT_FOUND" },
+    });
+
+    const postGuessed = await app.request("/api/scheduled-tasks/safe-task/conversations", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId: "guessed-builder", createNew: true }),
+    });
+    expect(postGuessed.status).toBe(404);
+    await expect(postGuessed.json()).resolves.toMatchObject({
+      error: { code: "CONVERSATION_NOT_FOUND" },
+    });
 
     await expect(
       db.selectFrom("scheduled_task_conversations").selectAll().where("task_id", "=", "safe-task").execute(),

--- a/packages/server/src/api/scheduled-task-conversations.ts
+++ b/packages/server/src/api/scheduled-task-conversations.ts
@@ -106,33 +106,52 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
     }
 
     let result: { association: Awaited<ReturnType<typeof conversations.associate>>; created: boolean };
-    if (kind === "builder" && !requestedConversationId && body.createNew !== true) {
-      result = await conversations.getOrCreateBuilderConversation(taskId, access.userId);
-    } else if (kind === "builder") {
-      const existing = requestedConversationId
-        ? await conversations.getForTranscriptUser(taskId, requestedConversationId, access.userId, {
-            includeArchived: true,
-          })
-        : undefined;
-      result = await conversations.createBuilderConversation(taskId, access.userId, requestedConversationId);
-      result.created = !existing;
-    } else {
-      const existing = await conversations.getForTranscriptUser(
-        taskId,
-        requestedConversationId as string,
-        access.userId,
-        {
-          includeArchived: true,
-        },
-      );
+    if (kind === "builder" && !requestedConversationId && body.createNew === true) {
+      result = await conversations.createBuilderConversation(taskId, access.userId);
+    } else if (!requestedConversationId) {
+      const activeBuilder = await conversations.listForTranscriptUser(taskId, access.userId, { kind: "builder" });
+      const existingConversationId = activeBuilder[0]?.conversationId;
+      if (!existingConversationId) {
+        return errorResponse(
+          c,
+          "CONVERSATION_NOT_FOUND",
+          "No active builder conversation exists; start a new chat explicitly",
+          404,
+        );
+      }
       result = {
         association: await conversations.associate({
           taskId,
-          conversationId: requestedConversationId as string,
+          conversationId: existingConversationId,
+          transcriptUserId: access.userId,
+          kind: "builder",
+        }),
+        created: false,
+      };
+    } else {
+      const existing = await conversations.getForTranscriptUser(taskId, requestedConversationId, access.userId, {
+        includeArchived: true,
+      });
+      if (!existing) {
+        return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation is not associated with this task", 404);
+      }
+
+      const active = await conversations.getForTranscriptUser(taskId, requestedConversationId, access.userId);
+      if (!active) {
+        return errorResponse(c, "CONVERSATION_ARCHIVED", "Conversation is archived; restore it before selecting", 409);
+      }
+      if (!active.kinds.includes(kind)) {
+        return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation kind is not associated with this task", 404);
+      }
+
+      result = {
+        association: await conversations.associate({
+          taskId,
+          conversationId: requestedConversationId,
           transcriptUserId: access.userId,
           kind,
         }),
-        created: !existing,
+        created: false,
       };
     }
 
@@ -183,19 +202,33 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
     const existing = await conversations.getForTranscriptUser(taskId, conversationId, access.userId, {
       includeArchived: true,
     });
+    if (!existing) {
+      return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation is not associated with this task", 404);
+    }
+    const active = await conversations.getForTranscriptUser(taskId, conversationId, access.userId);
+    if (!active) {
+      return errorResponse(c, "CONVERSATION_ARCHIVED", "Conversation is archived; restore it before selecting", 409);
+    }
+    if (body.kind !== undefined && !active.kinds.includes(kind)) {
+      return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation kind is not associated with this task", 404);
+    }
+    const selectedKind = body.kind === undefined ? active.kinds[0] : kind;
+    if (!selectedKind) {
+      return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation association is unavailable", 404);
+    }
     await conversations.associate({
       taskId,
       conversationId,
       transcriptUserId: access.userId,
-      kind,
+      kind: selectedKind,
     });
     const summary = await conversations.getForTranscriptUser(taskId, conversationId, access.userId, {
       includeArchived: true,
     });
     if (!summary) return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation association was not persisted", 409);
 
-    const response = { conversation: summary, created: !existing };
-    return existing ? c.json(response) : c.json(response, 201);
+    const response = { conversation: summary, created: false };
+    return c.json(response);
   });
 
   routes.patch("/:id/conversations/:conversationId", async (c) => {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -154,6 +154,24 @@ export interface ScheduledTaskOriginChatMessage {
   createdAt: string;
 }
 
+export type ScheduledTaskConversationKind = "builder" | "web_chat";
+
+export interface ScheduledTaskConversationSummary {
+  conversationId: string;
+  kinds: ScheduledTaskConversationKind[];
+  createdAt: string;
+  updatedAt: string;
+  lastActiveAt: string;
+  archivedAt: string | null;
+  state: "active" | "archived";
+}
+
+export interface ScheduledTaskConversationsResponse {
+  taskId: string;
+  conversations: ScheduledTaskConversationSummary[];
+  transcriptAccess: "viewer";
+}
+
 export interface WorkflowTriggerConfig {
   type: "webhook" | "schedule" | "canvas" | "slack_channel_message";
   channelId?: string;
@@ -2295,6 +2313,49 @@ export const api = {
     originChatMessages(taskId: string) {
       return request<{ messages: ScheduledTaskOriginChatMessage[] }>(
         `/api/scheduled-tasks/${taskId}/origin-chat/messages`,
+      );
+    },
+    conversations(taskId: string, options?: { includeArchived?: boolean }) {
+      const query = options?.includeArchived ? "?includeArchived=true" : "";
+      return request<ScheduledTaskConversationsResponse>(
+        `/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations${query}`,
+      );
+    },
+    createConversation(
+      taskId: string,
+      body: {
+        createNew: true;
+      },
+    ) {
+      return request<{
+        conversation: ScheduledTaskConversationSummary;
+        created: boolean;
+      }>(`/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    },
+    getConversation(taskId: string, conversationId: string) {
+      return request<{ conversation: ScheduledTaskConversationSummary }>(
+        `/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations/${encodeURIComponent(conversationId)}`,
+      );
+    },
+    selectConversation(taskId: string, conversationId: string, kind?: ScheduledTaskConversationKind) {
+      return request<{
+        conversation: ScheduledTaskConversationSummary;
+        created: false;
+      }>(`/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations/${encodeURIComponent(conversationId)}`, {
+        method: "PUT",
+        body: JSON.stringify(kind ? { kind } : {}),
+      });
+    },
+    archiveConversation(taskId: string, conversationId: string, archived: boolean) {
+      return request<{ conversation: ScheduledTaskConversationSummary }>(
+        `/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations/${encodeURIComponent(conversationId)}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ archived }),
+        },
       );
     },
     async save(taskId: string, body: AutomationBuilderSaveRequest) {

--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -1,5 +1,5 @@
 import type { AutomationDefinition } from "@/lib/api";
-import { ApiRequestError, api } from "@/lib/api";
+import { ApiRequestError } from "@/lib/api";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -9,9 +9,13 @@ import { AutomationBuilderPage } from "./automation-builder";
 
 const mocks = vi.hoisted(() => ({
   getAutomation: vi.fn(),
+  listConversations: vi.fn(),
   loadMessages: vi.fn(),
   navigate: vi.fn(),
   originChatMessages: vi.fn(),
+  createConversation: vi.fn(),
+  selectConversation: vi.fn(),
+  archiveConversation: vi.fn(),
   interruptChat: vi.fn(),
   runTask: vi.fn(),
   saveAutomation: vi.fn(),
@@ -33,6 +37,10 @@ vi.mock("@/lib/api", async (importOriginal) => {
     api: {
       scheduledTasks: {
         get: mocks.getAutomation,
+        conversations: mocks.listConversations,
+        createConversation: mocks.createConversation,
+        selectConversation: mocks.selectConversation,
+        archiveConversation: mocks.archiveConversation,
         originChatMessages: mocks.originChatMessages,
         run: mocks.runTask,
         save: mocks.saveAutomation,
@@ -249,9 +257,65 @@ describe("AutomationBuilderPage", () => {
   beforeEach(() => {
     mocks.getAutomation.mockClear();
     mocks.getAutomation.mockResolvedValue(automation);
+    mocks.listConversations.mockClear();
+    mocks.listConversations.mockResolvedValue({
+      taskId: "task-123",
+      conversations: [
+        {
+          conversationId: "chat-alpha",
+          kinds: ["web_chat"],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+          lastActiveAt: "2026-06-01T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+        },
+      ],
+      transcriptAccess: "viewer",
+    });
     mocks.loadMessages.mockClear();
     mocks.loadMessages.mockResolvedValue({ messages: [], updatedAt: null });
     mocks.originChatMessages.mockResolvedValue({ messages: [] });
+    mocks.createConversation.mockClear();
+    mocks.createConversation.mockResolvedValue({
+      conversation: {
+        conversationId: "builder-new",
+        kinds: ["builder"],
+        createdAt: "2026-06-02T00:00:00.000Z",
+        updatedAt: "2026-06-02T00:00:00.000Z",
+        lastActiveAt: "2026-06-02T00:00:00.000Z",
+        archivedAt: null,
+        state: "active",
+      },
+      created: true,
+    });
+    mocks.selectConversation.mockClear();
+    mocks.selectConversation.mockImplementation(async (_taskId: string, conversationId: string) => ({
+      conversation: {
+        conversationId,
+        kinds: ["builder"],
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-03T00:00:00.000Z",
+        lastActiveAt: "2026-06-03T00:00:00.000Z",
+        archivedAt: null,
+        state: "active",
+      },
+      created: false,
+    }));
+    mocks.archiveConversation.mockClear();
+    mocks.archiveConversation.mockImplementation(
+      async (_taskId: string, conversationId: string, archived: boolean) => ({
+        conversation: {
+          conversationId,
+          kinds: ["builder"],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-04T00:00:00.000Z",
+          lastActiveAt: "2026-06-03T00:00:00.000Z",
+          archivedAt: archived ? "2026-06-04T00:00:00.000Z" : null,
+          state: archived ? "archived" : "active",
+        },
+      }),
+    );
     mocks.interruptChat.mockClear();
     mocks.interruptChat.mockResolvedValue({ success: true, interrupted: true });
     mocks.navigate.mockClear();
@@ -292,13 +356,13 @@ describe("AutomationBuilderPage", () => {
     expect(screen.getAllByDisplayValue("C123").length).toBeGreaterThan(0);
   });
 
-  it("opens a fresh builder chat and sends the active automation id", async () => {
+  it("opens the selected associated chat and sends the active automation id", async () => {
     const user = userEvent.setup();
     renderBuilder();
 
     const input = await screen.findByLabelText("Message Sketch");
     await waitFor(() => expect(input).not.toBeDisabled());
-    expect(mocks.loadMessages).toHaveBeenCalledWith(expect.stringMatching(/^builder-task-123-/));
+    expect(mocks.loadMessages).toHaveBeenCalledWith("chat-alpha");
 
     await user.type(input, "Make it daily");
     await user.click(screen.getByLabelText("Send message"));
@@ -308,13 +372,13 @@ describe("AutomationBuilderPage", () => {
     });
   });
 
-  it("shows an automation-aware empty state for a fresh builder chat", async () => {
+  it("shows an automation-aware empty state for an associated empty chat", async () => {
     const user = userEvent.setup();
     renderBuilder();
 
     await screen.findByLabelText("Message Sketch");
-    expect(screen.getByText("Builder chat")).toBeInTheDocument();
-    expect(screen.getByText("Fresh")).toBeInTheDocument();
+    expect(screen.getByText("Current builder chat")).toBeInTheDocument();
+    expect(screen.getByText("Source chat")).toBeInTheDocument();
     expect(await screen.findByText("What should change?")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Add a step" }));
@@ -369,13 +433,13 @@ describe("AutomationBuilderPage", () => {
     expect(ownership).toHaveTextContent("Owner Alice Member");
     expect(ownership).toHaveTextContent("Last edited by Karan Admin");
   });
-  it("ignores origin web chat search params when choosing the builder chat", async () => {
+  it("honors an associated source chat search param", async () => {
     mocks.search = { conversationId: "chat-alpha" };
     renderBuilder();
 
     await screen.findByLabelText("Message Sketch");
-    expect(mocks.loadMessages).toHaveBeenCalledWith(expect.stringMatching(/^builder-task-123-/));
-    expect(mocks.loadMessages).not.toHaveBeenCalledWith("chat-alpha");
+    expect(mocks.loadMessages).toHaveBeenCalledWith("chat-alpha");
+    expect(mocks.loadMessages).not.toHaveBeenCalledWith(expect.stringMatching(/^builder-task-123-/));
   });
 
   it("auto-arranges generated vertical workflow positions", async () => {
@@ -389,46 +453,119 @@ describe("AutomationBuilderPage", () => {
     expect(flow).toHaveAttribute("data-node-positions", "trigger:0,0|check:245,0");
   });
 
-  it("starts a fresh builder chat for a Slack-origin automation", async () => {
+  it("opens the task chat list without a conversation search param", async () => {
     const user = userEvent.setup();
     mocks.search = {};
     mocks.getAutomation.mockResolvedValue({
       ...automation,
       originChat: { platform: "slack", conversationId: "42", providerThreadId: "1700.1", currentMessageId: 12 },
     });
-    mocks.originChatMessages.mockResolvedValue({
-      messages: [
-        {
-          id: "1",
-          role: "user",
-          senderName: "Alice",
-          text: "Alice: Create a Trustpilot review automation",
-          createdAt: "2026-06-01T00:00:00.000Z",
-        },
-      ],
-    });
-
     renderBuilder();
 
-    const input = await screen.findByLabelText("Message Sketch");
-    expect(screen.queryByText("Alice: Create a Trustpilot review automation")).not.toBeInTheDocument();
-    expect(mocks.loadMessages).toHaveBeenCalledWith(expect.stringMatching(/^builder-task-123-/));
+    expect(await screen.findByText("Builder chats")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Message Sketch")).not.toBeInTheDocument();
+    expect(mocks.loadMessages).not.toHaveBeenCalled();
     expect(mocks.originChatMessages).not.toHaveBeenCalled();
 
-    await waitFor(() => expect(input).not.toBeDisabled());
-    await user.type(input, "Tighten the filter");
-    await user.click(screen.getByLabelText("Send message"));
-
-    await waitFor(() =>
-      expect(mocks.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: "Tighten the filter" }), {
-        body: { automationTaskId: "task-123" },
+    await user.click(screen.getByRole("button", { name: "New chat" }));
+    await waitFor(() => expect(mocks.createConversation).toHaveBeenCalledWith("task-123", { createNew: true }));
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/scheduled-tasks/$taskId/edit",
+        params: { taskId: "task-123" },
+        search: { conversationId: "builder-new" },
       }),
     );
   });
 
-  it("can stop a stuck builder chat run", async () => {
+  it("selects an older task-scoped chat from the sidechat list", async () => {
     const user = userEvent.setup();
     mocks.search = {};
+    mocks.listConversations.mockResolvedValue({
+      taskId: "task-123",
+      conversations: [
+        {
+          conversationId: "chat-alpha",
+          kinds: ["builder"],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+          lastActiveAt: "2026-06-01T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+        },
+        {
+          conversationId: "chat-beta",
+          kinds: ["builder"],
+          createdAt: "2026-06-02T00:00:00.000Z",
+          updatedAt: "2026-06-02T00:00:00.000Z",
+          lastActiveAt: "2026-06-02T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+        },
+      ],
+      transcriptAccess: "viewer",
+    });
+
+    renderBuilder();
+    await user.click(await screen.findByTestId("automation-builder-conversation-chat-beta"));
+
+    await waitFor(() => expect(mocks.selectConversation).toHaveBeenCalledWith("task-123", "chat-beta", "builder"));
+    expect(mocks.navigate).toHaveBeenCalledWith(expect.objectContaining({ search: { conversationId: "chat-beta" } }));
+    expect(mocks.loadMessages).not.toHaveBeenCalled();
+  });
+
+  it("archives the current chat from the sidechat and returns to history", async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+
+    await user.click(await screen.findByRole("button", { name: "Archive builder chat" }));
+
+    await waitFor(() => expect(mocks.archiveConversation).toHaveBeenCalledWith("task-123", "chat-alpha", true));
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ search: {}, params: { taskId: "task-123" } }),
+    );
+  });
+
+  it("shows archived and unrelated route states without loading transcript content", async () => {
+    mocks.search = { conversationId: "chat-archived" };
+    mocks.listConversations.mockResolvedValue({
+      taskId: "task-123",
+      conversations: [
+        {
+          conversationId: "chat-archived",
+          kinds: ["builder"],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+          lastActiveAt: "2026-06-01T00:00:00.000Z",
+          archivedAt: "2026-06-03T00:00:00.000Z",
+          state: "archived",
+        },
+      ],
+      transcriptAccess: "viewer",
+    });
+
+    const user = userEvent.setup();
+    renderBuilder();
+
+    expect(await screen.findByTestId("automation-builder-chat-archived")).toBeInTheDocument();
+    expect(mocks.loadMessages).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Restore chat" }));
+    await waitFor(() => expect(mocks.archiveConversation).toHaveBeenCalledWith("task-123", "chat-archived", false));
+
+    mocks.search = { conversationId: "not-associated" };
+    mocks.listConversations.mockResolvedValue({
+      taskId: "task-123",
+      conversations: [],
+      transcriptAccess: "viewer",
+    });
+    renderBuilder();
+    expect(await screen.findByTestId("automation-builder-chat-unavailable")).toBeInTheDocument();
+    expect(mocks.loadMessages).not.toHaveBeenCalledWith("not-associated");
+  });
+
+  it("can stop a stuck builder chat run", async () => {
+    const user = userEvent.setup();
+    mocks.search = { conversationId: "chat-alpha" };
     mocks.getAutomation.mockResolvedValue({
       ...automation,
       originChat: { platform: "slack", conversationId: "42", providerThreadId: "1700.1", currentMessageId: 12 },
@@ -445,13 +582,12 @@ describe("AutomationBuilderPage", () => {
 
     await user.click(await screen.findByLabelText("Pause Sketch"));
 
-    expect(mocks.interruptChat).toHaveBeenCalledWith(expect.stringMatching(/^builder-task-123-/));
-    expect(mocks.interruptChat).not.toHaveBeenCalledWith("chat-alpha");
+    expect(mocks.interruptChat).toHaveBeenCalledWith("chat-alpha");
     expect(mocks.interruptChat).not.toHaveBeenCalledWith("42");
   });
 
   it("shows a stopped builder chat notice after reload", async () => {
-    mocks.search = {};
+    mocks.search = { conversationId: "chat-alpha" };
     mocks.getAutomation.mockResolvedValue({
       ...automation,
       originChat: { platform: "slack", conversationId: "42", providerThreadId: "1700.1", currentMessageId: 12 },

--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -10,6 +10,7 @@ import { AutomationBuilderPage } from "./automation-builder";
 const mocks = vi.hoisted(() => ({
   getAutomation: vi.fn(),
   listConversations: vi.fn(),
+  webChatConversations: vi.fn(),
   loadMessages: vi.fn(),
   navigate: vi.fn(),
   originChatMessages: vi.fn(),
@@ -48,6 +49,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
       },
       webChat: {
         messages: mocks.loadMessages,
+        conversations: mocks.webChatConversations,
         interrupt: mocks.interruptChat,
         uploadAttachment: vi.fn(),
         transcribe: vi.fn(),
@@ -273,6 +275,17 @@ describe("AutomationBuilderPage", () => {
       ],
       transcriptAccess: "viewer",
     });
+    mocks.webChatConversations.mockClear();
+    mocks.webChatConversations.mockResolvedValue({
+      conversations: [
+        {
+          id: "chat-alpha",
+          title: "Create an automation",
+          channel: "web",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+        },
+      ],
+    });
     mocks.loadMessages.mockClear();
     mocks.loadMessages.mockResolvedValue({ messages: [], updatedAt: null });
     mocks.originChatMessages.mockResolvedValue({ messages: [] });
@@ -438,6 +451,8 @@ describe("AutomationBuilderPage", () => {
     renderBuilder();
 
     await screen.findByLabelText("Message Sketch");
+    expect(screen.getByText("Create an automation")).toBeInTheDocument();
+    expect(screen.queryByText("chat-alpha")).not.toBeInTheDocument();
     expect(mocks.loadMessages).toHaveBeenCalledWith("chat-alpha");
     expect(mocks.loadMessages).not.toHaveBeenCalledWith(expect.stringMatching(/^builder-task-123-/));
   });
@@ -476,6 +491,87 @@ describe("AutomationBuilderPage", () => {
         search: { conversationId: "builder-new" },
       }),
     );
+  });
+
+  it("uses viewer-scoped transcript summaries for source and builder chat labels", async () => {
+    mocks.search = {};
+    mocks.listConversations.mockResolvedValue({
+      taskId: "task-123",
+      conversations: [
+        {
+          conversationId: "chat-source",
+          kinds: ["web_chat"],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+          lastActiveAt: "2026-06-01T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+        },
+        {
+          conversationId: "chat-builder",
+          kinds: ["builder"],
+          createdAt: "2026-06-02T00:00:00.000Z",
+          updatedAt: "2026-06-02T00:00:00.000Z",
+          lastActiveAt: "2026-06-02T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+        },
+      ],
+      transcriptAccess: "viewer",
+    });
+    mocks.webChatConversations.mockResolvedValue({
+      conversations: [
+        {
+          id: "chat-source",
+          title: "Review the source thread",
+          channel: "web",
+          updatedAt: "2026-06-03T00:00:00.000Z",
+        },
+        {
+          id: "chat-builder",
+          title: "Continue the builder plan",
+          channel: "web",
+          updatedAt: "2026-06-04T00:00:00.000Z",
+        },
+      ],
+    });
+
+    renderBuilder();
+
+    expect(await screen.findByText("Review the source thread")).toBeInTheDocument();
+    expect(screen.getByText("Continue the builder plan")).toBeInTheDocument();
+    expect(screen.queryByText("chat-source")).not.toBeInTheDocument();
+    expect(screen.queryByText("chat-builder")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Source chat").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Builder chat").length).toBeGreaterThan(0);
+    expect(screen.getByText("Jun 3")).toBeInTheDocument();
+    expect(screen.getByText("Jun 4")).toBeInTheDocument();
+  });
+
+  it("uses a generic title and subdued diagnostic ID when a transcript summary is missing", async () => {
+    mocks.search = {};
+    mocks.listConversations.mockResolvedValue({
+      taskId: "task-123",
+      conversations: [
+        {
+          conversationId: "chat-missing-summary",
+          kinds: ["builder"],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+          lastActiveAt: "2026-06-01T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+        },
+      ],
+      transcriptAccess: "viewer",
+    });
+    mocks.webChatConversations.mockResolvedValue({ conversations: [] });
+
+    renderBuilder();
+
+    expect((await screen.findAllByText("Builder chat")).length).toBeGreaterThan(0);
+    const diagnostic = screen.getByText("Conversation chat-missing-summary");
+    expect(diagnostic).toHaveClass("font-mono", "text-muted-foreground/60");
   });
 
   it("selects an older task-scoped chat from the sidechat list", async () => {

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -6,6 +6,8 @@ import {
   type AutomationBuilderSaveRequest,
   type AutomationDefinition,
   type AutomationStepContent,
+  type ScheduledTaskConversationSummary,
+  type ScheduledTaskConversationsResponse,
   type StepOutput,
   type WebChatUploadedAttachment,
   type WorkflowEdge,
@@ -14,6 +16,9 @@ import {
 } from "@/lib/api";
 import { useChat } from "@ai-sdk/react";
 import {
+  ArchiveIcon,
+  ArrowClockwiseIcon,
+  ArrowLeftIcon,
   BracketsCurlyIcon,
   CalendarDotsIcon,
   CaretDownIcon,
@@ -28,6 +33,7 @@ import {
   type IconProps,
   LightningIcon,
   PlayIcon,
+  PlusIcon,
   RobotIcon,
   SlackLogoIcon,
   SpinnerGapIcon,
@@ -50,7 +56,7 @@ import { Input } from "@sketch/ui/components/input";
 import { Textarea } from "@sketch/ui/components/textarea";
 import { cn } from "@sketch/ui/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createRoute, useNavigate, useParams } from "@tanstack/react-router";
+import { createRoute, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import {
   Background,
   BackgroundVariant,
@@ -289,10 +295,10 @@ function BuilderOwnership({ automation }: { automation: AutomationDefinition }) 
 
 export function AutomationBuilderPage() {
   const { taskId } = useParams({ from: automationBuilderRoute.id });
+  const { conversationId: requestedConversationId } = useSearch({ from: automationBuilderRoute.id });
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const queryKey = useMemo(() => ["scheduled-tasks", taskId, "builder"] as const, [taskId]);
-  const builderConversationId = useMemo(() => freshBuilderConversationId(taskId), [taskId]);
   const [draft, setDraft] = useState<DraftAutomation | null>(null);
   const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
@@ -442,7 +448,7 @@ export function AutomationBuilderPage() {
   return (
     <div className="relative flex h-[calc(100vh-3rem)] min-h-0 overflow-hidden bg-background md:h-screen">
       <BuilderChatSidecar
-        conversationId={builderConversationId}
+        requestedConversationId={requestedConversationId ?? null}
         taskId={taskId}
         title={builderTitle}
         queryKey={queryKey}
@@ -630,28 +636,422 @@ function outgoingBuilderRequestOptions(taskId: string, attachments: WebChatUploa
   };
 }
 
-function freshBuilderConversationId(taskId: string): string {
-  const safeTaskId = taskId.replace(/[^A-Za-z0-9_-]/g, "-").slice(0, 40) || "task";
-  const rawSuffix = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const suffix = rawSuffix.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 24) || String(Date.now());
-  return `builder-${safeTaskId}-${suffix}`;
+const builderConversationQueryKey = (taskId: string) => ["scheduled-tasks", taskId, "conversations"] as const;
+
+function replaceBuilderConversationCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  queryKey: readonly unknown[],
+  conversation: ScheduledTaskConversationSummary,
+) {
+  queryClient.setQueryData<ScheduledTaskConversationsResponse>(queryKey, (current) => {
+    if (!current) return current;
+    return {
+      ...current,
+      conversations: [
+        conversation,
+        ...current.conversations.filter((item) => item.conversationId !== conversation.conversationId),
+      ],
+    };
+  });
+}
+
+function conversationSourceLabel(conversation: ScheduledTaskConversationSummary): string {
+  const hasBuilder = conversation.kinds.includes("builder");
+  const hasWebChat = conversation.kinds.includes("web_chat");
+  if (hasBuilder && hasWebChat) return "Builder + source";
+  if (hasWebChat) return "Source chat";
+  return "Builder chat";
+}
+
+function conversationDateLabel(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Recently";
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
 }
 
 function BuilderChatSidecar({
-  conversationId,
+  requestedConversationId,
   taskId,
   title,
   queryKey,
   className,
 }: {
-  conversationId: string;
+  requestedConversationId: string | null;
   taskId: string;
   title: string;
   queryKey: readonly unknown[];
   className?: string;
 }) {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [loadedConversationId, setLoadedConversationId] = useState<string | null>(null);
+  const conversationsQueryKey = useMemo(() => builderConversationQueryKey(taskId), [taskId]);
+  const conversationsQuery = useQuery({
+    queryKey: conversationsQueryKey,
+    queryFn: () => api.scheduledTasks.conversations(taskId, { includeArchived: true }),
+  });
+  const selectedConversation = conversationsQuery.data?.conversations.find(
+    (conversation) => conversation.conversationId === requestedConversationId,
+  );
+
+  const openConversation = useCallback(
+    (conversationId: string) => {
+      void navigate({
+        to: "/scheduled-tasks/$taskId/edit",
+        params: { taskId },
+        search: { conversationId },
+        replace: true,
+      });
+    },
+    [navigate, taskId],
+  );
+  const openChatList = useCallback(() => {
+    void navigate({
+      to: "/scheduled-tasks/$taskId/edit",
+      params: { taskId },
+      search: {},
+      replace: true,
+    });
+  }, [navigate, taskId]);
+
+  const createMutation = useMutation({
+    mutationFn: () => api.scheduledTasks.createConversation(taskId, { createNew: true }),
+    onSuccess: ({ conversation }) => {
+      replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
+      openConversation(conversation.conversationId);
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to start a builder chat"),
+  });
+  const selectMutation = useMutation({
+    mutationFn: (conversation: ScheduledTaskConversationSummary) =>
+      api.scheduledTasks.selectConversation(taskId, conversation.conversationId, conversation.kinds[0]),
+    onSuccess: ({ conversation }) => {
+      replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
+      openConversation(conversation.conversationId);
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "This builder chat is unavailable"),
+  });
+  const archiveMutation = useMutation({
+    mutationFn: (conversationId: string) => api.scheduledTasks.archiveConversation(taskId, conversationId, true),
+    onSuccess: ({ conversation }) => {
+      replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
+      openChatList();
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to archive this builder chat"),
+  });
+  const restoreMutation = useMutation({
+    mutationFn: (conversationId: string) => api.scheduledTasks.archiveConversation(taskId, conversationId, false),
+    onSuccess: ({ conversation }) => {
+      replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
+      openConversation(conversation.conversationId);
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to restore this builder chat"),
+  });
+
+  const selectedIsArchived = selectedConversation?.state === "archived";
+  return (
+    <aside
+      data-testid="automation-builder-chat-sidecar"
+      className={cn(
+        "w-[400px] min-w-[320px] max-w-[600px] shrink-0 resize-x flex-col overflow-hidden border-r border-border bg-background text-foreground",
+        className,
+      )}
+    >
+      <BuilderChatHeader
+        conversation={selectedConversation}
+        title={title}
+        onBack={selectedConversation ? openChatList : undefined}
+        onNew={() => createMutation.mutate()}
+        newPending={createMutation.isPending}
+        onArchive={
+          selectedConversation && !selectedIsArchived
+            ? () => archiveMutation.mutate(selectedConversation.conversationId)
+            : undefined
+        }
+        archivePending={archiveMutation.isPending}
+      />
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {conversationsQuery.isError ? (
+          <BuilderChatNavigationError onRetry={() => void conversationsQuery.refetch()} />
+        ) : conversationsQuery.isLoading || !conversationsQuery.data ? (
+          <BuilderChatLoadingState />
+        ) : !requestedConversationId ? (
+          <BuilderChatListView
+            conversations={conversationsQuery.data.conversations}
+            onSelect={(conversation) => {
+              if (conversation.state === "archived") openConversation(conversation.conversationId);
+              else selectMutation.mutate(conversation);
+            }}
+            selectingConversationId={selectMutation.isPending ? selectMutation.variables?.conversationId : null}
+          />
+        ) : !selectedConversation ? (
+          <BuilderChatUnavailableState onBack={openChatList} />
+        ) : selectedIsArchived ? (
+          <BuilderChatArchivedState
+            onBack={openChatList}
+            onRestore={() => restoreMutation.mutate(selectedConversation.conversationId)}
+            restoring={restoreMutation.isPending}
+          />
+        ) : (
+          <BuilderChatTranscript
+            key={selectedConversation.conversationId}
+            conversationId={selectedConversation.conversationId}
+            taskId={taskId}
+            title={title}
+            queryKey={queryKey}
+            conversationsQueryKey={conversationsQueryKey}
+          />
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function BuilderChatHeader({
+  conversation,
+  title,
+  onBack,
+  onNew,
+  newPending,
+  onArchive,
+  archivePending,
+}: {
+  conversation?: ScheduledTaskConversationSummary;
+  title: string;
+  onBack?: () => void;
+  onNew: () => void;
+  newPending: boolean;
+  onArchive?: () => void;
+  archivePending: boolean;
+}) {
+  return (
+    <div className="shrink-0 border-b border-border bg-card px-4 py-3">
+      <div className="flex min-w-0 items-center gap-3">
+        {onBack ? (
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-8 shrink-0 rounded-[7px] text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Back to builder chats"
+            onClick={onBack}
+          >
+            <ArrowLeftIcon size={16} />
+          </Button>
+        ) : (
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-[8px] bg-brand-accent text-[#141100]">
+            <RobotIcon size={17} weight="fill" />
+          </span>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="truncate text-[13px] font-semibold">
+              {conversation ? "Current builder chat" : "Builder chats"}
+            </p>
+            <Badge className="rounded-[5px] border border-border bg-muted px-1.5 py-0 font-mono text-[10px] text-muted-foreground">
+              {conversation ? conversationSourceLabel(conversation) : "Task history"}
+            </Badge>
+          </div>
+          <p className="truncate text-[12px] text-muted-foreground">
+            {conversation ? `${title} · ${conversation.conversationId}` : title}
+          </p>
+        </div>
+        {conversation ? (
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-8 shrink-0 rounded-[7px] text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Archive builder chat"
+            disabled={!onArchive || archivePending}
+            onClick={onArchive}
+          >
+            {archivePending ? <SpinnerGapIcon size={15} className="animate-spin" /> : <ArchiveIcon size={16} />}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 shrink-0 gap-1.5 rounded-[7px] border-border/70 bg-card text-[12px] shadow-none"
+            onClick={onNew}
+            disabled={newPending}
+          >
+            {newPending ? <SpinnerGapIcon size={14} className="animate-spin" /> : <PlusIcon size={14} />}
+            New chat
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BuilderChatListView({
+  conversations,
+  onSelect,
+  selectingConversationId,
+}: {
+  conversations: ScheduledTaskConversationSummary[];
+  onSelect: (conversation: ScheduledTaskConversationSummary) => void;
+  selectingConversationId: string | null;
+}) {
+  const active = conversations.filter((conversation) => conversation.state === "active");
+  const archived = conversations.filter((conversation) => conversation.state === "archived");
+  const renderConversation = (conversation: ScheduledTaskConversationSummary) => (
+    <button
+      key={conversation.conversationId}
+      type="button"
+      data-testid={`automation-builder-conversation-${conversation.conversationId}`}
+      className="flex w-full items-start gap-3 rounded-[8px] border border-border bg-card px-3 py-2.5 text-left transition hover:border-brand-accent/40 hover:bg-brand-accent/5 disabled:cursor-wait disabled:opacity-60"
+      onClick={() => onSelect(conversation)}
+      disabled={selectingConversationId !== null}
+    >
+      <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-[7px] border border-border bg-background text-brand-accent">
+        <RobotIcon size={15} weight="fill" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-[12px] font-medium text-foreground">{conversation.conversationId}</span>
+          {selectingConversationId === conversation.conversationId ? (
+            <SpinnerGapIcon size={13} className="shrink-0 animate-spin text-muted-foreground" />
+          ) : null}
+        </span>
+        <span className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
+          <span>{conversationSourceLabel(conversation)}</span>
+          <span aria-hidden>·</span>
+          <span>{conversationDateLabel(conversation.lastActiveAt)}</span>
+        </span>
+      </span>
+    </button>
+  );
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+      <div className="flex min-h-full flex-col gap-5">
+        <div>
+          <p className="text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">Active chats</p>
+          {active.length > 0 ? (
+            <div className="mt-2 grid gap-2">{active.map(renderConversation)}</div>
+          ) : (
+            <div className="mt-2 rounded-[8px] border border-dashed border-border px-3 py-4 text-[12px] leading-5 text-muted-foreground">
+              No active builder chats yet. Start one when you are ready.
+            </div>
+          )}
+        </div>
+        {archived.length > 0 ? (
+          <div>
+            <p className="text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Archived history
+            </p>
+            <div className="mt-2 grid gap-2">{archived.map(renderConversation)}</div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function BuilderChatNavigationError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div data-testid="automation-builder-chat-error" className="flex min-h-full items-center justify-center px-5 py-6">
+      <div className="w-full rounded-[8px] border border-destructive/30 bg-card p-4">
+        <p className="text-[13px] font-semibold text-foreground">Builder chats unavailable</p>
+        <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
+          Sketch could not load the task chat history. Your automation is still available.
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3 h-8 rounded-[7px] border-border/70 bg-card text-[12px] shadow-none"
+          onClick={onRetry}
+        >
+          Try again
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function BuilderChatUnavailableState({ onBack }: { onBack: () => void }) {
+  return (
+    <div
+      data-testid="automation-builder-chat-unavailable"
+      className="flex min-h-full items-center justify-center px-5 py-6"
+    >
+      <div className="w-full rounded-[8px] border border-border bg-card p-4">
+        <p className="text-[13px] font-semibold text-foreground">Chat unavailable</p>
+        <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
+          This chat is not associated with this automation for your account, so its transcript was not opened.
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3 h-8 rounded-[7px] border-border/70 bg-card text-[12px] shadow-none"
+          onClick={onBack}
+        >
+          Back to chats
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function BuilderChatArchivedState({
+  onBack,
+  onRestore,
+  restoring,
+}: {
+  onBack: () => void;
+  onRestore: () => void;
+  restoring: boolean;
+}) {
+  return (
+    <div
+      data-testid="automation-builder-chat-archived"
+      className="flex min-h-full items-center justify-center px-5 py-6"
+    >
+      <div className="w-full rounded-[8px] border border-border bg-card p-4">
+        <p className="text-[13px] font-semibold text-foreground">Chat archived</p>
+        <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
+          This chat is kept for history but is not active. Restore it explicitly to continue the transcript.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            className="h-8 gap-1.5 rounded-[7px] bg-brand-accent text-[#161300] shadow-none hover:bg-brand-accent/90"
+            onClick={onRestore}
+            disabled={restoring}
+          >
+            {restoring ? <SpinnerGapIcon size={14} className="animate-spin" /> : <ArrowClockwiseIcon size={14} />}
+            Restore chat
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 rounded-[7px] border-border/70 bg-card text-[12px] shadow-none"
+            onClick={onBack}
+          >
+            Back to chats
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BuilderChatTranscript({
+  conversationId,
+  taskId,
+  title,
+  queryKey,
+  conversationsQueryKey,
+}: {
+  conversationId: string;
+  taskId: string;
+  title: string;
+  queryKey: readonly unknown[];
+  conversationsQueryKey: readonly unknown[];
+}) {
+  const queryClient = useQueryClient();
+  const [loadedHistoryKey, setLoadedHistoryKey] = useState<string | null>(null);
+  const [historyLoadError, setHistoryLoadError] = useState<string | null>(null);
+  const [historyLoadAttempt, setHistoryLoadAttempt] = useState(0);
   const [stoppingRun, setStoppingRun] = useState(false);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
   const wasBusyRef = useRef(false);
@@ -666,7 +1066,8 @@ function BuilderChatSidecar({
     id: conversationId,
     transport,
   });
-  const historyReady = loadedConversationId === conversationId;
+  const historyKey = `${conversationId}:${historyLoadAttempt}`;
+  const historyReady = loadedHistoryKey === historyKey;
   const latestMessage = chat.messages.at(-1);
   const threadScrollKey = latestMessage
     ? [
@@ -682,7 +1083,7 @@ function BuilderChatSidecar({
   const hasBackgroundRun = hasPendingBuilderAssistantProgress(chat.messages);
   const chatBusy = chat.status === "submitted" || chat.status === "streaming" || hasBackgroundRun || stoppingRun;
   const threadMessages = builderChatThreadMessages(chat.messages);
-  const showEmptyState = historyReady && threadMessages.length === 0 && !chatBusy && !chat.error;
+  const showEmptyState = historyReady && !historyLoadError && threadMessages.length === 0 && !chatBusy && !chat.error;
   const sendBuilderMessage = useCallback(
     (value: string, attachments: WebChatUploadedAttachment[] = []) => {
       void chat.sendMessage(
@@ -695,33 +1096,32 @@ function BuilderChatSidecar({
 
   useEffect(() => {
     let cancelled = false;
-    setLoadedConversationId(null);
+    setLoadedHistoryKey(null);
+    setHistoryLoadError(null);
     chat.setMessages([]);
     void api.webChat
       .messages(conversationId)
       .then(({ messages }) => {
-        if (!cancelled) {
-          chat.setMessages(messages as BuilderWebChatMessage[]);
-        }
+        if (!cancelled) chat.setMessages(messages as BuilderWebChatMessage[]);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) setHistoryLoadError(error instanceof Error ? error.message : "Transcript unavailable");
       })
       .finally(() => {
-        if (!cancelled) setLoadedConversationId(conversationId);
+        if (!cancelled) setLoadedHistoryKey(historyKey);
       });
     return () => {
       cancelled = true;
     };
-  }, [chat.setMessages, conversationId]);
+  }, [chat.setMessages, conversationId, historyKey]);
 
   useEffect(() => {
     if (!historyReady || !threadScrollKey) return;
     const frameId = window.requestAnimationFrame(() => {
       const el = threadScrollRef.current;
       if (!el) return;
-      if (typeof el.scrollTo === "function") {
-        el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
-      } else {
-        el.scrollTop = el.scrollHeight;
-      }
+      if (typeof el.scrollTo === "function") el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
+      else el.scrollTop = el.scrollHeight;
     });
     return () => window.cancelAnimationFrame(frameId);
   }, [historyReady, threadScrollKey]);
@@ -730,11 +1130,12 @@ function BuilderChatSidecar({
     if (!historyReady || !hasBackgroundRun || chat.status !== "ready") return;
     let cancelled = false;
     const intervalId = window.setInterval(() => {
-      void api.webChat.messages(conversationId).then(({ messages }) => {
-        if (!cancelled) {
-          chat.setMessages(messages as BuilderWebChatMessage[]);
-        }
-      });
+      void api.webChat
+        .messages(conversationId)
+        .then(({ messages }) => {
+          if (!cancelled) chat.setMessages(messages as BuilderWebChatMessage[]);
+        })
+        .catch(() => undefined);
     }, 1500);
     return () => {
       cancelled = true;
@@ -751,7 +1152,8 @@ function BuilderChatSidecar({
     if (!historyReady || !wasBusyRef.current) return;
     wasBusyRef.current = false;
     void queryClient.invalidateQueries({ queryKey });
-  }, [chat.status, historyReady, queryClient, queryKey]);
+    void queryClient.invalidateQueries({ queryKey: conversationsQueryKey });
+  }, [chat.status, conversationsQueryKey, historyReady, queryClient, queryKey]);
 
   const handleStop = useCallback(() => {
     if (stoppingRun) return;
@@ -763,31 +1165,30 @@ function BuilderChatSidecar({
   }, [conversationId, stoppingRun]);
 
   return (
-    <aside
-      className={cn(
-        "w-[400px] min-w-[320px] max-w-[600px] shrink-0 resize-x flex-col overflow-hidden border-r border-white/10 bg-[#050505] text-white",
-        className,
-      )}
-    >
-      <div className="border-b border-white/10 bg-[#080808] px-4 py-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <span className="flex size-8 shrink-0 items-center justify-center rounded-[8px] bg-brand-accent text-[#141100]">
-            <RobotIcon size={17} weight="fill" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-center gap-2">
-              <p className="truncate text-[13px] font-semibold">Builder chat</p>
-              <Badge className="rounded-[5px] border border-white/10 bg-white/[0.06] px-1.5 py-0 font-mono text-[10px] text-white/58">
-                Fresh
-              </Badge>
-            </div>
-            <p className="truncate text-[12px] text-white/46">{title}</p>
-          </div>
-        </div>
-      </div>
+    <>
       <div ref={threadScrollRef} className="chat-scrollbar min-h-0 flex-1 overflow-y-auto px-4 py-5">
         {!historyReady ? (
           <BuilderChatLoadingState />
+        ) : historyLoadError ? (
+          <div
+            data-testid="automation-builder-transcript-error"
+            className="flex min-h-full items-center justify-center"
+          >
+            <div className="w-full rounded-[8px] border border-border bg-card p-4">
+              <p className="text-[13px] font-semibold text-foreground">Transcript unavailable</p>
+              <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
+                This chat is associated with the task, but its transcript could not be loaded.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="mt-3 h-8 rounded-[7px] border-border/70 bg-card text-[12px] shadow-none"
+                onClick={() => setHistoryLoadAttempt((attempt) => attempt + 1)}
+              >
+                Try again
+              </Button>
+            </div>
+          </div>
         ) : showEmptyState ? (
           <BuilderChatEmptyState title={title} onPrompt={sendBuilderMessage} />
         ) : (
@@ -803,8 +1204,8 @@ function BuilderChatSidecar({
       <div className="shrink-0 border-t border-white/10 bg-[#050505] px-3 py-3">
         <ChatInput
           key={conversationId}
-          disabled={!historyReady || chatBusy}
-          disabledPlaceholder={historyReady ? "Sketch is thinking..." : "Loading conversation..."}
+          disabled={!historyReady || Boolean(historyLoadError) || chatBusy}
+          disabledPlaceholder={historyReady ? "Transcript unavailable" : "Loading conversation..."}
           running={chatBusy}
           runningPlaceholder="Sketch is thinking..."
           stopping={stoppingRun}
@@ -813,7 +1214,7 @@ function BuilderChatSidecar({
           onSubmit={sendBuilderMessage}
         />
       </div>
-    </aside>
+    </>
   );
 }
 

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -9,11 +9,13 @@ import {
   type ScheduledTaskConversationSummary,
   type ScheduledTaskConversationsResponse,
   type StepOutput,
+  type WebChatConversationSummary,
   type WebChatUploadedAttachment,
   type WorkflowEdge,
   type WorkflowStep,
   api,
 } from "@/lib/api";
+import { WEB_CHAT_CONVERSATIONS_QUERY_KEY } from "@/lib/web-chat-conversations";
 import { useChat } from "@ai-sdk/react";
 import {
   ArchiveIcon,
@@ -669,6 +671,22 @@ function conversationDateLabel(value: string): string {
   return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
 }
 
+function conversationDisplayTitle(
+  conversation: ScheduledTaskConversationSummary,
+  summary?: WebChatConversationSummary,
+): string {
+  const title = summary?.title.trim();
+  if (title) return title;
+  return conversation.kinds.includes("web_chat") ? "Source chat" : "Builder chat";
+}
+
+function conversationDisplayUpdatedAt(
+  conversation: ScheduledTaskConversationSummary,
+  summary?: WebChatConversationSummary,
+): string {
+  return summary?.updatedAt ?? conversation.lastActiveAt;
+}
+
 function BuilderChatSidecar({
   requestedConversationId,
   taskId,
@@ -689,6 +707,15 @@ function BuilderChatSidecar({
     queryKey: conversationsQueryKey,
     queryFn: () => api.scheduledTasks.conversations(taskId, { includeArchived: true }),
   });
+  const webChatConversationsQuery = useQuery({
+    queryKey: WEB_CHAT_CONVERSATIONS_QUERY_KEY,
+    queryFn: () => api.webChat.conversations(),
+    staleTime: 30_000,
+  });
+  const webChatSummaryById = useMemo(
+    () => new Map((webChatConversationsQuery.data?.conversations ?? []).map((summary) => [summary.id, summary])),
+    [webChatConversationsQuery.data],
+  );
   const selectedConversation = conversationsQuery.data?.conversations.find(
     (conversation) => conversation.conversationId === requestedConversationId,
   );
@@ -758,6 +785,7 @@ function BuilderChatSidecar({
     >
       <BuilderChatHeader
         conversation={selectedConversation}
+        summary={selectedConversation ? webChatSummaryById.get(selectedConversation.conversationId) : undefined}
         title={title}
         onBack={selectedConversation ? openChatList : undefined}
         onNew={() => createMutation.mutate()}
@@ -777,6 +805,7 @@ function BuilderChatSidecar({
         ) : !requestedConversationId ? (
           <BuilderChatListView
             conversations={conversationsQuery.data.conversations}
+            summaryById={webChatSummaryById}
             onSelect={(conversation) => {
               if (conversation.state === "archived") openConversation(conversation.conversationId);
               else selectMutation.mutate(conversation);
@@ -808,6 +837,7 @@ function BuilderChatSidecar({
 
 function BuilderChatHeader({
   conversation,
+  summary,
   title,
   onBack,
   onNew,
@@ -816,6 +846,7 @@ function BuilderChatHeader({
   archivePending,
 }: {
   conversation?: ScheduledTaskConversationSummary;
+  summary?: WebChatConversationSummary;
   title: string;
   onBack?: () => void;
   onNew: () => void;
@@ -851,8 +882,18 @@ function BuilderChatHeader({
             </Badge>
           </div>
           <p className="truncate text-[12px] text-muted-foreground">
-            {conversation ? `${title} · ${conversation.conversationId}` : title}
+            {conversation ? conversationDisplayTitle(conversation, summary) : title}
           </p>
+          {conversation ? (
+            <p className="truncate text-[11px] text-muted-foreground/75">
+              {title} · {conversationDateLabel(conversationDisplayUpdatedAt(conversation, summary))}
+              {!summary ? (
+                <span className="font-mono text-[10px] text-muted-foreground/60">
+                  {` · Conversation ${conversation.conversationId}`}
+                </span>
+              ) : null}
+            </p>
+          ) : null}
         </div>
         {conversation ? (
           <Button
@@ -884,42 +925,54 @@ function BuilderChatHeader({
 
 function BuilderChatListView({
   conversations,
+  summaryById,
   onSelect,
   selectingConversationId,
 }: {
   conversations: ScheduledTaskConversationSummary[];
+  summaryById: ReadonlyMap<string, WebChatConversationSummary>;
   onSelect: (conversation: ScheduledTaskConversationSummary) => void;
   selectingConversationId: string | null;
 }) {
   const active = conversations.filter((conversation) => conversation.state === "active");
   const archived = conversations.filter((conversation) => conversation.state === "archived");
-  const renderConversation = (conversation: ScheduledTaskConversationSummary) => (
-    <button
-      key={conversation.conversationId}
-      type="button"
-      data-testid={`automation-builder-conversation-${conversation.conversationId}`}
-      className="flex w-full items-start gap-3 rounded-[8px] border border-border bg-card px-3 py-2.5 text-left transition hover:border-brand-accent/40 hover:bg-brand-accent/5 disabled:cursor-wait disabled:opacity-60"
-      onClick={() => onSelect(conversation)}
-      disabled={selectingConversationId !== null}
-    >
-      <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-[7px] border border-border bg-background text-brand-accent">
-        <RobotIcon size={15} weight="fill" />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-[12px] font-medium text-foreground">{conversation.conversationId}</span>
-          {selectingConversationId === conversation.conversationId ? (
-            <SpinnerGapIcon size={13} className="shrink-0 animate-spin text-muted-foreground" />
+  const renderConversation = (conversation: ScheduledTaskConversationSummary) => {
+    const summary = summaryById.get(conversation.conversationId);
+    return (
+      <button
+        key={conversation.conversationId}
+        type="button"
+        data-testid={`automation-builder-conversation-${conversation.conversationId}`}
+        className="flex w-full items-start gap-3 rounded-[8px] border border-border bg-card px-3 py-2.5 text-left transition hover:border-brand-accent/40 hover:bg-brand-accent/5 disabled:cursor-wait disabled:opacity-60"
+        onClick={() => onSelect(conversation)}
+        disabled={selectingConversationId !== null}
+      >
+        <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-[7px] border border-border bg-background text-brand-accent">
+          <RobotIcon size={15} weight="fill" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-[12px] font-medium text-foreground">
+              {conversationDisplayTitle(conversation, summary)}
+            </span>
+            {selectingConversationId === conversation.conversationId ? (
+              <SpinnerGapIcon size={13} className="shrink-0 animate-spin text-muted-foreground" />
+            ) : null}
+          </span>
+          {!summary ? (
+            <span className="mt-0.5 block truncate font-mono text-[10px] text-muted-foreground/60">
+              Conversation {conversation.conversationId}
+            </span>
           ) : null}
+          <span className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span>{conversationSourceLabel(conversation)}</span>
+            <span aria-hidden>·</span>
+            <span>{conversationDateLabel(conversationDisplayUpdatedAt(conversation, summary))}</span>
+          </span>
         </span>
-        <span className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
-          <span>{conversationSourceLabel(conversation)}</span>
-          <span aria-hidden>·</span>
-          <span>{conversationDateLabel(conversation.lastActiveAt)}</span>
-        </span>
-      </span>
-    </button>
-  );
+      </button>
+    );
+  };
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">


### PR DESCRIPTION
## Summary

- replace mount-time random builder chats with durable task-scoped conversation navigation
- open a source chat when the automation card supplies an accessible conversation ID
- open the task's chat list when entering from Automations, with explicit select, continue, new, archive, and restore flows

## Linear Scope

- [SKE-332: Add durable automation chat navigation](https://linear.app/sketch-ai/issue/SKE-332/add-durable-automation-chat-navigation)

## Stack

- 5 of 7 in the automation hardening stack
- depends on [#437](https://github.com/canvasxai/sketch/pull/437)
- GitHub base: `fix/ske-302-admin-automation-access`

## Implementation Details

- consume the validated route `conversationId` only after the server confirms an active viewer association
- keep no-conversation list entry in a task chat browser; only an explicit New chat action creates an association
- preserve selected chat identity in the URL across refresh and keep task identity separate from the selected conversation
- support active and archived lists, selection/touch, archive, restore, unavailable/access-loss, empty, loading, and retry states
- load transcript content only from the existing viewer-scoped web-chat endpoint
- label chats from transcript summaries and dates, with subdued diagnostic IDs only when metadata is unavailable

## Verification

- Node 24 `pnpm biome check .` — passed; 1,313 files
- `pnpm typecheck` — passed
- `pnpm test` — passed; server 4,935 passed / 20 skipped, web 450 passed
- `pnpm build` — passed
- isolated route/card coverage includes list entry, source-card continuation, refresh, select, new, archive/restore, unrelated IDs, transcript failure, and summary fallback
- Node 24 pre-push gate — passed on the complete stack

## Risk / Rollout

- existing transcripts are retained; only provable task/chat relationships are exposed
- guessed, unrelated, archived, and foreign-owner conversation IDs fail safely without creating associations
- no migration beyond dependency PR #436 and no deployment or release
