### PR TITLE
SKE-371: Clarify polling versus event intent and reject unsupported automation triggers

### DIFF
--- a/packages/server/src/agent/prompt.test.ts
+++ b/packages/server/src/agent/prompt.test.ts
@@ -204,6 +204,10 @@ describe("buildSystemContext", () => {
     it("routes semantic authoring through natural-language ManageScheduledTasks requests when configured", () => {
       const result = buildSystemContext({ platform: "slack", automationAuthoringEnabled: true });
 
+      expect(result).toContain("use only the admitted schedule, webhook, or Slack channel-message trigger types");
+      expect(result).toContain("Do not invent a Canvas-managed app trigger or component key");
+      expect(result).toContain("if polling versus a native event is unclear, ask the user to choose");
+      expect(result).not.toContain("prefer a Canvas-managed trigger only when a Canvas skill/MCP is available");
       expect(result).toContain("pass the user's requested change as a natural-language request");
       expect(result).toContain("Do not construct or pass automation definition fields");
       expect(result).toContain("Never use updateStepContent");
@@ -216,6 +220,8 @@ describe("buildSystemContext", () => {
     it("preserves legacy structured authoring guidance when authoring is not configured", () => {
       const result = buildSystemContext({ platform: "slack" });
 
+      expect(result).toContain("prefer a Canvas-managed trigger only when a Canvas skill/MCP is available");
+      expect(result).not.toContain("use only the admitted schedule, webhook, or Slack channel-message trigger types");
       expect(result).not.toContain("Do not construct or pass automation definition fields");
       expect(result).not.toContain("Never use updateStepContent");
       expect(result).toContain("pass the resolved target ID in ManageScheduledTasks delivery");

--- a/packages/server/src/agent/prompt.ts
+++ b/packages/server/src/agent/prompt.ts
@@ -390,7 +390,9 @@ export function buildSystemContext(params: {
     "If a workflow is created from a Slack thread, default future workflow output to the parent channel top-level. Only set delivery.threadTs when the user explicitly asks to post workflow updates in that thread.",
     "When running a scheduled task, return the final message only; Sketch will automatically deliver your returned text to the task's configured Slack/WhatsApp destination, so do not try to find or use a chat-sending tool unless the task explicitly asks you to DM another person.",
     "When a scheduled task asks for reminders, follow-ups, outstanding commitments, or completed work, you must call ListFollowups first. Its durable follow-up state is authoritative: pending items stay pending, looks-resolved items require user review, confirmed or rejected work must not be reconstructed from chat history, and untracked items must remain labelled as untracked.",
-    "For external app events, prefer a Canvas-managed trigger only when a Canvas skill/MCP is available: use Canvas search_components to find the trigger, then create a workflow with triggerConfig.type='canvas'. If Canvas is not available, use a normal scheduled cron/interval/once trigger instead.",
+    params.automationAuthoringEnabled
+      ? "For external app events handled by semantic automation authoring, use only the admitted schedule, webhook, or Slack channel-message trigger types. Do not invent a Canvas-managed app trigger or component key; if polling versus a native event is unclear, ask the user to choose."
+      : "For external app events, prefer a Canvas-managed trigger only when a Canvas skill/MCP is available: use Canvas search_components to find the trigger, then create a workflow with triggerConfig.type='canvas'. If Canvas is not available, use a normal scheduled cron/interval/once trigger instead.",
   );
 
   if (!params.automationAuthoringEnabled) {

--- a/packages/server/src/automation/authoring/evaluation.test.ts
+++ b/packages/server/src/automation/authoring/evaluation.test.ts
@@ -1,7 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { AutomationValidationError, validateAutomationBuilderSaveRequest } from "../definition";
-import { poorGenerationFixtures } from "./fixtures";
+import { poorGenerationFixtures, validAuthoringDefinition } from "./fixtures";
 import { automationAuthoringDefinitionSchema, toAutomationBuilderSaveRequest } from "./schema";
+
+function gmailCanvasTriggerDefinition() {
+  return {
+    ...validAuthoringDefinition,
+    scheduleType: "external" as const,
+    scheduleValue: "canvas",
+    steps: validAuthoringDefinition.steps.map((step) =>
+      step.type === "trigger"
+        ? {
+            ...step,
+            triggerConfig: {
+              type: "canvas" as const,
+              app: "gmail",
+              eventDescription: "new invoice email",
+              componentKey: "gmail.new_invoice_email",
+            },
+          }
+        : step,
+    ),
+  };
+}
 
 describe("automation authoring deterministic evaluation fixtures", () => {
   it.each(poorGenerationFixtures)(
@@ -19,4 +40,22 @@ describe("automation authoring deterministic evaluation fixtures", () => {
       }
     },
   );
+
+  it("rejects a trigger that is outside the authoring capability set", () => {
+    const generated = automationAuthoringDefinitionSchema.parse(gmailCanvasTriggerDefinition());
+    const request = toAutomationBuilderSaveRequest(generated, { taskId: "eval-task", status: "active" });
+
+    expect(() =>
+      validateAutomationBuilderSaveRequest({
+        request,
+        brokerCapable: true,
+        supportedTriggerTypes: ["schedule", "webhook", "slack_channel_message"],
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        name: "AutomationValidationError",
+        issues: expect.arrayContaining([expect.objectContaining({ code: "UNSUPPORTED_TRIGGER" })]),
+      }),
+    );
+  });
 });

--- a/packages/server/src/automation/authoring/service.test.ts
+++ b/packages/server/src/automation/authoring/service.test.ts
@@ -40,6 +40,88 @@ function createHarness(outputs: unknown[]) {
   return { service, generate, telemetry };
 }
 
+function createRequest(request: string) {
+  return {
+    request,
+    serverContext: {
+      taskId: "task-new",
+      platform: "slack" as const,
+      contextType: "dm" as const,
+      deliveryDefaults: {
+        platform: "slack" as const,
+        targetType: "dm" as const,
+        targetId: "U123",
+        threadTs: null,
+        mode: "deliver" as const,
+      },
+      timezone: "Asia/Kolkata",
+      currentTime: "2026-07-27T12:00:00.000Z",
+    },
+    brokerCapable: true,
+  };
+}
+
+function pollingDefinition() {
+  return {
+    ...validAuthoringDefinition,
+    scheduleType: "interval" as const,
+    scheduleValue: "300",
+    steps: validAuthoringDefinition.steps.map((step) =>
+      step.id === "trigger"
+        ? {
+            ...step,
+            label: "Every five minutes",
+            triggerConfig: {
+              type: "schedule" as const,
+              scheduleType: "interval" as const,
+              scheduleValue: "300",
+              timezone: "Asia/Kolkata",
+            },
+          }
+        : step,
+    ),
+  };
+}
+
+function slackTriggerDefinition() {
+  return {
+    ...validAuthoringDefinition,
+    scheduleType: "external" as const,
+    scheduleValue: "slack_channel_message",
+    steps: validAuthoringDefinition.steps.map((step) =>
+      step.id === "trigger"
+        ? {
+            ...step,
+            label: "Slack channel message",
+            triggerConfig: { type: "slack_channel_message" as const, channelId: "C123" },
+          }
+        : step,
+    ),
+  };
+}
+
+function gmailCanvasTriggerDefinition() {
+  return {
+    ...validAuthoringDefinition,
+    scheduleType: "external" as const,
+    scheduleValue: "canvas",
+    steps: validAuthoringDefinition.steps.map((step) =>
+      step.id === "trigger"
+        ? {
+            ...step,
+            label: "Gmail invoice trigger",
+            triggerConfig: {
+              type: "canvas" as const,
+              app: "gmail",
+              eventDescription: "new invoice email",
+              componentKey: "gmail.new_invoice_email",
+            },
+          }
+        : step,
+    ),
+  };
+}
+
 describe("automation authoring service", () => {
   it("creates a complete definition using bounded structured generation", async () => {
     const { service, generate } = createHarness([{ kind: "definition", definition: validAuthoringDefinition }]);
@@ -118,6 +200,80 @@ describe("automation authoring service", () => {
       question: "Which Slack channel should receive it?",
     });
     expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("clarifies invoice forwarding when the request omits polling versus trigger intent", async () => {
+    const { service, generate, telemetry } = createHarness([{ kind: "definition", definition: pollingDefinition() }]);
+
+    await expect(service.create(createRequest("Forward invoice emails from Gmail to Slack"))).resolves.toEqual({
+      kind: "clarification",
+      question: expect.stringContaining("polling"),
+    });
+    expect(generate).not.toHaveBeenCalled();
+    expect(telemetry.recordAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ validationOutcome: "clarification", validationIssueCodes: ["TRIGGER_INTENT"] }),
+    );
+  });
+
+  it("rejects an explicitly requested Gmail event before generation", async () => {
+    const { service, generate } = createHarness([]);
+
+    await expect(
+      service.create(createRequest("When new invoice emails arrive in Gmail, forward them to Slack")),
+    ).resolves.toEqual({
+      kind: "clarification",
+      question: expect.stringContaining("Gmail event triggers are not available"),
+    });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a nonexistent Gmail event trigger even when the request explicitly chooses polling", async () => {
+    const { service, generate } = createHarness([
+      { kind: "definition", definition: gmailCanvasTriggerDefinition() },
+      { kind: "definition", definition: gmailCanvasTriggerDefinition() },
+    ]);
+
+    await expect(
+      service.create(createRequest("Poll Gmail every five minutes and forward new invoice emails")),
+    ).rejects.toMatchObject({
+      name: "AutomationAuthoringValidationError",
+      cause: expect.objectContaining({
+        name: "AutomationValidationError",
+        issues: expect.arrayContaining([expect.objectContaining({ code: "UNSUPPORTED_TRIGGER" })]),
+      }),
+    });
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts an explicitly scheduled polling definition", async () => {
+    const { service } = createHarness([{ kind: "definition", definition: pollingDefinition() }]);
+
+    const result = await service.create(createRequest("Poll Gmail every five minutes and forward new invoice emails"));
+    expect(result).toMatchObject({
+      kind: "definition",
+      definition: { scheduleType: "interval", scheduleValue: "300" },
+    });
+    if (result.kind === "definition") {
+      const trigger = result.definition.steps.find((step) => step.type === "trigger");
+      expect(trigger?.triggerConfig).toMatchObject({ type: "schedule", scheduleType: "interval" });
+    }
+  });
+
+  it("accepts the supported Slack channel event trigger", async () => {
+    const { service } = createHarness([{ kind: "definition", definition: slackTriggerDefinition() }]);
+
+    await expect(
+      service.create(createRequest("When a message is posted in Slack channel C123, process it")),
+    ).resolves.toMatchObject({
+      kind: "definition",
+      definition: {
+        scheduleType: "external",
+        scheduleValue: "slack_channel_message",
+        steps: expect.arrayContaining([
+          expect.objectContaining({ triggerConfig: { type: "slack_channel_message", channelId: "C123" } }),
+        ]),
+      },
+    });
   });
 
   it("gives code-heavy replacement edits enough output budget", async () => {

--- a/packages/server/src/automation/authoring/service.ts
+++ b/packages/server/src/automation/authoring/service.ts
@@ -1,4 +1,9 @@
-import type { AutomationBuilderSaveRequest, AutomationDefinition, WorkflowStep } from "@sketch/shared";
+import type {
+  AutomationBuilderSaveRequest,
+  AutomationDefinition,
+  WorkflowStep,
+  WorkflowTriggerConfig,
+} from "@sketch/shared";
 import type { LanguageModel } from "ai";
 import { z } from "zod";
 import type { CurrentAutomation } from "../../scheduler/types";
@@ -19,6 +24,12 @@ import type {
 const MAX_GENERATION_ATTEMPTS = 2;
 const GENERATION_TIMEOUT_MS = 60_000;
 const MAX_OUTPUT_TOKENS = 8192;
+
+export const AUTOMATION_AUTHORING_TRIGGER_TYPES = [
+  "schedule",
+  "webhook",
+  "slack_channel_message",
+] as const satisfies readonly WorkflowTriggerConfig["type"][];
 
 export interface AutomationAuthoringProvider {
   provider: "openrouter";
@@ -149,14 +160,44 @@ function isRetryableProviderFailure(error: unknown): boolean {
   return /(?:fetch|network|socket|connection|reset|temporarily unavailable)/i.test(error.message);
 }
 
-function authoringInstructions(operation: AutomationAuthoringOperation): string {
-  return `You design Sketch automations. Return a complete ${operation === "create" ? "new" : "replacement"} definition or one concise clarification question only when essential information is missing. Preserve every unspecified property and every stable step ID during edits. Never choose or emit an execution model or operational status. Keep the returned top-level schedule fields identical to the returned trigger step configuration. Every non-trigger step needs matching step content, and the graph must be connected and acyclic. For edits, the existingDefinition and its persisted revision are authoritative; currentAutomation is alignment metadata only, and neither prompt history nor an older builder snapshot may override the reloaded definition. For requests to run when a message is posted in a Slack channel, use the native Slack channel message trigger: set the trigger config type to "slack_channel_message", include the stable Slack channel ID in channelId, set scheduleType to "external" and scheduleValue to "slack_channel_message", and pass the message text and attachments through trigger data to the workflow. Trigger files can include a server-authenticated localPath inside the automation workspace. When an integration action needs those bytes, call ctx.integrations.executeAction with localFiles entries containing path and configuredProp; do not read or base64-encode the file in the script, put file bytes in CLI arguments, or fetch Slack urlPrivate without authentication. Do not implement this as polling or a scheduled Slack history check. Use the automation's native delivery configuration for the reply rather than adding a Slack send-message action solely for delivery.`;
+function triggerIntentClarification(request: string): string | undefined {
+  const normalized = request.toLowerCase();
+  const mentionsEventSource = /\b(?:gmail|email|emails|inbox|outlook|slack|linear|clickup|notion)\b/.test(normalized);
+  const mentionsEventObject =
+    /\b(?:invoice|invoices|email|emails|message|messages|attachment|attachments|issue|issues)\b/.test(normalized);
+  if (!mentionsEventSource || !mentionsEventObject) return undefined;
+
+  const explicitlyPolling =
+    /\b(?:poll(?:ing)?|schedule(?:d)?|cron|interval|daily|hourly|weekly)\b/.test(normalized) ||
+    /\bevery\s+(?:\d+|one|two|three|four|five|ten|fifteen|thirty|few)\s+(?:second|seconds|minute|minutes|hour|hours|day|days)\b/.test(
+      normalized,
+    );
+  if (explicitlyPolling) return undefined;
+
+  const explicitlyTriggered =
+    /\b(?:trigger|event|when(?:ever)?|as soon as|incoming)\b/.test(normalized) ||
+    /\bnew\s+(?:invoice|invoices|email|emails|message|messages|attachment|attachments|issue|issues)\b/.test(normalized);
+  if (!explicitlyTriggered) {
+    return "Should this use polling on a schedule (for example, every five minutes) or a native event trigger?";
+  }
+
+  if (/\bslack\s+channel\b/.test(normalized) || /\bwebhook\b/.test(normalized)) return undefined;
+  const source = normalized.match(/\b(?:gmail|outlook|linear|clickup|notion)\b/)?.[0] ?? "that app";
+  return `${source[0].toUpperCase()}${source.slice(1)} event triggers are not available in this authoring path. Should I poll it on a schedule instead?`;
+}
+
+function authoringInstructions(
+  operation: AutomationAuthoringOperation,
+  supportedTriggerTypes: readonly WorkflowTriggerConfig["type"][],
+): string {
+  return `You design Sketch automations. Return a complete ${operation === "create" ? "new" : "replacement"} definition or one concise clarification question only when essential information is missing. Preserve every unspecified property and every stable step ID during edits. Never choose or emit an execution model or operational status. Keep the returned top-level schedule fields identical to the returned trigger step configuration. Every non-trigger step needs matching step content, and the graph must be connected and acyclic. For edits, the existingDefinition and its persisted revision are authoritative; currentAutomation is alignment metadata only, and neither prompt history nor an older builder snapshot may override the reloaded definition. The current authoring capability set supports only these trigger types: ${supportedTriggerTypes.join(", ")}. Treat that list as authoritative. Never emit a Canvas-managed app trigger, invent a provider app, or invent a component key; an app event without an admitted capability must become a clarification question or be rejected. If the request does not explicitly choose polling/cadence versus an event trigger, ask which one it means instead of guessing. For requests to run when a message is posted in a Slack channel, use the native Slack channel message trigger: set the trigger config type to "slack_channel_message", include the stable Slack channel ID in channelId, set scheduleType to "external" and scheduleValue to "slack_channel_message", and pass the message text and attachments through trigger data to the workflow. Trigger files can include a server-authenticated localPath inside the automation workspace. When an integration action needs those bytes, call ctx.integrations.executeAction with localFiles entries containing path and configuredProp; do not read or base64-encode the file in the script, put file bytes in CLI arguments, or fetch Slack urlPrivate without authentication. Do not implement this as polling or a scheduled Slack history check. Use the automation's native delivery configuration for the reply rather than adding a Slack send-message action solely for delivery.`;
 }
 
 function createPrompt(input: {
   request: string;
   serverContext: AutomationAuthoringServerContext;
   brokerCapable: boolean;
+  supportedTriggerTypes: readonly WorkflowTriggerConfig["type"][];
   repair?: string;
   priorDraft?: unknown;
 }): string {
@@ -165,6 +206,7 @@ function createPrompt(input: {
     request: input.request,
     serverContext: input.serverContext,
     brokerCapable: input.brokerCapable,
+    supportedTriggerTypes: input.supportedTriggerTypes,
     ...(input.priorDraft !== undefined ? { priorDraft: input.priorDraft } : {}),
     ...(input.repair ? { priorValidationFailure: input.repair } : {}),
   });
@@ -177,6 +219,7 @@ function editPrompt(input: {
   currentAutomation?: CurrentAutomation;
   timezone?: string;
   currentTime?: string;
+  supportedTriggerTypes: readonly WorkflowTriggerConfig["type"][];
   repair?: string;
   priorDraft?: unknown;
 }): string {
@@ -192,6 +235,7 @@ function editPrompt(input: {
       ...(input.timezone ? { timezone: input.timezone } : {}),
       ...(input.currentTime ? { currentTime: input.currentTime } : {}),
     },
+    supportedTriggerTypes: input.supportedTriggerTypes,
     ...(input.priorDraft !== undefined ? { priorDraft: input.priorDraft } : {}),
     ...(input.repair ? { priorValidationFailure: input.repair } : {}),
   });
@@ -236,9 +280,11 @@ export function createAutomationAuthoringService(deps: {
   generator: StructuredAutomationAuthoringGenerator;
   telemetry: AutomationAuthoringTelemetry;
   configuredModelId: string;
+  supportedTriggerTypes?: readonly WorkflowTriggerConfig["type"][];
   now?: () => number;
 }): AutomationAuthoringService {
   const now = deps.now ?? Date.now;
+  const supportedTriggerTypes = deps.supportedTriggerTypes ?? AUTOMATION_AUTHORING_TRIGGER_TYPES;
 
   async function author(params: {
     operation: AutomationAuthoringOperation;
@@ -253,6 +299,23 @@ export function createAutomationAuthoringService(deps: {
     brokerCapable: boolean;
   }): Promise<AutomationAuthoringResult> {
     const operationStartedAt = now();
+    const clarification = triggerIntentClarification(params.request);
+    if (clarification) {
+      await deps.telemetry.recordAttempt({
+        operation: params.operation,
+        provider: "openrouter",
+        configuredModel: deps.configuredModelId,
+        responseModel: null,
+        attempt: 1,
+        latencyMs: Math.max(0, now() - operationStartedAt),
+        totalLatencyMs: Math.max(0, now() - operationStartedAt),
+        usage: emptyUsage(),
+        sdkCostUsd: 0,
+        validationOutcome: "clarification",
+        validationIssueCodes: ["TRIGGER_INTENT"],
+      });
+      return { kind: "clarification", question: clarification };
+    }
     let provider: AutomationAuthoringProvider;
     try {
       provider = await deps.loadProvider();
@@ -306,13 +369,14 @@ export function createAutomationAuthoringService(deps: {
         generation = await deps.generator.generate({
           operation: params.operation,
           provider,
-          instructions: authoringInstructions(params.operation),
+          instructions: authoringInstructions(params.operation, supportedTriggerTypes),
           prompt:
             params.operation === "create"
               ? createPrompt({
                   request: params.request,
                   serverContext: params.serverContext as AutomationAuthoringServerContext,
                   brokerCapable: params.brokerCapable,
+                  supportedTriggerTypes,
                   repair,
                   priorDraft,
                 })
@@ -323,6 +387,7 @@ export function createAutomationAuthoringService(deps: {
                   currentAutomation: params.currentAutomation,
                   timezone: params.timezone,
                   currentTime: params.currentTime,
+                  supportedTriggerTypes,
                   repair,
                   priorDraft,
                 }),
@@ -347,6 +412,7 @@ export function createAutomationAuthoringService(deps: {
         validateAutomationBuilderSaveRequest({
           request: definition,
           brokerCapable: params.brokerCapable,
+          supportedTriggerTypes,
         });
         validationOutcome = "valid";
         return { kind: "definition", definition };

--- a/packages/server/src/automation/chat-authoring.test.ts
+++ b/packages/server/src/automation/chat-authoring.test.ts
@@ -227,6 +227,46 @@ describe("chat automation authoring orchestration", () => {
     expect(refreshTaskSchedule).not.toHaveBeenCalled();
   });
 
+  it("does not persist a trigger outside the configured authoring capabilities", async () => {
+    const unsupported = definition({
+      scheduleType: "external",
+      scheduleValue: "canvas",
+      steps: definition().steps.map((step) =>
+        step.type === "trigger"
+          ? {
+              ...step,
+              triggerConfig: {
+                type: "canvas" as const,
+                app: "gmail",
+                eventDescription: "new invoice email",
+                componentKey: "gmail.new_invoice_email",
+              },
+            }
+          : step,
+      ),
+    });
+    const refreshTaskSchedule = vi.fn();
+    const service = createChatAutomationAuthoring({
+      db,
+      authoring: {
+        create: vi.fn(async () => ({ kind: "definition" as const, definition: unsupported })),
+        edit: vi.fn(),
+      },
+      scheduler: { refreshTaskSchedule, getTaskById: vi.fn() },
+      loadIntegrationProvider: async () => null,
+      createId: () => "unsupported-trigger-task",
+    });
+
+    await expect(
+      service.author({ action: "create", request: "Poll Gmail for invoices", taskContext: taskContext() }),
+    ).resolves.toMatchObject({
+      kind: "error",
+      message: "Automation trigger is not supported. No changes were saved.",
+    });
+    await expect(createScheduledTaskRepository(db).getById("unsupported-trigger-task")).resolves.toBeUndefined();
+    expect(refreshTaskSchedule).not.toHaveBeenCalled();
+  });
+
   it("loads the complete owned definition for edit and reports revision conflicts without refreshing", async () => {
     await createAutomationDefinition({
       db,

--- a/packages/server/src/automation/chat-authoring.ts
+++ b/packages/server/src/automation/chat-authoring.ts
@@ -8,8 +8,8 @@ import type { IntegrationProvider } from "../integrations/types";
 import { resolveScheduledTaskAccess } from "../scheduler/access";
 import type { TaskScheduler } from "../scheduler/service";
 import type { CurrentAutomation, ScheduledTask, TaskContext } from "../scheduler/types";
-import type { AutomationAuthoringService } from "./authoring/service";
-import { buildAutomationDefinition } from "./definition";
+import { AUTOMATION_AUTHORING_TRIGGER_TYPES, type AutomationAuthoringService } from "./authoring/service";
+import { AutomationValidationError, buildAutomationDefinition } from "./definition";
 import { createAutomationDefinition, replaceAutomationDefinition } from "./persistence";
 import { webChatTaskConversationAssociation } from "./task-conversations";
 
@@ -51,6 +51,12 @@ function artifactFromDefinition(definition: AutomationBuilderSaveRequest) {
     scheduleValue: definition.scheduleValue,
     timezone: definition.timezone,
   };
+}
+
+function persistenceValidationMessage(error: AutomationValidationError): string {
+  return error.issues.some((issue) => issue.code === "UNSUPPORTED_TRIGGER")
+    ? "Automation trigger is not supported. No changes were saved."
+    : "Automation definition is invalid. No changes were saved.";
 }
 
 async function brokerCapable(
@@ -128,24 +134,32 @@ export function createChatAutomationAuthoring(deps: {
       return { kind: "clarification", message: result.question };
     }
 
-    await createAutomationDefinition({
-      db: deps.db,
-      request: result.definition,
-      context: {
-        id: taskId,
-        platform: input.taskContext.platform,
-        contextType: input.taskContext.contextType,
-        deliveryTarget: input.taskContext.deliveryTarget,
-        threadTs: input.taskContext.threadTs ?? null,
-        createdBy: input.taskContext.createdBy,
-        originPlatform: input.taskContext.origin?.platform ?? null,
-        originConversationId: input.taskContext.origin?.conversationId ?? null,
-        originProviderThreadId: input.taskContext.origin?.providerThreadId ?? null,
-        originMessageId: input.taskContext.origin?.currentMessageId ?? null,
-      },
-      brokerCapable: canUseBroker,
-      ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
-    });
+    try {
+      await createAutomationDefinition({
+        db: deps.db,
+        request: result.definition,
+        context: {
+          id: taskId,
+          platform: input.taskContext.platform,
+          contextType: input.taskContext.contextType,
+          deliveryTarget: input.taskContext.deliveryTarget,
+          threadTs: input.taskContext.threadTs ?? null,
+          createdBy: input.taskContext.createdBy,
+          originPlatform: input.taskContext.origin?.platform ?? null,
+          originConversationId: input.taskContext.origin?.conversationId ?? null,
+          originProviderThreadId: input.taskContext.origin?.providerThreadId ?? null,
+          originMessageId: input.taskContext.origin?.currentMessageId ?? null,
+        },
+        brokerCapable: canUseBroker,
+        supportedTriggerTypes: AUTOMATION_AUTHORING_TRIGGER_TYPES,
+        ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
+      });
+    } catch (error) {
+      if (error instanceof AutomationValidationError) {
+        return { kind: "error", message: persistenceValidationMessage(error) };
+      }
+      throw error;
+    }
     return refreshOrError(taskId, artifactFromDefinition(result.definition));
   }
 
@@ -182,17 +196,26 @@ export function createChatAutomationAuthoring(deps: {
       return { kind: "clarification", message: result.question };
     }
 
-    const saved = await replaceAutomationDefinition({
-      db: deps.db,
-      taskId: accessibleRow.id,
-      request: result.definition,
-      actor: {
-        userId: input.taskContext.createdBy,
-        canManageAnyTask: input.taskContext.canManageAnyTask ?? false,
-      },
-      brokerCapable: canUseBroker,
-      ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
-    });
+    let saved: Awaited<ReturnType<typeof replaceAutomationDefinition>>;
+    try {
+      saved = await replaceAutomationDefinition({
+        db: deps.db,
+        taskId: accessibleRow.id,
+        request: result.definition,
+        actor: {
+          userId: input.taskContext.createdBy,
+          canManageAnyTask: input.taskContext.canManageAnyTask ?? false,
+        },
+        brokerCapable: canUseBroker,
+        supportedTriggerTypes: AUTOMATION_AUTHORING_TRIGGER_TYPES,
+        ...(taskConversationAssociation ? { taskConversationAssociation } : {}),
+      });
+    } catch (error) {
+      if (error instanceof AutomationValidationError) {
+        return { kind: "error", message: persistenceValidationMessage(error) };
+      }
+      throw error;
+    }
     if (saved.kind === "not_found") return { kind: "error", message: "Automation not found." };
     if (saved.kind === "revision_conflict") {
       return {

--- a/packages/server/src/automation/definition.ts
+++ b/packages/server/src/automation/definition.ts
@@ -5,6 +5,7 @@ import {
   type AutomationStepContent,
   type WorkflowEdge,
   type WorkflowStep,
+  type WorkflowTriggerConfig,
   automationBuilderSaveRequestSchema,
   stepOutputSchema,
   workflowEdgeSchema,
@@ -31,6 +32,13 @@ export class AutomationValidationError extends Error {
     this.issues = issues;
   }
 }
+
+const DEFAULT_SUPPORTED_TRIGGER_TYPES: readonly WorkflowTriggerConfig["type"][] = [
+  "webhook",
+  "schedule",
+  "canvas",
+  "slack_channel_message",
+];
 
 function parseJson<T>(value: string | null, fallback: T): T {
   if (!value) return fallback;
@@ -249,6 +257,7 @@ function addIssue(issues: BuilderValidationIssue[], code: string, message: strin
 export function validateAutomationBuilderSaveRequest(params: {
   request: AutomationBuilderSaveRequest;
   brokerCapable: boolean;
+  supportedTriggerTypes?: readonly WorkflowTriggerConfig["type"][];
 }): void {
   const { request } = params;
   const issues = validateWorkflowGraph(request.steps, request.edges);
@@ -283,6 +292,12 @@ export function validateAutomationBuilderSaveRequest(params: {
     }
   }
 
+  validateTriggerCapability(
+    request.steps.find((step) => step.type === "trigger"),
+    params.supportedTriggerTypes ?? DEFAULT_SUPPORTED_TRIGGER_TYPES,
+    issues,
+  );
+
   validateTriggerSchedule(
     request,
     request.steps.find((step) => step.type === "trigger"),
@@ -291,6 +306,21 @@ export function validateAutomationBuilderSaveRequest(params: {
   validateScheduleValue(request, issues);
 
   if (issues.length > 0) throw new AutomationValidationError(issues);
+}
+
+function validateTriggerCapability(
+  trigger: WorkflowStep | undefined,
+  supportedTriggerTypes: readonly WorkflowTriggerConfig["type"][],
+  issues: BuilderValidationIssue[],
+): void {
+  const type = trigger?.triggerConfig?.type;
+  if (!type || supportedTriggerTypes.includes(type)) return;
+  addIssue(
+    issues,
+    "UNSUPPORTED_TRIGGER",
+    `Trigger type "${type}" is not supported by the current automation capability set`,
+    `steps.${trigger?.id ?? "trigger"}.triggerConfig.type`,
+  );
 }
 
 export function validateWorkflowGraph(steps: WorkflowStep[], edges: WorkflowEdge[]): BuilderValidationIssue[] {

--- a/packages/server/src/automation/persistence.ts
+++ b/packages/server/src/automation/persistence.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowDelivery,
   WorkflowEdge,
   WorkflowStep,
+  WorkflowTriggerConfig,
 } from "@sketch/shared";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
@@ -97,9 +98,13 @@ class AutomationDeletionRaceError extends Error {
   }
 }
 
-function validatedRequest(request: AutomationBuilderSaveRequest, brokerCapable: boolean): AutomationBuilderSaveRequest {
+function validatedRequest(
+  request: AutomationBuilderSaveRequest,
+  brokerCapable: boolean,
+  supportedTriggerTypes?: readonly WorkflowTriggerConfig["type"][],
+): AutomationBuilderSaveRequest {
   const parsed = parseAutomationBuilderSaveRequest(request);
-  validateAutomationBuilderSaveRequest({ request: parsed, brokerCapable });
+  validateAutomationBuilderSaveRequest({ request: parsed, brokerCapable, supportedTriggerTypes });
   return parsed;
 }
 
@@ -378,6 +383,7 @@ export async function updateAutomationDefinition(params: {
   patch: AutomationDefinitionPatch;
   actor: AutomationEditActor;
   brokerCapable: boolean;
+  supportedTriggerTypes?: readonly WorkflowTriggerConfig["type"][];
   taskConversationAssociation?: AutomationTaskConversationAssociation;
 }): Promise<AutomationMutationResult> {
   return params.db.transaction().execute(async (trx) => {
@@ -405,6 +411,7 @@ export async function updateAutomationDefinition(params: {
     const request = validatedRequest(
       applyDefinitionPatch(currentDefinition, params.patch, expectedRevision),
       params.brokerCapable,
+      params.supportedTriggerTypes,
     );
 
     const updateResult = await trx
@@ -449,9 +456,10 @@ export async function createAutomationDefinition(params: {
   request: AutomationBuilderSaveRequest;
   context: AutomationCreateContext;
   brokerCapable: boolean;
+  supportedTriggerTypes?: readonly WorkflowTriggerConfig["type"][];
   taskConversationAssociation?: AutomationTaskConversationAssociation;
 }): Promise<AutomationCreateResult> {
-  const request = validatedRequest(params.request, params.brokerCapable);
+  const request = validatedRequest(params.request, params.brokerCapable, params.supportedTriggerTypes);
   const id = params.context.id ?? randomUUID();
 
   const row = await params.db.transaction().execute(async (trx) => {
@@ -504,9 +512,10 @@ export async function replaceAutomationDefinition(params: {
   request: AutomationBuilderSaveRequest;
   actor: AutomationEditActor;
   brokerCapable: boolean;
+  supportedTriggerTypes?: readonly WorkflowTriggerConfig["type"][];
   taskConversationAssociation?: AutomationTaskConversationAssociation;
 }): Promise<AutomationReplaceResult> {
-  const request = validatedRequest(params.request, params.brokerCapable);
+  const request = validatedRequest(params.request, params.brokerCapable, params.supportedTriggerTypes);
 
   return params.db.transaction().execute(async (trx) => {
     const current = await trx


### PR DESCRIPTION
## Summary

Make semantic automation authoring deterministic around polling versus event intent and reject unsupported provider event triggers before persistence.

## Linear Scope

- [SKE-371](https://linear.app/sketch-ai/issue/SKE-371/clarify-polling-versus-event-intent-and-reject-unsupported-automation)
- Parent Linear issue: [SKE-370](https://linear.app/sketch-ai/issue/SKE-370/automation-reliability-refresh-ownership-builder-locking-and)

## Root Cause

The authoring path allowed the model to emit arbitrary trigger metadata. When a request mentioned invoice/email work without choosing polling or a native event, the model could drift into an invented Gmail event trigger even though that trigger is not available in Sketch.

## Implementation Details

- Ask one clarification question when polling cadence versus event intent is unspecified.
- Explicitly explain that Gmail/Outlook/other unsupported provider event triggers are unavailable in this authoring path.
- Make the admitted semantic-authoring trigger set authoritative: schedule, webhook, and Slack channel message.
- Validate trigger capability again at persistence and return a no-save error on unsupported output.
- Add prompt, intent, validation, service, persistence, and chat-authoring coverage.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Risk / Rollout

Only the semantic chat-authoring path is narrowed. Direct builder validation keeps its existing supported trigger set; unsupported semantic output cannot be persisted.

## Stack

Third layer; based on PR #472 and targets `fix/ske-373-builder-chat-lock`. PR #474 depends on this branch.