### PR TITLE
SKE-372: Refresh automation views and builder state automatically

### DIFF
--- a/packages/web/src/lib/automation-refresh.ts
+++ b/packages/web/src/lib/automation-refresh.ts
@@ -1,0 +1,21 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+export const AUTOMATION_QUERY_KEY = ["scheduled-tasks"] as const;
+export const AUTOMATION_REFRESH_INTERVAL_MS = 5_000;
+export const AUTOMATION_ACTIVE_RUN_REFRESH_INTERVAL_MS = 1_500;
+
+export const automationDefinitionQueryKey = (taskId: string) => [...AUTOMATION_QUERY_KEY, taskId, "builder"] as const;
+export const automationRunsQueryKey = (taskId: string) => ["automation-runs", taskId] as const;
+export const automationStepContentQueryKey = (taskId: string) => ["automation-step-content", taskId] as const;
+
+export function invalidateAutomationQueries(queryClient: QueryClient, taskIds: readonly string[] = []) {
+  const uniqueTaskIds = [...new Set(taskIds.filter((taskId) => taskId.trim().length > 0))];
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: AUTOMATION_QUERY_KEY, exact: true }),
+    ...uniqueTaskIds.flatMap((taskId) => [
+      queryClient.invalidateQueries({ queryKey: automationDefinitionQueryKey(taskId), exact: true }),
+      queryClient.invalidateQueries({ queryKey: automationRunsQueryKey(taskId), exact: true }),
+      queryClient.invalidateQueries({ queryKey: automationStepContentQueryKey(taskId), exact: true }),
+    ]),
+  ]);
+}

--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -1,10 +1,11 @@
 import type { AutomationDefinition } from "@/lib/api";
 import { ApiRequestError } from "@/lib/api";
+import { AUTOMATION_REFRESH_INTERVAL_MS } from "@/lib/automation-refresh";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AutomationBuilderPage } from "./automation-builder";
 
 const mocks = vi.hoisted(() => ({
@@ -299,6 +300,10 @@ function renderBuilder() {
 }
 
 describe("AutomationBuilderPage", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     mocks.getAutomation.mockClear();
     mocks.getAutomation.mockResolvedValue(automation);
@@ -346,18 +351,20 @@ describe("AutomationBuilderPage", () => {
       created: true,
     });
     mocks.selectConversation.mockClear();
-    mocks.selectConversation.mockImplementation(async (_taskId: string, conversationId: string) => ({
-      conversation: {
-        conversationId,
-        kinds: ["builder"],
-        createdAt: "2026-06-01T00:00:00.000Z",
-        updatedAt: "2026-06-03T00:00:00.000Z",
-        lastActiveAt: "2026-06-03T00:00:00.000Z",
-        archivedAt: null,
-        state: "active",
-      },
-      created: false,
-    }));
+    mocks.selectConversation.mockImplementation(
+      async (_taskId: string, conversationId: string, kind: "builder" | "web_chat" = "builder") => ({
+        conversation: {
+          conversationId,
+          kinds: [kind],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-03T00:00:00.000Z",
+          lastActiveAt: "2026-06-03T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+        },
+        created: false,
+      }),
+    );
     mocks.archiveConversation.mockClear();
     mocks.archiveConversation.mockImplementation(
       async (_taskId: string, conversationId: string, archived: boolean) => ({
@@ -451,6 +458,47 @@ describe("AutomationBuilderPage", () => {
     await waitFor(() => expect(mocks.loadMessages).toHaveBeenCalledWith("chat-alpha", expect.any(Object)));
   });
 
+  it("refreshes the graph and latest run after an external automation update", async () => {
+    vi.useFakeTimers();
+    const refreshedAutomation = automationWithStepOutput("fresh run output");
+    refreshedAutomation.steps = [
+      ...refreshedAutomation.steps,
+      {
+        id: "notify",
+        type: "action",
+        label: "Notify Slack",
+        icon: "slack",
+        position: { x: 460, y: 0 },
+      },
+    ];
+    refreshedAutomation.edges = [...refreshedAutomation.edges, { id: "check-notify", from: "check", to: "notify" }];
+    refreshedAutomation.stepContent.notify = {
+      taskId: automation.id,
+      stepId: "notify",
+      contentType: "script",
+      content: "return input;",
+      apps: ["Slack"],
+      updatedAt: null,
+    };
+    mocks.getAutomation.mockReset().mockResolvedValueOnce(automation).mockResolvedValue(refreshedAutomation);
+
+    renderBuilder();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(screen.getByRole("button", { name: "Check rating" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Notify Slack" })).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTOMATION_REFRESH_INTERVAL_MS);
+    });
+
+    expect(screen.getByRole("button", { name: "Notify Slack" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Viewing/ })).toBeInTheDocument();
+    expect(mocks.getAutomation).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps the active run label constrained inside the builder toolbar", async () => {
     mocks.getAutomation.mockResolvedValue(automationWithStepOutput("latest step output"));
 
@@ -467,7 +515,7 @@ describe("AutomationBuilderPage", () => {
 
     await screen.findByLabelText("Message Sketch");
     expect(screen.getByText("Create an automation")).toBeInTheDocument();
-    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(await screen.findByText("Source")).toBeInTheDocument();
     expect(await screen.findByText("What should change?")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Add a step" }));
@@ -957,7 +1005,7 @@ describe("AutomationBuilderPage", () => {
 
     await user.click(await screen.findByLabelText("Pause Sketch"));
 
-    expect(mocks.interruptChat).toHaveBeenCalledWith("chat-alpha");
+    expect(mocks.interruptChat).toHaveBeenCalledWith("chat-alpha", "task-123");
     expect(mocks.interruptChat).not.toHaveBeenCalledWith("42");
   });
 
@@ -1147,6 +1195,7 @@ describe("AutomationBuilderPage", () => {
   });
 
   it("serializes prompt and drag saves against the latest accepted revision", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
     const user = userEvent.setup();
     const firstSave = deferred<AutomationDefinition>();
     mocks.saveAutomation
@@ -1170,6 +1219,9 @@ describe("AutomationBuilderPage", () => {
     await user.click(screen.getByRole("button", { name: "Save prompt" }));
 
     await waitFor(() => expect(mocks.saveAutomation).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      vi.advanceTimersByTime(AUTOMATION_REFRESH_INTERVAL_MS);
+    });
     await user.click(screen.getByRole("button", { name: "Move Check rating" }));
     expect(mocks.saveAutomation).toHaveBeenCalledTimes(1);
 

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -18,6 +18,12 @@ import {
   type WorkflowStep,
   api,
 } from "@/lib/api";
+import {
+  AUTOMATION_ACTIVE_RUN_REFRESH_INTERVAL_MS,
+  AUTOMATION_REFRESH_INTERVAL_MS,
+  automationDefinitionQueryKey,
+  invalidateAutomationQueries,
+} from "@/lib/automation-refresh";
 import { WEB_CHAT_CONVERSATIONS_QUERY_KEY } from "@/lib/web-chat-conversations";
 import { useChat } from "@ai-sdk/react";
 import {
@@ -303,22 +309,27 @@ export function AutomationBuilderPage() {
   const { conversationId: requestedConversationId } = useSearch({ from: automationBuilderRoute.id });
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const queryKey = useMemo(() => ["scheduled-tasks", taskId, "builder"] as const, [taskId]);
+  const queryKey = useMemo(() => automationDefinitionQueryKey(taskId), [taskId]);
   const [draft, setDraft] = useState<DraftAutomation | null>(null);
   const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [savingPromptStepId, setSavingPromptStepId] = useState<string | null>(null);
   const latestDraftRef = useRef<DraftAutomation | null>(null);
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const pendingSaveCountRef = useRef(0);
 
   const automationQuery = useQuery({
     queryKey,
     queryFn: () => api.scheduledTasks.get(taskId),
-    refetchInterval: (query) => (query.state.data?.recentRuns.some((run) => run.status === "running") ? 1500 : false),
+    refetchInterval: (query) =>
+      query.state.data?.recentRuns.some((run) => run.status === "running")
+        ? AUTOMATION_ACTIVE_RUN_REFRESH_INTERVAL_MS
+        : AUTOMATION_REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
   });
 
   useEffect(() => {
-    if (!automationQuery.data) return;
+    if (!automationQuery.data || pendingSaveCountRef.current > 0) return;
     const nextDraft = draftFromDefinition(automationQuery.data);
     latestDraftRef.current = nextDraft;
     setDraft(nextDraft);
@@ -328,7 +339,7 @@ export function AutomationBuilderPage() {
     mutationFn: () => api.scheduledTasks.run(taskId),
     onSuccess: async () => {
       toast.success("Run requested");
-      await queryClient.invalidateQueries({ queryKey });
+      await invalidateAutomationQueries(queryClient, [taskId]);
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : "Could not start the run"),
   });
@@ -337,7 +348,7 @@ export function AutomationBuilderPage() {
     mutationFn: (stepId: string) => api.scheduledTasks.testStep(taskId, stepId, { useLatestUpstreamOutput: true }),
     onSuccess: async () => {
       toast.success("Test complete");
-      await queryClient.invalidateQueries({ queryKey });
+      await invalidateAutomationQueries(queryClient, [taskId]);
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : "Test failed"),
   });
@@ -348,6 +359,7 @@ export function AutomationBuilderPage() {
       options: { message?: string; promptStepId?: string } = {},
     ) => {
       if (options.promptStepId) setSavingPromptStepId(options.promptStepId);
+      pendingSaveCountRef.current += 1;
       const save = saveQueueRef.current
         .catch(() => undefined)
         .then(async () => {
@@ -365,6 +377,7 @@ export function AutomationBuilderPage() {
             latestDraftRef.current = updatedDraft;
             queryClient.setQueryData(queryKey, updatedAutomation);
             setDraft(updatedDraft);
+            await invalidateAutomationQueries(queryClient, [taskId]);
             if (options.message) toast.success(options.message);
           } catch (error) {
             toast.error(error instanceof Error ? error.message : "Failed to save automation");
@@ -375,7 +388,7 @@ export function AutomationBuilderPage() {
               queryClient.setQueryData(queryKey, refreshed);
               setDraft(refreshedDraft);
             } catch {
-              await queryClient.invalidateQueries({ queryKey });
+              await invalidateAutomationQueries(queryClient, [taskId]);
             }
             throw error;
           } finally {
@@ -383,6 +396,9 @@ export function AutomationBuilderPage() {
               setSavingPromptStepId((current) => (current === options.promptStepId ? null : current));
             }
           }
+        })
+        .finally(() => {
+          pendingSaveCountRef.current -= 1;
         });
       saveQueueRef.current = save.catch(() => undefined);
     },
@@ -1383,9 +1399,9 @@ function BuilderChatTranscript({
     }
     if (!historyReady || !wasBusyRef.current) return;
     wasBusyRef.current = false;
-    void queryClient.invalidateQueries({ queryKey });
+    void invalidateAutomationQueries(queryClient, [taskId]);
     void queryClient.invalidateQueries({ queryKey: conversationsQueryKey });
-  }, [chat.status, conversationsQueryKey, historyReady, queryClient, queryKey]);
+  }, [chat.status, conversationsQueryKey, historyReady, queryClient, taskId]);
 
   const handleStop = useCallback(() => {
     if (stoppingRun) return;

--- a/packages/web/src/routes/chat.isolated.test.tsx
+++ b/packages/web/src/routes/chat.isolated.test.tsx
@@ -1,3 +1,4 @@
+import { AUTOMATION_QUERY_KEY, automationRunsQueryKey, automationStepContentQueryKey } from "@/lib/automation-refresh";
 import { setPendingWebChatSubmission, takePendingWebChatSubmission } from "@/lib/chat-target";
 import { WEB_CHAT_CONVERSATIONS_QUERY_KEY } from "@/lib/web-chat-conversations";
 import { renderWithProviders } from "@/test/utils";
@@ -334,6 +335,60 @@ describe("chat route", () => {
         automations: [artifact],
       },
     ]);
+  });
+
+  it("invalidates automation caches when a streamed automation card arrives", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    mocks.search = {};
+    mockChatMessages = [
+      { id: "u-automation", role: "user", parts: [{ type: "text", text: "Update the automation" }] },
+      {
+        id: "a-automation",
+        role: "assistant",
+        parts: [
+          {
+            type: "data-automation",
+            id: "automation-0",
+            data: {
+              taskId: "task-123",
+              kind: "Updated automation",
+              title: "Daily account brief",
+              description: "Summarizes account updates.",
+              tags: ["Scheduled"],
+              scheduleLabel: "Daily at 9:00 AM",
+              deliveryLabel: "Slack DM",
+              builderUrl: "/scheduled-tasks/task-123/edit",
+              status: "active",
+            },
+          },
+        ],
+      },
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChatPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: AUTOMATION_QUERY_KEY, exact: true }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["scheduled-tasks", "task-123", "builder"],
+      exact: true,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: automationRunsQueryKey("task-123"), exact: true });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: automationStepContentQueryKey("task-123"),
+      exact: true,
+    });
   });
 
   it("extracts structured assistant progress from AI SDK data parts before final text arrives", () => {

--- a/packages/web/src/routes/chat.tsx
+++ b/packages/web/src/routes/chat.tsx
@@ -31,6 +31,7 @@ import {
   type WorkspaceSummary,
   api,
 } from "@/lib/api";
+import { invalidateAutomationQueries } from "@/lib/automation-refresh";
 import {
   createWebChatConversationId,
   hasPendingWebChatSubmission,
@@ -889,6 +890,19 @@ export function ChatPage() {
   const chatTitle = titleFromChatMessages(chat.messages);
   const hasBackgroundRun = hasPendingAssistantProgress(chat.messages);
   const chatBusy = chat.status === "submitted" || chat.status === "streaming" || hasBackgroundRun || stoppingRun;
+  const latestAutomationRefresh = useMemo(() => {
+    const latestMessage = chat.messages.at(-1);
+    if (!latestMessage || latestMessage.role !== "assistant") return { key: "", taskIds: [] as string[] };
+    const taskIds = [...new Set(automationsFromMessage(latestMessage).map((automation) => automation.taskId))];
+    return { key: `${latestMessage.id}:${taskIds.join(",")}`, taskIds };
+  }, [chat.messages]);
+  const lastAutomationRefreshKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (!historyReady || !latestAutomationRefresh.key) return;
+    if (lastAutomationRefreshKey.current === latestAutomationRefresh.key) return;
+    lastAutomationRefreshKey.current = latestAutomationRefresh.key;
+    void invalidateAutomationQueries(queryClient, latestAutomationRefresh.taskIds);
+  }, [historyReady, latestAutomationRefresh, queryClient]);
   const rawThreadMessages = useMemo(() => buildChatThreadMessages(chat.messages), [chat.messages]);
   const threadMessages = useSmoothedChatThreadMessages(rawThreadMessages, chatBusy, conversationId);
   const integrationConnectionCards = useMemo(

--- a/packages/web/src/routes/scheduled-tasks.isolated.test.tsx
+++ b/packages/web/src/routes/scheduled-tasks.isolated.test.tsx
@@ -1,7 +1,8 @@
-import type { ScheduledTaskListItem } from "@/lib/api";
+import type { AutomationRunItem, ScheduledTaskListItem } from "@/lib/api";
+import { AUTOMATION_REFRESH_INTERVAL_MS } from "@/lib/automation-refresh";
 import { server } from "@/test/msw";
 import { renderWithProviders } from "@/test/utils";
-import { screen, waitFor, within } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -27,6 +28,7 @@ vi.mock("@tanstack/react-router", async () => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   mockAuth = { role: "admin", email: "admin@test.com" };
   mockNavigate.mockReset();
 });
@@ -163,6 +165,75 @@ describe("ScheduledTasksPage", () => {
         "Create an automation by asking the assistant to set up a recurring task or multi-step workflow.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("refreshes the list graph and run history after an external run starts", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const initialTask = buildTask({
+      title: "Stale workflow",
+      steps: JSON.stringify([
+        { id: "trigger", type: "trigger", label: "Schedule", icon: "clock" },
+        { id: "check", type: "agent", label: "Check rating", icon: "robot" },
+      ]),
+      stepCount: 2,
+    });
+    const freshRun: AutomationRunItem = {
+      id: "run-fresh",
+      task_id: initialTask.id,
+      trigger_data: null,
+      status: "completed",
+      step_outputs: JSON.stringify({
+        check: { output: "fresh output", status: "completed", duration_ms: 10 },
+      }),
+      error_message: null,
+      started_at: "2026-03-15T03:30:00.000Z",
+      completed_at: "2026-03-15T03:30:01.000Z",
+    };
+    const freshTask = buildTask({
+      ...initialTask,
+      title: "Fresh workflow",
+      steps: JSON.stringify([
+        { id: "trigger", type: "trigger", label: "Schedule", icon: "clock" },
+        { id: "check", type: "agent", label: "Check rating", icon: "robot" },
+        { id: "notify", type: "action", label: "Notify Slack", icon: "slack" },
+      ]),
+      stepCount: 3,
+      runCount: 1,
+      lastRunStatus: "completed",
+      lastRunAt: freshRun.completed_at,
+    });
+    let taskRequests = 0;
+    let runRequests = 0;
+    server.use(
+      http.get("/api/scheduled-tasks", () => {
+        taskRequests += 1;
+        return HttpResponse.json({ tasks: [taskRequests === 1 ? initialTask : freshTask] });
+      }),
+      http.get("/api/scheduled-tasks/:id/runs", () => {
+        runRequests += 1;
+        return HttpResponse.json({ runs: runRequests === 1 ? [] : [freshRun] });
+      }),
+      http.get("/api/scheduled-tasks/:id/step-content", () => HttpResponse.json({ stepContent: [] })),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ScheduledTasksPage />);
+
+    await waitFor(() => expect(screen.getByText("Stale workflow")).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: /Show details for Stale workflow/i }));
+    expect(screen.getByText("Recent Runs")).toBeInTheDocument();
+    expect(screen.queryByText(/Mar 1[45]/)).not.toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(AUTOMATION_REFRESH_INTERVAL_MS);
+    });
+
+    await waitFor(() => expect(screen.getByText("Fresh workflow")).toBeInTheDocument());
+    expect(screen.getByText("Notify Slack")).toBeInTheDocument();
+    expect(screen.getByText("Recent Runs")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Mar 15, 2026/ })).toBeInTheDocument();
+    expect(taskRequests).toBeGreaterThanOrEqual(2);
+    expect(runRequests).toBeGreaterThanOrEqual(2);
   });
 
   it("renders the workspace subtitle", async () => {

--- a/packages/web/src/routes/scheduled-tasks.tsx
+++ b/packages/web/src/routes/scheduled-tasks.tsx
@@ -1,4 +1,11 @@
 import { type AutomationRunItem, type AutomationStepContentItem, type ScheduledTaskListItem, api } from "@/lib/api";
+import {
+  AUTOMATION_QUERY_KEY,
+  AUTOMATION_REFRESH_INTERVAL_MS,
+  automationRunsQueryKey,
+  automationStepContentQueryKey,
+  invalidateAutomationQueries,
+} from "@/lib/automation-refresh";
 import { useDashboardAuth } from "@/routes/dashboard";
 import {
   CaretRightIcon,
@@ -56,7 +63,7 @@ export const scheduledTasksRoute = createRoute({
   component: ScheduledTasksPage,
 });
 
-const TASKS_QUERY_KEY = ["scheduled-tasks"];
+const TASKS_QUERY_KEY = AUTOMATION_QUERY_KEY;
 
 type OwnershipTab = "all" | "mine" | "system";
 type StatusFilter = "all" | "active" | "attention" | "paused";
@@ -416,12 +423,15 @@ export function ScheduledTasksPage() {
   const tasksQuery = useQuery({
     queryKey: TASKS_QUERY_KEY,
     queryFn: () => api.scheduledTasks.list(),
+    refetchInterval: AUTOMATION_REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
   });
 
   const pauseMutation = useMutation({
     mutationFn: (taskId: string) => api.scheduledTasks.pause(taskId),
     onSuccess: (task) => {
       queryClient.setQueryData<ScheduledTaskListItem[]>(TASKS_QUERY_KEY, (tasks) => replaceTaskInCache(tasks, task));
+      void invalidateAutomationQueries(queryClient, [task.id]);
       toast.success("Automation paused");
     },
     onError: (error) => {
@@ -433,6 +443,7 @@ export function ScheduledTasksPage() {
     mutationFn: (taskId: string) => api.scheduledTasks.resume(taskId),
     onSuccess: (task) => {
       queryClient.setQueryData<ScheduledTaskListItem[]>(TASKS_QUERY_KEY, (tasks) => replaceTaskInCache(tasks, task));
+      void invalidateAutomationQueries(queryClient, [task.id]);
       toast.success("Automation resumed");
     },
     onError: (error) => {
@@ -444,6 +455,7 @@ export function ScheduledTasksPage() {
     mutationFn: (taskId: string) => api.scheduledTasks.remove(taskId),
     onSuccess: (_result, taskId) => {
       queryClient.setQueryData<ScheduledTaskListItem[]>(TASKS_QUERY_KEY, (tasks) => removeTaskFromCache(tasks, taskId));
+      void invalidateAutomationQueries(queryClient, [taskId]);
       setDeletingTask(null);
       setExpandedTaskId((current) => (current === taskId ? null : current));
       toast.success("Automation deleted");
@@ -455,7 +467,8 @@ export function ScheduledTasksPage() {
 
   const triggerMutation = useMutation({
     mutationFn: (taskId: string) => api.scheduledTasks.trigger(taskId),
-    onSuccess: () => {
+    onSuccess: (_result, taskId) => {
+      void invalidateAutomationQueries(queryClient, [taskId]);
       toast.success("Automation triggered");
     },
     onError: (error) => {
@@ -1087,8 +1100,10 @@ function StepsList({ task }: { task: ScheduledTaskListItem }) {
   const [expandedStepIds, setExpandedStepIds] = useState<Set<string>>(new Set());
 
   const stepContentQuery = useQuery({
-    queryKey: ["automation-step-content", task.id],
+    queryKey: automationStepContentQueryKey(task.id),
     queryFn: () => api.scheduledTasks.getStepContent(task.id),
+    refetchInterval: AUTOMATION_REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
   });
 
   if (!task.steps) return null;
@@ -1204,8 +1219,10 @@ function RunHistory({ taskId }: { taskId: string }) {
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
 
   const runsQuery = useQuery({
-    queryKey: ["automation-runs", taskId],
+    queryKey: automationRunsQueryKey(taskId),
     queryFn: () => api.scheduledTasks.listRuns(taskId),
+    refetchInterval: AUTOMATION_REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
   });
 
   const runs = runsQuery.data ?? [];


### PR DESCRIPTION
## Summary

Refresh automation lists, graphs, step content, and run history automatically, including after chat-driven changes and while runs are active.

## Linear Scope

- [SKE-372](https://linear.app/sketch-ai/issue/SKE-372/refresh-automation-views-and-builder-state-automatically)
- Parent Linear issue: [SKE-370](https://linear.app/sketch-ai/issue/SKE-370/automation-reliability-refresh-ownership-builder-locking-and)

## Root Cause

Automation queries were fetched once in several views, focus revalidation was disabled, and builder polling stopped when no run was already marked active. Chat-driven and fire-and-forget updates could therefore land after the last invalidation, leaving graphs and run history stale until a manual refresh.

## Implementation Details

- Add shared exact query keys and invalidation helpers.
- Poll automation lists, builder definitions, step content, and run history; use a faster interval for active runs.
- Revalidate on window focus and invalidate after run/test/save/pause/resume/delete/trigger and automation artifacts emitted by chat.
- Protect queued builder saves from being overwritten by a polling response.
- Add regression coverage for external graph/run refresh and related chat/list refresh behavior.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Risk / Rollout

Frontend-only polling and cache invalidation. It increases read frequency modestly and uses a shorter interval only while a run is active.

## Stack

Top layer; based on PR #473 and targets `fix/ske-371-deterministic-trigger-authoring`.