### PR TITLE
SKE-333: Polish automation chats, graph, and execution feedback

### DIFF
--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   selectConversation: vi.fn(),
   archiveConversation: vi.fn(),
   interruptChat: vi.fn(),
+  clearError: vi.fn(),
   runTask: vi.fn(),
   saveAutomation: vi.fn(),
   testStep: vi.fn(),
@@ -29,6 +30,7 @@ const mocks = vi.hoisted(() => ({
     { id: "a1", role: "assistant", parts: [{ type: "text", text: "All set." }] },
   ] as Array<{ id: string; role: string; parts: Array<Record<string, unknown>> }>,
   chatStatus: "ready",
+  chatError: undefined as Error | undefined,
 }));
 
 vi.mock("@/lib/api", async (importOriginal) => {
@@ -62,7 +64,8 @@ vi.mock("@ai-sdk/react", () => ({
   useChat: () => ({
     messages: mocks.chatMessages,
     status: mocks.chatStatus,
-    error: undefined,
+    error: mocks.chatError,
+    clearError: mocks.clearError,
     setMessages: mocks.setMessages,
     sendMessage: mocks.sendMessage,
   }),
@@ -371,6 +374,8 @@ describe("AutomationBuilderPage", () => {
     );
     mocks.interruptChat.mockClear();
     mocks.interruptChat.mockResolvedValue({ success: true, interrupted: true });
+    mocks.clearError.mockClear();
+    mocks.chatError = undefined;
     mocks.navigate.mockClear();
     mocks.runTask.mockResolvedValue({ status: "queued" });
     mocks.saveAutomation.mockClear();
@@ -423,6 +428,37 @@ describe("AutomationBuilderPage", () => {
     expect(mocks.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: "Make it daily" }), {
       body: { automationTaskId: "task-123" },
     });
+  });
+
+  it("reloads persisted chat progress when returning to the builder window", async () => {
+    mocks.chatMessages = [
+      {
+        id: "a-progress",
+        role: "assistant",
+        parts: [{ type: "data-progress", data: { lines: ["Updating automation"] } }],
+      },
+    ];
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+
+    renderBuilder();
+
+    await screen.findByLabelText("Message Sketch");
+    await waitFor(() => expect(mocks.loadMessages).toHaveBeenCalledWith("chat-alpha"));
+    mocks.loadMessages.mockClear();
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => expect(mocks.loadMessages).toHaveBeenCalledWith("chat-alpha", expect.any(Object)));
+  });
+
+  it("keeps the active run label constrained inside the builder toolbar", async () => {
+    mocks.getAutomation.mockResolvedValue(automationWithStepOutput("latest step output"));
+
+    renderBuilder();
+
+    const viewingButton = await screen.findByRole("button", { name: /Viewing/ });
+    expect(viewingButton).toHaveClass("min-w-0", "max-w-full");
+    expect(viewingButton.querySelector("span")).toHaveClass("min-w-0", "max-w-full", "truncate");
   });
 
   it("shows an automation-aware empty state for an associated empty chat", async () => {

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -1,5 +1,6 @@
 import { ChatInput } from "@/components/sketch/chat-input";
 import { ChatThread, type ChatThreadInterruption, type ChatThreadMessage } from "@/components/sketch/chat-thread";
+import { useWebChatReconciliation } from "@/hooks/use-web-chat-reconciliation";
 import {
   ApiRequestError,
   type AutomationArtifact,
@@ -1198,6 +1199,22 @@ function BuilderChatTranscript({
     [chat.sendMessage, taskId],
   );
 
+  const loadMessagesForReconciliation = useCallback(async (targetConversationId: string, signal: AbortSignal) => {
+    const response = await api.webChat.messages(targetConversationId, { signal });
+    return { ...response, messages: response.messages as BuilderWebChatMessage[] };
+  }, []);
+  useWebChatReconciliation({
+    conversationId,
+    historyReady,
+    status: chat.status,
+    error: chat.error,
+    messages: chat.messages,
+    hasPendingProgress: hasPendingBuilderAssistantProgress,
+    loadMessages: loadMessagesForReconciliation,
+    setMessages: chat.setMessages,
+    clearError: chat.clearError,
+  });
+
   useEffect(() => {
     let cancelled = false;
     setLoadedHistoryKey(null);
@@ -1229,23 +1246,6 @@ function BuilderChatTranscript({
     });
     return () => window.cancelAnimationFrame(frameId);
   }, [historyReady, threadScrollKey]);
-
-  useEffect(() => {
-    if (!historyReady || !hasBackgroundRun || chat.status !== "ready") return;
-    let cancelled = false;
-    const intervalId = window.setInterval(() => {
-      void api.webChat
-        .messages(conversationId)
-        .then(({ messages }) => {
-          if (!cancelled) chat.setMessages(messages as BuilderWebChatMessage[]);
-        })
-        .catch(() => undefined);
-    }, 1500);
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-    };
-  }, [chat.setMessages, chat.status, conversationId, hasBackgroundRun, historyReady]);
 
   useEffect(() => {
     const busy = chat.status === "submitted" || chat.status === "streaming";
@@ -2022,9 +2022,15 @@ function RunsMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="sm" variant="outline" className={cn(canvasToolbarButtonClass, "gap-1.5 text-foreground/75")}>
+        <Button
+          size="sm"
+          variant="outline"
+          className={cn(canvasToolbarButtonClass, "min-w-0 max-w-full gap-1.5 text-foreground/75")}
+        >
           {activeRunId ? <EyeIcon size={14} weight="fill" /> : <CaretDownIcon size={13} />}
-          {activeRunId && active ? `Viewing · ${formatRunDate(active.startedAt)}` : `Runs · ${runs.length}`}
+          <span className="min-w-0 max-w-full truncate">
+            {activeRunId && active ? `Viewing · ${formatRunDate(active.startedAt)}` : `Runs · ${runs.length}`}
+          </span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-[310px]">


### PR DESCRIPTION
## Summary

- keep the automation builder transcript synchronized when the browser window becomes visible or reconnects after a stream interruption
- constrain the active `Viewing · ...` run selector so long labels cannot push the builder toolbar beyond its available width

## Linear Scope

- [SKE-333: Polish automation chats, graph, and execution feedback](https://linear.app/sketch-ai/issue/SKE-333/polish-automation-chats-graph-and-execution-feedback)

## Implementation Details

- reuse `useWebChatReconciliation` in `BuilderChatTranscript` for visibility/online recovery, pending-progress polling, and stream-error reconciliation
- replace the builder-only ready-state polling with the shared reconciliation behavior
- bound the run selector and truncate its label, with isolated regression coverage for both behaviors

## Verification

- Node 24 `pnpm biome check .` — passed; 1,313 files
- Node 24 `pnpm typecheck` — passed
- Node 24 `pnpm test` — passed; server 4,944 passed / 20 skipped, web 458 passed
- Node 24 `pnpm build` — passed
- focused Vitest for reconciliation and builder coverage — 51 passed
- local browser QA — builder loaded, no horizontal document overflow at 420px, no browser errors

## Risk / Rollout

- frontend-only; no API, schema, migration, provider, or configuration changes
- reconciliation uses the existing authenticated transcript reload path; the run-label change is presentation-only