### PR TITLE
SKE-358: Prefer deterministic action steps for fixed automations

### DIFF
--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -189,6 +189,18 @@ describe("buildSystemContext", () => {
       expect(result).toContain("durable follow-up state is authoritative");
     });
 
+    it("prefers deterministic action steps for fixed automation work", () => {
+      const result = buildSystemContext({ platform: "slack" });
+
+      expect(result).toContain("Prefer explicit workflow steps for deterministic automations");
+      expect(result).toContain("mapping fields, filtering records, normalizing data, calculations");
+      expect(result).toContain("bounded JSON transformations");
+      expect(result).toContain("action steps with script content");
+      expect(result).toContain("legacy shorthand creates an agent step");
+      expect(result).toContain("only when the workflow needs interpretation, classification, planning, summarization");
+      expect(result).toContain("Operational actions remain deterministic");
+    });
+
     it("routes semantic authoring through natural-language ManageScheduledTasks requests when configured", () => {
       const result = buildSystemContext({ platform: "slack", automationAuthoringEnabled: true });
 
@@ -207,6 +219,7 @@ describe("buildSystemContext", () => {
       expect(result).not.toContain("Do not construct or pass automation definition fields");
       expect(result).not.toContain("Never use updateStepContent");
       expect(result).toContain("pass the resolved target ID in ManageScheduledTasks delivery");
+      expect(result).toContain("Operational actions remain deterministic");
     });
   });
 

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -393,13 +393,23 @@ export function buildSystemContext(params: {
     "For external app events, prefer a Canvas-managed trigger only when a Canvas skill/MCP is available: use Canvas search_components to find the trigger, then create a workflow with triggerConfig.type='canvas'. If Canvas is not available, use a normal scheduled cron/interval/once trigger instead.",
   );
 
+  if (!params.automationAuthoringEnabled) {
+    sections.push(
+      "Prefer explicit workflow steps for deterministic automations. For mapping fields, filtering records, normalizing data, calculations, bounded JSON transformations, routing, or known integration reads and writes, call ManageScheduledTasks with a steps array containing a trigger step and one or more action steps with script content. Do not use the simple prompt field for this work because that legacy shorthand creates an agent step.",
+      "Use an explicit agent step, or the legacy prompt form, only when the workflow needs interpretation, classification, planning, summarization, or natural-language generation. For hybrid workflows, use action steps for deterministic work before and after the bounded semantic step.",
+    );
+  }
+
+  sections.push(
+    "Operational actions remain deterministic: use ManageScheduledTasks directly to list, pause, resume, run, delete, and inspect run history without an authoring request.",
+  );
+
   if (params.automationAuthoringEnabled) {
     sections.push(
       "When creating or semantically editing an automation, pass the user's requested change as a natural-language request to ManageScheduledTasks. For edits, include the task ID.",
       "When the user names a Slack channel as the source for a native Slack channel-message trigger, call SearchDeliveryTargets with platform='slack' and targetType='channel' first. Pass the matched channel's targetId and label in the natural-language authoring request; never invent a channel ID. If there is no unique match, ask the user to clarify.",
       "Do not construct or pass automation definition fields such as schedules, timezones, delivery, titles, descriptions, steps, edges, prompts, scripts, apps, modes, skills, MCP servers, or models. The automation authoring model owns the complete definition.",
       "Never use updateStepContent. Prompt, script, app, mode, skill, MCP, schedule, delivery, and structural changes must use a full ManageScheduledTasks update with the user's natural-language request.",
-      "Operational actions remain deterministic: use ManageScheduledTasks directly to list, pause, resume, run, delete, and inspect run history without an authoring request.",
     );
   }
 

--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -32,16 +32,31 @@ const workflowStepSchema = z.object({
   script: z
     .string()
     .optional()
-    .describe("Script content for action steps. Stored in automation_step_content, not in steps JSON."),
+    .describe(
+      "Script content for deterministic action steps. Use for fixed mapping, filtering, normalization, calculations, bounded JSON transformations, routing, or known integration operations. Action scripts use the existing action executor, receive (input, ctx, signal), and must return JSON-serializable output. Stored in automation_step_content, not in steps JSON.",
+    ),
   agentPrompt: z
     .string()
     .optional()
-    .describe("Prompt content for agent steps. Stored in automation_step_content, not in steps JSON."),
-  apps: z.array(z.string()).optional().describe("MCP server slugs this step uses (e.g. ['clickup', 'slack'])."),
-  agentMode: z.enum(["light", "sketch"]).optional(),
-  agentSkills: z.array(z.string()).optional(),
-  agentModel: z.string().optional(),
-  agentMcpServers: z.array(z.string()).optional(),
+    .describe(
+      "Prompt content for explicit agent steps. Use only when the workflow needs interpretation, classification, planning, summarization, or natural-language generation. Stored in automation_step_content, not in steps JSON.",
+    ),
+  apps: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "MCP server slugs associated with this step (for example, ['clickup', 'slack']). This does not turn an action step into an agent step; action scripts use ctx.integrations.executeAction for known integration operations.",
+    ),
+  agentMode: z
+    .enum(["light", "sketch"])
+    .optional()
+    .describe("Execution mode for agent steps. Not used by action steps."),
+  agentSkills: z.array(z.string()).optional().describe("Skills available to an agent step. Not used by action steps."),
+  agentModel: z.string().optional().describe("Model override for an agent step. Not used by action steps."),
+  agentMcpServers: z
+    .array(z.string())
+    .optional()
+    .describe("MCP servers available to an agent step. Not used by action steps."),
   timeout: z.number().optional().describe("Step timeout in seconds. Default: 1800 (30 min)."),
   triggerConfig: z
     .object({
@@ -79,7 +94,7 @@ const manageScheduledTasksSchema = {
     .enum(["list", "add", "update", "remove", "pause", "resume", "run", "getRun", "share", "updateStepContent"])
     .describe(
       `Action to perform.
-- 'add': create an automation (simple: prompt + schedule_type + schedule_value; multi-step: title + steps)
+- 'add': create an automation (legacy agent form: prompt + schedule_type + schedule_value; deterministic form: title + steps with action scripts)
 - 'list': list automations in this context
 - 'update': modify an automation (requires task_id)
 - 'remove': delete an automation (requires task_id)
@@ -93,7 +108,9 @@ const manageScheduledTasksSchema = {
   prompt: z
     .string()
     .optional()
-    .describe("The instruction the agent executes each run. For simple automations (no steps array)."),
+    .describe(
+      "Legacy/simple automation prompt. When used without steps, Sketch expands it to one Sketch-mode agent step. Keep it for agent-driven or legacy automations; for deterministic work, pass an explicit steps array with action script content.",
+    ),
   schedule_type: z
     .enum(["cron", "interval", "once"])
     .optional()
@@ -122,7 +139,9 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
   steps: z
     .array(workflowStepSchema)
     .optional()
-    .describe("Workflow steps. When provided, creates a multi-step automation."),
+    .describe(
+      "Explicit workflow steps. Use this for deterministic work: include a trigger step and one or more action steps with script content. Use agent steps only when semantic judgment is needed. Legacy prompt-only automations remain supported.",
+    ),
   edges: z
     .array(z.object({ id: z.string(), from: z.string(), to: z.string() }))
     .optional()
@@ -141,7 +160,12 @@ For once: ISO 8601 datetime string. A naked local time (e.g. '2026-03-14T15:00:0
   delivery: deliverySchema.optional().describe("Canonical final-output delivery destination for the workflow."),
   run_id: z.string().optional().describe("Run ID for getRun action. Omit for latest run."),
   step_id: z.string().optional().describe("Step ID for updateStepContent action."),
-  step_content: z.string().optional().describe("New prompt or script content for updateStepContent action."),
+  step_content: z
+    .string()
+    .optional()
+    .describe(
+      "New content for updateStepContent: use script content for action steps and prompt content for agent steps.",
+    ),
   step_apps: z.array(z.string()).optional().describe("Updated MCP server slugs for updateStepContent action."),
 };
 

--- a/packages/server/src/scheduler/tool.test.ts
+++ b/packages/server/src/scheduler/tool.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { handleManageScheduledTasks } from "../agent/sketch-tools";
+import { createManageScheduledTasksTool } from "../agent/tools/scheduled-tasks";
 import {
   AutomationAuthoringGeneratedOutputError,
   AutomationAuthoringValidationError,
@@ -126,6 +127,37 @@ const whatsappGroupContext: TaskContext = {
 };
 
 const stepContentRepo = makeMockStepContentRepo();
+
+type StructuredManageScheduledTasksTool = {
+  inputSchema: {
+    prompt: { description?: string };
+    steps: {
+      description?: string;
+      unwrap: () => {
+        element: {
+          shape: {
+            script: { description?: string };
+            agentPrompt: { description?: string };
+          };
+        };
+      };
+    };
+  };
+};
+
+describe("ManageScheduledTasks tool contract", () => {
+  it("distinguishes deterministic action steps from legacy agent prompts", () => {
+    const definition = createManageScheduledTasksTool({}) as unknown as StructuredManageScheduledTasksTool;
+    const stepSchema = definition.inputSchema.steps.unwrap().element;
+
+    expect(definition.inputSchema.prompt.description).toContain("Legacy/simple automation prompt");
+    expect(definition.inputSchema.prompt.description).toContain("one Sketch-mode agent step");
+    expect(definition.inputSchema.steps.description).toContain("deterministic work");
+    expect(definition.inputSchema.steps.description).toContain("action steps with script content");
+    expect(stepSchema.shape.script.description).toContain("deterministic action steps");
+    expect(stepSchema.shape.agentPrompt.description).toContain("explicit agent steps");
+  });
+});
 
 describe("handleManageScheduledTasks — configured chat authoring", () => {
   it("routes natural-language creation through the authorer and collects the saved artifact", async () => {


### PR DESCRIPTION
## Summary

- make the main Sketch agent prefer explicit deterministic `action` steps for fixed automation work
- keep the existing action executor and legacy prompt-only automation behavior unchanged
- clarify the ManageScheduledTasks contract so action scripts and agent prompts are distinct

## Linear Scope

- [SKE-358: Prefer deterministic action steps for fixed automations](https://linear.app/sketch-ai/issue/SKE-358/prefer-deterministic-action-steps-for-fixed-automations)

## Implementation Details

- add deterministic-first guidance to the default main-agent scheduled-tasks context for mapping, filtering, normalization, calculations, bounded JSON transformations, routing, and known integration operations
- direct deterministic requests to an explicit `steps` array with `action` script content
- clarify legacy prompt-only behavior and agent-only semantic use in the ManageScheduledTasks tool schema
- preserve existing action runtime, legacy task compatibility, and the separate automation-authoring subsystem

## Verification

- Node 24 `pnpm biome check .` — blocked by 22 pre-existing formatting diagnostics in untracked `.pi-subagents/artifacts` JSON files; tracked-file Biome check passed for 1,302 files
- Node 24 `pnpm typecheck` — passed
- Node 24 `pnpm test` — 5 unrelated existing WhatsApp checkpoint failures; 415 files passed, 4,879 tests passed, 2 files skipped
- focused Vitest — passed; 210 tests
- focused Biome — passed
- `git diff --check` — passed
- Node 24 `pnpm build` — passed

## Risk / Rollout

- prompt/tool guidance only; no runtime, schema, migration, or authoring-model changes
- legacy prompt-only automations still create agent steps for compatibility
- no sandbox, retry, idempotency, receipt, or reconciliation changes in this PR
- full repository lint is currently affected by unrelated untracked `.pi-subagents` artifacts; those files are excluded from the commit