### PR TITLE
fix: keep WhatsApp backfill tests within history lookback

### DIFF
--- a/packages/server/src/whatsapp/adapter.isolated.test.ts
+++ b/packages/server/src/whatsapp/adapter.isolated.test.ts
@@ -1729,8 +1729,10 @@ describe("whatsapp/adapter", () => {
       const deps = makeDeps();
       const checkpointRepo = deps.repos.conversationSlices;
       if (!checkpointRepo) throw new Error("expected checkpoint repository");
+      const checkpointTimestamp = new Date(Date.now() - 24 * 60 * 60_000).toISOString();
+      const replayedTimestamp = new Date(Date.parse(checkpointTimestamp) - 5 * 60_000).toISOString();
       const completeCheckpointKey = encodeWhatsAppBackfillCheckpointKey({
-        providerTimestamp: "2026-07-07T09:05:00.000Z",
+        providerTimestamp: checkpointTimestamp,
         providerMessageId: "checkpoint",
       });
       vi.mocked(checkpointRepo.getBackfillCheckpoint).mockResolvedValue({
@@ -1742,7 +1744,7 @@ describe("whatsapp/adapter", () => {
         graph_last_served_at: null,
         graph_halted_at: null,
         graph_halt_reason: null,
-        updated_at: "2026-07-07T09:05:00.000Z",
+        updated_at: checkpointTimestamp,
       });
 
       const { mock, getHistoryHandler } = createMockWhatsApp();
@@ -1757,7 +1759,7 @@ describe("whatsapp/adapter", () => {
             providerMessageId: "history-not-yet-stored",
             providerConversationId: "group@g.us",
             canonicalConversationId: "group:group@g.us",
-            providerTimestamp: "2026-07-07T09:00:00.000Z",
+            providerTimestamp: replayedTimestamp,
             senderName: "Bob",
             senderProviderId: "5555@s.whatsapp.net",
             senderPhoneE164: "+5555",

--- a/packages/server/src/whatsapp/backfill-checkpoint.integration.test.ts
+++ b/packages/server/src/whatsapp/backfill-checkpoint.integration.test.ts
@@ -25,6 +25,10 @@ interface HistoryHarness {
   runAgent: ReturnType<typeof vi.fn>;
 }
 
+function recentHistoryTimestamp(minutesAgo: number): string {
+  return new Date(Date.now() - 24 * 60 * 60_000 - minutesAgo * 60_000).toISOString();
+}
+
 function createMockRuntime(): WhatsAppRuntime & Pick<HistoryHarness, "emitHistory"> {
   let historyHandler:
     | ((messages: WhatsAppInboundMessage[], metadata?: WhatsAppHistoryBatchMetadata) => Promise<unknown>)
@@ -192,12 +196,12 @@ function runBackfillCheckpointSuite(label: string, getDb: () => Promise<Kysely<D
         groupMessage({
           groupJid,
           providerMessageId: "history-001",
-          providerTimestamp: "2026-07-07T09:05:00.000Z",
+          providerTimestamp: recentHistoryTimestamp(0),
         }),
         groupMessage({
           groupJid,
           providerMessageId: "history-002",
-          providerTimestamp: "2026-07-07T09:04:00.000Z",
+          providerTimestamp: recentHistoryTimestamp(1),
         }),
       ];
       const batch2 = [
@@ -205,7 +209,7 @@ function runBackfillCheckpointSuite(label: string, getDb: () => Promise<Kysely<D
         groupMessage({
           groupJid,
           providerMessageId: "history-003",
-          providerTimestamp: "2026-07-07T09:03:00.000Z",
+          providerTimestamp: recentHistoryTimestamp(2),
         }),
       ];
       const conversations = createConversationRepository(db);
@@ -271,12 +275,12 @@ function runBackfillCheckpointSuite(label: string, getDb: () => Promise<Kysely<D
             groupMessage({
               groupJid,
               providerMessageId: "chunk-newer",
-              providerTimestamp: "2026-07-07T09:10:00.000Z",
+              providerTimestamp: recentHistoryTimestamp(0),
             }),
             groupMessage({
               groupJid,
               providerMessageId: "chunk-older",
-              providerTimestamp: "2026-07-07T09:00:00.000Z",
+              providerTimestamp: recentHistoryTimestamp(1),
             }),
           ],
           { progress: 100 },
@@ -287,7 +291,7 @@ function runBackfillCheckpointSuite(label: string, getDb: () => Promise<Kysely<D
         db,
         groups: [group],
         logger: createTestLogger(),
-        now: new Date("2026-07-07T09:20:00.000Z"),
+        now: new Date(),
       });
       const slices = await db.selectFrom("conversation_slices").selectAll().orderBy("started_at", "asc").execute();
 


### PR DESCRIPTION
## Summary

- Replace fixed July 2026 WhatsApp history timestamps in checkpoint tests with timestamps relative to the current test clock.
- Keep fixtures one day old so they remain inside the production 30-day WhatsApp history lookback while preserving checkpoint ordering and replay semantics.
- No production code or runtime behavior changed.

## Root cause

The tests used timestamps from 2026-07-07. Once CI ran after the 30-day lookback boundary, the adapter correctly classified those fixtures as old and skipped them. This caused five post-merge main failures after #439; the #439 stack itself did not modify WhatsApp code.

## Validation

- `pnpm biome check .`
- `pnpm typecheck`
- `pnpm test` — server: 4,944 passed, 20 skipped; web: 456 passed
- `pnpm build`
- All pre-push checks passed under Node 24