### PR TITLE
SKE-373: Serialize automation builder chats with a per-automation lock

### DIFF
--- a/packages/server/src/agent/active-runs.ts
+++ b/packages/server/src/agent/active-runs.ts
@@ -94,6 +94,10 @@ export function webChatRunKey(userId: string, conversationId: string): string {
   return `${userId}:${conversationId}`;
 }
 
+export function builderWebChatRunKey(taskId: string): string {
+  return `builder:${taskId}`;
+}
+
 export function withActiveWebChatRun<T>(
   userId: string,
   conversationId: string,
@@ -103,6 +107,18 @@ export function withActiveWebChatRun<T>(
   return withActiveRun(webChatRunKey(userId, conversationId), abortController, fn, { platform: "web" });
 }
 
+export function withActiveBuilderWebChatRun<T>(
+  taskId: string,
+  abortController: AbortController,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withActiveRun(builderWebChatRunKey(taskId), abortController, fn, { platform: "web" });
+}
+
 export function interruptActiveWebChatRun(userId: string, conversationId: string): boolean {
   return abortActiveRun(webChatRunKey(userId, conversationId));
+}
+
+export function interruptActiveBuilderWebChatRun(taskId: string): boolean {
+  return abortActiveRun(builderWebChatRunKey(taskId));
 }

--- a/packages/server/src/api/scheduled-task-conversations.test.ts
+++ b/packages/server/src/api/scheduled-task-conversations.test.ts
@@ -104,6 +104,13 @@ describe("scheduled task conversation API", () => {
     expect(refresh.status).toBe(200);
     expect((await refresh.json()).conversation.conversationId).toBe(firstConversationId);
 
+    const archive = await app.request(`/api/scheduled-tasks/task-conversations/conversations/${firstConversationId}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: true }),
+    });
+    expect(archive.status).toBe(200);
+
     const second = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
       method: "POST",
       headers: { Cookie: cookie, "Content-Type": "application/json" },
@@ -113,23 +120,17 @@ describe("scheduled task conversation API", () => {
     const secondConversationId = (await second.json()).conversation.conversationId;
     expect(secondConversationId).not.toBe(firstConversationId);
 
-    const list = await app.request("/api/scheduled-tasks/task-conversations/conversations", {
+    const list = await app.request("/api/scheduled-tasks/task-conversations/conversations?includeArchived=true", {
       headers: { Cookie: cookie },
     });
     expect(list.status).toBe(200);
     expect((await list.json()).conversations).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ conversationId: firstConversationId, state: "active" }),
+        expect.objectContaining({ conversationId: firstConversationId, state: "archived" }),
         expect.objectContaining({ conversationId: secondConversationId, state: "active" }),
       ]),
     );
 
-    const archive = await app.request(`/api/scheduled-tasks/task-conversations/conversations/${firstConversationId}`, {
-      method: "PATCH",
-      headers: { Cookie: cookie, "Content-Type": "application/json" },
-      body: JSON.stringify({ archived: true }),
-    });
-    expect(archive.status).toBe(200);
     expect((await archive.json()).conversation).toMatchObject({
       conversationId: firstConversationId,
       state: "archived",
@@ -216,6 +217,43 @@ describe("scheduled task conversation API", () => {
     });
     expect(memberResponse.status).toBe(404);
     expect(admin.id).not.toBe(owner.id);
+  });
+
+  it("does not let an admin create a second active builder chat while the owner holds one", async () => {
+    await seedAdmin(db);
+    const owner = await createUserRepository(db).create({ name: "Owner", email: "owner-builder-lock@test.com" });
+    await seedTask(db, "locked-task", owner.id);
+
+    const app = createApp(db, config, {
+      scheduler: {
+        pauseTask: vi.fn(),
+        resumeTask: vi.fn(),
+        removeTask: vi.fn(),
+        executeTaskById: vi.fn(),
+      },
+    });
+    const ownerCookie = await memberCookie(db, owner.id);
+    const ownerStart = await app.request("/api/scheduled-tasks/locked-task/conversations", {
+      method: "POST",
+      headers: { Cookie: ownerCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ createNew: true }),
+    });
+    expect(ownerStart.status).toBe(201);
+
+    const adminCookie = await loginAdmin(app);
+    const adminStart = await app.request("/api/scheduled-tasks/locked-task/conversations", {
+      method: "POST",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ createNew: true }),
+    });
+
+    expect(adminStart.status).toBe(409);
+    await expect(adminStart.json()).resolves.toMatchObject({
+      error: { code: "BUILDER_CHAT_LOCKED" },
+    });
+    await expect(
+      db.selectFrom("scheduled_task_conversations").selectAll().where("task_id", "=", "locked-task").execute(),
+    ).resolves.toEqual([expect.objectContaining({ transcript_user_id: owner.id, kind: "builder" })]);
   });
 
   it("rejects unrelated or malformed selections without creating associations", async () => {

--- a/packages/server/src/api/scheduled-task-conversations.ts
+++ b/packages/server/src/api/scheduled-task-conversations.ts
@@ -2,7 +2,11 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
-import { createAutomationTaskConversationService } from "../automation/task-conversations";
+import {
+  type AutomationTaskConversationLockSummary,
+  type BuilderConversationAccessResult,
+  createAutomationTaskConversationService,
+} from "../automation/task-conversations";
 import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
 import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
@@ -15,8 +19,27 @@ interface ScheduledTaskConversationRouteOptions {
   logger?: Logger;
 }
 
-function errorResponse(c: Context, code: string, message: string, status: 400 | 403 | 404 | 409) {
-  return c.json({ error: { code, message } }, status);
+function errorResponse(
+  c: Context,
+  code: string,
+  message: string,
+  status: 400 | 403 | 404 | 409,
+  details: Record<string, unknown> = {},
+) {
+  return c.json({ error: { code, message, ...details } }, status);
+}
+
+function builderLockError(c: Context, lock: AutomationTaskConversationLockSummary) {
+  return c.json(
+    {
+      error: {
+        code: "BUILDER_CHAT_LOCKED",
+        message: "This automation's builder chat is in use by another session",
+        builderLock: lock,
+      },
+    },
+    409,
+  );
 }
 
 function parseConversationId(value: unknown): string | null {
@@ -83,7 +106,8 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
 
     const includeArchived = c.req.query("includeArchived") === "true";
     const taskConversations = await conversations.listForTranscriptUser(taskId, access.userId, { includeArchived });
-    return c.json({ taskId, conversations: taskConversations, transcriptAccess: "viewer" as const });
+    const builderLock = await conversations.getBuilderLock(taskId, access.userId);
+    return c.json({ taskId, conversations: taskConversations, builderLock, transcriptAccess: "viewer" as const });
   });
 
   routes.post("/:id/conversations", async (c) => {
@@ -105,13 +129,22 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
       return errorResponse(c, "VALIDATION_ERROR", "A web chat conversation id is required", 400);
     }
 
-    let result: { association: Awaited<ReturnType<typeof conversations.associate>>; created: boolean };
+    let result:
+      | {
+          kind: "created";
+          association: Awaited<ReturnType<typeof conversations.associate>>;
+          created: true;
+          lock: AutomationTaskConversationLockSummary;
+        }
+      | BuilderConversationAccessResult;
     if (kind === "builder" && !requestedConversationId && body.createNew === true) {
       result = await conversations.createBuilderConversation(taskId, access.userId);
     } else if (!requestedConversationId) {
       const activeBuilder = await conversations.listForTranscriptUser(taskId, access.userId, { kind: "builder" });
       const existingConversationId = activeBuilder[0]?.conversationId;
       if (!existingConversationId) {
+        const builderLock = await conversations.getBuilderLock(taskId, access.userId);
+        if (builderLock.state === "held") return builderLockError(c, builderLock);
         return errorResponse(
           c,
           "CONVERSATION_NOT_FOUND",
@@ -119,15 +152,7 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
           404,
         );
       }
-      result = {
-        association: await conversations.associate({
-          taskId,
-          conversationId: existingConversationId,
-          transcriptUserId: access.userId,
-          kind: "builder",
-        }),
-        created: false,
-      };
+      result = await conversations.selectBuilderConversation(taskId, existingConversationId, access.userId, "builder");
     } else {
       const existing = await conversations.getForTranscriptUser(taskId, requestedConversationId, access.userId, {
         includeArchived: true,
@@ -144,15 +169,25 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
         return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation kind is not associated with this task", 404);
       }
 
-      result = {
-        association: await conversations.associate({
-          taskId,
-          conversationId: requestedConversationId,
-          transcriptUserId: access.userId,
-          kind,
-        }),
-        created: false,
-      };
+      result =
+        kind === "builder"
+          ? await conversations.selectBuilderConversation(taskId, requestedConversationId, access.userId, kind)
+          : {
+              kind: "active" as const,
+              association: await conversations.associate({
+                taskId,
+                conversationId: requestedConversationId,
+                transcriptUserId: access.userId,
+                kind,
+              }),
+              lock: await conversations.getBuilderLock(taskId, access.userId),
+              created: false as const,
+            };
+    }
+
+    if (result.kind === "locked") return builderLockError(c, result.lock);
+    if (result.kind !== "active" && result.kind !== "created") {
+      return errorResponse(c, "CONVERSATION_UNAVAILABLE", "Conversation is temporarily unavailable", 409);
     }
 
     const summary = await conversations.getForTranscriptUser(
@@ -165,7 +200,11 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
       return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation association was not persisted", 409);
     }
 
-    const response = { conversation: summary, created: result.created };
+    const response = {
+      conversation: summary,
+      created: result.kind === "created",
+      builderLock: result.lock,
+    };
     return result.created ? c.json(response, 201) : c.json(response);
   });
 
@@ -183,7 +222,10 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
     });
     if (!summary)
       return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation is not associated with this task", 404);
-    return c.json({ conversation: summary });
+    return c.json({
+      conversation: summary,
+      builderLock: await conversations.getBuilderLock(taskId, access.userId),
+    });
   });
 
   routes.put("/:id/conversations/:conversationId", async (c) => {
@@ -216,18 +258,33 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
     if (!selectedKind) {
       return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation association is unavailable", 404);
     }
-    await conversations.associate({
-      taskId,
-      conversationId,
-      transcriptUserId: access.userId,
-      kind: selectedKind,
-    });
+    let lock = await conversations.getBuilderLock(taskId, access.userId);
+    if (selectedKind === "builder") {
+      const selection = await conversations.selectBuilderConversation(
+        taskId,
+        conversationId,
+        access.userId,
+        selectedKind,
+      );
+      if (selection.kind === "locked") return builderLockError(c, selection.lock);
+      if (selection.kind !== "active") {
+        return errorResponse(c, "CONVERSATION_UNAVAILABLE", "Conversation is temporarily unavailable", 409);
+      }
+      lock = selection.lock;
+    } else {
+      await conversations.associate({
+        taskId,
+        conversationId,
+        transcriptUserId: access.userId,
+        kind: selectedKind,
+      });
+    }
     const summary = await conversations.getForTranscriptUser(taskId, conversationId, access.userId, {
       includeArchived: true,
     });
     if (!summary) return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation association was not persisted", 409);
 
-    const response = { conversation: summary, created: false };
+    const response = { conversation: summary, created: false, builderLock: lock };
     return c.json(response);
   });
 
@@ -248,7 +305,10 @@ export function scheduledTaskConversationRoutes(db: Kysely<DB>, options: Schedul
     const summary = await conversations.archiveForTranscriptUser(taskId, conversationId, access.userId, body.archived);
     if (!summary)
       return errorResponse(c, "CONVERSATION_NOT_FOUND", "Conversation is not associated with this task", 404);
-    return c.json({ conversation: summary });
+    return c.json({
+      conversation: summary,
+      builderLock: await conversations.getBuilderLock(taskId, access.userId),
+    });
   });
 
   return routes;

--- a/packages/server/src/api/web-chat.ts
+++ b/packages/server/src/api/web-chat.ts
@@ -14,15 +14,23 @@ import {
 } from "@sketch/shared";
 import { Hono } from "hono";
 import type { Kysely } from "kysely";
-import { interruptActiveWebChatRun, webChatRunKey, withActiveWebChatRun } from "../agent/active-runs";
+import {
+  builderWebChatRunKey,
+  interruptActiveBuilderWebChatRun,
+  interruptActiveWebChatRun,
+  webChatRunKey,
+  withActiveBuilderWebChatRun,
+  withActiveWebChatRun,
+} from "../agent/active-runs";
 import { buildSketchContext } from "../agent/prompt";
 import type { McpServerConfig, ProgressEvent, RunAgentParams, RunAgentResult } from "../agent/runner";
 import { archiveRuntimeSessions } from "../agent/sessions";
 import { createProgressRenderer, createWebProgressData } from "../agent/tool-progress";
 import { ensureWorkspace } from "../agent/workspace";
 import {
+  type AutomationTaskConversationLockSummary,
+  BUILDER_CHAT_LOCK_RENEWAL_INTERVAL_MS,
   createAutomationTaskConversationService,
-  touchActiveAutomationTaskConversationAssociations,
 } from "../automation/task-conversations";
 import { TOOL_PROGRESS_OPTIONS, type ToolProgressCommand } from "../commands";
 import type { Config } from "../config";
@@ -326,6 +334,8 @@ type AutomationBuilderConversationAccess =
   | { kind: "active" }
   | { kind: "not_found" }
   | { kind: "archived" }
+  | { kind: "locked"; lock: AutomationTaskConversationLockSummary }
+  | { kind: "unavailable" }
   | { kind: "error" };
 
 async function resolveAutomationBuilderConversationAccess(params: {
@@ -336,46 +346,15 @@ async function resolveAutomationBuilderConversationAccess(params: {
   logger: Logger;
 }): Promise<AutomationBuilderConversationAccess> {
   try {
-    return await params.deps.db.transaction().execute(async (trx) => {
-      const conversationService = createAutomationTaskConversationService(trx);
-      const existing = await conversationService.getForTranscriptUser(
-        params.taskId,
-        params.conversationId,
-        params.transcriptUserId,
-        { includeArchived: true },
-      );
-      if (!existing) return { kind: "not_found" as const };
-
-      const active = await conversationService.getForTranscriptUser(
-        params.taskId,
-        params.conversationId,
-        params.transcriptUserId,
-      );
-      if (!active) return { kind: "archived" as const };
-
-      const touchedRows = await touchActiveAutomationTaskConversationAssociations(trx, {
-        taskId: params.taskId,
-        conversationId: params.conversationId,
-        transcriptUserId: params.transcriptUserId,
-      });
-      if (touchedRows === 0) {
-        const latest = await conversationService.getForTranscriptUser(
-          params.taskId,
-          params.conversationId,
-          params.transcriptUserId,
-          { includeArchived: true },
-        );
-        if (!latest) return { kind: "not_found" as const };
-        const latestActive = await conversationService.getForTranscriptUser(
-          params.taskId,
-          params.conversationId,
-          params.transcriptUserId,
-        );
-        if (!latestActive) return { kind: "archived" as const };
-        return { kind: "error" as const };
-      }
-      return { kind: "active" as const };
-    });
+    const access = await createAutomationTaskConversationService(params.deps.db).acquireBuilderConversationLock(
+      params.taskId,
+      params.conversationId,
+      params.transcriptUserId,
+    );
+    if (access.kind === "locked") return access;
+    if (access.kind === "active") return { kind: "active" as const };
+    if (access.kind === "not_found" || access.kind === "archived") return access;
+    return { kind: "error" as const };
   } catch (err) {
     params.logger.warn(
       {
@@ -799,8 +778,7 @@ async function withWebChatTranscriptLock<T>(userId: string, conversationId: stri
   }
 }
 
-async function withWebChatAgentRunLock<T>(userId: string, conversationId: string, fn: () => Promise<T>): Promise<T> {
-  const key = webChatRunKey(userId, conversationId);
+async function withWebChatAgentRunLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
   const previous = webChatAgentRunLocks.get(key) ?? Promise.resolve();
   let release: () => void = () => {};
   const current = new Promise<void>((resolveLock) => {
@@ -1474,7 +1452,63 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
       return c.json(badRequest("VALIDATION_ERROR", "Conversation id is invalid"), 400);
     }
 
-    const interruptedActiveRun = interruptActiveWebChatRun(currentUser.id, conversationId);
+    const automationTaskId = extractAutomationTaskId({ automationTaskId: c.req.query("automationTaskId") });
+    let builderInterruption = false;
+    let builderConversationRequest = false;
+    if (automationTaskId && deps.scheduler?.getTaskById) {
+      const task = await deps.scheduler.getTaskById(automationTaskId).catch((err) => {
+        deps.logger.warn({ err, taskId: automationTaskId }, "Failed to resolve builder interruption task");
+        return null;
+      });
+      const accessibleTask = resolveScheduledTaskAccess(task, task?.createdBy, {
+        userId: currentUser.id,
+        role: c.get("role"),
+      });
+      if (!accessibleTask) {
+        return c.json(badRequest("AUTOMATION_NOT_FOUND", "Automation not found"), 404);
+      }
+
+      const conversationAccess = await createAutomationTaskConversationService(deps.db)
+        .acquireBuilderConversationLock(accessibleTask.id, conversationId, currentUser.id)
+        .catch((err) => {
+          deps.logger.warn(
+            { err, taskId: accessibleTask.id, conversationId, userId: currentUser.id },
+            "Failed to resolve builder interruption conversation",
+          );
+          return { kind: "unavailable" as const };
+        });
+      if (conversationAccess.kind === "not_found") {
+        return c.json(badRequest("CONVERSATION_NOT_FOUND", "Conversation is not associated with this task"), 404);
+      }
+      if (conversationAccess.kind === "archived") {
+        return c.json(
+          badRequest("CONVERSATION_ARCHIVED", "Conversation is archived; restore it before selecting"),
+          409,
+        );
+      }
+      if (conversationAccess.kind === "locked") {
+        return c.json(
+          {
+            error: {
+              code: "BUILDER_CHAT_LOCKED",
+              message: "This automation's builder chat is in use by another session",
+              builderLock: conversationAccess.lock,
+            },
+          },
+          409,
+        );
+      }
+      if (conversationAccess.kind === "unavailable") {
+        return c.json(badRequest("CONVERSATION_UNAVAILABLE", "Conversation is temporarily unavailable"), 503);
+      }
+
+      builderConversationRequest = true;
+      builderInterruption = interruptActiveBuilderWebChatRun(accessibleTask.id);
+    }
+
+    const interruptedActiveRun = builderConversationRequest
+      ? builderInterruption
+      : interruptActiveWebChatRun(currentUser.id, conversationId);
     if (interruptedActiveRun) {
       return c.json({ success: true, interrupted: true });
     }
@@ -1721,6 +1755,18 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
           409,
         );
       }
+      if (conversationAccess.kind === "locked") {
+        return c.json(
+          {
+            error: {
+              code: "BUILDER_CHAT_LOCKED",
+              message: "This automation's builder chat is in use by another session",
+              builderLock: conversationAccess.lock,
+            },
+          },
+          409,
+        );
+      }
       if (conversationAccess.kind === "error") {
         return c.json(badRequest("CONVERSATION_UNAVAILABLE", "Conversation is temporarily unavailable"), 503);
       }
@@ -1863,80 +1909,103 @@ export function webChatRoutes(deps: WebChatRouteDeps) {
       };
 
       try {
-        const result = await withWebChatAgentRunLock(currentUser.id, conversationId, () =>
-          withActiveWebChatRun(currentUser.id, conversationId, abortController, () =>
-            deps.runAgent({
-              db: deps.db,
-              workspaceKey: currentUser.id,
-              threadTs: conversationId,
-              userMessage,
-              workspaceDir,
-              claudeConfigDir: deps.config.CLAUDE_CONFIG_DIR,
-              userName: currentUser.name,
-              userEmail: currentUser.email,
-              userPhone: currentUser.whatsapp_number,
-              logger: deps.logger,
-              getSlack: deps.getSlack,
-              platform: deliveryPlatform,
-              responseSurface: "web",
-              contextType: "dm",
-              onProgressEvent: async (event) => {
-                if (shouldBufferWebChatTextAfterProgress(event)) bufferTextDeltas = true;
-                if (event.kind === "tool_use" && event.toolName === "ManageScheduledTasks") {
-                  sawAutomationTool = true;
-                  closeTextPart();
-                }
-                progressRenderer.renderEvent(event);
-                const lines = progressRenderer.getLines();
-                const progressData = createWebProgressData(event, progressSettings, progressMode, lines);
-                if (progressMode === "off" && wroteOffProgress) return;
-                if (progressData) {
-                  if (progressMode === "off") wroteOffProgress = true;
-                  closeTextPart();
-                  await updateWebChatProgressMessage(
-                    deps.config,
-                    workspaceDir,
-                    currentUser.id,
-                    deps.logger,
-                    conversationId,
-                    progressMessageId,
-                    progressData,
-                  );
-                  const progressPartId = `progress-${progressPartIndex}`;
-                  progressPartIndex += 1;
-                  write({ type: "data-progress", id: progressPartId, data: progressData });
-                }
-              },
-              onTextDelta: async (delta) => {
-                if (sawAutomationTool) {
-                  bufferedTextAfterAutomationTool += delta;
-                  return;
-                }
-                writeOrBufferTextDelta(delta);
-              },
-              onSessionId: async () => {},
-              abortController,
-              sessionMode: "chat",
-              persistSession: true,
-              orgName: settingsRow?.org_name,
-              botName: settingsRow?.bot_name,
-              integrationMcpServers,
-              loadIntegrationProvider: deps.loadIntegrationProvider,
-              scheduler: deps.scheduler,
-              stepContentRepo: deps.stepContentRepo,
-              automationRunsRepo: deps.automationRunsRepo,
-              queueManager: deps.queueManager,
-              toolConfig,
-              inboxMessagesRepo: deps.inboxMessagesRepo,
-              userRepo: deps.users,
-              currentUserId: currentUser.id,
-              sendDm: deps.sendDm,
-              ...(attachments.length > 0 ? { attachments } : {}),
-              ...(taskContext ? { taskContext } : {}),
-              ...(taskContext?.currentAutomation ? { currentAutomation: taskContext.currentAutomation } : {}),
-            }),
-          ),
-        );
+        const activeBuilderTaskId = automationBuilderContext?.task.id;
+        const runKey = activeBuilderTaskId
+          ? builderWebChatRunKey(activeBuilderTaskId)
+          : webChatRunKey(currentUser.id, conversationId);
+        const runAgent = () =>
+          deps.runAgent({
+            db: deps.db,
+            workspaceKey: currentUser.id,
+            threadTs: conversationId,
+            userMessage,
+            workspaceDir,
+            claudeConfigDir: deps.config.CLAUDE_CONFIG_DIR,
+            userName: currentUser.name,
+            userEmail: currentUser.email,
+            userPhone: currentUser.whatsapp_number,
+            logger: deps.logger,
+            getSlack: deps.getSlack,
+            platform: deliveryPlatform,
+            responseSurface: "web",
+            contextType: "dm",
+            onProgressEvent: async (event) => {
+              if (shouldBufferWebChatTextAfterProgress(event)) bufferTextDeltas = true;
+              if (event.kind === "tool_use" && event.toolName === "ManageScheduledTasks") {
+                sawAutomationTool = true;
+                closeTextPart();
+              }
+              progressRenderer.renderEvent(event);
+              const lines = progressRenderer.getLines();
+              const progressData = createWebProgressData(event, progressSettings, progressMode, lines);
+              if (progressMode === "off" && wroteOffProgress) return;
+              if (progressData) {
+                if (progressMode === "off") wroteOffProgress = true;
+                closeTextPart();
+                await updateWebChatProgressMessage(
+                  deps.config,
+                  workspaceDir,
+                  currentUser.id,
+                  deps.logger,
+                  conversationId,
+                  progressMessageId,
+                  progressData,
+                );
+                const progressPartId = `progress-${progressPartIndex}`;
+                progressPartIndex += 1;
+                write({ type: "data-progress", id: progressPartId, data: progressData });
+              }
+            },
+            onTextDelta: async (delta) => {
+              if (sawAutomationTool) {
+                bufferedTextAfterAutomationTool += delta;
+                return;
+              }
+              writeOrBufferTextDelta(delta);
+            },
+            onSessionId: async () => {},
+            abortController,
+            sessionMode: "chat",
+            persistSession: true,
+            orgName: settingsRow?.org_name,
+            botName: settingsRow?.bot_name,
+            integrationMcpServers,
+            loadIntegrationProvider: deps.loadIntegrationProvider,
+            scheduler: deps.scheduler,
+            stepContentRepo: deps.stepContentRepo,
+            automationRunsRepo: deps.automationRunsRepo,
+            queueManager: deps.queueManager,
+            toolConfig,
+            inboxMessagesRepo: deps.inboxMessagesRepo,
+            userRepo: deps.users,
+            currentUserId: currentUser.id,
+            sendDm: deps.sendDm,
+            ...(attachments.length > 0 ? { attachments } : {}),
+            ...(taskContext ? { taskContext } : {}),
+            ...(taskContext?.currentAutomation ? { currentAutomation: taskContext.currentAutomation } : {}),
+          });
+        let leaseRenewalTimer: ReturnType<typeof setInterval> | undefined;
+        if (activeBuilderTaskId) {
+          leaseRenewalTimer = setInterval(() => {
+            void createAutomationTaskConversationService(deps.db)
+              .acquireBuilderConversationLock(activeBuilderTaskId, conversationId, currentUser.id)
+              .then((access) => {
+                if (access.kind !== "active") abortController.abort();
+              })
+              .catch(() => abortController.abort());
+          }, BUILDER_CHAT_LOCK_RENEWAL_INTERVAL_MS);
+        }
+
+        let result: RunAgentResult;
+        try {
+          result = await withWebChatAgentRunLock(runKey, () =>
+            activeBuilderTaskId
+              ? withActiveBuilderWebChatRun(activeBuilderTaskId, abortController, runAgent)
+              : withActiveWebChatRun(currentUser.id, conversationId, abortController, runAgent),
+          );
+        } finally {
+          if (leaseRenewalTimer) clearInterval(leaseRenewalTimer);
+        }
 
         const fileParts: Array<{ id: string; data: WebChatFile }> = [];
         for (const [index, filePath] of result.pendingUploads.entries()) {

--- a/packages/server/src/automation/task-conversations.ts
+++ b/packages/server/src/automation/task-conversations.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { type Kysely, sql } from "kysely";
 import {
+  type ScheduledTaskBuilderLockRow,
   type ScheduledTaskConversationKind,
   type ScheduledTaskConversationRow,
   type UpsertScheduledTaskConversationInput,
@@ -10,6 +11,16 @@ import type { DB } from "../db/schema";
 import type { TaskContext } from "../scheduler/types";
 
 export type { ScheduledTaskConversationKind } from "../db/repositories/scheduled-task-conversations";
+
+export const BUILDER_CHAT_LOCK_LEASE_MS = 5 * 60 * 1000;
+export const BUILDER_CHAT_LOCK_RENEWAL_INTERVAL_MS = 60 * 1000;
+
+export interface AutomationTaskConversationLockSummary {
+  state: "available" | "held";
+  conversationId: string | null;
+  owner: "self" | "other" | null;
+  expiresAt: string | null;
+}
 
 export interface AutomationTaskConversationSummary {
   conversationId: string;
@@ -102,6 +113,63 @@ function generatedBuilderConversationId(): string {
   return `builder-${randomUUID()}`;
 }
 
+function availableBuilderLock(): AutomationTaskConversationLockSummary {
+  return { state: "available", conversationId: null, owner: null, expiresAt: null };
+}
+
+function summarizeBuilderLock(
+  row: ScheduledTaskBuilderLockRow | undefined,
+  transcriptUserId: string,
+  nowMs = Date.now(),
+): AutomationTaskConversationLockSummary {
+  if (!row || row.expires_at <= nowMs) return availableBuilderLock();
+  return {
+    state: "held",
+    conversationId: row.conversation_id,
+    owner: row.transcript_user_id === transcriptUserId ? "self" : "other",
+    expiresAt: new Date(row.expires_at).toISOString(),
+  };
+}
+
+async function claimBuilderLock(
+  repo: ReturnType<typeof createScheduledTaskConversationRepository>,
+  taskId: string,
+  conversationId: string,
+  transcriptUserId: string,
+): Promise<{ acquired: boolean; lock: AutomationTaskConversationLockSummary }> {
+  const nowMs = Date.now();
+  const result = await repo.acquireBuilderLock({
+    taskId,
+    conversationId,
+    transcriptUserId,
+    nowMs,
+    nowIso: new Date(nowMs).toISOString(),
+    expiresAt: nowMs + BUILDER_CHAT_LOCK_LEASE_MS,
+  });
+  return { acquired: result.acquired, lock: summarizeBuilderLock(result.lock, transcriptUserId, nowMs) };
+}
+
+export type BuilderConversationAccessResult =
+  | {
+      kind: "active";
+      association: ScheduledTaskConversationRow;
+      lock: AutomationTaskConversationLockSummary;
+      created: false;
+    }
+  | { kind: "locked"; lock: AutomationTaskConversationLockSummary }
+  | { kind: "not_found" | "archived" | "unavailable" };
+
+/**
+ * Builder transcripts remain scoped to the authenticated transcript user. A task
+ * may have historical associations for several users, but it has at most one
+ * non-expired builder lease. The lease owner may renew it through builder
+ * requests or the client heartbeat; archiving the leased conversation releases
+ * it, and an idle lease becomes available after five minutes. Another user may
+ * inspect and edit the task definition while the lease is held, but cannot read
+ * or mutate the leased transcript until the owner releases it or the lease
+ * expires.
+ */
+
 export function createAutomationTaskConversationService(db: Kysely<DB>) {
   const repo = createScheduledTaskConversationRepository(db);
 
@@ -134,6 +202,10 @@ export function createAutomationTaskConversationService(db: Kysely<DB>) {
       return summarizeRows(rows);
     },
 
+    async getBuilderLock(taskId: string, transcriptUserId: string): Promise<AutomationTaskConversationLockSummary> {
+      return summarizeBuilderLock(await repo.getBuilderLock(taskId), transcriptUserId);
+    },
+
     async hasAnyAssociation(taskId: string, conversationId: string): Promise<boolean> {
       return (await repo.listByTaskConversation(taskId, conversationId)).length > 0;
     },
@@ -144,7 +216,17 @@ export function createAutomationTaskConversationService(db: Kysely<DB>) {
       transcriptUserId: string,
       archived: boolean,
     ): Promise<AutomationTaskConversationSummary | undefined> {
-      const changed = await repo.setArchivedForTaskConversation(taskId, conversationId, transcriptUserId, archived);
+      const changed = await db.transaction().execute(async (trx) => {
+        const trxRepo = createScheduledTaskConversationRepository(trx);
+        const updated = await trxRepo.setArchivedForTaskConversation(
+          taskId,
+          conversationId,
+          transcriptUserId,
+          archived,
+        );
+        if (updated && archived) await trxRepo.releaseBuilderLock(taskId, conversationId, transcriptUserId);
+        return updated;
+      });
       if (!changed) return undefined;
       return this.getForTranscriptUser(taskId, conversationId, transcriptUserId, { includeArchived: true });
     },
@@ -154,32 +236,86 @@ export function createAutomationTaskConversationService(db: Kysely<DB>) {
         kind: "builder",
       });
       if (existing.length > 0) {
-        const association = await repo.upsert({
-          taskId,
-          conversationId: existing[0].conversation_id,
-          transcriptUserId,
-          kind: "builder",
-        });
-        return { association, created: false };
+        return this.selectBuilderConversation(taskId, existing[0].conversation_id, transcriptUserId, "builder");
       }
 
-      const association = await repo.upsert({
-        taskId,
-        conversationId: generatedBuilderConversationId(),
-        transcriptUserId,
-        kind: "builder",
-      });
-      return { association, created: true };
+      return this.createBuilderConversation(taskId, transcriptUserId);
     },
 
     async createBuilderConversation(taskId: string, transcriptUserId: string, conversationId?: string) {
-      const association = await repo.upsert({
-        taskId,
-        conversationId: conversationId ?? generatedBuilderConversationId(),
-        transcriptUserId,
-        kind: "builder",
+      return db.transaction().execute(async (trx) => {
+        const trxRepo = createScheduledTaskConversationRepository(trx);
+        const builderConversationId = conversationId ?? generatedBuilderConversationId();
+        const claimed = await claimBuilderLock(trxRepo, taskId, builderConversationId, transcriptUserId);
+        if (!claimed.acquired) return { kind: "locked" as const, lock: claimed.lock };
+
+        const association = await trxRepo.upsert({
+          taskId,
+          conversationId: builderConversationId,
+          transcriptUserId,
+          kind: "builder",
+        });
+        return { kind: "created" as const, association, created: true as const, lock: claimed.lock };
       });
-      return { association, created: true };
+    },
+
+    async selectBuilderConversation(
+      taskId: string,
+      conversationId: string,
+      transcriptUserId: string,
+      kind?: ScheduledTaskConversationKind,
+    ): Promise<BuilderConversationAccessResult> {
+      return db.transaction().execute(async (trx) => {
+        const trxRepo = createScheduledTaskConversationRepository(trx);
+        const rows = await trxRepo.listByTaskConversationForTranscriptUser(taskId, conversationId, transcriptUserId, {
+          includeArchived: true,
+        });
+        if (rows.length === 0) return { kind: "not_found" as const };
+
+        const activeRows = rows.filter((row) => row.archived_at === null);
+        if (activeRows.length === 0) return { kind: "archived" as const };
+        const selectedKind = kind ?? (activeRows[0]?.kind as ScheduledTaskConversationKind | undefined);
+        if (!selectedKind || !activeRows.some((row) => row.kind === selectedKind)) {
+          return { kind: "not_found" as const };
+        }
+
+        const claimed = await claimBuilderLock(trxRepo, taskId, conversationId, transcriptUserId);
+        if (!claimed.acquired) return { kind: "locked" as const, lock: claimed.lock };
+        const touchedRows = await touchActiveAutomationTaskConversationAssociations(trx, {
+          taskId,
+          conversationId,
+          transcriptUserId,
+        });
+        if (touchedRows === 0) return { kind: "unavailable" as const };
+        const association = activeRows.find((row) => row.kind === selectedKind) ?? activeRows[0];
+        return { kind: "active" as const, association, lock: claimed.lock, created: false };
+      });
+    },
+
+    async acquireBuilderConversationLock(
+      taskId: string,
+      conversationId: string,
+      transcriptUserId: string,
+    ): Promise<BuilderConversationAccessResult> {
+      return db.transaction().execute(async (trx) => {
+        const trxRepo = createScheduledTaskConversationRepository(trx);
+        const rows = await trxRepo.listByTaskConversationForTranscriptUser(taskId, conversationId, transcriptUserId, {
+          includeArchived: true,
+        });
+        if (rows.length === 0) return { kind: "not_found" as const };
+        const activeRows = rows.filter((row) => row.archived_at === null);
+        if (activeRows.length === 0) return { kind: "archived" as const };
+
+        const claimed = await claimBuilderLock(trxRepo, taskId, conversationId, transcriptUserId);
+        if (!claimed.acquired) return { kind: "locked" as const, lock: claimed.lock };
+        const touchedRows = await touchActiveAutomationTaskConversationAssociations(trx, {
+          taskId,
+          conversationId,
+          transcriptUserId,
+        });
+        if (touchedRows === 0) return { kind: "unavailable" as const };
+        return { kind: "active" as const, association: activeRows[0], lock: claimed.lock, created: false };
+      });
     },
   };
 }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -165,6 +165,7 @@ import * as m162 from "./migrations/162-user-entity-links";
 import * as m163 from "./migrations/163-slack-file-access-backfill-cleanup";
 import * as m164 from "./migrations/164-outlook-calendar-provider-file-scope";
 import * as m165 from "./migrations/165-typed-access-principals";
+import * as m166 from "./migrations/166-scheduled-task-builder-locks";
 import type { DB } from "./schema";
 
 /**
@@ -339,6 +340,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "163-slack-file-access-backfill-cleanup": m163,
           "164-outlook-calendar-provider-file-scope": m164,
           "165-typed-access-principals": m165,
+          "166-scheduled-task-builder-locks": m166,
         };
       },
     },

--- a/packages/server/src/db/migrations/166-scheduled-task-builder-locks.ts
+++ b/packages/server/src/db/migrations/166-scheduled-task-builder-locks.ts
@@ -1,0 +1,19 @@
+import { type Kysely, sql } from "kysely";
+
+const TABLE = "scheduled_task_builder_locks";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable(TABLE)
+    .addColumn("task_id", "text", (col) => col.notNull().primaryKey())
+    .addColumn("conversation_id", "text", (col) => col.notNull())
+    .addColumn("transcript_user_id", "text", (col) => col.notNull())
+    .addColumn("acquired_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("renewed_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("expires_at", "integer", (col) => col.notNull())
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable(TABLE).execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -23,7 +23,7 @@ import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as slackFileAccessBackfillCleanupMigration from "./163-slack-file-access-backfill-cleanup";
 import * as typedAccessPrincipalsMigration from "./165-typed-access-principals";
 
-const EXPECTED_MIGRATION_COUNT = 161;
+const EXPECTED_MIGRATION_COUNT = 162;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -199,6 +199,7 @@ describe("runMigrations on Postgres — full sequence", () => {
     expect(names[158]).toBe("163-slack-file-access-backfill-cleanup");
     expect(names[159]).toBe("164-outlook-calendar-provider-file-scope");
     expect(names[160]).toBe("165-typed-access-principals");
+    expect(names[161]).toBe("166-scheduled-task-builder-locks");
   });
 
   it("upgrades existing email access rows on Postgres", async () => {
@@ -278,11 +279,12 @@ describe("runMigrations on Postgres — full sequence", () => {
       SELECT table_name
       FROM information_schema.tables
       WHERE table_schema = 'public'
-        AND table_name IN ('organization_domains', 'slack_user_sync_state', 'slack_sync_runs')
+        AND table_name IN ('organization_domains', 'scheduled_task_builder_locks', 'slack_user_sync_state', 'slack_sync_runs')
       ORDER BY table_name
     `.execute(db);
     expect(tables.rows.map((row) => row.table_name)).toEqual([
       "organization_domains",
+      "scheduled_task_builder_locks",
       "slack_sync_runs",
       "slack_user_sync_state",
     ]);

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -28,7 +28,7 @@ import * as slackEntityLifecycleMigration from "./160-slack-entity-lifecycle-syn
 import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as outlookCalendarProviderFileScopeMigration from "./164-outlook-calendar-provider-file-scope";
 
-const EXPECTED_MIGRATION_COUNT = 161;
+const EXPECTED_MIGRATION_COUNT = 162;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -233,6 +233,7 @@ describe("runMigrations — full sequence", () => {
     expect(names[158]).toBe("163-slack-file-access-backfill-cleanup");
     expect(names[159]).toBe("164-outlook-calendar-provider-file-scope");
     expect(names[160]).toBe("165-typed-access-principals");
+    expect(names[161]).toBe("166-scheduled-task-builder-locks");
   });
 
   it("backfills only exact web origin task conversations", async () => {
@@ -320,11 +321,12 @@ describe("runMigrations — full sequence", () => {
     const tables = await sql<{ name: string }>`
       SELECT name FROM sqlite_master
       WHERE type = 'table'
-        AND name IN ('organization_domains', 'slack_user_sync_state', 'slack_sync_runs')
+        AND name IN ('organization_domains', 'scheduled_task_builder_locks', 'slack_user_sync_state', 'slack_sync_runs')
       ORDER BY name
     `.execute(db);
     expect(tables.rows.map((row) => row.name)).toEqual([
       "organization_domains",
+      "scheduled_task_builder_locks",
       "slack_sync_runs",
       "slack_user_sync_state",
     ]);

--- a/packages/server/src/db/repositories/scheduled-task-conversations.test.ts
+++ b/packages/server/src/db/repositories/scheduled-task-conversations.test.ts
@@ -87,10 +87,24 @@ describe("scheduled task conversation repository", () => {
   });
 
   it("reuses the active builder association and creates a new one after archival", async () => {
+    await db
+      .insertInto("scheduled_tasks")
+      .values({
+        id: "task-reuse",
+        platform: "slack",
+        context_type: "dm",
+        delivery_target: "D-reuse",
+        prompt: "Reuse this task",
+        schedule_type: "cron",
+        schedule_value: "0 9 * * *",
+        created_by: "owner-reuse",
+      })
+      .execute();
     const service = createAutomationTaskConversationService(db);
     const first = await service.getOrCreateBuilderConversation("task-reuse", "owner-reuse");
     const reused = await service.getOrCreateBuilderConversation("task-reuse", "owner-reuse");
 
+    if (first.kind !== "created" || reused.kind !== "active") throw new Error("Expected builder lock acquisition");
     expect(first.created).toBe(true);
     expect(reused.created).toBe(false);
     expect(reused.association.conversation_id).toBe(first.association.conversation_id);
@@ -98,10 +112,106 @@ describe("scheduled task conversation repository", () => {
     await service.archiveForTranscriptUser("task-reuse", first.association.conversation_id, "owner-reuse", true);
     const replacement = await service.getOrCreateBuilderConversation("task-reuse", "owner-reuse");
 
+    if (replacement.kind !== "created") throw new Error("Expected a replacement builder conversation");
     expect(replacement.created).toBe(true);
     expect(replacement.association.conversation_id).not.toBe(first.association.conversation_id);
     await expect(
       service.listForTranscriptUser("task-reuse", "owner-reuse", { includeArchived: true }),
     ).resolves.toHaveLength(2);
+  });
+
+  it("serializes builder leases, expires stale owners, and releases on archival", async () => {
+    await db
+      .insertInto("scheduled_tasks")
+      .values({
+        id: "task-lock",
+        platform: "slack",
+        context_type: "dm",
+        delivery_target: "D-lock",
+        prompt: "Lock this task",
+        schedule_type: "cron",
+        schedule_value: "0 9 * * *",
+        created_by: "owner-lock",
+      })
+      .execute();
+
+    const repo = createScheduledTaskConversationRepository(db);
+    await expect(
+      repo.acquireBuilderLock({
+        taskId: "task-lock",
+        conversationId: "owner-chat",
+        transcriptUserId: "owner-lock",
+        nowMs: 1_000,
+        nowIso: "2026-08-07T00:00:01.000Z",
+        expiresAt: 2_000,
+      }),
+    ).resolves.toMatchObject({ acquired: true, lock: { conversation_id: "owner-chat" } });
+
+    await expect(
+      repo.acquireBuilderLock({
+        taskId: "task-lock",
+        conversationId: "admin-chat",
+        transcriptUserId: "admin-lock",
+        nowMs: 1_500,
+        nowIso: "2026-08-07T00:00:01.500Z",
+        expiresAt: 2_500,
+      }),
+    ).resolves.toMatchObject({ acquired: false, lock: { transcript_user_id: "owner-lock" } });
+
+    await expect(
+      repo.acquireBuilderLock({
+        taskId: "task-lock",
+        conversationId: "admin-chat",
+        transcriptUserId: "admin-lock",
+        nowMs: 2_000,
+        nowIso: "2026-08-07T00:00:02.000Z",
+        expiresAt: 3_000,
+      }),
+    ).resolves.toMatchObject({ acquired: true, lock: { transcript_user_id: "admin-lock" } });
+
+    await expect(repo.releaseBuilderLock("task-lock", "admin-chat", "admin-lock")).resolves.toBe(true);
+    await expect(repo.getBuilderLock("task-lock")).resolves.toBeUndefined();
+  });
+
+  it("locks source-chat authoring without exposing another user's transcript", async () => {
+    await db
+      .insertInto("scheduled_tasks")
+      .values({
+        id: "task-source-lock",
+        platform: "slack",
+        context_type: "dm",
+        delivery_target: "D-source-lock",
+        prompt: "Lock source chat",
+        schedule_type: "cron",
+        schedule_value: "0 9 * * *",
+        created_by: "owner-source",
+      })
+      .execute();
+
+    const service = createAutomationTaskConversationService(db);
+    await service.associate({
+      taskId: "task-source-lock",
+      conversationId: "owner-source-chat",
+      transcriptUserId: "owner-source",
+      kind: "web_chat",
+    });
+    await service.associate({
+      taskId: "task-source-lock",
+      conversationId: "admin-source-chat",
+      transcriptUserId: "admin-source",
+      kind: "web_chat",
+    });
+
+    await expect(
+      service.acquireBuilderConversationLock("task-source-lock", "owner-source-chat", "owner-source"),
+    ).resolves.toMatchObject({ kind: "active", lock: { owner: "self" } });
+    await expect(
+      service.acquireBuilderConversationLock("task-source-lock", "admin-source-chat", "admin-source"),
+    ).resolves.toMatchObject({ kind: "locked", lock: { owner: "other" } });
+
+    await service.archiveForTranscriptUser("task-source-lock", "owner-source-chat", "owner-source", true);
+    await expect(
+      service.acquireBuilderConversationLock("task-source-lock", "admin-source-chat", "admin-source"),
+    ).resolves.toMatchObject({ kind: "active", lock: { owner: "self" } });
   });
 });

--- a/packages/server/src/db/repositories/scheduled-task-conversations.ts
+++ b/packages/server/src/db/repositories/scheduled-task-conversations.ts
@@ -1,8 +1,9 @@
 import type { Insertable, Kysely, Selectable } from "kysely";
 import { sql } from "kysely";
-import type { DB, ScheduledTaskConversationsTable } from "../schema";
+import type { DB, ScheduledTaskBuilderLocksTable, ScheduledTaskConversationsTable } from "../schema";
 
 export type ScheduledTaskConversationRow = Selectable<ScheduledTaskConversationsTable>;
+export type ScheduledTaskBuilderLockRow = Selectable<ScheduledTaskBuilderLocksTable>;
 
 export type ScheduledTaskConversationKind = "builder" | "web_chat";
 
@@ -16,6 +17,15 @@ export interface UpsertScheduledTaskConversationInput {
 export interface ListScheduledTaskConversationOptions {
   includeArchived?: boolean;
   kind?: ScheduledTaskConversationKind;
+}
+
+export interface AcquireScheduledTaskBuilderLockInput {
+  taskId: string;
+  conversationId: string;
+  transcriptUserId: string;
+  expiresAt: number;
+  nowMs: number;
+  nowIso: string;
 }
 
 export function createScheduledTaskConversationRepository(db: Kysely<DB>) {
@@ -117,8 +127,68 @@ export function createScheduledTaskConversationRepository(db: Kysely<DB>) {
       return (result.numUpdatedRows ?? 0n) > 0n;
     },
 
+    async getBuilderLock(taskId: string): Promise<ScheduledTaskBuilderLockRow | undefined> {
+      return db.selectFrom("scheduled_task_builder_locks").selectAll().where("task_id", "=", taskId).executeTakeFirst();
+    },
+
+    async acquireBuilderLock(
+      input: AcquireScheduledTaskBuilderLockInput,
+    ): Promise<{ acquired: boolean; lock: ScheduledTaskBuilderLockRow }> {
+      await db
+        .insertInto("scheduled_task_builder_locks")
+        .values({
+          task_id: input.taskId,
+          conversation_id: input.conversationId,
+          transcript_user_id: input.transcriptUserId,
+          acquired_at: input.nowIso,
+          renewed_at: input.nowIso,
+          expires_at: input.expiresAt,
+        })
+        .onConflict((oc) => oc.column("task_id").doNothing())
+        .execute();
+
+      const result = await db
+        .updateTable("scheduled_task_builder_locks")
+        .set({
+          conversation_id: input.conversationId,
+          transcript_user_id: input.transcriptUserId,
+          acquired_at: input.nowIso,
+          renewed_at: input.nowIso,
+          expires_at: input.expiresAt,
+        })
+        .where("task_id", "=", input.taskId)
+        .where((eb) =>
+          eb.or([
+            eb("expires_at", "<=", input.nowMs),
+            eb.and([
+              eb("conversation_id", "=", input.conversationId),
+              eb("transcript_user_id", "=", input.transcriptUserId),
+            ]),
+          ]),
+        )
+        .executeTakeFirst();
+
+      const lock = await db
+        .selectFrom("scheduled_task_builder_locks")
+        .selectAll()
+        .where("task_id", "=", input.taskId)
+        .executeTakeFirstOrThrow();
+      return { acquired: Number(result.numUpdatedRows ?? 0) > 0, lock };
+    },
+
+    async releaseBuilderLock(taskId: string, conversationId: string, transcriptUserId: string): Promise<boolean> {
+      const result = await db
+        .deleteFrom("scheduled_task_builder_locks")
+        .where("task_id", "=", taskId)
+        .where("conversation_id", "=", conversationId)
+        .where("transcript_user_id", "=", transcriptUserId)
+        .executeTakeFirst();
+      return Number(result.numDeletedRows ?? 0) > 0;
+    },
+
     async deleteByTaskId(taskId: string): Promise<void> {
       await db.deleteFrom("scheduled_task_conversations").where("task_id", "=", taskId).execute();
+      await db.deleteFrom("scheduled_task_builder_locks").where("task_id", "=", taskId).execute();
     },
   };
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -839,6 +839,15 @@ export interface ScheduledTaskConversationsTable {
   archived_at: string | null;
 }
 
+export interface ScheduledTaskBuilderLocksTable {
+  task_id: string;
+  conversation_id: string;
+  transcript_user_id: string;
+  acquired_at: Generated<string>;
+  renewed_at: Generated<string>;
+  expires_at: number;
+}
+
 export interface AgentOutputsTable {
   id: string;
   agent_key: string;
@@ -1551,6 +1560,7 @@ export interface DB {
   automation_runs: AutomationRunsTable;
   automation_step_content: AutomationStepContentTable;
   scheduled_task_conversations: ScheduledTaskConversationsTable;
+  scheduled_task_builder_locks: ScheduledTaskBuilderLocksTable;
   agent_outputs: AgentOutputsTable;
   agent_output_items: AgentOutputItemsTable;
   agent_output_deliveries: AgentOutputDeliveriesTable;

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -156,6 +156,13 @@ export interface ScheduledTaskOriginChatMessage {
 
 export type ScheduledTaskConversationKind = "builder" | "web_chat";
 
+export interface ScheduledTaskConversationLock {
+  state: "available" | "held";
+  conversationId: string | null;
+  owner: "self" | "other" | null;
+  expiresAt: string | null;
+}
+
 export interface ScheduledTaskConversationSummary {
   conversationId: string;
   kinds: ScheduledTaskConversationKind[];
@@ -169,6 +176,7 @@ export interface ScheduledTaskConversationSummary {
 export interface ScheduledTaskConversationsResponse {
   taskId: string;
   conversations: ScheduledTaskConversationSummary[];
+  builderLock: ScheduledTaskConversationLock;
   transcriptAccess: "viewer";
 }
 
@@ -1561,9 +1569,11 @@ export const api = {
         method: "DELETE",
       });
     },
-    interrupt(conversationId: string) {
+    interrupt(conversationId: string, automationTaskId?: string) {
+      const query = new URLSearchParams({ conversationId });
+      if (automationTaskId) query.set("automationTaskId", automationTaskId);
       return request<{ success: boolean; interrupted: boolean }>(
-        `/api/web-chat/conversations/${encodeURIComponent(conversationId)}/interruptions`,
+        `/api/web-chat/conversations/${encodeURIComponent(conversationId)}/interruptions?${query.toString()}`,
         { method: "POST" },
       );
     },
@@ -2332,13 +2342,14 @@ export const api = {
       return request<{
         conversation: ScheduledTaskConversationSummary;
         created: boolean;
+        builderLock: ScheduledTaskConversationLock;
       }>(`/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations`, {
         method: "POST",
         body: JSON.stringify(body),
       });
     },
     getConversation(taskId: string, conversationId: string) {
-      return request<{ conversation: ScheduledTaskConversationSummary }>(
+      return request<{ conversation: ScheduledTaskConversationSummary; builderLock: ScheduledTaskConversationLock }>(
         `/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations/${encodeURIComponent(conversationId)}`,
       );
     },
@@ -2346,13 +2357,14 @@ export const api = {
       return request<{
         conversation: ScheduledTaskConversationSummary;
         created: false;
+        builderLock: ScheduledTaskConversationLock;
       }>(`/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations/${encodeURIComponent(conversationId)}`, {
         method: "PUT",
         body: JSON.stringify(kind ? { kind } : {}),
       });
     },
     archiveConversation(taskId: string, conversationId: string, archived: boolean) {
-      return request<{ conversation: ScheduledTaskConversationSummary }>(
+      return request<{ conversation: ScheduledTaskConversationSummary; builderLock: ScheduledTaskConversationLock }>(
         `/api/scheduled-tasks/${encodeURIComponent(taskId)}/conversations/${encodeURIComponent(conversationId)}`,
         {
           method: "PATCH",

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -7,6 +7,8 @@ import {
   type AutomationBuilderSaveRequest,
   type AutomationDefinition,
   type AutomationStepContent,
+  type ScheduledTaskConversationKind,
+  type ScheduledTaskConversationLock,
   type ScheduledTaskConversationSummary,
   type ScheduledTaskConversationsResponse,
   type StepOutput,
@@ -724,6 +726,13 @@ function conversationDisplayUpdatedAt(
   return summary?.updatedAt ?? conversation.lastActiveAt;
 }
 
+function builderChatMutationError(error: unknown, fallback: string): string {
+  if (error instanceof ApiRequestError && error.code === "BUILDER_CHAT_LOCKED") {
+    return "This automation's builder chat is in use by another user. You can edit the automation, but chat is temporarily locked.";
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
 function BuilderChatSidecar({
   requestedConversationId,
   taskId,
@@ -783,7 +792,7 @@ function BuilderChatSidecar({
       replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
       openConversation(conversation.conversationId);
     },
-    onError: (error) => toast.error(error instanceof Error ? error.message : "Could not start a chat"),
+    onError: (error) => toast.error(builderChatMutationError(error, "Could not start a chat")),
   });
   const selectMutation = useMutation({
     mutationFn: (conversation: ScheduledTaskConversationSummary) =>
@@ -792,7 +801,7 @@ function BuilderChatSidecar({
       replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
       openConversation(conversation.conversationId);
     },
-    onError: (error) => toast.error(error instanceof Error ? error.message : "This chat is unavailable"),
+    onError: (error) => toast.error(builderChatMutationError(error, "This chat is unavailable")),
   });
   const archiveMutation = useMutation({
     mutationFn: (conversationId: string) => api.scheduledTasks.archiveConversation(taskId, conversationId, true),
@@ -843,6 +852,7 @@ function BuilderChatSidecar({
         ) : !requestedConversationId ? (
           <BuilderChatListView
             conversations={conversationsQuery.data.conversations}
+            builderLock={conversationsQuery.data.builderLock}
             summaryById={webChatSummaryById}
             onSelect={(conversation) => {
               if (conversation.state === "archived") openConversation(conversation.conversationId);
@@ -862,10 +872,12 @@ function BuilderChatSidecar({
           <BuilderChatTranscript
             key={selectedConversation.conversationId}
             conversationId={selectedConversation.conversationId}
+            conversationKind={selectedConversation.kinds[0]}
             taskId={taskId}
             title={title}
             queryKey={queryKey}
             conversationsQueryKey={conversationsQueryKey}
+            onBack={openChatList}
           />
         )}
       </div>
@@ -973,11 +985,13 @@ function BuilderChatHeader({
 
 function BuilderChatListView({
   conversations,
+  builderLock,
   summaryById,
   onSelect,
   selectingConversationId,
 }: {
   conversations: ScheduledTaskConversationSummary[];
+  builderLock?: ScheduledTaskConversationLock;
   summaryById: ReadonlyMap<string, WebChatConversationSummary>;
   onSelect: (conversation: ScheduledTaskConversationSummary) => void;
   selectingConversationId: string | null;
@@ -1029,6 +1043,7 @@ function BuilderChatListView({
   return (
     <div className="chat-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-2 py-3">
       <div className="flex min-h-full flex-col gap-5">
+        {builderLock?.state === "held" ? <BuilderChatLockNotice lock={builderLock} /> : null}
         <div>
           <p className="px-2.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">Recent</p>
           {active.length > 0 ? (
@@ -1048,6 +1063,25 @@ function BuilderChatListView({
           </div>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function BuilderChatLockNotice({ lock }: { lock: ScheduledTaskConversationLock }) {
+  const isOtherUser = lock.owner === "other";
+  return (
+    <div
+      data-testid="automation-builder-chat-lock-notice"
+      className="mx-2.5 border-l-2 border-amber-500/70 pl-3 text-[12px] leading-5 text-muted-foreground"
+    >
+      <p className="font-medium text-foreground">
+        {isOtherUser ? "Builder chat is in use" : "Builder chat is open in another session"}
+      </p>
+      <p>
+        {isOtherUser
+          ? "You can still inspect and edit this automation. Chat becomes available when the other session leaves or goes idle."
+          : "Return to the open session to continue this chat, or wait for its lease to expire."}
+      </p>
     </div>
   );
 }
@@ -1097,6 +1131,44 @@ function BuilderChatUnavailableState({ onBack }: { onBack: () => void }) {
   );
 }
 
+function BuilderChatLockState({
+  locked,
+  onBack,
+  onRetry,
+}: {
+  locked: boolean;
+  onBack: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <div data-testid="automation-builder-chat-locked" className="flex min-h-full items-center justify-center px-5 py-6">
+      <div className="w-full border-l-2 border-amber-500/70 pl-4">
+        <p className="text-[13px] font-semibold text-foreground">
+          {locked ? "Builder chat is in use" : "Builder chat unavailable"}
+        </p>
+        <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
+          {locked
+            ? "Another session owns this active chat. You can still inspect and edit the automation; chat becomes available when the lease is released or expires."
+            : "Sketch could not verify the builder chat lease. Try again before sending a message."}
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 rounded-[7px] border-border/70 bg-background text-[12px] shadow-none"
+            onClick={onRetry}
+          >
+            Try again
+          </Button>
+          <Button size="sm" variant="ghost" className="h-8 rounded-[7px] text-[12px] shadow-none" onClick={onBack}>
+            Back to chats
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function BuilderChatArchivedState({
   onBack,
   onRestore,
@@ -1140,20 +1212,29 @@ function BuilderChatArchivedState({
   );
 }
 
+type BuilderChatLockStatus = "loading" | "ready" | "locked" | "error";
+
+const BUILDER_CHAT_LOCK_RENEWAL_INTERVAL_MS = 60_000;
+
 function BuilderChatTranscript({
   conversationId,
+  conversationKind,
   taskId,
   title,
   queryKey,
   conversationsQueryKey,
+  onBack,
 }: {
   conversationId: string;
+  conversationKind: ScheduledTaskConversationKind;
   taskId: string;
   title: string;
   queryKey: readonly unknown[];
   conversationsQueryKey: readonly unknown[];
+  onBack: () => void;
 }) {
   const queryClient = useQueryClient();
+  const [lockStatus, setLockStatus] = useState<BuilderChatLockStatus>("loading");
   const [loadedHistoryKey, setLoadedHistoryKey] = useState<string | null>(null);
   const [historyLoadError, setHistoryLoadError] = useState<string | null>(null);
   const [historyLoadAttempt, setHistoryLoadAttempt] = useState(0);
@@ -1171,8 +1252,32 @@ function BuilderChatTranscript({
     id: conversationId,
     transport,
   });
+  const selectBuilderConversation = useCallback(
+    async (isCancelled?: () => boolean) => {
+      setLockStatus("loading");
+      try {
+        const { conversation } = await api.scheduledTasks.selectConversation(taskId, conversationId, conversationKind);
+        if (isCancelled?.()) return;
+        replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
+        setLockStatus("ready");
+      } catch (error: unknown) {
+        if (isCancelled?.()) return;
+        setLockStatus(error instanceof ApiRequestError && error.code === "BUILDER_CHAT_LOCKED" ? "locked" : "error");
+      }
+    },
+    [conversationId, conversationKind, conversationsQueryKey, queryClient, taskId],
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void selectBuilderConversation(() => cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [selectBuilderConversation]);
+
+  const lockReady = lockStatus === "ready";
   const historyKey = `${conversationId}:${historyLoadAttempt}`;
-  const historyReady = loadedHistoryKey === historyKey;
+  const historyReady = lockReady && loadedHistoryKey === historyKey;
   const latestMessage = chat.messages.at(-1);
   const threadScrollKey = latestMessage
     ? [
@@ -1217,6 +1322,14 @@ function BuilderChatTranscript({
 
   useEffect(() => {
     let cancelled = false;
+    if (!lockReady) {
+      setLoadedHistoryKey(null);
+      setHistoryLoadError(null);
+      chat.setMessages([]);
+      return () => {
+        cancelled = true;
+      };
+    }
     setLoadedHistoryKey(null);
     setHistoryLoadError(null);
     chat.setMessages([]);
@@ -1234,7 +1347,22 @@ function BuilderChatTranscript({
     return () => {
       cancelled = true;
     };
-  }, [chat.setMessages, conversationId, historyKey]);
+  }, [chat.setMessages, conversationId, historyKey, lockReady]);
+
+  useEffect(() => {
+    if (!lockReady) return;
+    const timer = window.setInterval(() => {
+      void api.scheduledTasks
+        .selectConversation(taskId, conversationId, conversationKind)
+        .then(({ conversation }) => {
+          replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
+        })
+        .catch((error: unknown) => {
+          setLockStatus(error instanceof ApiRequestError && error.code === "BUILDER_CHAT_LOCKED" ? "locked" : "error");
+        });
+    }, BUILDER_CHAT_LOCK_RENEWAL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [conversationId, conversationKind, conversationsQueryKey, lockReady, queryClient, taskId]);
 
   useEffect(() => {
     if (!historyReady || !threadScrollKey) return;
@@ -1263,10 +1391,20 @@ function BuilderChatTranscript({
     if (stoppingRun) return;
     setStoppingRun(true);
     void api.webChat
-      .interrupt(conversationId)
+      .interrupt(conversationId, taskId)
       .catch(() => undefined)
       .finally(() => setStoppingRun(false));
-  }, [conversationId, stoppingRun]);
+  }, [conversationId, stoppingRun, taskId]);
+
+  if (lockStatus === "locked" || lockStatus === "error") {
+    return (
+      <BuilderChatLockState
+        locked={lockStatus === "locked"}
+        onBack={onBack}
+        onRetry={() => void selectBuilderConversation()}
+      />
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary

Serialize automation builder chats with a task-scoped lease so only one user can actively author a given automation at a time while task-definition access remains available to admins.

## Linear Scope

- [SKE-373](https://linear.app/sketch-ai/issue/SKE-373/serialize-automation-builder-chats-with-a-per-automation-lock)
- Parent Linear issue: [SKE-370](https://linear.app/sketch-ai/issue/SKE-370/automation-reliability-refresh-ownership-builder-locking-and)

## Root Cause

Conversation associations are transcript-user scoped, so owner and admin sessions could have separate builder conversations for the same task. Active web-chat runs were also keyed by user and conversation, allowing concurrent authoring runs.

## Implementation Details

- Add migration 164 and a portable task-scoped builder-lock repository.
- Acquire/renew a five-minute lease with a 60-second heartbeat; return `BUILDER_CHAT_LOCKED` with the current holder metadata on contention.
- Keep transcripts user-scoped while locking the automation task globally.
- Key active builder runs by task ID, validate builder stops through the same access/lock path, and release the lease on archive.
- Add owner/admin contention, archive, repository, API, and migration coverage.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Risk / Rollout

Adds one table and task-scoped lease state. Expired leases are reclaimable, so abandoned sessions recover automatically.

## Stack

Second layer; based on PR #471 and targets `fix/ske-362-admin-automation-delete`. PR #473 depends on this branch.