### PR TITLE
SKE-362: Allow admins to delete any automation

### DIFF
--- a/packages/server/src/api/scheduled-tasks.test.ts
+++ b/packages/server/src/api/scheduled-tasks.test.ts
@@ -1241,6 +1241,62 @@ describe("Scheduled Tasks API", () => {
     expect(scheduler.removeTaskRuntime).toHaveBeenCalledWith("task-delete");
   });
 
+  it("allows an admin to delete a foreign-owned task without detaching scheduler cleanup", async () => {
+    await seedAdmin(db);
+    const users = createUserRepository(db);
+    const tasks = createScheduledTaskRepository(db);
+    const owner = await users.create({ name: "Owner", email: "owner-delete@test.com" });
+    const member = await users.create({ name: "Member", email: "member-delete@test.com" });
+
+    await tasks.add({
+      id: "task-delete-foreign",
+      platform: "whatsapp",
+      context_type: "dm",
+      delivery_target: "owner@s.whatsapp.net",
+      thread_ts: null,
+      prompt: "Delete a foreign task",
+      schedule_type: "interval",
+      schedule_value: "3600",
+      timezone: "UTC",
+      session_mode: "fresh",
+      created_by: owner.id,
+      status: "active",
+      next_run_at: null,
+    });
+
+    class InstanceBoundScheduler {
+      removedTaskIds: string[] = [];
+      pauseTask = vi.fn();
+      resumeTask = vi.fn();
+      removeTask = vi.fn();
+      executeTaskById = vi.fn();
+
+      removeTaskRuntime(id: string) {
+        this.removedTaskIds.push(id);
+        return Promise.resolve(true);
+      }
+    }
+
+    const scheduler = new InstanceBoundScheduler();
+    const app = createApp(db, config, { scheduler });
+    const memberResponse = await app.request("/api/scheduled-tasks/task-delete-foreign", {
+      method: "DELETE",
+      headers: { Cookie: await getMemberCookie(db, member.id) },
+    });
+    expect(memberResponse.status).toBe(404);
+    expect(scheduler.removedTaskIds).toEqual([]);
+    await expect(tasks.getById("task-delete-foreign")).resolves.toBeDefined();
+
+    const adminResponse = await app.request("/api/scheduled-tasks/task-delete-foreign", {
+      method: "DELETE",
+      headers: { Cookie: await loginAdmin(app) },
+    });
+    expect(adminResponse.status).toBe(200);
+    expect(await adminResponse.json()).toEqual({ success: true });
+    expect(scheduler.removedTaskIds).toEqual(["task-delete-foreign"]);
+    await expect(tasks.getById("task-delete-foreign")).resolves.toBeUndefined();
+  });
+
   it("surfaces runtime cleanup failure after committing API deletion", async () => {
     await seedAdmin(db);
     const users = createUserRepository(db);

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -609,7 +609,8 @@ export function scheduledTaskRoutes(
     const id = c.req.param("id");
     const access = await loadAccessibleTask(c, id);
     if ("response" in access) return access.response;
-    if (!scheduler.removeTaskRuntime) {
+    const removeTaskRuntime = scheduler.removeTaskRuntime;
+    if (!removeTaskRuntime) {
       return c.json(
         { error: { code: "SCHEDULER_UNAVAILABLE", message: "Scheduler runtime cleanup is unavailable" } },
         503,
@@ -620,7 +621,7 @@ export function scheduledTaskRoutes(
       db,
       taskId: id,
       actor: { userId, canManageAnyTask: c.get("role") === "admin" },
-      scheduler: { removeTaskRuntime: scheduler.removeTaskRuntime },
+      scheduler: { removeTaskRuntime: removeTaskRuntime.bind(scheduler) },
     });
     if (deletion.kind === "not_found" || deletion.kind === "access_denied") {
       return c.json({ error: { code: "NOT_FOUND", message: "Scheduled task not found" } }, 404);


### PR DESCRIPTION
## Summary

Fix admin deletion of foreign-owned automations by preserving the scheduler instance context during runtime cleanup.

## Linear Scope

- [SKE-362](https://linear.app/sketch-ai/issue/SKE-362/allow-admins-to-delete-any-automation)
- Parent Linear issue: [SKE-370](https://linear.app/sketch-ai/issue/SKE-370/automation-reliability-refresh-ownership-builder-locking-and)

## Root Cause

Authorization already allowed admins to manage another user's automation. The DELETE route passed the instance method `scheduler.removeTaskRuntime` into persistence without its receiver. Instance-bound schedulers then lost `this`, so the database deletion committed but the route returned a scheduler-cleanup error.

## Implementation Details

- Bind `removeTaskRuntime` to the scheduler before passing it to deletion persistence.
- Add coverage for an admin deleting a foreign-owned task with an instance-bound scheduler.
- Preserve the existing member denial and post-commit cleanup-failure behavior.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Risk / Rollout

Small server-only fix. No migration or API shape change.

## Stack

Bottom layer; targets `main`. PR #472 depends on this branch.