### PR TITLE
feat: stop a running Slack agent with "stop", "kill" or "cancel"

### DIFF
--- a/packages/server/src/agent/active-runs.test.ts
+++ b/packages/server/src/agent/active-runs.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   abortActiveRun,
+  abortActiveRuns,
+  createChildAbortController,
   isActiveRun,
   listActiveRuns,
   registerActiveRun,
@@ -70,6 +72,64 @@ describe("active runs", () => {
 
   it("returns false when interrupting a run that is not live", () => {
     expect(abortActiveRun("missing")).toBe(false);
+  });
+
+  it("aborts only live runs selected by metadata", async () => {
+    const targetController = new AbortController();
+    const secondTargetController = new AbortController();
+    const otherController = new AbortController();
+    const waitForAbort = (controller: AbortController) =>
+      new Promise<void>((resolve) => {
+        controller.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    const targetRun = withActiveRun("target-run", targetController, () => waitForAbort(targetController), {
+      platform: "slack",
+      channelId: "C1",
+      threadTs: "1",
+    });
+    const secondTargetRun = withActiveRun(
+      "second-target-run",
+      secondTargetController,
+      () => waitForAbort(secondTargetController),
+      { platform: "slack", channelId: "C1", threadTs: "1" },
+    );
+    const otherRun = withActiveRun("other-run", otherController, () => waitForAbort(otherController), {
+      platform: "slack",
+      channelId: "C1",
+      threadTs: "2",
+    });
+
+    expect(
+      abortActiveRuns(
+        (entry) =>
+          entry.metadata?.platform === "slack" && entry.metadata.channelId === "C1" && entry.metadata.threadTs === "1",
+      ),
+    ).toBe(2);
+    expect(targetController.signal.aborted).toBe(true);
+    expect(secondTargetController.signal.aborted).toBe(true);
+    expect(otherController.signal.aborted).toBe(false);
+    expect(
+      abortActiveRuns(
+        (entry) =>
+          entry.metadata?.platform === "slack" && entry.metadata.channelId === "C1" && entry.metadata.threadTs === "1",
+      ),
+    ).toBe(0);
+
+    otherController.abort();
+    await Promise.all([targetRun, secondTargetRun, otherRun]);
+  });
+
+  it("links a child controller to its parent without sharing upward aborts", () => {
+    const parentController = new AbortController();
+    const childController = createChildAbortController(parentController.signal);
+
+    childController.abort();
+    expect(childController.signal.aborted).toBe(true);
+    expect(parentController.signal.aborted).toBe(false);
+
+    const secondChildController = createChildAbortController(parentController.signal);
+    parentController.abort();
+    expect(secondChildController.signal.aborted).toBe(true);
   });
 
   it("builds the web chat key from user and conversation", () => {

--- a/packages/server/src/agent/active-runs.ts
+++ b/packages/server/src/agent/active-runs.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 export interface ActiveRunMetadata {
   platform: "slack" | "web";
   channelId?: string;
@@ -11,6 +13,10 @@ export interface ActiveRunEntry {
 }
 
 const activeRuns = new Map<string, ActiveRunEntry>();
+const activeRunContext = new AsyncLocalStorage<{
+  controller: AbortController;
+  metadata?: ActiveRunMetadata;
+}>();
 
 export function registerActiveRun(key: string, controller: AbortController, metadata?: ActiveRunMetadata): void {
   activeRuns.set(key, { key, controller, metadata });
@@ -26,6 +32,39 @@ export function abortActiveRun(key: string): boolean {
   if (!activeRun || activeRun.controller.signal.aborted) return false;
   activeRun.controller.abort();
   return true;
+}
+
+export function abortActiveRuns(predicate: (entry: ActiveRunEntry) => boolean): number {
+  let aborted = 0;
+  for (const entry of activeRuns.values()) {
+    if (!predicate(entry) || entry.controller.signal.aborted) continue;
+    entry.controller.abort();
+    aborted += 1;
+  }
+  return aborted;
+}
+
+export function createChildAbortController(parentSignal?: AbortSignal): AbortController {
+  const childController = new AbortController();
+  if (!parentSignal) return childController;
+
+  const combinedSignal = AbortSignal.any([parentSignal, childController.signal]);
+  const abortChild = () => childController.abort(combinedSignal.reason);
+  if (combinedSignal.aborted) {
+    abortChild();
+  } else {
+    combinedSignal.addEventListener("abort", abortChild, { once: true });
+  }
+  return childController;
+}
+
+export function getActiveRunContext():
+  | {
+      controller: AbortController;
+      metadata?: ActiveRunMetadata;
+    }
+  | undefined {
+  return activeRunContext.getStore();
 }
 
 export function isActiveRun(key: string): boolean {
@@ -45,7 +84,7 @@ export async function withActiveRun<T>(
 ): Promise<T> {
   registerActiveRun(key, controller, metadata);
   try {
-    return await fn();
+    return await activeRunContext.run({ controller, metadata }, fn);
   } finally {
     unregisterActiveRun(key, controller);
   }

--- a/packages/server/src/agents/run/generation.ts
+++ b/packages/server/src/agents/run/generation.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { createChildAbortController, getActiveRunContext } from "../../agent/active-runs";
 import { AgentRunAdmissionCancelledError } from "../../agent/concurrency-limiter";
 import { buildSketchContext } from "../../agent/prompt";
 import type { RunAgentParams, RunAgentResult } from "../../agent/runner";
@@ -252,7 +253,15 @@ export class AgentRunGenerationLayer extends AgentRunOutputLayer {
           },
         });
       } else {
-        result = await this.deps.runAgent(agentParams);
+        const parentContext = getActiveRunContext();
+        const abortController =
+          parentContext?.metadata?.platform === "slack"
+            ? createChildAbortController(parentContext.controller.signal)
+            : undefined;
+        result = await this.deps.runAgent({
+          ...agentParams,
+          ...(abortController ? { abortController } : {}),
+        });
       }
       if (!saved) {
         if (writeAttempted) {

--- a/packages/server/src/queue.test.ts
+++ b/packages/server/src/queue.test.ts
@@ -25,6 +25,27 @@ function createWork(order: number[], id: number, delayMs = 0): () => Promise<voi
 }
 
 describe("ChannelQueue", () => {
+  it("clears only the backlog and returns the number of dropped items", async () => {
+    const queue = new ChannelQueue();
+    const running = createGatedWork();
+    const completed: number[] = [];
+
+    queue.enqueue(running.work);
+    queue.enqueue(async () => {
+      completed.push(1);
+    });
+    queue.enqueue(async () => {
+      completed.push(2);
+    });
+
+    expect(queue.clear()).toBe(2);
+    expect(queue.clear()).toBe(0);
+    running.release();
+
+    await vi.waitFor(() => expect(queue.isIdle()).toBe(true));
+    expect(completed).toEqual([]);
+  });
+
   it("processes items sequentially in enqueue order", async () => {
     const queue = new ChannelQueue();
     const order: number[] = [];
@@ -101,6 +122,31 @@ describe("ChannelQueue", () => {
 });
 
 describe("QueueManager", () => {
+  it("clears an existing queue without creating a missing queue", async () => {
+    const manager = new QueueManager();
+    expect(manager.clear("missing")).toBe(0);
+    expect(manager.size()).toBe(0);
+
+    const running = createGatedWork();
+    const otherRunning = createGatedWork();
+    const queue = manager.getQueue("target");
+    const otherQueue = manager.getQueue("other");
+    queue.enqueue(running.work);
+    queue.enqueue(async () => {});
+    queue.enqueue(async () => {});
+    otherQueue.enqueue(otherRunning.work);
+
+    expect(manager.clear("target")).toBe(2);
+    expect(otherQueue.isIdle()).toBe(false);
+    expect(manager.size()).toBe(2);
+
+    running.release();
+    await vi.waitFor(() => expect(manager.size()).toBe(1));
+    otherRunning.release();
+    await vi.waitFor(() => expect(manager.size()).toBe(0));
+    expect(manager.clear("target")).toBe(0);
+  });
+
   it("returns the same instance for the same channelId", () => {
     const manager = new QueueManager();
     const q1 = manager.getQueue("channel-1");

--- a/packages/server/src/queue.ts
+++ b/packages/server/src/queue.ts
@@ -53,6 +53,12 @@ export class ChannelQueue {
     return true;
   }
 
+  clear(): number {
+    const dropped = this.queue.length;
+    this.queue = [];
+    return dropped;
+  }
+
   /**
    * True when nothing is queued and nothing is running, so the owner can
    * safely evict this instance without dropping in-flight work.
@@ -116,6 +122,14 @@ export class QueueManager {
    */
   size(): number {
     return this.queues.size;
+  }
+
+  clear(channelId: string): number {
+    const queue = this.queues.get(channelId);
+    if (!queue) return 0;
+    const dropped = queue.clear();
+    this.evictIfIdle(channelId, queue);
+    return dropped;
   }
 
   /**

--- a/packages/server/src/scheduler/service.isolated.test.ts
+++ b/packages/server/src/scheduler/service.isolated.test.ts
@@ -11,6 +11,7 @@
  */
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withActiveRun } from "../agent/active-runs";
 import { createConversationRepository } from "../db/repositories/conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import type { ScheduledTaskRow } from "../db/repositories/scheduled-tasks";
@@ -1302,11 +1303,83 @@ describe("executeTaskById() queueing", () => {
     await vi.waitFor(() => expect(calls).toHaveLength(1));
     expect(calls[0].runAgent).toBe(scheduledRunAgent);
     expect(calls[0].limitAgentExecution).toBe(scheduledLimit);
+    expect(calls[0].parentAbortSignal).toBeUndefined();
 
     await scheduler.executeTaskById(row.id);
     expect(calls).toHaveLength(2);
     expect(calls[1].runAgent).toBe(interactiveRunAgent);
     expect(calls[1].limitAgentExecution).toBe(interactiveLimit);
+  });
+
+  it("captures each manual run parent before it waits behind another run of the same task", async () => {
+    const { executeAutomation } = await import("../workflows/runtime");
+    const executeAutomationMock = vi.mocked(executeAutomation);
+    const calls: ExecuteAutomationParams[] = [];
+    let releaseFirst: (() => void) | undefined;
+    let callCount = 0;
+    executeAutomationMock.mockImplementation(async (params: ExecuteAutomationParams) => {
+      calls.push(params);
+      callCount += 1;
+      if (callCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return { runId: `run-${callCount}`, status: "completed", finalOutput: null, stepOutputs: {} };
+    });
+
+    const scheduler = new TaskScheduler(buildDeps(db) as never);
+    const row = await repo.add({ ...baseTaskFields });
+    const firstParent = new AbortController();
+    const secondParent = new AbortController();
+
+    const firstRun = withActiveRun("slack:first", firstParent, () => scheduler.executeTaskById(row.id), {
+      platform: "slack",
+      channelId: "C123",
+      threadTs: "1.1",
+    });
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+
+    const secondRun = withActiveRun("slack:second", secondParent, () => scheduler.executeTaskById(row.id), {
+      platform: "slack",
+      channelId: "C123",
+      threadTs: "1.1",
+    });
+    releaseFirst?.();
+
+    await firstRun;
+    await secondRun;
+
+    expect(calls[0]?.parentAbortSignal).toBe(firstParent.signal);
+    expect(calls[1]?.parentAbortSignal).toBe(secondParent.signal);
+  });
+
+  it("does not update the automation task after an aborted manual run", async () => {
+    const { executeAutomation } = await import("../workflows/runtime");
+    vi.mocked(executeAutomation).mockResolvedValue({
+      runId: "aborted-run",
+      status: "failed",
+      finalOutput: null,
+      stepOutputs: {},
+      aborted: true,
+    });
+    const scheduler = new TaskScheduler(buildDeps(db) as never);
+    const row = await repo.add({
+      ...baseTaskFields,
+      schedule_type: "once",
+      schedule_value: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+
+    await scheduler.executeTaskById(row.id);
+
+    const after = await repo.getById(row.id);
+    expect(after).toMatchObject({
+      status: "active",
+      last_run_at: null,
+      next_run_at: null,
+      prompt: row.prompt,
+      steps: row.steps,
+    });
   });
 
   it("serializes manual runs through the scheduler queue", async () => {

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -21,6 +21,7 @@ import { pipeline } from "node:stream/promises";
 import { workflowTriggerConfigSchema } from "@sketch/shared";
 import { Cron } from "croner";
 import type { Kysely } from "kysely";
+import { getActiveRunContext } from "../agent/active-runs";
 import type { McpServerConfig, runAgent } from "../agent/runner";
 import { resolveAgentRuntimeProviderConfigFromSettings } from "../agent/runtime/provider";
 import type { Config } from "../config";
@@ -55,6 +56,16 @@ import { getScheduledTaskRowQueueKey } from "./queue-key";
 import type { ScheduledTask } from "./types";
 
 type AgentExecutionQueue = "interactive" | "scheduled";
+
+interface EnqueueTaskOptions {
+  localFileRoot?: string;
+  propagateParentAbort?: boolean;
+}
+
+function getSlackParentAbortSignal(): AbortSignal | undefined {
+  const context = getActiveRunContext();
+  return context?.metadata?.platform === "slack" ? context.controller.signal : undefined;
+}
 
 function parseSlackTriggerSteps(value: string | null): Array<{ type?: string; triggerConfig?: unknown }> {
   if (!value) return [];
@@ -341,6 +352,7 @@ export class TaskScheduler {
     task: ScheduledTaskRow,
     executionQueue: AgentExecutionQueue,
     trigger?: { provided: boolean; data: unknown; localFileRoot?: string },
+    parentAbortSignal?: AbortSignal,
   ): Promise<AutomationExecutionResult> {
     const { config, logger, loadIntegrationProvider } = this.deps;
     const delivery = resolveWorkflowDelivery(task);
@@ -362,7 +374,8 @@ export class TaskScheduler {
       listAgentEnvForRuntime: this.deps.listAgentEnvForRuntime,
       userRepo: this.deps.userRepo,
       runAgent: executionQueue === "scheduled" ? this.deps.runScheduledAgent : this.deps.runAgent,
-      propagateParentAbort: executionQueue === "interactive",
+      propagateParentAbort: executionQueue === "interactive" && parentAbortSignal !== undefined,
+      parentAbortSignal,
       buildMcpServers: this.deps.buildMcpServers,
       getSlack: this.deps.getSlack,
       inboxMessagesRepo: this.deps.inboxMessagesRepo,
@@ -376,16 +389,18 @@ export class TaskScheduler {
       trustedLocalFileRoot: trigger?.localFileRoot,
     });
 
-    const now = new Date().toISOString();
-    const cron = this.cronInstances.get(task.id);
-    const nextRun = task.schedule_type === "once" ? null : (cron?.nextRun()?.toISOString() ?? null);
-    await this.repo.updateRunTimestamps(task.id, now, nextRun);
+    if (!result.aborted) {
+      const now = new Date().toISOString();
+      const cron = this.cronInstances.get(task.id);
+      const nextRun = task.schedule_type === "once" ? null : (cron?.nextRun()?.toISOString() ?? null);
+      await this.repo.updateRunTimestamps(task.id, now, nextRun);
 
-    if (task.schedule_type === "once") {
-      await this.repo.updateStatus(task.id, "completed");
-      await this.repo.update(task.id, { next_run_at: null });
-      this.unscheduleTask(task.id);
-      this.deps.logger.debug({ taskId: task.id }, "TaskScheduler: once task completed, unscheduled");
+      if (task.schedule_type === "once") {
+        await this.repo.updateStatus(task.id, "completed");
+        await this.repo.update(task.id, { next_run_at: null });
+        this.unscheduleTask(task.id);
+        this.deps.logger.debug({ taskId: task.id }, "TaskScheduler: once task completed, unscheduled");
+      }
     }
 
     return result;
@@ -396,6 +411,7 @@ export class TaskScheduler {
     getTask: () => Promise<ScheduledTaskRow | null>,
     executionQueue: AgentExecutionQueue,
     trigger?: { provided: boolean; data: unknown; localFileRoot?: string },
+    parentAbortSignal?: AbortSignal,
   ): Promise<AutomationExecutionResult | null> {
     const queueKey = this.getQueueKey(task);
     return new Promise<AutomationExecutionResult | null>((resolve, reject) => {
@@ -406,7 +422,7 @@ export class TaskScheduler {
             resolve(null);
             return;
           }
-          resolve(await this.executeTaskNow(current, executionQueue, trigger));
+          resolve(await this.executeTaskNow(current, executionQueue, trigger, parentAbortSignal));
         } catch (err) {
           reject(err);
         }
@@ -594,13 +610,16 @@ export class TaskScheduler {
     if (!row) throw new Error(`Task ${id} not found`);
     if (row.status === "completed" && row.schedule_type === "once") return null;
     if (row.status !== "active") throw new Error(`Task ${id} is not active`);
-    return this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive");
+    return this.enqueueTaskRun(
+      row,
+      () => this.getRunnableTask(id, true),
+      "interactive",
+      undefined,
+      getSlackParentAbortSignal(),
+    );
   }
 
-  async enqueueTaskById(
-    id: string,
-    ...triggerData: [] | [unknown] | [unknown, { localFileRoot: string }]
-  ): Promise<void> {
+  async enqueueTaskById(id: string, ...triggerData: [] | [unknown] | [unknown, EnqueueTaskOptions]): Promise<void> {
     const row = await this.repo.getById(id);
     if (!row) throw new Error(`Task ${id} not found`);
     if (row.status === "completed" && row.schedule_type === "once") return;
@@ -610,7 +629,8 @@ export class TaskScheduler {
       triggerData.length === 0
         ? undefined
         : { provided: true, data: triggerData[0], localFileRoot: triggerData[1]?.localFileRoot };
-    this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive", trigger)
+    const parentAbortSignal = triggerData[1]?.propagateParentAbort === false ? undefined : getSlackParentAbortSignal();
+    this.enqueueTaskRun(row, () => this.getRunnableTask(id, true), "interactive", trigger, parentAbortSignal)
       .catch((err) => {
         this.deps.logger.error({ err, taskId: id }, "Automation background execution failed");
       })
@@ -696,9 +716,9 @@ export class TaskScheduler {
         });
         localFileRoot = copied.localFileRoot;
         if (localFileRoot) {
-          await this.enqueueTaskById(task.id, copied.triggerData, { localFileRoot });
+          await this.enqueueTaskById(task.id, copied.triggerData, { localFileRoot, propagateParentAbort: false });
         } else {
-          await this.enqueueTaskById(task.id, copied.triggerData);
+          await this.enqueueTaskById(task.id, copied.triggerData, { propagateParentAbort: false });
         }
       } catch (err) {
         if (localFileRoot) await rm(localFileRoot, { recursive: true, force: true });

--- a/packages/server/src/scheduler/service.ts
+++ b/packages/server/src/scheduler/service.ts
@@ -362,6 +362,7 @@ export class TaskScheduler {
       listAgentEnvForRuntime: this.deps.listAgentEnvForRuntime,
       userRepo: this.deps.userRepo,
       runAgent: executionQueue === "scheduled" ? this.deps.runScheduledAgent : this.deps.runAgent,
+      propagateParentAbort: executionQueue === "interactive",
       buildMcpServers: this.deps.buildMcpServers,
       getSlack: this.deps.getSlack,
       inboxMessagesRepo: this.deps.inboxMessagesRepo,

--- a/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
+++ b/packages/server/src/scheduler/slack-channel-message-dispatch.isolated.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withActiveRun } from "../agent/active-runs";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import type { DB } from "../db/schema";
 import { QueueManager } from "../queue";
@@ -95,12 +96,24 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
     const deps = makeDeps(db);
     const scheduler = new TaskScheduler(deps as never);
     const triggerData = { messageTs: "1.2", nested: { exact: true } };
+    const parentController = new AbortController();
 
-    await scheduler.dispatchSlackChannelMessage("C_MATCH", triggerData);
+    await withActiveRun(
+      "slack:mention",
+      parentController,
+      () => scheduler.dispatchSlackChannelMessage("C_MATCH", triggerData),
+      {
+        platform: "slack",
+        channelId: "C_MATCH",
+        threadTs: "1.2",
+      },
+    );
 
     await vi.waitFor(() => expect(executionParams).toHaveLength(1));
     expect(deps.getSlack().isUserInChannel).toHaveBeenCalledWith("C_MATCH", "U_CREATOR");
     expect(executionParams[0]?.triggerData).toBe(triggerData);
+    expect(executionParams[0]?.parentAbortSignal).toBeUndefined();
+    expect(executionParams[0]?.propagateParentAbort).toBe(false);
   });
 
   it("copies authenticated Slack files into each automation workspace before dispatch", async () => {
@@ -291,8 +304,13 @@ describe("TaskScheduler.dispatchSlackChannelMessage", () => {
     await scheduler.dispatchSlackChannelMessage("C_MATCH", { messageTs: "1.2" });
 
     await vi.waitFor(() => expect(executionParams).toHaveLength(1));
-    expect(enqueueTaskById).toHaveBeenNthCalledWith(1, first.id, { messageTs: "1.2" });
-    expect(enqueueTaskById).toHaveBeenNthCalledWith(2, second.id, { messageTs: "1.2" });
+    expect(enqueueTaskById).toHaveBeenNthCalledWith(1, first.id, { messageTs: "1.2" }, { propagateParentAbort: false });
+    expect(enqueueTaskById).toHaveBeenNthCalledWith(
+      2,
+      second.id,
+      { messageTs: "1.2" },
+      { propagateParentAbort: false },
+    );
     expect(deps.getSlack().isUserInChannel).toHaveBeenCalledOnce();
   });
 

--- a/packages/server/src/slack/adapter.isolated.test.ts
+++ b/packages/server/src/slack/adapter.isolated.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { listActiveRuns } from "../agent/active-runs";
+import { listActiveRuns, registerActiveRun, unregisterActiveRun } from "../agent/active-runs";
 import { PROMPT_TOO_LONG_RECOVERY_MESSAGE, PROMPT_TOO_LONG_SHARED_RECOVERY_MESSAGE } from "../agent/errors";
 import { NEW_SESSION_CONFIRMATIONS } from "../commands";
 import { refreshSlackChannelName } from "../connectors/slack-salience";
@@ -16,6 +16,14 @@ function deferred<T>() {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+function heldWork(): { work: () => Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { work: () => promise, release };
 }
 
 // --- Fixtures ---
@@ -543,6 +551,130 @@ describe("slack/adapter", () => {
   });
 
   describe("DM handler", () => {
+    it("intercepts stop before enqueue, aborts the DM run, clears backlog, and reacts once", async () => {
+      const queue = new QueueManager();
+      const running = heldWork();
+      const dmQueue = queue.getQueue("u1");
+      dmQueue.enqueue(running.work);
+      dmQueue.enqueue(async () => {});
+      const controller = new AbortController();
+      registerActiveRun("stop-dm-run", controller, { platform: "slack", channelId: "D1", threadTs: null });
+      const getQueue = vi.spyOn(queue, "getQueue");
+      const deps = makeDeps({ queue });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { dm } = getHandlers();
+
+      await dm({ text: "stop it please!", userId: "S1", channelId: "D1", ts: "2", type: "dm" });
+
+      expect(controller.signal.aborted).toBe(true);
+      expect(getQueue).not.toHaveBeenCalled();
+      expect(deps.runAgent).not.toHaveBeenCalled();
+      expect(deps.repos.conversations.insertMessage).not.toHaveBeenCalled();
+      expect(mockBotInstance.addReaction).toHaveBeenCalledExactlyOnceWith("D1", "2", "white_check_mark");
+      expect(mockBotInstance.postMessage).not.toHaveBeenCalled();
+
+      running.release();
+      await vi.waitFor(() => expect(queue.size()).toBe(0));
+      unregisterActiveRun("stop-dm-run", controller);
+    });
+
+    it("reacts to an idle stop without sending a textual reply", async () => {
+      const deps = makeDeps();
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { dm } = getHandlers();
+
+      await dm({ text: "cancel", userId: "S1", channelId: "D1", ts: "2", type: "dm" });
+
+      expect(mockBotInstance.addReaction).toHaveBeenCalledExactlyOnceWith("D1", "2", "white_check_mark");
+      expect(mockBotInstance.postMessage).not.toHaveBeenCalled();
+      expect(deps.runAgent).not.toHaveBeenCalled();
+    });
+
+    it("handles concurrent DM stops without throwing or reviving the run", async () => {
+      const controller = new AbortController();
+      registerActiveRun("concurrent-stop-run", controller, { platform: "slack", channelId: "D1", threadTs: null });
+      const deps = makeDeps();
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { dm } = getHandlers();
+
+      await Promise.all([
+        dm({ text: "stop", userId: "S1", channelId: "D1", ts: "2", type: "dm" }),
+        dm({ text: "kill", userId: "S1", channelId: "D1", ts: "3", type: "dm" }),
+      ]);
+
+      expect(controller.signal.aborted).toBe(true);
+      expect(mockBotInstance.addReaction).toHaveBeenCalledTimes(2);
+      expect(mockBotInstance.postMessage).not.toHaveBeenCalled();
+      unregisterActiveRun("concurrent-stop-run", controller);
+    });
+
+    it("suppresses every output leak and advances the DM watermark on a returned abort", async () => {
+      const deps = makeDeps({
+        runAgent: vi.fn().mockResolvedValue(
+          makeAgentResult({
+            messageSent: true,
+            stopReason: "aborted",
+            pendingUploads: ["/tmp/stopped.pdf"],
+            trace: { progressEvents: [], finalText: "partial answer" },
+          }),
+        ),
+      });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { dm } = getHandlers();
+
+      await dm({ text: "work", userId: "S1", channelId: "D1", ts: "1", type: "dm" });
+      await flush();
+
+      expect(mockBotInstance.postMessage).not.toHaveBeenCalledWith("D1", "partial answer");
+      expect(mockBotInstance.postMessage).not.toHaveBeenCalledWith("D1", "_No response_");
+      expect(mockBotInstance.uploadFile).not.toHaveBeenCalled();
+      expect(deps.repos.conversations.updateWatermark).toHaveBeenCalledWith(1, 1);
+      expect(deps.inboxMessagesRepo?.markConsumed).not.toHaveBeenCalled();
+    });
+
+    it("suppresses a thrown abort and advances the DM watermark", async () => {
+      const deps = makeDeps({
+        runAgent: vi.fn().mockImplementation(async (params) => {
+          params.abortController?.abort();
+          throw new DOMException("The operation was aborted.", "AbortError");
+        }),
+      });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { dm } = getHandlers();
+
+      await dm({ text: "work", userId: "S1", channelId: "D1", ts: "1", type: "dm" });
+      await flush();
+
+      expect(mockBotInstance.postMessage).not.toHaveBeenCalled();
+      expect(mockBotInstance.uploadFile).not.toHaveBeenCalled();
+      expect(deps.repos.conversations.updateWatermark).toHaveBeenCalledWith(1, 1);
+    });
+
+    it("registers before preprocessing so a stop during MCP setup suppresses the run", async () => {
+      const mcpSetup = deferred<Record<string, never>>();
+      const deps = makeDeps({
+        buildMcpServers: vi.fn().mockReturnValue(mcpSetup.promise),
+        runAgent: vi.fn().mockResolvedValue(makeAgentResult()),
+      });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { dm } = getHandlers();
+      const original = dm({ text: "work", userId: "S1", channelId: "D1", ts: "1", type: "dm" });
+
+      await vi.waitFor(() =>
+        expect(listActiveRuns()).toEqual([
+          expect.objectContaining({ metadata: { platform: "slack", channelId: "D1", threadTs: null } }),
+        ]),
+      );
+      await dm({ text: "stop", userId: "S1", channelId: "D1", ts: "2", type: "dm" });
+      mcpSetup.resolve({});
+      await original;
+      await flush();
+
+      expect(deps.runAgent).not.toHaveBeenCalled();
+      expect(mockBotInstance.postMessage).not.toHaveBeenCalled();
+      expect(deps.repos.conversations.updateWatermark).toHaveBeenCalledWith(1, 1);
+    });
+
     it.each([
       ["  confirm   done a1b2  ", "Marked the follow-up done."],
       ["dismiss c3d4", "Dismissed that reconstructed follow-up."],
@@ -1072,6 +1204,126 @@ describe("slack/adapter", () => {
   });
 
   describe("channel mention handler", () => {
+    it("intercepts stop before enqueue and only aborts the matching thread", async () => {
+      const queue = new QueueManager();
+      const running = heldWork();
+      const targetQueue = queue.getQueue("C1:1");
+      targetQueue.enqueue(running.work);
+      targetQueue.enqueue(async () => {});
+      const targetController = new AbortController();
+      const otherController = new AbortController();
+      registerActiveRun("stop-thread-run", targetController, {
+        platform: "slack",
+        channelId: "C1",
+        threadTs: "1",
+      });
+      registerActiveRun("other-thread-run", otherController, {
+        platform: "slack",
+        channelId: "C1",
+        threadTs: "2",
+      });
+      const getQueue = vi.spyOn(queue, "getQueue");
+      const deps = makeDeps({ queue });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { mention } = getHandlers();
+
+      await mention({
+        text: "<@U123> stop it please!",
+        userId: "S1",
+        channelId: "C1",
+        ts: "3",
+        threadTs: "1",
+        type: "channel_mention",
+      });
+
+      expect(targetController.signal.aborted).toBe(true);
+      expect(otherController.signal.aborted).toBe(false);
+      expect(getQueue).not.toHaveBeenCalled();
+      expect(deps.runAgent).not.toHaveBeenCalled();
+      expect(deps.repos.conversations.insertMessage).not.toHaveBeenCalled();
+      expect(mockBotInstance.addReaction).toHaveBeenCalledExactlyOnceWith("C1", "3", "white_check_mark");
+      expect(mockBotInstance.postThreadReply).not.toHaveBeenCalled();
+
+      running.release();
+      await vi.waitFor(() => expect(queue.size()).toBe(0));
+      otherController.abort();
+      unregisterActiveRun("stop-thread-run", targetController);
+      unregisterActiveRun("other-thread-run", otherController);
+    });
+
+    it("ignores a bot-authored stop mention", async () => {
+      const controller = new AbortController();
+      registerActiveRun("bot-stop-target", controller, { platform: "slack", channelId: "C1", threadTs: "1" });
+      const deps = makeDeps();
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { mention } = getHandlers();
+
+      await mention({
+        text: "stop",
+        userId: "S1",
+        botId: "B_WORKFLOW",
+        subtype: "bot_message",
+        channelId: "C1",
+        ts: "2",
+        threadTs: "1",
+        type: "channel_mention",
+      });
+
+      expect(controller.signal.aborted).toBe(false);
+      expect(mockBotInstance.addReaction).not.toHaveBeenCalled();
+      unregisterActiveRun("bot-stop-target", controller);
+    });
+
+    it("suppresses every output leak and advances the channel cursor on a returned abort", async () => {
+      const deps = makeDeps({
+        runAgent: vi.fn().mockResolvedValue(
+          makeAgentResult({
+            messageSent: true,
+            stopReason: "aborted",
+            pendingUploads: ["/tmp/stopped.pdf"],
+            trace: { progressEvents: [], finalText: "partial answer" },
+          }),
+        ),
+      });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { mention } = getHandlers();
+
+      await mention({ text: "work", userId: "S1", channelId: "C1", ts: "1", type: "channel_mention" });
+      await flush();
+
+      expect(mockBotInstance.postThreadReply).not.toHaveBeenCalledWith("C1", "1", "partial answer");
+      expect(mockBotInstance.postThreadReply).not.toHaveBeenCalledWith("C1", "1", "_No response_");
+      expect(mockBotInstance.uploadFile).not.toHaveBeenCalled();
+      expect(deps.repos.conversations.updateCursor).toHaveBeenCalledWith({
+        conversationId: 1,
+        scopeType: "slack_thread",
+        scopeKey: "1",
+        messageId: 1,
+      });
+    });
+
+    it("suppresses a thrown abort and advances the channel cursor", async () => {
+      const deps = makeDeps({
+        runAgent: vi.fn().mockImplementation(async (params) => {
+          params.abortController?.abort();
+          throw new DOMException("The operation was aborted.", "AbortError");
+        }),
+      });
+      createConfiguredSlackBot({ botToken: "xoxb-test", appToken: "xapp-test" }, deps);
+      const { mention } = getHandlers();
+
+      await mention({ text: "work", userId: "S1", channelId: "C1", ts: "1", type: "channel_mention" });
+      await flush();
+
+      expect(mockBotInstance.postThreadReply).not.toHaveBeenCalled();
+      expect(mockBotInstance.uploadFile).not.toHaveBeenCalled();
+      expect(deps.repos.conversations.updateCursor).toHaveBeenCalledWith({
+        conversationId: 1,
+        scopeType: "slack_thread",
+        scopeKey: "1",
+        messageId: 1,
+      });
+    });
     it("returns the current channel tool progress on /toolprogress with no args", async () => {
       const deps = makeDeps({
         repos: {

--- a/packages/server/src/slack/adapter.ts
+++ b/packages/server/src/slack/adapter.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { parseAllowedTools } from "@sketch/shared";
 import type { Kysely } from "kysely";
-import { withActiveRun } from "../agent/active-runs";
+import { abortActiveRuns, withActiveRun } from "../agent/active-runs";
 import type { AuxLlmCall } from "../agent/aux-cost";
 import { PROMPT_TOO_LONG_SHARED_RECOVERY_MESSAGE, agentFailureMessage } from "../agent/errors";
 import {
@@ -23,6 +23,7 @@ import {
   type RunAgentResult,
   canUseVisualAnalysisTool,
 } from "../agent/runner";
+import { isRuntimeAbortError } from "../agent/runtime/errors";
 import { archiveRuntimeSessions } from "../agent/sessions";
 import { createProgressRenderer } from "../agent/tool-progress";
 import { ensureAgentSubWorkspace, ensureChannelWorkspace, ensureWorkspace } from "../agent/workspace";
@@ -76,6 +77,7 @@ import type { SlackEntitySyncService } from "./entity-sync";
 import { HOME_ACTION_REASONING_TEXT, HOME_ACTION_TOOL_PROGRESS, buildHomeView } from "./home";
 import { createSlackMessageHandler } from "./message-handler";
 import { SlackIdentityConflictError, resolveSlackUser } from "./resolve-user";
+import { isSlackStopCommand } from "./stop";
 import type { UserCache } from "./user-cache";
 
 type UserRepository = ReturnType<typeof createUserRepository>;
@@ -88,6 +90,25 @@ type SlackChannelParticipantsRepository = ReturnType<typeof createSlackChannelPa
 const INLINE_BACKLOG_LIMIT = 10;
 const SLACK_THREAD_CURSOR_SCOPE = "slack_thread";
 const SLACK_AGENT_ERROR_MESSAGE = "_Something went wrong, try again_";
+const SLACK_STOP_REACTION = "white_check_mark";
+
+function isAbortedRunResult(result: RunAgentResult): boolean {
+  const legacyResult = result as RunAgentResult & { stopReason?: string | null };
+  return result.rawUsage?.stopReason === "aborted" || legacyResult.stopReason === "aborted";
+}
+
+function abortSlackRunsForScope(channelId: string, threadTs: string | null, isDm: boolean): number {
+  return abortActiveRuns((entry) => {
+    const metadata = entry.metadata;
+    return (
+      metadata?.platform === "slack" && metadata.channelId === channelId && (isDm || metadata.threadTs === threadTs)
+    );
+  });
+}
+
+function isBotAuthoredSlackMessage(message: SlackMessage): boolean {
+  return Boolean(message.botId) || message.subtype === "bot_message";
+}
 
 function parseInboxMetadata(value: string | null): Record<string, unknown> | null {
   if (!value) return null;
@@ -640,159 +661,176 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
       throw err;
     }
     const activeQueueKey = user.id;
+    if (!isBotAuthoredSlackMessage(message) && isSlackStopCommand(message.text)) {
+      abortSlackRunsForScope(message.channelId, null, true);
+      queue.clear(activeQueueKey);
+      await slackBot.addReaction(message.channelId, message.ts, SLACK_STOP_REACTION);
+      return;
+    }
     const userQueue = queue.getQueue(activeQueueKey);
 
     userQueue.enqueue(async () => {
-      logger.info({ slackUserId: message.userId, channelId: message.channelId }, "Processing message");
-
-      const command = parseSketchCommand(message.text);
-      const dmConversation = await repos.conversations.getOrCreate(slackConversationRefForMessage(message), user.name);
-      const followupReview = await handleFollowupReviewCommand({
-        text: message.text,
-        userId: user.id,
-        surface: "slack",
-      });
-      if (followupReview.handled) {
-        await captureSlackMessage({
-          message,
-          senderName: user.name,
-          senderUserId: user.id,
-          addressedToSketch: true,
-          attachments: [],
-          displayName: user.name,
-        });
-        await replyToUser(followupReview.message);
-        return;
-      }
-      if (command === "new_session") {
-        await archiveRuntimeSessions(db, user.id);
-        await repos.conversations.advanceWatermarkToCurrentMax(dmConversation.id);
-        await replyToUser(getNewSessionConfirmation());
-        return;
-      }
-
-      if (!command && isToolProgressCommand(message.text)) {
-        await replyToUser(getUnknownToolProgressMessage(message.text));
-        return;
-      }
-
-      if (!command && isReasoningTextCommand(message.text)) {
-        await replyToUser(getUnknownReasoningTextMessage(message.text));
-        return;
-      }
-
-      const currentProgressSettings = resolveProgressDisplaySettings(user);
-      if (command === "tool_progress_query") {
-        await replyToUser(getToolProgressCurrent(currentProgressSettings));
-        return;
-      }
-
-      if (command === "reasoning_text_query") {
-        await replyToUser(getReasoningTextCurrent(currentProgressSettings));
-        return;
-      }
-
-      const requestedToolProgress = resolveCommandToolProgress(command);
-      if (requestedToolProgress) {
-        await repos.users.update(user.id, { toolProgress: requestedToolProgress });
-        await replyToUser(getToolProgressConfirmation(requestedToolProgress, currentProgressSettings.reasoningText));
-        return;
-      }
-
-      const requestedReasoningText = resolveCommandReasoningText(command);
-      if (requestedReasoningText) {
-        const enabled = requestedReasoningText === "on";
-        await repos.users.update(user.id, { reasoningText: enabled });
-        await replyToUser(getReasoningTextConfirmation(enabled));
-        return;
-      }
-
-      const workspaceDir = await ensureWorkspace(config, user.id);
-      const settingsRow = await repos.settings.get();
-
-      let attachments = await downloadMessageAttachments({
-        files: message.files,
-        workspaceDir,
-        botToken: settingsRow?.slack_bot_token,
-        maxBytes: maxFileBytes,
-        logger,
-      });
-      const eagerAuxCalls: AuxLlmCall[] = [];
-      attachments = await transcribeEagerAttachments(attachments, {
-        loadSettings: () => repos.settings.get(),
-        logger,
-        onUsage: (call) => eagerAuxCalls.push(call),
-      });
-      const capture = await captureSlackMessage({
-        message,
-        senderName: user.name,
-        senderUserId: user.id,
-        addressedToSketch: true,
-        attachments,
-        displayName: user.name,
-      });
-      if (!capture.captured) return;
-
-      const backlog = await repos.conversations.listBacklog({
-        conversationId: capture.conversation.id,
-        afterMessageId: dmConversation.last_seen_message_id,
-        beforeMessageId: capture.captured.id,
-        limit: INLINE_BACKLOG_LIMIT,
-      });
-      const conversationBacklog =
-        backlog.messages.length > 0 || backlog.hasMore
-          ? {
-              messages: backlog.messages,
-              afterMessageId: dmConversation.last_seen_message_id,
-              beforeMessageId: capture.captured.id,
-              hasMore: backlog.hasMore,
-              nextCursor: backlog.nextCursor,
-            }
-          : undefined;
-
-      const assistantThreadTs = message.threadTs;
-      const shimmerThreadTs = message.threadTs ?? message.ts;
-
-      const onFinalMessage = createSlackMessageHandler(slackBot, message.channelId, assistantThreadTs);
+      const abortController = new AbortController();
+      let capture: Awaited<ReturnType<typeof captureSlackMessage>> | undefined;
       let clearAssistantStatus: (() => Promise<void>) | null = null;
       let pendingInbox: Awaited<ReturnType<typeof loadPendingInboxMessages>> | null = null;
+      await withActiveRun(
+        `slack:${randomUUID()}`,
+        abortController,
+        async () => {
+          logger.info({ slackUserId: message.userId, channelId: message.channelId }, "Processing message");
 
-      try {
-        const shimmer = createShimmer(
-          slackBot,
-          message.channelId,
-          shimmerThreadTs,
-          resolveProgressDisplaySettings(user),
-        );
-        clearAssistantStatus = shimmer.clear;
-        const { onProgressEvent } = shimmer;
+          const command = parseSketchCommand(message.text);
+          const dmConversation = await repos.conversations.getOrCreate(
+            slackConversationRefForMessage(message),
+            user.name,
+          );
+          const followupReview = await handleFollowupReviewCommand({
+            text: message.text,
+            userId: user.id,
+            surface: "slack",
+          });
+          if (followupReview.handled) {
+            await captureSlackMessage({
+              message,
+              senderName: user.name,
+              senderUserId: user.id,
+              addressedToSketch: true,
+              attachments: [],
+              displayName: user.name,
+            });
+            await replyToUser(followupReview.message);
+            return;
+          }
+          if (command === "new_session") {
+            await archiveRuntimeSessions(db, user.id);
+            await repos.conversations.advanceWatermarkToCurrentMax(dmConversation.id);
+            await replyToUser(getNewSessionConfirmation());
+            return;
+          }
 
-        const integrationMcpServers = await buildMcpServers(user.email);
-        pendingInbox = await loadPendingInboxMessages(user.id);
+          if (!command && isToolProgressCommand(message.text)) {
+            await replyToUser(getUnknownToolProgressMessage(message.text));
+            return;
+          }
 
-        const visionConfig = resolveVisionConfigFromAppConfig(config, settingsRow);
-        const visualAnalysisAllowed = canUseVisualAnalysisTool(visionConfig, null);
-        const sketchContext: SketchContextParams = {
-          messages: [],
-          currentUserName: user.name,
-          currentMessage: message.text || "See attached files.",
-          currentUserEmail: user.email,
-          workspaceDir,
-          orgDir: config.CLAUDE_CONFIG_DIR,
-          timezone: user.timezone,
-          isSharedContext: false,
-          inboxMessages: pendingInbox.messages,
-          conversationBacklog,
-          visionAnalysisEnabled: visualAnalysisAllowed,
-        };
-        const userMessage = buildSketchContext(sketchContext);
+          if (!command && isReasoningTextCommand(message.text)) {
+            await replyToUser(getUnknownReasoningTextMessage(message.text));
+            return;
+          }
 
-        const abortController = new AbortController();
-        const result = await withActiveRun(
-          `slack:${randomUUID()}`,
-          abortController,
-          () =>
-            runAgent({
+          const currentProgressSettings = resolveProgressDisplaySettings(user);
+          if (command === "tool_progress_query") {
+            await replyToUser(getToolProgressCurrent(currentProgressSettings));
+            return;
+          }
+
+          if (command === "reasoning_text_query") {
+            await replyToUser(getReasoningTextCurrent(currentProgressSettings));
+            return;
+          }
+
+          const requestedToolProgress = resolveCommandToolProgress(command);
+          if (requestedToolProgress) {
+            await repos.users.update(user.id, { toolProgress: requestedToolProgress });
+            await replyToUser(
+              getToolProgressConfirmation(requestedToolProgress, currentProgressSettings.reasoningText),
+            );
+            return;
+          }
+
+          const requestedReasoningText = resolveCommandReasoningText(command);
+          if (requestedReasoningText) {
+            const enabled = requestedReasoningText === "on";
+            await repos.users.update(user.id, { reasoningText: enabled });
+            await replyToUser(getReasoningTextConfirmation(enabled));
+            return;
+          }
+
+          try {
+            const workspaceDir = await ensureWorkspace(config, user.id);
+            const settingsRow = await repos.settings.get();
+
+            let attachments = await downloadMessageAttachments({
+              files: message.files,
+              workspaceDir,
+              botToken: settingsRow?.slack_bot_token,
+              maxBytes: maxFileBytes,
+              logger,
+            });
+            const eagerAuxCalls: AuxLlmCall[] = [];
+            attachments = await transcribeEagerAttachments(attachments, {
+              loadSettings: () => repos.settings.get(),
+              logger,
+              onUsage: (call) => eagerAuxCalls.push(call),
+            });
+            capture = await captureSlackMessage({
+              message,
+              senderName: user.name,
+              senderUserId: user.id,
+              addressedToSketch: true,
+              attachments,
+              displayName: user.name,
+            });
+            if (!capture.captured) return;
+
+            const backlog = await repos.conversations.listBacklog({
+              conversationId: capture.conversation.id,
+              afterMessageId: dmConversation.last_seen_message_id,
+              beforeMessageId: capture.captured.id,
+              limit: INLINE_BACKLOG_LIMIT,
+            });
+            const conversationBacklog =
+              backlog.messages.length > 0 || backlog.hasMore
+                ? {
+                    messages: backlog.messages,
+                    afterMessageId: dmConversation.last_seen_message_id,
+                    beforeMessageId: capture.captured.id,
+                    hasMore: backlog.hasMore,
+                    nextCursor: backlog.nextCursor,
+                  }
+                : undefined;
+
+            const assistantThreadTs = message.threadTs;
+            const shimmerThreadTs = message.threadTs ?? message.ts;
+
+            const onFinalMessage = createSlackMessageHandler(slackBot, message.channelId, assistantThreadTs);
+
+            const shimmer = createShimmer(
+              slackBot,
+              message.channelId,
+              shimmerThreadTs,
+              resolveProgressDisplaySettings(user),
+            );
+            clearAssistantStatus = shimmer.clear;
+            const { onProgressEvent } = shimmer;
+
+            const integrationMcpServers = await buildMcpServers(user.email);
+            pendingInbox = await loadPendingInboxMessages(user.id);
+
+            const visionConfig = resolveVisionConfigFromAppConfig(config, settingsRow);
+            const visualAnalysisAllowed = canUseVisualAnalysisTool(visionConfig, null);
+            const sketchContext: SketchContextParams = {
+              messages: [],
+              currentUserName: user.name,
+              currentMessage: message.text || "See attached files.",
+              currentUserEmail: user.email,
+              workspaceDir,
+              orgDir: config.CLAUDE_CONFIG_DIR,
+              timezone: user.timezone,
+              isSharedContext: false,
+              inboxMessages: pendingInbox.messages,
+              conversationBacklog,
+              visionAnalysisEnabled: visualAnalysisAllowed,
+            };
+            const userMessage = buildSketchContext(sketchContext);
+
+            if (abortController.signal.aborted) {
+              await repos.conversations.updateWatermark(capture.conversation.id, capture.captured.id);
+              return;
+            }
+
+            const result = await runAgent({
               db,
               workspaceKey: user.id,
               seedAuxCalls: eagerAuxCalls,
@@ -842,50 +880,64 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
               sendDm,
               conversationRepo: repos.conversations,
               conversationContext: { conversationId: capture.conversation.id, currentMessageId: capture.captured.id },
-            }),
-          { platform: "slack", channelId: message.channelId, threadTs: assistantThreadTs ?? null },
-        );
+            });
 
-        const finalText = appendIntegrationConnectionLinks(
-          appendAutomationBuilderLinks(result.trace.finalText, result.trace.automationArtifacts ?? []),
-          result.pendingIntegrationConnections,
-          "slack",
-          toolConfig,
-        );
-        if (finalText) {
-          const sent = await onFinalMessage(finalText);
-          await captureSlackBotReplies({
-            conversationId: capture.conversation.id,
-            sent,
-            channelId: message.channelId,
-            threadTs: assistantThreadTs,
-            botName: settingsRow?.bot_name,
-          });
-        }
+            if (isAbortedRunResult(result)) {
+              await clearAssistantStatus();
+              await repos.conversations.updateWatermark(capture.conversation.id, capture.captured.id);
+              return;
+            }
 
-        for (const filePath of result.pendingUploads) {
-          try {
-            await slackBot.uploadFile(message.channelId, filePath, assistantThreadTs);
+            const finalText = appendIntegrationConnectionLinks(
+              appendAutomationBuilderLinks(result.trace.finalText, result.trace.automationArtifacts ?? []),
+              result.pendingIntegrationConnections,
+              "slack",
+              toolConfig,
+            );
+            if (finalText) {
+              const sent = await onFinalMessage(finalText);
+              await captureSlackBotReplies({
+                conversationId: capture.conversation.id,
+                sent,
+                channelId: message.channelId,
+                threadTs: assistantThreadTs,
+                botName: settingsRow?.bot_name,
+              });
+            }
+
+            for (const filePath of result.pendingUploads) {
+              try {
+                await slackBot.uploadFile(message.channelId, filePath, assistantThreadTs);
+              } catch (err) {
+                logger.warn({ err, filePath }, "Failed to upload file to Slack");
+              }
+            }
+
+            await clearAssistantStatus();
+            if (pendingInbox && pendingInbox.ids.length > 0 && inboxMessagesRepo) {
+              await inboxMessagesRepo.markConsumed(pendingInbox.ids);
+            }
+            if (result.messageSent || result.pendingUploads.length > 0) {
+              await repos.conversations.updateWatermark(capture.conversation.id, capture.captured.id);
+            }
+            if (!finalText) {
+              await replyToUser("_No response_");
+            }
           } catch (err) {
-            logger.warn({ err, filePath }, "Failed to upload file to Slack");
+            if (isRuntimeAbortError(err, abortController.signal)) {
+              await clearAssistantStatus?.();
+              if (capture?.captured) {
+                await repos.conversations.updateWatermark(capture.conversation.id, capture.captured.id);
+              }
+              return;
+            }
+            logger.error({ err, userId: user.id }, "Agent run failed");
+            await clearAssistantStatus?.();
+            await replyToUser(agentFailureMessage(err, SLACK_AGENT_ERROR_MESSAGE));
           }
-        }
-
-        await clearAssistantStatus();
-        if (pendingInbox && pendingInbox.ids.length > 0 && inboxMessagesRepo) {
-          await inboxMessagesRepo.markConsumed(pendingInbox.ids);
-        }
-        if (result.messageSent || result.pendingUploads.length > 0) {
-          await repos.conversations.updateWatermark(capture.conversation.id, capture.captured.id);
-        }
-        if (!finalText) {
-          await replyToUser("_No response_");
-        }
-      } catch (err) {
-        logger.error({ err, userId: user.id }, "Agent run failed");
-        await clearAssistantStatus?.();
-        await replyToUser(agentFailureMessage(err, SLACK_AGENT_ERROR_MESSAGE));
-      }
+        },
+        { platform: "slack", channelId: message.channelId, threadTs: message.threadTs ?? null },
+      );
     });
   });
 
@@ -1020,225 +1072,260 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
     void participantObservation.catch(() => undefined);
     const threadTs = message.threadTs ?? message.ts;
     const activeQueueKey = `${message.channelId}:${threadTs}`;
+    if (!isBotAuthoredSlackMessage(message) && isSlackStopCommand(message.text)) {
+      abortSlackRunsForScope(message.channelId, threadTs, false);
+      queue.clear(activeQueueKey);
+      await slackBot.addReaction(message.channelId, message.ts, SLACK_STOP_REACTION);
+      return;
+    }
     const mentionQueue = queue.getQueue(activeQueueKey);
 
     mentionQueue.enqueue(async () => {
-      logger.info({ slackUserId: message.userId, channelId: message.channelId }, "Processing channel mention");
+      const abortController = new AbortController();
+      let consumedMessageId: number | undefined;
+      let consumedConversationId: number | undefined;
+      await withActiveRun(
+        `slack:${randomUUID()}`,
+        abortController,
+        async () => {
+          logger.info({ slackUserId: message.userId, channelId: message.channelId }, "Processing channel mention");
 
-      let user: Awaited<ReturnType<typeof resolveUser>> | undefined;
-      let clearAssistantStatus: (() => Promise<void>) | null = null;
+          let user: Awaited<ReturnType<typeof resolveUser>> | undefined;
+          let clearAssistantStatus: (() => Promise<void>) | null = null;
 
-      try {
-        await participantObservation;
-        user = await resolveUser(userId);
+          try {
+            await participantObservation;
+            user = await resolveUser(userId);
 
-        let channel = await ensureChannelRow(message.channelId);
+            let channel = await ensureChannelRow(message.channelId);
 
-        const boundAgent = channel.agent_user_id ? await repos.users.findById(channel.agent_user_id) : null;
-        if (channel.agent_user_id && !boundAgent) {
-          logger.warn(
-            { channelId: channel.id, agentUserId: channel.agent_user_id },
-            "Channel binding references missing agent; running with default behaviour",
-          );
-        }
+            const boundAgent = channel.agent_user_id ? await repos.users.findById(channel.agent_user_id) : null;
+            if (channel.agent_user_id && !boundAgent) {
+              logger.warn(
+                { channelId: channel.id, agentUserId: channel.agent_user_id },
+                "Channel binding references missing agent; running with default behaviour",
+              );
+            }
 
-        /**
-         * Workspace key must include the agent prefix when the channel is
-         * bound to an agent — otherwise /new clears the wrong session and
-         * the next mention resumes stale context.
-         */
-        const channelWorkspaceKey = boundAgent
-          ? `agent-${boundAgent.id}/channel-${message.channelId}`
-          : `channel-${message.channelId}`;
+            /**
+             * Workspace key must include the agent prefix when the channel is
+             * bound to an agent — otherwise /new clears the wrong session and
+             * the next mention resumes stale context.
+             */
+            const channelWorkspaceKey = boundAgent
+              ? `agent-${boundAgent.id}/channel-${message.channelId}`
+              : `channel-${message.channelId}`;
 
-        const command = parseSketchCommand(message.text);
-        const channelConversation = await repos.conversations.getOrCreate(
-          slackConversationRefForMessage(message),
-          channel.name,
-        );
-        const followupReview = await handleFollowupReviewCommand({
-          text: message.text,
-          userId: user.id,
-          surface: "slack",
-        });
-        if (followupReview.handled) {
-          await captureSlackMessage({
-            message,
-            senderName: user.name,
-            senderUserId: user.id,
-            addressedToSketch: true,
-            attachments: [],
-            displayName: channel.name,
-          });
-          await slackBot.postThreadReply(message.channelId, threadTs, followupReview.message);
-          return;
-        }
-        if (command === "new_session") {
-          await archiveRuntimeSessions(db, channelWorkspaceKey, threadTs);
-          await repos.conversations.advanceCursorToCurrentMax({
-            conversationId: channelConversation.id,
-            scopeType: SLACK_THREAD_CURSOR_SCOPE,
-            scopeKey: threadTs,
-            providerThreadId: threadTs,
-          });
-          await slackBot.postThreadReply(message.channelId, threadTs, getNewSessionConfirmation());
-          return;
-        }
-
-        if (!command && isToolProgressCommand(message.text)) {
-          await slackBot.postThreadReply(message.channelId, threadTs, getUnknownToolProgressMessage(message.text));
-          return;
-        }
-
-        if (!command && isReasoningTextCommand(message.text)) {
-          await slackBot.postThreadReply(message.channelId, threadTs, getUnknownReasoningTextMessage(message.text));
-          return;
-        }
-
-        const currentProgressSettings = resolveProgressDisplaySettings(channel);
-        if (command === "tool_progress_query") {
-          await slackBot.postThreadReply(message.channelId, threadTs, getToolProgressCurrent(currentProgressSettings));
-          return;
-        }
-
-        if (command === "reasoning_text_query") {
-          await slackBot.postThreadReply(message.channelId, threadTs, getReasoningTextCurrent(currentProgressSettings));
-          return;
-        }
-
-        const requestedToolProgress = resolveCommandToolProgress(command);
-        if (requestedToolProgress) {
-          channel = await repos.channels.update(channel.id, { toolProgress: requestedToolProgress });
-          await slackBot.postThreadReply(
-            message.channelId,
-            threadTs,
-            getToolProgressConfirmation(requestedToolProgress, currentProgressSettings.reasoningText),
-          );
-          return;
-        }
-
-        const requestedReasoningText = resolveCommandReasoningText(command);
-        if (requestedReasoningText) {
-          const enabled = requestedReasoningText === "on";
-          channel = await repos.channels.update(channel.id, { reasoningText: enabled });
-          await slackBot.postThreadReply(message.channelId, threadTs, getReasoningTextConfirmation(enabled));
-          return;
-        }
-
-        const workspaceDir = boundAgent
-          ? await ensureAgentSubWorkspace(config, boundAgent.id, `channel-${message.channelId}`)
-          : await ensureChannelWorkspace(config, message.channelId);
-        const settingsRow = await repos.settings.get();
-
-        let attachments = await downloadMessageAttachments({
-          files: message.files,
-          workspaceDir,
-          botToken: settingsRow?.slack_bot_token,
-          maxBytes: maxFileBytes,
-          logger,
-        });
-        const eagerAuxCalls: AuxLlmCall[] = [];
-        attachments = await transcribeEagerAttachments(attachments, {
-          loadSettings: () => repos.settings.get(),
-          logger,
-          onUsage: (call) => eagerAuxCalls.push(call),
-        });
-        const capture = await captureSlackMessage({
-          message: channel.type === "mpim" ? { ...message, channelType: "mpim" } : message,
-          senderName: user.name,
-          senderUserId: user.id,
-          addressedToSketch: true,
-          attachments,
-          displayName: channel.name,
-        });
-        if (!capture.captured) return;
-        if (capture.inserted && !message.threadTs && channel.type !== "mpim" && scheduler) {
-          await scheduler.dispatchSlackChannelMessage(
-            message.channelId,
-            {
-              type: "slack_channel_message",
-              channelId: message.channelId,
-              messageTs: message.ts,
+            const command = parseSketchCommand(message.text);
+            const channelConversation = await repos.conversations.getOrCreate(
+              slackConversationRefForMessage(message),
+              channel.name,
+            );
+            const followupReview = await handleFollowupReviewCommand({
               text: message.text,
-              userId: message.userId ?? null,
-              botId: message.botId ?? null,
-              appId: message.appId ?? null,
-              subtype: message.subtype ?? null,
-              files: filesForAutomationTrigger(message.files, attachments),
-              capturedMessageId: capture.captured.id,
+              userId: user.id,
+              surface: "slack",
+            });
+            if (followupReview.handled) {
+              await captureSlackMessage({
+                message,
+                senderName: user.name,
+                senderUserId: user.id,
+                addressedToSketch: true,
+                attachments: [],
+                displayName: channel.name,
+              });
+              await slackBot.postThreadReply(message.channelId, threadTs, followupReview.message);
+              return;
+            }
+            if (command === "new_session") {
+              await archiveRuntimeSessions(db, channelWorkspaceKey, threadTs);
+              await repos.conversations.advanceCursorToCurrentMax({
+                conversationId: channelConversation.id,
+                scopeType: SLACK_THREAD_CURSOR_SCOPE,
+                scopeKey: threadTs,
+                providerThreadId: threadTs,
+              });
+              await slackBot.postThreadReply(message.channelId, threadTs, getNewSessionConfirmation());
+              return;
+            }
+
+            if (!command && isToolProgressCommand(message.text)) {
+              await slackBot.postThreadReply(message.channelId, threadTs, getUnknownToolProgressMessage(message.text));
+              return;
+            }
+
+            if (!command && isReasoningTextCommand(message.text)) {
+              await slackBot.postThreadReply(message.channelId, threadTs, getUnknownReasoningTextMessage(message.text));
+              return;
+            }
+
+            const currentProgressSettings = resolveProgressDisplaySettings(channel);
+            if (command === "tool_progress_query") {
+              await slackBot.postThreadReply(
+                message.channelId,
+                threadTs,
+                getToolProgressCurrent(currentProgressSettings),
+              );
+              return;
+            }
+
+            if (command === "reasoning_text_query") {
+              await slackBot.postThreadReply(
+                message.channelId,
+                threadTs,
+                getReasoningTextCurrent(currentProgressSettings),
+              );
+              return;
+            }
+
+            const requestedToolProgress = resolveCommandToolProgress(command);
+            if (requestedToolProgress) {
+              channel = await repos.channels.update(channel.id, { toolProgress: requestedToolProgress });
+              await slackBot.postThreadReply(
+                message.channelId,
+                threadTs,
+                getToolProgressConfirmation(requestedToolProgress, currentProgressSettings.reasoningText),
+              );
+              return;
+            }
+
+            const requestedReasoningText = resolveCommandReasoningText(command);
+            if (requestedReasoningText) {
+              const enabled = requestedReasoningText === "on";
+              channel = await repos.channels.update(channel.id, { reasoningText: enabled });
+              await slackBot.postThreadReply(message.channelId, threadTs, getReasoningTextConfirmation(enabled));
+              return;
+            }
+
+            const workspaceDir = boundAgent
+              ? await ensureAgentSubWorkspace(config, boundAgent.id, `channel-${message.channelId}`)
+              : await ensureChannelWorkspace(config, message.channelId);
+            const settingsRow = await repos.settings.get();
+
+            let attachments = await downloadMessageAttachments({
+              files: message.files,
+              workspaceDir,
+              botToken: settingsRow?.slack_bot_token,
+              maxBytes: maxFileBytes,
+              logger,
+            });
+            const eagerAuxCalls: AuxLlmCall[] = [];
+            attachments = await transcribeEagerAttachments(attachments, {
+              loadSettings: () => repos.settings.get(),
+              logger,
+              onUsage: (call) => eagerAuxCalls.push(call),
+            });
+            const capture = await captureSlackMessage({
+              message: channel.type === "mpim" ? { ...message, channelType: "mpim" } : message,
+              senderName: user.name,
+              senderUserId: user.id,
+              addressedToSketch: true,
+              attachments,
+              displayName: channel.name,
+            });
+            consumedMessageId = capture.captured?.id;
+            consumedConversationId = capture.conversation.id;
+            if (!capture.captured) return;
+            if (capture.inserted && !message.threadTs && channel.type !== "mpim" && scheduler) {
+              await scheduler.dispatchSlackChannelMessage(
+                message.channelId,
+                {
+                  type: "slack_channel_message",
+                  channelId: message.channelId,
+                  messageTs: message.ts,
+                  text: message.text,
+                  userId: message.userId ?? null,
+                  botId: message.botId ?? null,
+                  appId: message.appId ?? null,
+                  subtype: message.subtype ?? null,
+                  files: filesForAutomationTrigger(message.files, attachments),
+                  capturedMessageId: capture.captured.id,
+                  conversationId: capture.conversation.id,
+                },
+                { sourceWorkspaceDir: workspaceDir },
+              );
+            }
+
+            const cursor = await repos.conversations.getCursor({
               conversationId: capture.conversation.id,
-            },
-            { sourceWorkspaceDir: workspaceDir },
-          );
-        }
+              scopeType: SLACK_THREAD_CURSOR_SCOPE,
+              scopeKey: threadTs,
+            });
+            const backlog = await repos.conversations.listBacklog({
+              conversationId: capture.conversation.id,
+              afterMessageId: cursor?.last_seen_message_id,
+              beforeMessageId: capture.captured.id,
+              limit: INLINE_BACKLOG_LIMIT,
+              providerThreadId: message.threadTs ? threadTs : undefined,
+              isThreadReply: message.threadTs ? undefined : false,
+            });
+            const conversationBacklog =
+              backlog.messages.length > 0 || backlog.hasMore
+                ? {
+                    messages: backlog.messages,
+                    afterMessageId: cursor?.last_seen_message_id,
+                    beforeMessageId: capture.captured.id,
+                    hasMore: backlog.hasMore,
+                    nextCursor: backlog.nextCursor,
+                  }
+                : undefined;
+            const bootstrapMessages = !conversationBacklog
+              ? await loadSlackBootstrapMessages({
+                  channelId: message.channelId,
+                  currentMessageTs: message.ts,
+                  ...(message.threadTs ? { threadTs } : {}),
+                })
+              : [];
+            const threadTag = message.threadTs ? "thread" : "channel_history";
 
-        const cursor = await repos.conversations.getCursor({
-          conversationId: capture.conversation.id,
-          scopeType: SLACK_THREAD_CURSOR_SCOPE,
-          scopeKey: threadTs,
-        });
-        const backlog = await repos.conversations.listBacklog({
-          conversationId: capture.conversation.id,
-          afterMessageId: cursor?.last_seen_message_id,
-          beforeMessageId: capture.captured.id,
-          limit: INLINE_BACKLOG_LIMIT,
-          providerThreadId: message.threadTs ? threadTs : undefined,
-          isThreadReply: message.threadTs ? undefined : false,
-        });
-        const conversationBacklog =
-          backlog.messages.length > 0 || backlog.hasMore
-            ? {
-                messages: backlog.messages,
-                afterMessageId: cursor?.last_seen_message_id,
-                beforeMessageId: capture.captured.id,
-                hasMore: backlog.hasMore,
-                nextCursor: backlog.nextCursor,
+            const rawText = message.text || "See attached files.";
+            const visionConfig = resolveVisionConfigFromAppConfig(config, settingsRow);
+            const agentInstructions = boundAgent?.description ?? null;
+            const agentAllowedTools = boundAgent ? parseAllowedTools(boundAgent.allowed_tools) : null;
+            const visualAnalysisAllowed = canUseVisualAnalysisTool(visionConfig, agentAllowedTools);
+            const sketchContext: SketchContextParams = {
+              messages: bootstrapMessages,
+              currentUserName: user.name,
+              currentMessage: rawText,
+              currentUserEmail: user.email,
+              workspaceDir,
+              orgDir: config.CLAUDE_CONFIG_DIR,
+              timezone: user.timezone,
+              isSharedContext: true,
+              threadTag,
+              channelContext: { channelName: channel.name },
+              conversationBacklog,
+              visionAnalysisEnabled: visualAnalysisAllowed,
+            };
+            const userMessage = buildSketchContext(sketchContext);
+
+            const onFinalMessage = createSlackMessageHandler(slackBot, message.channelId, threadTs);
+            const shimmer = createShimmer(
+              slackBot,
+              message.channelId,
+              threadTs,
+              resolveProgressDisplaySettings(channel),
+            );
+            clearAssistantStatus = shimmer.clear;
+            const onProgressEvent = shimmer.onProgressEvent;
+
+            const integrationMcpServers = await buildMcpServers(user.email);
+            const activeUser = user;
+
+            if (abortController.signal.aborted) {
+              if (consumedConversationId !== undefined && consumedMessageId !== undefined) {
+                await repos.conversations.updateCursor({
+                  conversationId: consumedConversationId,
+                  scopeType: SLACK_THREAD_CURSOR_SCOPE,
+                  scopeKey: threadTs,
+                  messageId: consumedMessageId,
+                });
               }
-            : undefined;
-        const bootstrapMessages = !conversationBacklog
-          ? await loadSlackBootstrapMessages({
-              channelId: message.channelId,
-              currentMessageTs: message.ts,
-              ...(message.threadTs ? { threadTs } : {}),
-            })
-          : [];
-        const threadTag = message.threadTs ? "thread" : "channel_history";
+              return;
+            }
 
-        const rawText = message.text || "See attached files.";
-        const visionConfig = resolveVisionConfigFromAppConfig(config, settingsRow);
-        const agentInstructions = boundAgent?.description ?? null;
-        const agentAllowedTools = boundAgent ? parseAllowedTools(boundAgent.allowed_tools) : null;
-        const visualAnalysisAllowed = canUseVisualAnalysisTool(visionConfig, agentAllowedTools);
-        const sketchContext: SketchContextParams = {
-          messages: bootstrapMessages,
-          currentUserName: user.name,
-          currentMessage: rawText,
-          currentUserEmail: user.email,
-          workspaceDir,
-          orgDir: config.CLAUDE_CONFIG_DIR,
-          timezone: user.timezone,
-          isSharedContext: true,
-          threadTag,
-          channelContext: { channelName: channel.name },
-          conversationBacklog,
-          visionAnalysisEnabled: visualAnalysisAllowed,
-        };
-        const userMessage = buildSketchContext(sketchContext);
-
-        const onFinalMessage = createSlackMessageHandler(slackBot, message.channelId, threadTs);
-        const shimmer = createShimmer(slackBot, message.channelId, threadTs, resolveProgressDisplaySettings(channel));
-        clearAssistantStatus = shimmer.clear;
-        const onProgressEvent = shimmer.onProgressEvent;
-
-        const integrationMcpServers = await buildMcpServers(user.email);
-        const activeUser = user;
-
-        const abortController = new AbortController();
-        const result = await withActiveRun(
-          `slack:${randomUUID()}`,
-          abortController,
-          () =>
-            runAgent({
+            const result = await runAgent({
               db,
               workspaceKey: channelWorkspaceKey,
               seedAuxCalls: eagerAuxCalls,
@@ -1296,74 +1383,100 @@ export function createConfiguredSlackBot(tokens: { botToken: string; appToken?: 
                 providerThreadId: message.threadTs ? threadTs : undefined,
                 ...(message.threadTs ? {} : { isThreadReply: false }),
               },
-            }),
-          { platform: "slack", channelId: message.channelId, threadTs },
-        );
+            });
 
-        const finalText = appendIntegrationConnectionLinks(
-          appendAutomationBuilderLinks(result.trace.finalText, result.trace.automationArtifacts ?? []),
-          result.pendingIntegrationConnections,
-          "slack",
-          toolConfig,
-        );
-        if (finalText) {
-          const sent = await onFinalMessage(finalText);
-          await captureSlackBotReplies({
-            conversationId: capture.conversation.id,
-            sent,
-            channelId: message.channelId,
-            threadTs,
-            botName: settingsRow?.bot_name,
-          });
-        }
+            if (isAbortedRunResult(result)) {
+              await clearAssistantStatus?.();
+              if (consumedConversationId !== undefined && consumedMessageId !== undefined) {
+                await repos.conversations.updateCursor({
+                  conversationId: consumedConversationId,
+                  scopeType: SLACK_THREAD_CURSOR_SCOPE,
+                  scopeKey: threadTs,
+                  messageId: consumedMessageId,
+                });
+              }
+              return;
+            }
 
-        for (const filePath of result.pendingUploads) {
-          try {
-            await slackBot.uploadFile(message.channelId, filePath, threadTs);
+            const finalText = appendIntegrationConnectionLinks(
+              appendAutomationBuilderLinks(result.trace.finalText, result.trace.automationArtifacts ?? []),
+              result.pendingIntegrationConnections,
+              "slack",
+              toolConfig,
+            );
+            if (finalText) {
+              const sent = await onFinalMessage(finalText);
+              await captureSlackBotReplies({
+                conversationId: capture.conversation.id,
+                sent,
+                channelId: message.channelId,
+                threadTs,
+                botName: settingsRow?.bot_name,
+              });
+            }
+
+            for (const filePath of result.pendingUploads) {
+              try {
+                await slackBot.uploadFile(message.channelId, filePath, threadTs);
+              } catch (err) {
+                logger.warn({ err, filePath }, "Failed to upload file to Slack");
+              }
+            }
+
+            await clearAssistantStatus?.();
+            if (result.messageSent || result.pendingUploads.length > 0) {
+              await repos.conversations.updateCursor({
+                conversationId: capture.conversation.id,
+                scopeType: SLACK_THREAD_CURSOR_SCOPE,
+                scopeKey: threadTs,
+                messageId: capture.captured.id,
+              });
+            }
+            if (!finalText) {
+              await slackBot.postThreadReply(message.channelId, threadTs, "_No response_");
+            }
           } catch (err) {
-            logger.warn({ err, filePath }, "Failed to upload file to Slack");
+            if (isRuntimeAbortError(err, abortController.signal)) {
+              await clearAssistantStatus?.();
+              if (consumedConversationId !== undefined && consumedMessageId !== undefined) {
+                await repos.conversations.updateCursor({
+                  conversationId: consumedConversationId,
+                  scopeType: SLACK_THREAD_CURSOR_SCOPE,
+                  scopeKey: threadTs,
+                  messageId: consumedMessageId,
+                });
+              }
+              return;
+            }
+            if (err instanceof SlackIdentityConflictError) {
+              logger.warn(
+                {
+                  slackUserId: message.userId,
+                  channelId: message.channelId,
+                  email: err.conflict.email,
+                  existingUserId: err.conflict.existingUserId,
+                  existingSlackUserId: err.conflict.existingSlackUserId,
+                },
+                "Skipping channel mention because Slack identity conflicts with an existing user",
+              );
+              await slackBot.postThreadReply(
+                message.channelId,
+                threadTs,
+                "I can't reply right now because your Slack account mapping conflicts with an existing Sketch identity. Please ask your admin to reconnect Slack for your workspace.",
+              );
+              return;
+            }
+            logger.error({ err, channelId: message.channelId }, "Channel mention handler failed");
+            await clearAssistantStatus?.();
+            await slackBot.postThreadReply(
+              message.channelId,
+              threadTs,
+              agentFailureMessage(err, SLACK_AGENT_ERROR_MESSAGE, PROMPT_TOO_LONG_SHARED_RECOVERY_MESSAGE),
+            );
           }
-        }
-
-        await clearAssistantStatus?.();
-        if (result.messageSent || result.pendingUploads.length > 0) {
-          await repos.conversations.updateCursor({
-            conversationId: capture.conversation.id,
-            scopeType: SLACK_THREAD_CURSOR_SCOPE,
-            scopeKey: threadTs,
-            messageId: capture.captured.id,
-          });
-        }
-        if (!finalText) {
-          await slackBot.postThreadReply(message.channelId, threadTs, "_No response_");
-        }
-      } catch (err) {
-        if (err instanceof SlackIdentityConflictError) {
-          logger.warn(
-            {
-              slackUserId: message.userId,
-              channelId: message.channelId,
-              email: err.conflict.email,
-              existingUserId: err.conflict.existingUserId,
-              existingSlackUserId: err.conflict.existingSlackUserId,
-            },
-            "Skipping channel mention because Slack identity conflicts with an existing user",
-          );
-          await slackBot.postThreadReply(
-            message.channelId,
-            threadTs,
-            "I can't reply right now because your Slack account mapping conflicts with an existing Sketch identity. Please ask your admin to reconnect Slack for your workspace.",
-          );
-          return;
-        }
-        logger.error({ err, channelId: message.channelId }, "Channel mention handler failed");
-        await clearAssistantStatus?.();
-        await slackBot.postThreadReply(
-          message.channelId,
-          threadTs,
-          agentFailureMessage(err, SLACK_AGENT_ERROR_MESSAGE, PROMPT_TOO_LONG_SHARED_RECOVERY_MESSAGE),
-        );
-      }
+        },
+        { platform: "slack", channelId: message.channelId, threadTs },
+      );
     });
   });
 

--- a/packages/server/src/slack/bot-events.isolated.test.ts
+++ b/packages/server/src/slack/bot-events.isolated.test.ts
@@ -3,6 +3,7 @@ import { createTestLogger } from "../test-utils";
 
 const mocks = vi.hoisted(() => ({
   messageHandler: undefined as undefined | ((event: { message: Record<string, unknown> }) => Promise<void>),
+  mentionHandler: undefined as undefined | ((event: { event: Record<string, unknown> }) => Promise<void>),
   auth: { user_id: "U_SKETCH", bot_id: "B_SKETCH", team_id: "T_SKETCH" },
 }));
 
@@ -12,7 +13,9 @@ vi.mock("@slack/bolt", () => ({
     message(handler: (event: { message: Record<string, unknown> }) => Promise<void>) {
       mocks.messageHandler = handler;
     }
-    event() {}
+    event(name: string, handler: (event: { event: Record<string, unknown> }) => Promise<void>) {
+      if (name === "app_mention") mocks.mentionHandler = handler;
+    }
     action() {}
     async start() {}
     async stop() {}
@@ -38,6 +41,7 @@ describe("SlackBot channel message normalization", () => {
 
   beforeEach(() => {
     mocks.messageHandler = undefined;
+    mocks.mentionHandler = undefined;
     mocks.auth = { user_id: "U_SKETCH", bot_id: "B_SKETCH", team_id: "T_SKETCH" };
   });
 
@@ -79,6 +83,33 @@ describe("SlackBot channel message normalization", () => {
     await deliver({ type: "message", bot_id: "B_SKETCH", channel: "C1", text: "self", ts: "2" });
 
     expect(onChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it("forwards bot metadata on app mentions", async () => {
+    const bot = makeBot();
+    const onChannelMention = vi.fn().mockResolvedValue(undefined);
+    bot.onChannelMention(onChannelMention);
+    await bot.start();
+
+    await mocks.mentionHandler?.({
+      event: {
+        user: "U_WORKFLOW",
+        bot_id: "B_WORKFLOW",
+        subtype: "bot_message",
+        channel: "C1",
+        text: "<@U_SKETCH> stop",
+        ts: "1.2",
+      },
+    });
+
+    expect(onChannelMention).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "channel_mention",
+        userId: "U_WORKFLOW",
+        botId: "B_WORKFLOW",
+        subtype: "bot_message",
+      }),
+    );
   });
 
   it("does not forward a userless bot thread reply to the passive thread handler", async () => {

--- a/packages/server/src/slack/bot.ts
+++ b/packages/server/src/slack/bot.ts
@@ -411,6 +411,8 @@ export class SlackBot {
       if (!this.isEventForActiveTeam(mentionTeamId)) return;
 
       const hasText = event.text;
+      const botId = "bot_id" in event && typeof event.bot_id === "string" ? event.bot_id : undefined;
+      const subtype = "subtype" in event && typeof event.subtype === "string" ? event.subtype : undefined;
       const rawFiles = "files" in event && Array.isArray(event.files) ? event.files : [];
       const hasFiles = rawFiles.length > 0;
 
@@ -428,6 +430,8 @@ export class SlackBot {
         type: "channel_mention",
         text: cleanText,
         userId: event.user,
+        ...(botId ? { botId } : {}),
+        ...(subtype ? { subtype } : {}),
         channelId: event.channel,
         ts: event.ts,
         threadTs: event.thread_ts,

--- a/packages/server/src/slack/stop.test.ts
+++ b/packages/server/src/slack/stop.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isSlackStopCommand, normalizeSlackStopCommand } from "./stop";
+
+describe("Slack stop command normalisation", () => {
+  it.each([
+    ["<@UBOT> stop it please!", "stop", true],
+    ["<@UBOT> KILL", "kill", true],
+    ["<@UBOT> stop the deploy", "stop deploy", false],
+    ["<@UBOT> can you stop", "can you stop", false],
+    ["<@UBOT> <https://x.test|stop>", "", false],
+    ["<@UBOT> <@U123> stop", "stop", true],
+    ["<@UBOT> `*cancel*`!!!", "cancel", true],
+    ["<@UBOT> please kill it", "kill", true],
+    ["<@UBOT> please stop this", "stop this", false],
+    ["<@UBOT> 😤 stop 🤖", "stop", true],
+    ["<@UBOT> arrête", "arrête", false],
+    ["<@UBOT> detente", "detente", false],
+    ["<@UBOT> stopping", "stopping", false],
+    ["<@UBOT> stop me", "stop me", false],
+  ])("normalises %s", (input, expected, shouldMatch) => {
+    expect(normalizeSlackStopCommand(input)).toBe(expected);
+    expect(isSlackStopCommand(input)).toBe(shouldMatch);
+  });
+});

--- a/packages/server/src/slack/stop.ts
+++ b/packages/server/src/slack/stop.ts
@@ -1,0 +1,18 @@
+const STOP_COMMANDS = new Set(["stop", "kill", "cancel"]);
+const STOP_FILLERS = new Set(["please", "it", "the", "now", "just", "pls"]);
+
+export function normalizeSlackStopCommand(text: string): string {
+  const withoutMentions = text.replace(/<@[^>\s]+>/gu, " ");
+  const withoutLinks = withoutMentions.replace(/<[^>\r\n]*\|[^>\r\n]*>/gu, " ");
+  const words = withoutLinks
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ")
+    .split(/\s+/u)
+    .filter((word) => word.length > 0 && !STOP_FILLERS.has(word));
+  return words.join(" ");
+}
+
+export function isSlackStopCommand(text: string): boolean {
+  return STOP_COMMANDS.has(normalizeSlackStopCommand(text));
+}

--- a/packages/server/src/workflows/runtime.isolated.test.ts
+++ b/packages/server/src/workflows/runtime.isolated.test.ts
@@ -193,6 +193,72 @@ function makeStepContent(rows: Array<{ stepId: string; content: string }>) {
   };
 }
 
+describe("executeAutomation stopped Sketch agent steps", () => {
+  it.each([
+    {
+      outcome: "returned an aborted result",
+      runAgent: vi.fn().mockResolvedValue({
+        pendingUploads: [],
+        trace: { finalText: "partial output" },
+        rawUsage: { stopReason: "aborted", toolCalls: [] },
+      }),
+    },
+    {
+      outcome: "threw after its abort controller fired",
+      runAgent: vi.fn().mockImplementation(async (agentParams) => {
+        agentParams.abortController?.abort();
+        throw new Error("Claude SDK aborted");
+      }),
+    },
+  ])("stops later steps when the Sketch agent $outcome on both runtimes", async ({ runAgent }) => {
+    const logger = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const params = makeParams({
+      logger,
+      runAgent,
+      propagateParentAbort: true,
+      parentAbortSignal: new AbortController().signal,
+      task: makeActionTask([
+        {
+          id: "agent1",
+          type: "agent",
+          label: "Research",
+          icon: "sketch-ai",
+          position: { x: 0, y: 100 },
+          agentMode: "sketch",
+        },
+        { id: "later", type: "action", label: "Send ticket", icon: "code", position: { x: 0, y: 200 } },
+      ]),
+      stepContentRepo: makeStepContent([
+        { stepId: "agent1", content: "Research the issue." },
+        { stepId: "later", content: "return { sent: true };" },
+      ]),
+    });
+
+    for (const runtime of ["sdk", "aisdk"] as const) {
+      params.config.AGENT_RUNTIME = runtime;
+      const result = await executeAutomation(params as never);
+
+      expect(result.status).toBe("failed");
+      expect(result.stepOutputs.agent1?.status).toBe("failed");
+      expect(result.stepOutputs.later?.status).toBe("skipped");
+      expect(params.sendMessage).not.toHaveBeenCalled();
+      expect(params._runsRepo.update).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          status: "failed",
+          errorMessage: expect.stringContaining("aborted"),
+          completedAt: expect.any(String),
+        }),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ stepId: "agent1" }),
+        "Automation: execution stopped by user",
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    }
+  });
+});
+
 describe("executeAutomation agent steps", () => {
   it("links an interactive workflow child to its Slack parent without sharing its controller", async () => {
     const parentController = new AbortController();
@@ -205,7 +271,11 @@ describe("executeAutomation agent steps", () => {
         rawUsage: { toolCalls: [] },
       };
     });
-    const params = makeParams({ runAgent, propagateParentAbort: true });
+    const params = makeParams({
+      runAgent,
+      propagateParentAbort: true,
+      parentAbortSignal: parentController.signal,
+    });
 
     await withActiveRun("workflow-parent", parentController, () => executeAutomation(params as never), {
       platform: "slack",
@@ -235,7 +305,11 @@ describe("executeAutomation agent steps", () => {
         rawUsage: { toolCalls: [] },
       };
     });
-    const params = makeParams({ runAgent, propagateParentAbort: true });
+    const params = makeParams({
+      runAgent,
+      propagateParentAbort: true,
+      parentAbortSignal: parentController.signal,
+    });
 
     await withActiveRun("workflow-parent", parentController, () => executeAutomation(params as never), {
       platform: "slack",

--- a/packages/server/src/workflows/runtime.isolated.test.ts
+++ b/packages/server/src/workflows/runtime.isolated.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { withActiveRun } from "../agent/active-runs";
 import { runAgentRuntimeCore } from "../agent/runtime/core";
 import { DEFAULT_AGENT_RUNTIME_COST_TABLE } from "../agent/runtime/pricing";
 import { executeAutomation, testAutomationStep } from "./runtime";
@@ -193,6 +194,78 @@ function makeStepContent(rows: Array<{ stepId: string; content: string }>) {
 }
 
 describe("executeAutomation agent steps", () => {
+  it("links an interactive workflow child to its Slack parent without sharing its controller", async () => {
+    const parentController = new AbortController();
+    let childController: AbortController | undefined;
+    const runAgent = vi.fn().mockImplementation(async (params) => {
+      childController = params.abortController;
+      return {
+        pendingUploads: [],
+        trace: { finalText: "sketch result" },
+        rawUsage: { toolCalls: [] },
+      };
+    });
+    const params = makeParams({ runAgent, propagateParentAbort: true });
+
+    await withActiveRun("workflow-parent", parentController, () => executeAutomation(params as never), {
+      platform: "slack",
+      channelId: "D123",
+      threadTs: null,
+    });
+
+    expect(childController).toBeInstanceOf(AbortController);
+    expect(childController).not.toBe(parentController);
+    parentController.abort();
+    expect(childController?.signal.aborted).toBe(true);
+  });
+
+  /**
+   * "Run my automation now" from a thread is reentrant under that run, but the automation's own
+   * delivery target is configured at creation time and often points elsewhere. Linking must follow
+   * causation, or a user could start work from a thread and then be unable to stop it.
+   */
+  it("links a child whose automation delivers somewhere other than the triggering thread", async () => {
+    const parentController = new AbortController();
+    let childController: AbortController | undefined;
+    const runAgent = vi.fn().mockImplementation(async (params) => {
+      childController = params.abortController;
+      return {
+        pendingUploads: [],
+        trace: { finalText: "sketch result" },
+        rawUsage: { toolCalls: [] },
+      };
+    });
+    const params = makeParams({ runAgent, propagateParentAbort: true });
+
+    await withActiveRun("workflow-parent", parentController, () => executeAutomation(params as never), {
+      platform: "slack",
+      channelId: "C_SOMEWHERE_ELSE",
+      threadTs: "9999.0000",
+    });
+
+    expect(childController).toBeInstanceOf(AbortController);
+    parentController.abort();
+    expect(childController?.signal.aborted).toBe(true);
+  });
+
+  it("does not link scheduled workflow execution to an interactive parent", async () => {
+    const parentController = new AbortController();
+    const runAgent = vi.fn().mockResolvedValue({
+      pendingUploads: [],
+      trace: { finalText: "sketch result" },
+      rawUsage: { toolCalls: [] },
+    });
+    const params = makeParams({ runAgent, propagateParentAbort: false });
+
+    await withActiveRun("scheduled-parent", parentController, () => executeAutomation(params as never), {
+      platform: "slack",
+      channelId: "D123",
+      threadTs: null,
+    });
+
+    expect(runAgent.mock.calls[0]?.[0].abortController).toBeUndefined();
+  });
+
   it("defaults scheduled agent steps without an explicit mode to the Sketch runtime", async () => {
     const runAgent = vi.fn().mockResolvedValue({
       pendingUploads: [],

--- a/packages/server/src/workflows/runtime.ts
+++ b/packages/server/src/workflows/runtime.ts
@@ -12,6 +12,7 @@
 import { mkdir, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { join, sep } from "node:path";
 import type { Kysely } from "kysely";
+import { createChildAbortController, getActiveRunContext } from "../agent/active-runs";
 import { removeReservedAgentEnv } from "../agent/environment";
 import { buildPlatformFormattingLines, buildSketchContext } from "../agent/prompt";
 import type { McpServerConfig, RunAgentParams, runAgent } from "../agent/runner";
@@ -61,6 +62,7 @@ export interface ExecuteAutomationParams {
   limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
   loadAgentRuntimeProviderConfig?: () => Promise<AgentRuntimeProviderFactoryConfig | null>;
   trustedLocalFileRoot?: string;
+  propagateParentAbort?: boolean;
 }
 
 export type AutomationExecutionEvent =
@@ -467,6 +469,7 @@ async function executeWorkflowStep(params: {
       recordWorkflowStep: runtimeParams.recordWorkflowStep,
       limitAgentExecution: runtimeParams.limitAgentExecution,
       loadAgentRuntimeProviderConfig: runtimeParams.loadAgentRuntimeProviderConfig,
+      propagateParentAbort: runtimeParams.propagateParentAbort,
     });
   }
 
@@ -927,6 +930,7 @@ interface AgentStepParams {
   recordWorkflowStep?: RecordWorkflowStep;
   limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
   loadAgentRuntimeProviderConfig?: () => Promise<AgentRuntimeProviderFactoryConfig | null>;
+  propagateParentAbort?: boolean;
 }
 
 /**
@@ -1166,6 +1170,15 @@ async function executeSketchAgentStep(params: AgentStepParams): Promise<unknown>
   });
 
   const integrationMcpServers = buildMcpServers ? await buildMcpServers(creatorEmail) : {};
+  /**
+   * Linking is decided by what CAUSED this step, not by where its output lands. A user who runs an
+   * automation from a thread and then says "stop" expects it to die even when that automation is
+   * configured to deliver elsewhere. Scheduled work is already excluded upstream via
+   * propagateParentAbort, so the delivery target carries no information about stoppability.
+   */
+  const parentContext = getActiveRunContext();
+  const inheritsParentAbort = params.propagateParentAbort !== false && parentContext?.metadata?.platform === "slack";
+  const abortController = inheritsParentAbort ? createChildAbortController(parentContext.controller.signal) : undefined;
   const result = await runSketchAgent({
     db: params.db,
     workspaceKey: resolveWorkspaceKey(task),
@@ -1190,6 +1203,7 @@ async function executeSketchAgentStep(params: AgentStepParams): Promise<unknown>
     toolConfig: { BASE_URL: params.config.BASE_URL, PORT: params.config.PORT },
     model: step.agentModel,
     maxTurns: 50,
+    ...(abortController ? { abortController } : {}),
   });
 
   if (result.pendingUploads.length > 0) {

--- a/packages/server/src/workflows/runtime.ts
+++ b/packages/server/src/workflows/runtime.ts
@@ -12,7 +12,7 @@
 import { mkdir, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { join, sep } from "node:path";
 import type { Kysely } from "kysely";
-import { createChildAbortController, getActiveRunContext } from "../agent/active-runs";
+import { createChildAbortController } from "../agent/active-runs";
 import { removeReservedAgentEnv } from "../agent/environment";
 import { buildPlatformFormattingLines, buildSketchContext } from "../agent/prompt";
 import type { McpServerConfig, RunAgentParams, runAgent } from "../agent/runner";
@@ -63,6 +63,7 @@ export interface ExecuteAutomationParams {
   loadAgentRuntimeProviderConfig?: () => Promise<AgentRuntimeProviderFactoryConfig | null>;
   trustedLocalFileRoot?: string;
   propagateParentAbort?: boolean;
+  parentAbortSignal?: AbortSignal;
 }
 
 export type AutomationExecutionEvent =
@@ -100,6 +101,14 @@ export interface AutomationExecutionResult {
   status: string;
   finalOutput: unknown;
   stepOutputs: Record<string, StepOutput>;
+  aborted?: boolean;
+}
+
+export class AutomationRunAbortedError extends Error {
+  constructor() {
+    super("Automation run aborted by user");
+    this.name = "AutomationRunAbortedError";
+  }
 }
 
 export async function executeAutomation(params: ExecuteAutomationParams): Promise<AutomationExecutionResult> {
@@ -164,6 +173,7 @@ export async function executeAutomation(params: ExecuteAutomationParams): Promis
   const stepOutputs: Record<string, StepOutput> = {};
   let previousOutput: unknown = triggerData ?? null;
   let failed = false;
+  let aborted = false;
 
   for (const step of executionSteps) {
     const content = contentMap.get(step.id);
@@ -229,14 +239,25 @@ export async function executeAutomation(params: ExecuteAutomationParams): Promis
         status: "failed",
         stepOutputs,
         completedAt: new Date().toISOString(),
-        errorMessage: `Step "${step.label}" failed: ${error.message}`,
+        errorMessage:
+          error instanceof AutomationRunAbortedError
+            ? `Automation run aborted by user at step "${step.label}"`
+            : `Step "${step.label}" failed: ${error.message}`,
       });
 
       failed = true;
-      logger.error(
-        { err, taskId: task.id, runId, stepId: step.id, stepLabel: step.label, durationMs },
-        "Automation: step failed",
-      );
+      aborted = error instanceof AutomationRunAbortedError;
+      if (error instanceof AutomationRunAbortedError) {
+        logger.info(
+          { taskId: task.id, runId, stepId: step.id, stepLabel: step.label, durationMs },
+          "Automation: execution stopped by user",
+        );
+      } else {
+        logger.error(
+          { err, taskId: task.id, runId, stepId: step.id, stepLabel: step.label, durationMs },
+          "Automation: step failed",
+        );
+      }
       await emitEvent({
         type: "step.failed",
         runId,
@@ -247,7 +268,7 @@ export async function executeAutomation(params: ExecuteAutomationParams): Promis
         error: { message: error.message },
       });
 
-      if (sendMessage) {
+      if (!(error instanceof AutomationRunAbortedError) && sendMessage) {
         await sendMessage(`Automation '${task.title ?? task.prompt}' failed at step '${step.label}': ${error.message}`);
       }
       break;
@@ -304,7 +325,13 @@ export async function executeAutomation(params: ExecuteAutomationParams): Promis
     logger,
   });
 
-  return { runId, status: failed ? "failed" : "completed", finalOutput, stepOutputs };
+  return {
+    runId,
+    status: failed ? "failed" : "completed",
+    finalOutput,
+    stepOutputs,
+    ...(aborted ? { aborted: true } : {}),
+  };
 }
 
 export async function testAutomationStep(
@@ -470,6 +497,7 @@ async function executeWorkflowStep(params: {
       limitAgentExecution: runtimeParams.limitAgentExecution,
       loadAgentRuntimeProviderConfig: runtimeParams.loadAgentRuntimeProviderConfig,
       propagateParentAbort: runtimeParams.propagateParentAbort,
+      parentAbortSignal: runtimeParams.parentAbortSignal,
     });
   }
 
@@ -931,6 +959,7 @@ interface AgentStepParams {
   limitAgentExecution?: <T>(work: () => Promise<T>) => Promise<T>;
   loadAgentRuntimeProviderConfig?: () => Promise<AgentRuntimeProviderFactoryConfig | null>;
   propagateParentAbort?: boolean;
+  parentAbortSignal?: AbortSignal;
 }
 
 /**
@@ -1170,41 +1199,44 @@ async function executeSketchAgentStep(params: AgentStepParams): Promise<unknown>
   });
 
   const integrationMcpServers = buildMcpServers ? await buildMcpServers(creatorEmail) : {};
-  /**
-   * Linking is decided by what CAUSED this step, not by where its output lands. A user who runs an
-   * automation from a thread and then says "stop" expects it to die even when that automation is
-   * configured to deliver elsewhere. Scheduled work is already excluded upstream via
-   * propagateParentAbort, so the delivery target carries no information about stoppability.
-   */
-  const parentContext = getActiveRunContext();
-  const inheritsParentAbort = params.propagateParentAbort !== false && parentContext?.metadata?.platform === "slack";
-  const abortController = inheritsParentAbort ? createChildAbortController(parentContext.controller.signal) : undefined;
-  const result = await runSketchAgent({
-    db: params.db,
-    workspaceKey: resolveWorkspaceKey(task),
-    userMessage,
-    workspaceDir,
-    claudeConfigDir: params.config.CLAUDE_CONFIG_DIR,
-    userName: creator?.name ?? "Automation",
-    userEmail: creatorEmail,
-    logger,
-    platform: outputPlatform,
-    onProgressEvent: async () => {},
-    integrationMcpServers,
-    getSlack: params.getSlack,
-    loadIntegrationProvider: params.loadIntegrationProvider,
-    sessionMode: "fresh",
-    contextType: "scheduled_task",
-    currentUserId: task.created_by,
-    taskContext: buildRunAgentTaskContext(task),
-    userRepo: params.userRepo,
-    inboxMessagesRepo: params.inboxMessagesRepo,
-    sendDm: params.sendDm,
-    toolConfig: { BASE_URL: params.config.BASE_URL, PORT: params.config.PORT },
-    model: step.agentModel,
-    maxTurns: 50,
-    ...(abortController ? { abortController } : {}),
-  });
+  const inheritsParentAbort = params.propagateParentAbort !== false && params.parentAbortSignal !== undefined;
+  const abortController = inheritsParentAbort ? createChildAbortController(params.parentAbortSignal) : undefined;
+  let result: Awaited<ReturnType<typeof runAgent>>;
+  try {
+    result = await runSketchAgent({
+      db: params.db,
+      workspaceKey: resolveWorkspaceKey(task),
+      userMessage,
+      workspaceDir,
+      claudeConfigDir: params.config.CLAUDE_CONFIG_DIR,
+      userName: creator?.name ?? "Automation",
+      userEmail: creatorEmail,
+      logger,
+      platform: outputPlatform,
+      onProgressEvent: async () => {},
+      integrationMcpServers,
+      getSlack: params.getSlack,
+      loadIntegrationProvider: params.loadIntegrationProvider,
+      sessionMode: "fresh",
+      contextType: "scheduled_task",
+      currentUserId: task.created_by,
+      taskContext: buildRunAgentTaskContext(task),
+      userRepo: params.userRepo,
+      inboxMessagesRepo: params.inboxMessagesRepo,
+      sendDm: params.sendDm,
+      toolConfig: { BASE_URL: params.config.BASE_URL, PORT: params.config.PORT },
+      model: step.agentModel,
+      maxTurns: 50,
+      ...(abortController ? { abortController } : {}),
+    });
+  } catch (err) {
+    if (abortController?.signal.aborted) throw new AutomationRunAbortedError();
+    throw err;
+  }
+
+  if (abortController?.signal.aborted || result.rawUsage.stopReason === "aborted") {
+    throw new AutomationRunAbortedError();
+  }
 
   if (result.pendingUploads.length > 0) {
     logger.warn(


### PR DESCRIPTION
Part B of [SKE-357](https://linear.app/sketch-ai/issue/SKE-357). Stacks on #465, which is already merged.

## What this adds

Slack had **no way to interrupt a running agent**. The web surface has a stop button; the primary surface had nothing. A user watching the agent do the wrong thing could only wait it out.

Say `stop`, `kill` or `cancel` and the run dies — along with everything it started and anything queued behind it. A single ✅ reaction is the whole acknowledgement.

| | |
|---|---|
| Channel | Stops that thread |
| DM | Stops everything in that DM |
| Reply | None, ever — just the reaction |

## The four things that make it work

**Detection happens before the message is enqueued.** The queue is single-flight per key, so a stop sent through the normal path would wait *behind the very run it targets* and execute after it finished. This is the whole feature.

**Matching is exact after normalising.** All mention tokens stripped, Slack links unwrapped to nothing rather than their label, formatting and punctuation replaced with **spaces** — so an inserted zero-width character splits `stop` into `st op` rather than collapsing to a match. `stop the deploy` and `can you stop` run normally. A wrongly matched stop destroys work, so the bias is deliberately conservative.

**Children die with the parent.** Reentrant runs are linked via `AbortSignal.any`. Each child gets its own controller, never the parent's, so abort travels **down but never up**. Linking follows what *caused* a run rather than where its output goes — a user who runs an automation from a thread expects stop to reach it even when that automation delivers elsewhere. Scheduled work is excluded upstream.

**Silence is load-bearing.** Four things had to stop speaking: the partial answer, the `_No response_` fallback, the failure message on the thrown-abort path, and pending file uploads. An aborted run also advances the conversation watermark — without it, the killed request returns as backlog on the next message and the agent resumes exactly what it was told to abandon.

Bot-authored mentions are excluded. `app_mention` doesn't carry `bot_id` by default, so a bot saying "stop" could have killed a human's run.

## Review

Implemented from a plan that went through three review rounds, then reviewed again as code:

- **Stop-path review** — clean. Verified interception order, all four leaks, watermark on both abort paths, queue eviction.
- **Normaliser review** — clean. Attacked with zero-width characters, combining marks, fullwidth forms, `<!channel>` syntax and bare auto-links; produced no false positives.
- **Signal-propagation review** — found one real gap, **fixed in this PR**: linking was gated on the automation's *delivery target* instead of what triggered it, so "run my automation now" from a thread produced an unstoppable child whenever that automation delivered elsewhere. That is precisely the failure this PR exists to close. Fixed, with a test that fails against the old logic.

One reviewer finding was a false positive (it reported a missing bot-exclusion test that exists at `adapter.isolated.test.ts:1254`) and was rejected rather than actioned.

## Scale of the change

660 insertions / **32 deletions** ignoring whitespace — the raw diff looks larger because handlers are re-indented into `withActiveRun`. Every deletion is a move, not removed behaviour; verified by comparing symbol counts before and after. Adapter tests grew 73 → 83.

## Verification

`pnpm biome check` · `pnpm typecheck` · `pnpm test` (server 5,195 passed / 20 pre-existing skips; web 460 passed) · `pnpm build` — all green, checked by exit code.

Planning submodule branch `feat/ske-357b-slack-stop` needs merging alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)