### PR TITLE
SKE-347: Automation hardening stack — two pre-merge fixes and deploy ordering

### DIFF
--- a/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks-canonical.test.ts
@@ -220,6 +220,15 @@ function schedulerFor(taskId: string, createdBy = "owner-1") {
   } as never;
 }
 
+function schedulerWithoutRefresh(taskId: string, createdBy = "owner-1") {
+  const task = taskFor(taskId, createdBy);
+  return {
+    getTaskById: vi.fn().mockResolvedValue(task),
+    addTask: vi.fn(),
+    updateTask: vi.fn(),
+  } as never;
+}
+
 describe("ManageScheduledTasks canonical structured mutations", () => {
   let db: Awaited<ReturnType<typeof createTestDb>>;
 
@@ -296,6 +305,157 @@ describe("ManageScheduledTasks canonical structured mutations", () => {
         apps: JSON.stringify(["clickup", "slack"]),
       }),
     ]);
+  });
+
+  it("reports a thrown scheduler refresh after add instead of reading the saved row", async () => {
+    const scheduler = schedulerFor("thrown-refresh-add");
+    const refreshTaskSchedule = (scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule;
+    refreshTaskSchedule.mockRejectedValue(new Error("refresh failed"));
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "add",
+        title: "Daily account brief",
+        prompt: "Summarize account activity.",
+        schedule_type: "interval",
+        schedule_value: "120",
+        steps: [
+          definition().steps[0],
+          {
+            ...definition().steps[1],
+            agentPrompt: "Check activity and summarize changes.",
+            apps: ["clickup", "slack"],
+          },
+        ],
+        edges: definition().edges,
+      },
+      { db, scheduler, taskContext: taskContextFor("thrown-refresh-add") },
+    );
+
+    expect(result.content[0].text).toContain("saved, but its scheduler state could not be refreshed");
+    expect((scheduler as { getTaskById: ReturnType<typeof vi.fn> }).getTaskById).not.toHaveBeenCalled();
+    await expect(createScheduledTaskRepository(db).listAll()).resolves.toEqual([
+      expect.objectContaining({ revision: 0 }),
+    ]);
+  });
+
+  it("reports a thrown scheduler refresh after update instead of reading the saved row", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("thrown-refresh-update"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("thrown-refresh-update");
+    const refreshTaskSchedule = (scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule;
+    refreshTaskSchedule.mockRejectedValue(new Error("refresh failed"));
+
+    const result = await handleManageScheduledTasks(
+      { action: "update", task_id: "thrown-refresh-update", title: "Renamed brief", expected_revision: 0 },
+      { db, scheduler, taskContext: taskContextFor("thrown-refresh-update") },
+    );
+
+    expect(result.content[0].text).toContain("saved, but its scheduler state could not be refreshed");
+    expect((scheduler as { getTaskById: ReturnType<typeof vi.fn> }).getTaskById).toHaveBeenCalledOnce();
+    await expect(createScheduledTaskRepository(db).getById("thrown-refresh-update")).resolves.toMatchObject({
+      title: "Renamed brief",
+      revision: 1,
+    });
+  });
+
+  it("reports a thrown scheduler refresh after step-content update instead of reading the saved row", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("thrown-refresh-content"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("thrown-refresh-content");
+    const refreshTaskSchedule = (scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule;
+    refreshTaskSchedule.mockRejectedValue(new Error("refresh failed"));
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "updateStepContent",
+        task_id: "thrown-refresh-content",
+        step_id: "agent",
+        step_content: "Use the activity report and call out blockers.",
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("thrown-refresh-content") },
+    );
+
+    expect(result.content[0].text).toContain("saved, but its scheduler state could not be refreshed");
+    expect((scheduler as { getTaskById: ReturnType<typeof vi.fn> }).getTaskById).toHaveBeenCalledOnce();
+    await expect(createAutomationStepContentRepository(db).getByTask("thrown-refresh-content")).resolves.toEqual([
+      expect.objectContaining({ content: "Use the activity report and call out blockers." }),
+    ]);
+  });
+
+  it("falls back to a row read when the scheduler refresh method is unavailable", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("missing-refresh-method"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerWithoutRefresh("missing-refresh-method");
+
+    const result = await handleManageScheduledTasks(
+      { action: "update", task_id: "missing-refresh-method", title: "Renamed brief", expected_revision: 0 },
+      { db, scheduler, taskContext: taskContextFor("missing-refresh-method") },
+    );
+
+    expect(result.content[0].text).toContain("Automation updated:");
+    expect((scheduler as { getTaskById: ReturnType<typeof vi.fn> }).getTaskById).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a synchronous scheduler refresh throw instead of reading the saved row", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("sync-refresh-throw"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("sync-refresh-throw");
+    const refreshTaskSchedule = (scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule;
+    refreshTaskSchedule.mockImplementation(() => {
+      throw new Error("synchronous refresh failed");
+    });
+
+    const result = await handleManageScheduledTasks(
+      { action: "update", task_id: "sync-refresh-throw", title: "Renamed brief", expected_revision: 0 },
+      { db, scheduler, taskContext: taskContextFor("sync-refresh-throw") },
+    );
+
+    expect(result.content[0].text).toContain("saved, but its scheduler state could not be refreshed");
+    expect((scheduler as { getTaskById: ReturnType<typeof vi.fn> }).getTaskById).toHaveBeenCalledOnce();
+  });
+
+  it("does not fall back to a row read when a present scheduler refresh returns null", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("null-refresh-result"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("null-refresh-result");
+    const refreshTaskSchedule = (scheduler as { refreshTaskSchedule: ReturnType<typeof vi.fn> }).refreshTaskSchedule;
+    refreshTaskSchedule.mockResolvedValue(null);
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "updateStepContent",
+        task_id: "null-refresh-result",
+        step_id: "agent",
+        step_content: "Use the activity report and call out blockers.",
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("null-refresh-result") },
+    );
+
+    expect(result.content[0].text).toContain("saved, but its scheduler state could not be refreshed");
+    expect((scheduler as { getTaskById: ReturnType<typeof vi.fn> }).getTaskById).toHaveBeenCalledOnce();
   });
 
   it("rejects unsupported fan-out graphs through canonical validation before persistence", async () => {
@@ -467,6 +627,123 @@ describe("ManageScheduledTasks canonical structured mutations", () => {
       created_by: "owner-1",
       last_edited_by: "owner-1",
       revision: 1,
+    });
+  });
+
+  it("reconciles inherited schedule metadata on a title-only edit while preserving a custom trigger label", async () => {
+    const initial = definition({
+      steps: [{ ...definition().steps[0], label: "Custom trigger label" }, definition().steps[1]],
+    });
+    await createAutomationDefinition({
+      db,
+      request: initial,
+      context: context("drifted-schedule-task"),
+      brokerCapable: true,
+    });
+
+    await createScheduledTaskRepository(db).update("drifted-schedule-task", {
+      steps: JSON.stringify([
+        {
+          ...initial.steps[0],
+          triggerConfig: {
+            type: "schedule",
+            scheduleType: "cron",
+            scheduleValue: "0 9 * * 1",
+            timezone: "Asia/Kolkata",
+          },
+        },
+        initial.steps[1],
+      ]),
+    });
+
+    const result = await handleManageScheduledTasks(
+      { action: "update", task_id: "drifted-schedule-task", title: "Renamed brief", expected_revision: 0 },
+      { db, scheduler: schedulerFor("drifted-schedule-task"), taskContext: taskContextFor("drifted-schedule-task") },
+    );
+
+    expect(result.content[0].text).toContain("Automation updated:");
+    const row = await createScheduledTaskRepository(db).getById("drifted-schedule-task");
+    const steps = JSON.parse(row?.steps ?? "[]");
+    expect(row).toMatchObject({ title: "Renamed brief", revision: 1 });
+    expect(steps[0]).toMatchObject({
+      label: "Custom trigger label",
+      triggerConfig: {
+        type: "schedule",
+        scheduleType: "interval",
+        scheduleValue: "120",
+        timezone: "UTC",
+      },
+    });
+  });
+
+  it("rejects a schedule change that conflicts with an explicitly supplied trigger config", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("explicit-trigger-conflict"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("explicit-trigger-conflict");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "explicit-trigger-conflict",
+        schedule_value: "300",
+        steps: [
+          {
+            ...definition().steps[0],
+            triggerConfig: {
+              type: "schedule",
+              scheduleType: "interval",
+              scheduleValue: "120",
+              timezone: "UTC",
+            },
+          },
+          definition().steps[1],
+        ],
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("explicit-trigger-conflict") },
+    );
+
+    expect(result.content[0].text).toContain("SCHEDULE_TRIGGER_MISMATCH");
+    await expect(createScheduledTaskRepository(db).getById("explicit-trigger-conflict")).resolves.toMatchObject({
+      schedule_value: "120",
+      revision: 0,
+    });
+  });
+
+  it("rejects a partial explicitly supplied schedule config instead of repairing it", async () => {
+    await createAutomationDefinition({
+      db,
+      request: definition(),
+      context: context("partial-explicit-trigger"),
+      brokerCapable: true,
+    });
+    const scheduler = schedulerFor("partial-explicit-trigger");
+
+    const result = await handleManageScheduledTasks(
+      {
+        action: "update",
+        task_id: "partial-explicit-trigger",
+        schedule_value: "300",
+        steps: [
+          {
+            ...definition().steps[0],
+            triggerConfig: { type: "schedule", scheduleType: "interval" },
+          },
+          definition().steps[1],
+        ],
+        expected_revision: 0,
+      },
+      { db, scheduler, taskContext: taskContextFor("partial-explicit-trigger") },
+    );
+
+    expect(result.content[0].text).toContain("SCHEDULE_TRIGGER_MISMATCH");
+    await expect(createScheduledTaskRepository(db).getById("partial-explicit-trigger")).resolves.toMatchObject({
+      schedule_value: "120",
+      revision: 0,
     });
   });
 

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -509,6 +509,24 @@ function buildBuilderUrl(taskId: string, config: ManageScheduledTasksDeps["confi
   return `${base}${path}`;
 }
 
+/**
+ * Uses the scheduler refresh result when available and keeps the row-read fallback only for older scheduler implementations without that method.
+ */
+async function refreshTaskAfterMutation(
+  scheduler: TaskScheduler,
+  taskId: string,
+): Promise<{ task: ScheduledTask | null; failed: boolean }> {
+  if (typeof scheduler.refreshTaskSchedule !== "function") {
+    return { task: await scheduler.getTaskById(taskId), failed: false };
+  }
+
+  try {
+    return { task: await scheduler.refreshTaskSchedule(taskId), failed: false };
+  } catch {
+    return { task: null, failed: true };
+  }
+}
+
 function buildArtifactTags(params: {
   steps: Array<WorkflowStep & { apps?: string[] }>;
   scheduleType: string;
@@ -957,12 +975,11 @@ export async function handleManageScheduledTasks(
         throw error;
       }
 
-      const task =
-        typeof deps.scheduler.refreshTaskSchedule === "function"
-          ? await deps.scheduler.refreshTaskSchedule(saved.row.id).catch(() => null)
-          : null;
-      const refreshedTask = task ?? (await deps.scheduler.getTaskById(saved.row.id));
-      if (!refreshedTask) {
+      const { task: refreshedTask, failed: refreshFailed } = await refreshTaskAfterMutation(
+        deps.scheduler,
+        saved.row.id,
+      );
+      if (refreshFailed || !refreshedTask) {
         return text("Error: automation was saved, but its scheduler state could not be refreshed.");
       }
 
@@ -1043,12 +1060,9 @@ export async function handleManageScheduledTasks(
         );
       }
 
-      const refreshed =
-        typeof deps.scheduler.refreshTaskSchedule === "function"
-          ? await deps.scheduler.refreshTaskSchedule(saved.row.id).catch(() => null)
-          : null;
-      const updated = refreshed ?? (await deps.scheduler.getTaskById(saved.row.id));
-      if (!updated) return text("Error: automation was saved, but its scheduler state could not be refreshed.");
+      const { task: updated, failed: refreshFailed } = await refreshTaskAfterMutation(deps.scheduler, saved.row.id);
+      if (refreshFailed || !updated)
+        return text("Error: automation was saved, but its scheduler state could not be refreshed.");
       return text(`Automation updated:\n${JSON.stringify(updated, null, 2)}`);
     }
 
@@ -1208,12 +1222,9 @@ export async function handleManageScheduledTasks(
           `Error: automation revision conflict. Task ${task_id} is now at revision ${saved.currentRevision}; refresh before retrying.`,
         );
       }
-      const refreshed =
-        typeof deps.scheduler.refreshTaskSchedule === "function"
-          ? await deps.scheduler.refreshTaskSchedule(saved.row.id).catch(() => null)
-          : null;
-      const updated = refreshed ?? (await deps.scheduler.getTaskById(saved.row.id));
-      if (!updated) return text("Error: automation was saved, but its scheduler state could not be refreshed.");
+      const { task: updated, failed: refreshFailed } = await refreshTaskAfterMutation(deps.scheduler, saved.row.id);
+      if (refreshFailed || !updated)
+        return text("Error: automation was saved, but its scheduler state could not be refreshed.");
       return text(`Step ${params.step_id} content updated at revision ${saved.row.revision}.`);
     }
   }

--- a/packages/server/src/automation/persistence.ts
+++ b/packages/server/src/automation/persistence.ts
@@ -146,6 +146,43 @@ function mergeSteps(current: WorkflowStep[], requested: WorkflowStep[] | undefin
   });
 }
 
+/**
+ * Reconciles scheduler-authoritative fields onto inherited trigger JSON before an unrelated canonical edit.
+ * This intentional hidden write repairs drift while preserving a custom label; explicit trigger configs are merged afterward and remain caller-owned through validation.
+ */
+function reconcileInheritedScheduleTriggerSteps(
+  steps: WorkflowStep[],
+  params: {
+    scheduleType: "cron" | "interval" | "once";
+    scheduleValue: string;
+    timezone: string;
+  },
+): WorkflowStep[] {
+  let updated = false;
+  const next = steps.map((step) => {
+    if (step.type !== "trigger" || step.triggerConfig?.type !== "schedule") return step;
+    if (
+      step.triggerConfig.scheduleType === params.scheduleType &&
+      step.triggerConfig.scheduleValue === params.scheduleValue &&
+      step.triggerConfig.timezone === params.timezone
+    ) {
+      return step;
+    }
+    updated = true;
+    return {
+      ...step,
+      triggerConfig: {
+        ...step.triggerConfig,
+        scheduleType: params.scheduleType,
+        scheduleValue: params.scheduleValue,
+        timezone: params.timezone,
+      },
+    };
+  });
+
+  return updated ? next : steps;
+}
+
 function contentTypeForStep(step: WorkflowStep | undefined): "prompt" | "script" {
   return step?.type === "action" ? "script" : "prompt";
 }
@@ -187,7 +224,17 @@ function applyDefinitionPatch(
   let scheduleType = patch.scheduleType ?? definition.scheduleType;
   let scheduleValue = patch.scheduleValue ?? definition.scheduleValue;
   const timezone = patch.timezone ?? definition.timezone;
-  let steps = mergeSteps(definition.steps, patch.steps);
+  let inheritedSteps = definition.steps;
+  if (definition.scheduleType !== "external") {
+    inheritedSteps = reconcileInheritedScheduleTriggerSteps(inheritedSteps, {
+      scheduleType: definition.scheduleType,
+      scheduleValue: definition.scheduleValue,
+      timezone: definition.timezone,
+    });
+  }
+  const hasExplicitTriggerConfig =
+    patch.steps?.some((step) => step.type === "trigger" && step.triggerConfig !== undefined) ?? false;
+  let steps = mergeSteps(inheritedSteps, patch.steps);
   const trigger = steps.find((step) => step.type === "trigger")?.triggerConfig;
 
   if (trigger?.type === "slack_channel_message") {
@@ -199,7 +246,8 @@ function applyDefinitionPatch(
   } else if (
     (patch.scheduleType !== undefined || patch.scheduleValue !== undefined || patch.timezone !== undefined) &&
     scheduleType !== "external" &&
-    trigger?.type === "schedule"
+    trigger?.type === "schedule" &&
+    !hasExplicitTriggerConfig
   ) {
     steps = normalizeScheduleTriggerSteps(steps, { scheduleType, scheduleValue, timezone });
   }


### PR DESCRIPTION
## Summary

- reconcile inherited schedule metadata before validating edits while preserving custom trigger labels
- surface thrown scheduler refresh failures instead of reporting a false success, while retaining the method-missing fallback

## Linear Scope

- [SKE-347: Automation hardening stack — two pre-merge fixes and deploy ordering](https://linear.app/sketch-ai/issue/SKE-347/automation-hardening-stack-two-pre-merge-fixes-and-deploy-ordering)

## Stack

- 2 of 7 in the automation hardening stack
- depends on [#435](https://github.com/canvasxai/sketch/pull/435)
- #436 through #439 must be deployed together after #435 because the server-side chat association contract precedes the frontend durable-chat navigation fixes

## Implementation Details

- reconcile inherited `scheduleType`, `scheduleValue`, and `timezone` onto drifted trigger metadata before validation without rewriting a custom trigger label unless the schedule itself changes
- distinguish a missing scheduler refresh method from a refresh that throws at the `add`, `update`, and `updateStepContent` call sites
- preserve the existing actionable saved-but-not-refreshed error for thrown refresh failures and keep the fallback read only for a missing refresh method

## Verification

- Node 24 `pnpm biome check .` — passed; 1,323 files
- `pnpm typecheck` — passed
- `pnpm test` — passed; server 5,009 passed / 20 skipped, web 456 passed
- `pnpm build` — passed
- Node 24 pre-push gate — passed on the complete stack
- `git diff --check` — passed

## Risk / Rollout

- drift reconciliation intentionally changes writes for rows whose trigger metadata has diverged from scheduler columns; custom labels remain protected
- thrown refresh failures become visible instead of being reported as successful persistence
- merge #435 independently if desired, then merge and deploy #436 through #439 together; rollback remains safe because the #436 migration is additive and old code ignores its table