### PR TITLE
chore: default AGENT_RUNTIME to aisdk (SKE-363)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ LOG_LEVEL=info          # debug | info | warn | error
 # MAX_CONCURRENT_INTERACTIVE_AGENT_RUNS=4
 # MAX_CONCURRENT_SCHEDULED_AGENT_RUNS=4
 
+# Agent runtime. aisdk (default) runs the agent loop in-process on the Vercel AI SDK.
+# sdk is the legacy Claude Agent SDK runtime, which spawns a subprocess per run and
+# does not honour the per-request model deadline. Only set this to opt back in.
+# AGENT_RUNTIME=aisdk
+
 # Files
 # Per-file download cap (MB). Files larger than this are rejected at download.
 # MAX_FILE_SIZE_MB=20

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -51,7 +51,7 @@ describe("configSchema", () => {
         expect(result.data.MAX_CONCURRENT_SCHEDULED_AGENT_RUNS).toBe(4);
         expect(result.data.MAX_FILE_SIZE_MB).toBe(20);
         expect(result.data.VISION_ENABLED).toBe(false);
-        expect(result.data.AGENT_RUNTIME).toBe("sdk");
+        expect(result.data.AGENT_RUNTIME).toBe("aisdk");
       }
     });
 
@@ -60,6 +60,14 @@ describe("configSchema", () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.AGENT_RUNTIME).toBe("aisdk");
+      }
+    });
+
+    it("still accepts an explicit opt-in to the legacy sdk runtime", () => {
+      const result = configSchema.safeParse({ AGENT_RUNTIME: "sdk" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.AGENT_RUNTIME).toBe("sdk");
       }
     });
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -58,7 +58,7 @@ export const configSchema = z.object({
   FEATURE_ARCHIVE_MAX_PER_RUN: z.coerce.number().int().min(1).default(1000),
   GEMINI_MAX_RPM: z.coerce.number().int().min(1).default(60),
   GEMINI_MAX_RETRIES: z.coerce.number().int().min(0).default(4),
-  AGENT_RUNTIME: z.enum(["sdk", "aisdk"]).default("sdk"),
+  AGENT_RUNTIME: z.enum(["sdk", "aisdk"]).default("aisdk"),
 
   // Sync reconciliation
   SYNC_ALLOW_LARGE_RECONCILE: z


### PR DESCRIPTION
Closes [SKE-363](https://linear.app/sketch-ai/issue/SKE-363/flip-agent-runtime-default-from-sdk-to-aisdk).

One-line default flip, split out of [#465](https://github.com/canvasxai/sketch/pull/465) so it is visible on its own rather than buried in a bug fix.

## Why

`AGENT_RUNTIME` still defaulted to `"sdk"`, the legacy Claude Agent SDK runtime, even though `aisdk` is what every deployment actually runs.

It surfaced while fixing SKE-357. The per-request model deadline added there lives in `createAgentRuntimeProvider`, which **only the `aisdk` path uses** — the legacy path calls `query()` directly ([runner.ts:1102-1107](packages/server/src/agent/runner.ts:1102)) and never touches the provider factory. So a deployment left on the default got no request deadline at all.

## Blast radius

Narrow, and verified rather than assumed:

- Managed tenants already set `AGENT_RUNTIME=aisdk` explicitly in their ECS task definition (checked on `sketch-canvas-ai:53`), and every run in the SKE-357 incident bundle logs `"runtime":"aisdk"`.
- So this changes behaviour only for deployments that never set the variable — self-hosted on defaults, and local dev.

## Changes

- Default flipped in `config.ts`.
- `.env.example` documents the choice and notes the legacy runtime does not honour the per-request deadline.
- Test updated for the new default, plus a new case asserting `AGENT_RUNTIME=sdk` still parses — the legacy runtime is untouched and remains available by explicit opt-in.

Removing the Claude Agent SDK dependency and the `runAgentWithClaudeSdk` path stays out of scope; the agent-runtime v1 plan deferred that to its own release.

## Verification

`pnpm biome check` · `pnpm typecheck` · `pnpm test` (server 4,947 passed / 20 pre-existing skips; web 458 passed) · `pnpm build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)