### PR TITLE
SKE-375: Add native and Canvas webhook trigger support

### DIFF
--- a/packages/server/src/agent/tools/scheduled-tasks.ts
+++ b/packages/server/src/agent/tools/scheduled-tasks.ts
@@ -2,6 +2,7 @@ import { tool } from "@anthropic-ai/claude-agent-sdk";
 import {
   type AutomationBuilderSaveRequest,
   automationActionCapabilitiesSchema,
+  canvasWebhookEndpointSchema,
   workflowStepUsesIntegrationActions,
 } from "@sketch/shared";
 import type { Kysely } from "kysely";
@@ -17,6 +18,7 @@ import {
   updateAutomationDefinition,
 } from "../../automation/persistence";
 import { webChatTaskConversationAssociation } from "../../automation/task-conversations";
+import { buildAutomationWebhookUrl } from "../../automation/webhook";
 import type { createAutomationRunsRepository } from "../../db/repositories/automation-runs";
 import type { createAutomationStepContentRepository } from "../../db/repositories/automation-step-content";
 import type { DB } from "../../db/schema";
@@ -82,6 +84,7 @@ const workflowStepSchema = z.object({
       canvasWorkflowId: z.string().optional(),
       canvasTriggerNodeId: z.string().optional(),
       canvasActionNodeId: z.string().optional(),
+      canvasEndpoint: canvasWebhookEndpointSchema.optional(),
       errorMessage: z.string().optional(),
     })
     .describe(
@@ -1025,8 +1028,10 @@ export async function handleManageScheduledTasks(
       const triggerStep = steps.find((s) => s.triggerConfig?.type === "webhook");
       let webhookUrl: string | undefined;
       if (triggerStep && deps.config) {
-        const baseUrl = deps.config.BASE_URL ?? `http://localhost:${deps.config.PORT}`;
-        webhookUrl = `${baseUrl}/api/webhooks/wf/${refreshedTask.id}`;
+        webhookUrl = buildAutomationWebhookUrl(refreshedTask.id, {
+          baseUrl: deps.config.BASE_URL,
+          port: deps.config.PORT,
+        });
       }
 
       collectAutomationArtifact({

--- a/packages/server/src/api/middleware.ts
+++ b/packages/server/src/api/middleware.ts
@@ -47,6 +47,10 @@ const PUBLIC_SETUP_PATHS = new Set(["/api/setup/status", "/api/setup/account"]);
 const ONBOARDING_PATHS_PREFIX = "/api/channels/whatsapp";
 const PLATFORM_COOKIE = "sketch_platform_session";
 
+function isPublicWebhookPath(path: string): boolean {
+  return /^\/api\/webhooks\/wf\/[^/]+$/.test(path);
+}
+
 type SettingsRepo = ReturnType<typeof createSettingsRepository>;
 
 export interface ViewerIdentity {
@@ -121,7 +125,7 @@ export function createAuthMiddleware(settings: SettingsRepo, opts?: AuthMiddlewa
     }
 
     const isSetupPath = path.startsWith(SETUP_PATHS_PREFIX);
-    const isPublicPath = PUBLIC_PATHS.has(path);
+    const isPublicPath = PUBLIC_PATHS.has(path) || isPublicWebhookPath(path);
     const isPublicSetupPath = PUBLIC_SETUP_PATHS.has(path);
 
     // Setup bootstrap paths are always accessible.

--- a/packages/server/src/api/scheduled-tasks.ts
+++ b/packages/server/src/api/scheduled-tasks.ts
@@ -42,6 +42,8 @@ interface ScheduledTaskMutationDeps {
 interface ScheduledTaskRouteOptions {
   logger?: Logger;
   loadIntegrationProvider?: () => Promise<IntegrationProvider | null>;
+  baseUrl?: string | null;
+  port?: number;
 }
 
 interface ScheduledTaskListItem {
@@ -408,6 +410,8 @@ export function scheduledTaskRoutes(
       runRows,
       createdByName: owner?.name ?? null,
       lastEditedByName: editor?.name ?? null,
+      webhookBaseUrl: options.baseUrl,
+      webhookPort: options.port,
     });
   }
 

--- a/packages/server/src/api/webhooks.test.ts
+++ b/packages/server/src/api/webhooks.test.ts
@@ -1,0 +1,122 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import type { DB } from "../db/schema";
+import { createTestDb } from "../test-utils";
+import { automationWebhookRoutes } from "./webhooks";
+
+function webhookSteps() {
+  return JSON.stringify([
+    {
+      id: "trigger-1",
+      type: "trigger",
+      triggerConfig: { type: "webhook" },
+    },
+    {
+      id: "agent-1",
+      type: "agent",
+      agentMode: "sketch",
+    },
+  ]);
+}
+
+describe("automation webhook route", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("accepts JSON payloads and queues the matching active automation", async () => {
+    const tasks = createScheduledTaskRepository(db);
+    await tasks.add({
+      id: "task-webhook",
+      platform: "web",
+      context_type: "dm",
+      delivery_target: "conversation-1",
+      thread_ts: null,
+      prompt: "Process the webhook",
+      schedule_type: "external",
+      schedule_value: "webhook",
+      timezone: "UTC",
+      session_mode: "fresh",
+      created_by: null,
+      status: "active",
+      next_run_at: null,
+      steps: webhookSteps(),
+    });
+
+    const enqueueTaskById = vi.fn().mockResolvedValue(undefined);
+    const app = new Hono();
+    app.route("/api/webhooks", automationWebhookRoutes({ db, scheduler: { enqueueTaskById } }));
+
+    const response = await app.request("/api/webhooks/wf/task-webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event: "created", id: "evt-1" }),
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      accepted: true,
+      taskId: "task-webhook",
+      trigger: { type: "webhook", method: "POST", contentType: "application/json" },
+    });
+    expect(enqueueTaskById).toHaveBeenCalledWith(
+      "task-webhook",
+      expect.objectContaining({
+        source: "webhook",
+        data: { event: "created", id: "evt-1" },
+      }),
+      { propagateParentAbort: false },
+    );
+  });
+
+  it("does not expose inactive or non-webhook automations as endpoints", async () => {
+    const tasks = createScheduledTaskRepository(db);
+    await tasks.add({
+      id: "task-paused",
+      platform: "web",
+      context_type: "dm",
+      delivery_target: "conversation-1",
+      thread_ts: null,
+      prompt: "Process the webhook",
+      schedule_type: "external",
+      schedule_value: "webhook",
+      timezone: "UTC",
+      session_mode: "fresh",
+      created_by: null,
+      status: "paused",
+      next_run_at: null,
+      steps: webhookSteps(),
+    });
+    await tasks.add({
+      id: "task-schedule",
+      platform: "web",
+      context_type: "dm",
+      delivery_target: "conversation-1",
+      thread_ts: null,
+      prompt: "Run on a schedule",
+      schedule_type: "cron",
+      schedule_value: "0 * * * *",
+      timezone: "UTC",
+      session_mode: "fresh",
+      created_by: null,
+      status: "active",
+      next_run_at: null,
+      steps: JSON.stringify([{ id: "trigger-1", type: "trigger", triggerConfig: { type: "schedule" } }]),
+    });
+
+    const app = new Hono();
+    app.route("/api/webhooks", automationWebhookRoutes({ db, scheduler: { enqueueTaskById: vi.fn() } }));
+
+    expect((await app.request("/api/webhooks/wf/task-paused", { method: "POST" })).status).toBe(409);
+    expect((await app.request("/api/webhooks/wf/task-schedule", { method: "POST" })).status).toBe(404);
+    expect((await app.request("/api/webhooks/wf/missing", { method: "POST" })).status).toBe(404);
+  });
+});

--- a/packages/server/src/api/webhooks.ts
+++ b/packages/server/src/api/webhooks.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import type { Logger } from "pino";
+import { isAutomationWebhookTrigger, parseAutomationTriggerConfig } from "../automation/webhook";
+import { createScheduledTaskRepository } from "../db/repositories/scheduled-tasks";
+import type { DB } from "../db/schema";
+import type { TaskScheduler } from "../scheduler/service";
+
+const MAX_WEBHOOK_BODY_BYTES = 1_000_000;
+
+interface AutomationWebhookRouteDeps {
+  db: Kysely<DB>;
+  logger?: Logger;
+  scheduler: Pick<TaskScheduler, "enqueueTaskById">;
+}
+
+export function automationWebhookRoutes(deps: AutomationWebhookRouteDeps) {
+  const routes = new Hono();
+  const tasks = createScheduledTaskRepository(deps.db);
+
+  routes.post("/wf/:taskId", async (c) => {
+    const taskId = c.req.param("taskId");
+    const task = await tasks.getById(taskId);
+    const trigger = task
+      ? parseAutomationTriggerConfig(task.steps, {
+          scheduleType: task.schedule_type,
+          scheduleValue: task.schedule_value,
+        })
+      : undefined;
+
+    if (!task || !trigger || !isAutomationWebhookTrigger(trigger)) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Webhook endpoint not found" } }, 404);
+    }
+    if (task.status !== "active") {
+      return c.json({ error: { code: "AUTOMATION_INACTIVE", message: "Automation is not active" } }, 409);
+    }
+
+    const contentLength = Number(c.req.header("content-length") ?? 0);
+    if (contentLength > MAX_WEBHOOK_BODY_BYTES) {
+      return c.json({ error: { code: "PAYLOAD_TOO_LARGE", message: "Webhook payload is too large" } }, 413);
+    }
+
+    const rawBody = await c.req.text();
+    if (Buffer.byteLength(rawBody, "utf8") > MAX_WEBHOOK_BODY_BYTES) {
+      return c.json({ error: { code: "PAYLOAD_TOO_LARGE", message: "Webhook payload is too large" } }, 413);
+    }
+
+    let data: unknown = null;
+    if (rawBody.trim().length > 0) {
+      try {
+        data = JSON.parse(rawBody);
+      } catch {
+        data = rawBody;
+      }
+    }
+
+    const triggerData = {
+      source: "webhook" as const,
+      requestedAt: new Date().toISOString(),
+      data,
+    };
+
+    try {
+      await deps.scheduler.enqueueTaskById(taskId, triggerData, { propagateParentAbort: false });
+    } catch (error) {
+      deps.logger?.warn({ taskId, error }, "Automation webhook rejected by scheduler");
+      return c.json({ error: { code: "AUTOMATION_UNAVAILABLE", message: "Automation could not be queued" } }, 503);
+    }
+
+    return c.json(
+      {
+        accepted: true,
+        taskId,
+        trigger: {
+          type: trigger.type,
+          method: "POST",
+          contentType: "application/json",
+        },
+      },
+      202,
+    );
+  });
+
+  return routes;
+}

--- a/packages/server/src/automation/definition.ts
+++ b/packages/server/src/automation/definition.ts
@@ -22,6 +22,7 @@ import { parseOnceSchedule } from "../scheduler/parse-once";
 import { formatIntervalScheduleLabel, normalizeScheduleTriggerSteps } from "../scheduler/trigger-metadata";
 import { resolveWorkflowDelivery } from "../workflows/delivery";
 import { hasInvalidAutomationSketchToolNamespace, undeclaredAutomationSketchTools } from "./action-script";
+import { addWebhookMetadata } from "./webhook";
 
 export type BuilderValidationIssue = { code: string; message: string; path?: string };
 
@@ -169,8 +170,19 @@ export function buildAutomationDefinition(params: {
   normalizeScheduleTriggers?: boolean;
   createdByName?: string | null;
   lastEditedByName?: string | null;
+  webhookBaseUrl?: string | null;
+  webhookPort?: number;
 }): AutomationDefinition {
-  const steps = safeSteps(params.row, params.normalizeScheduleTriggers);
+  const steps = safeSteps(params.row, params.normalizeScheduleTriggers).map((step) => {
+    if (step.type !== "trigger" || !step.triggerConfig || params.webhookBaseUrl === undefined) return step;
+    return {
+      ...step,
+      triggerConfig: addWebhookMetadata(step.triggerConfig, params.row.id, {
+        baseUrl: params.webhookBaseUrl,
+        port: params.webhookPort,
+      }),
+    };
+  });
   const edges = safeEdges(params.row, steps);
   const delivery = resolveWorkflowDelivery(params.row);
   const recentRuns = params.runRows.map(parseRun);

--- a/packages/server/src/automation/webhook.test.ts
+++ b/packages/server/src/automation/webhook.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  addWebhookMetadata,
+  buildAutomationWebhookUrl,
+  isAutomationWebhookTrigger,
+  parseAutomationTriggerConfig,
+} from "./webhook";
+
+describe("automation webhook contracts", () => {
+  it("builds a stable URL from the configured public base URL", () => {
+    expect(
+      buildAutomationWebhookUrl("task/with spaces", {
+        baseUrl: "https://sketch.example/",
+      }),
+    ).toBe("https://sketch.example/api/webhooks/wf/task%2Fwith%20spaces");
+  });
+
+  it("recognizes only the Sketch-owned webhook trigger", () => {
+    expect(isAutomationWebhookTrigger({ type: "webhook" })).toBe(true);
+    expect(isAutomationWebhookTrigger({ type: "canvas", componentKey: "webhook-trigger" })).toBe(false);
+    expect(isAutomationWebhookTrigger({ type: "canvas", componentKey: "slack-new-message" })).toBe(false);
+    expect(isAutomationWebhookTrigger({ type: "schedule" })).toBe(false);
+  });
+
+  it("reads the trigger from persisted workflow steps and ignores malformed values", () => {
+    expect(
+      parseAutomationTriggerConfig(
+        JSON.stringify([
+          { id: "trigger-1", type: "trigger", label: "Webhook", triggerConfig: { type: "webhook" } },
+          { id: "action-1", type: "action", label: "Process payload" },
+        ]),
+        { scheduleType: "cron", scheduleValue: "* * * * *" },
+      ),
+    ).toEqual({ type: "webhook" });
+
+    expect(
+      parseAutomationTriggerConfig("not-json", { scheduleType: "external", scheduleValue: "webhook" }),
+    ).toBeUndefined();
+    expect(parseAutomationTriggerConfig(null, { scheduleType: "external", scheduleValue: "webhook" })).toEqual({
+      type: "webhook",
+    });
+  });
+
+  it("adds metadata only to the native endpoint", () => {
+    expect(addWebhookMetadata({ type: "webhook" }, "task-1", { baseUrl: "https://sketch.example" })).toMatchObject({
+      type: "webhook",
+      webhookUrl: "https://sketch.example/api/webhooks/wf/task-1",
+      webhookMethod: "POST",
+      webhookContentType: "application/json",
+    });
+  });
+});

--- a/packages/server/src/automation/webhook.ts
+++ b/packages/server/src/automation/webhook.ts
@@ -1,0 +1,54 @@
+import { type WorkflowTriggerConfig, workflowTriggerConfigSchema } from "@sketch/shared";
+
+export const AUTOMATION_WEBHOOK_PATH = "/api/webhooks/wf";
+
+export function buildAutomationWebhookUrl(
+  taskId: string,
+  options: { baseUrl?: string | null; port?: number } = {},
+): string {
+  const baseUrl = options.baseUrl?.trim().replace(/\/+$/, "") || `http://localhost:${options.port ?? 3000}`;
+  return `${baseUrl}${AUTOMATION_WEBHOOK_PATH}/${encodeURIComponent(taskId)}`;
+}
+
+export function isAutomationWebhookTrigger(config: WorkflowTriggerConfig | undefined): boolean {
+  return config?.type === "webhook";
+}
+
+export function parseAutomationTriggerConfig(
+  value: string | null,
+  fallback: { scheduleType: string; scheduleValue: string },
+): WorkflowTriggerConfig | undefined {
+  if (value) {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        const trigger = parsed.find(
+          (step): step is { type: "trigger"; triggerConfig?: unknown } =>
+            typeof step === "object" && step !== null && step.type === "trigger",
+        );
+        const result = workflowTriggerConfigSchema.safeParse(trigger?.triggerConfig);
+        if (result.success) return result.data;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (fallback.scheduleType !== "external") return undefined;
+  if (fallback.scheduleValue === "webhook") return { type: "webhook" };
+  return undefined;
+}
+
+export function addWebhookMetadata(
+  config: WorkflowTriggerConfig,
+  taskId: string,
+  options: { baseUrl?: string | null; port?: number } = {},
+): WorkflowTriggerConfig {
+  if (!isAutomationWebhookTrigger(config)) return config;
+  return {
+    ...config,
+    webhookUrl: buildAutomationWebhookUrl(taskId, options),
+    webhookMethod: "POST",
+    webhookContentType: "application/json",
+  };
+}

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -44,6 +44,7 @@ import { usageRoutes } from "./api/usage";
 import { userRoutes } from "./api/users";
 import { watiWebhookRoutes } from "./api/wati-webhook";
 import { webChatRoutes } from "./api/web-chat";
+import { automationWebhookRoutes } from "./api/webhooks";
 import { whatsappRoutes } from "./api/whatsapp";
 import { workflowRoutes } from "./api/workflows";
 import { createWorkspaceApi } from "./api/workspace";
@@ -115,6 +116,7 @@ interface AppDeps {
   onLlmSettingsUpdated?: () => Promise<void>;
   onSmtpUpdated?: () => Promise<void>;
   scheduler?: Pick<TaskScheduler, "pauseTask" | "resumeTask" | "removeTask" | "executeTaskById"> &
+    Partial<Pick<TaskScheduler, "enqueueTaskById">> &
     Partial<Pick<TaskScheduler, "removeTaskRuntime">> &
     Partial<Pick<TaskScheduler, "refreshTaskSchedule" | "executeStepById" | "getTaskById">>;
   runAgent?: (params: RunAgentParams) => Promise<RunAgentResult>;
@@ -315,6 +317,17 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
 
   if (deps?.watiWebhook && deps.queueManager) {
     app.route("/whatsapp/wati", watiWebhookRoutes(deps.watiWebhook, deps.queueManager, logger));
+  }
+
+  if (deps?.scheduler?.enqueueTaskById) {
+    app.route(
+      "/api/webhooks",
+      automationWebhookRoutes({
+        db,
+        logger,
+        scheduler: { enqueueTaskById: deps.scheduler.enqueueTaskById },
+      }),
+    );
   }
 
   app.use(
@@ -560,6 +573,8 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       scheduledTaskRoutes(db, deps.scheduler, {
         logger,
         loadIntegrationProvider: deps.loadIntegrationProvider,
+        baseUrl: config.BASE_URL,
+        port: config.PORT,
       }),
     );
   }

--- a/packages/shared/src/automation.ts
+++ b/packages/shared/src/automation.ts
@@ -1,5 +1,17 @@
 import { z } from "zod";
 
+export const canvasWebhookEndpointSchema = z
+  .object({
+    url: z.string().url(),
+    method: z.literal("POST"),
+    authentication: z.literal("none"),
+    contentType: z.literal("application/json"),
+    payload: z.string().default("Any JSON value"),
+  })
+  .strict();
+
+export type CanvasWebhookEndpoint = z.infer<typeof canvasWebhookEndpointSchema>;
+
 export const workflowTriggerConfigSchema = z
   .object({
     type: z.enum(["webhook", "schedule", "canvas", "slack_channel_message"]),
@@ -10,6 +22,10 @@ export const workflowTriggerConfigSchema = z
     app: z.string().optional(),
     eventDescription: z.string().optional(),
     componentKey: z.string().optional(),
+    webhookUrl: z.string().url().optional(),
+    webhookMethod: z.literal("POST").optional(),
+    webhookContentType: z.literal("application/json").optional(),
+    canvasEndpoint: canvasWebhookEndpointSchema.optional(),
     configuredProps: z.record(z.string(), z.unknown()).optional(),
     status: z.enum(["pending_canvas_setup", "active", "error"]).optional(),
     canvasWorkflowId: z.string().optional(),

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   AutomationDefinition,
   AutomationRun,
   AutomationStepContent,
+  CanvasWebhookEndpoint,
   FileMetadata,
   IntegrationApp,
   IntegrationConnection,
@@ -30,6 +31,7 @@ export type {
   AutomationDefinition,
   AutomationRun,
   AutomationStepContent,
+  CanvasWebhookEndpoint,
   StepOutput,
   WorkflowEdge,
   WorkflowStep,
@@ -189,6 +191,10 @@ export interface WorkflowTriggerConfig {
   app?: string;
   eventDescription?: string;
   componentKey?: string;
+  webhookUrl?: string;
+  webhookMethod?: "POST";
+  webhookContentType?: "application/json";
+  canvasEndpoint?: CanvasWebhookEndpoint;
   configuredProps?: Record<string, unknown>;
   status?: "pending_canvas_setup" | "active" | "error";
   canvasWorkflowId?: string;

--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -421,6 +421,124 @@ describe("AutomationBuilderPage", () => {
     expect(screen.getAllByDisplayValue("C123").length).toBeGreaterThan(0);
   });
 
+  it("renders the Canvas-managed webhook contract and active setup guidance", async () => {
+    const user = userEvent.setup();
+    mocks.getAutomation.mockResolvedValue({
+      ...automation,
+      scheduleType: "external",
+      scheduleValue: "canvas",
+      steps: [
+        {
+          ...automation.steps[0],
+          label: "Canvas webhook trigger",
+          icon: "webhooks",
+          triggerConfig: {
+            type: "canvas",
+            app: "Canvas",
+            eventDescription: "webhook received",
+            componentKey: "webhook-trigger",
+            status: "active",
+            canvasEndpoint: {
+              url: "https://sketch.example/api/webhooks/wf/task-123",
+              method: "POST",
+              authentication: "none",
+              contentType: "application/json",
+              payload: "JSON object",
+            },
+          },
+        },
+        ...automation.steps.slice(1),
+      ],
+    });
+    renderBuilder();
+
+    await user.click(await screen.findByRole("button", { name: "Canvas webhook trigger" }));
+
+    expect(await screen.findByTestId("canvas-trigger-details")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("https://sketch.example/api/webhooks/wf/task-123")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("POST")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("None required")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("application/json")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("JSON object")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-trigger-setup-guidance")).toHaveTextContent(
+      "Canvas setup is complete. Send POST requests with JSON to the canonical URL above; no authentication is required.",
+    );
+  });
+
+  it.each([
+    [
+      "pending_canvas_setup",
+      "Setup pending",
+      "Canvas is still setting up this trigger. Complete setup in Canvas before sending requests.",
+    ],
+    [
+      "error",
+      "Setup error",
+      "Canvas could not finish setting up this trigger. Fix the trigger in Canvas and retry setup.",
+    ],
+  ] as const)("shows explicit Canvas %s guidance", async (status, statusLabel, guidance) => {
+    const user = userEvent.setup();
+    mocks.getAutomation.mockResolvedValue({
+      ...automation,
+      scheduleType: "external",
+      scheduleValue: "canvas",
+      steps: [
+        {
+          ...automation.steps[0],
+          label: "Canvas trigger",
+          icon: "webhooks",
+          triggerConfig: {
+            type: "canvas",
+            componentKey: "webhook-trigger",
+            status,
+            ...(status === "error" ? { errorMessage: "Canvas setup failed" } : {}),
+          },
+        },
+        ...automation.steps.slice(1),
+      ],
+    });
+    renderBuilder();
+
+    await user.click(await screen.findByRole("button", { name: "Canvas trigger" }));
+
+    expect(await screen.findByText(statusLabel)).toBeInTheDocument();
+    const guidanceRegion = screen.getByTestId("canvas-trigger-setup-guidance");
+    expect(guidanceRegion).toHaveTextContent(guidance);
+    if (status === "error") {
+      expect(guidanceRegion).toHaveAttribute("role", "alert");
+      expect(guidanceRegion).toHaveTextContent("Canvas error: Canvas setup failed");
+    }
+  });
+
+  it("keeps the native Sketch webhook trigger out of the Canvas setup panel", async () => {
+    const user = userEvent.setup();
+    mocks.getAutomation.mockResolvedValue({
+      ...automation,
+      scheduleType: "external",
+      scheduleValue: "webhook",
+      steps: [
+        {
+          ...automation.steps[0],
+          label: "Sketch webhook",
+          triggerConfig: {
+            type: "webhook",
+            webhookUrl: "https://sketch.example/api/webhooks/wf/task-123",
+            webhookMethod: "POST",
+            webhookContentType: "application/json",
+          },
+        },
+        ...automation.steps.slice(1),
+      ],
+    });
+    renderBuilder();
+
+    await user.click(await screen.findByRole("button", { name: "Sketch webhook" }));
+
+    expect(await screen.findByDisplayValue("webhook")).toBeInTheDocument();
+    expect(screen.queryByTestId("canvas-trigger-details")).not.toBeInTheDocument();
+  });
+
   it("opens the selected associated chat and sends the active automation id", async () => {
     const user = userEvent.setup();
     renderBuilder();

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -7,6 +7,7 @@ import {
   type AutomationBuilderSaveRequest,
   type AutomationDefinition,
   type AutomationStepContent,
+  type CanvasWebhookEndpoint,
   type ScheduledTaskConversationKind,
   type ScheduledTaskConversationLock,
   type ScheduledTaskConversationSummary,
@@ -16,6 +17,7 @@ import {
   type WebChatUploadedAttachment,
   type WorkflowEdge,
   type WorkflowStep,
+  type WorkflowTriggerConfig,
   api,
 } from "@/lib/api";
 import {
@@ -2514,9 +2516,11 @@ function NodeInputPanel({
 function TriggerFields({ draft }: { draft: DraftAutomation }) {
   const triggerStep = draft.steps.find((step) => step.type === "trigger");
   const config = triggerStep?.triggerConfig ?? { type: "schedule" as const };
-  const isCanvasWebhook = config.type === "canvas" && config.componentKey === "webhook-trigger";
-  const triggerLabel = isCanvasWebhook
-    ? "Canvas webhook"
+  const canvasConfig = config.type === "canvas" ? config : undefined;
+  const triggerLabel = canvasConfig
+    ? canvasConfig.componentKey === "webhook-trigger"
+      ? "Canvas webhook"
+      : "Canvas trigger"
     : config.type === "slack_channel_message"
       ? "Slack channel message"
       : config.type;
@@ -2530,7 +2534,13 @@ function TriggerFields({ draft }: { draft: DraftAutomation }) {
           <Input value={config.channelId ?? ""} className={builderReadOnlyInputClass} readOnly aria-readonly="true" />
         </Field>
       ) : null}
-      {isCanvasWebhook ? <CanvasWebhookFields endpoint={config.canvasEndpoint} /> : null}
+      {canvasConfig ? (
+        <CanvasWebhookFields
+          endpoint={canvasConfig.canvasEndpoint}
+          status={canvasConfig.status}
+          errorMessage={canvasConfig.errorMessage}
+        />
+      ) : null}
       {config.type === "schedule" ? (
         <>
           <Field label="Schedule type">
@@ -2555,15 +2565,14 @@ function TriggerFields({ draft }: { draft: DraftAutomation }) {
 
 function CanvasWebhookFields({
   endpoint,
+  status,
+  errorMessage,
 }: {
-  endpoint?: {
-    url: string;
-    method: "POST";
-    authentication: "none";
-    contentType: "application/json";
-    payload: string;
-  };
+  endpoint?: CanvasWebhookEndpoint;
+  status?: WorkflowTriggerConfig["status"];
+  errorMessage?: string;
 }) {
+  const statusDetails = getCanvasWebhookStatusDetails(status, endpoint);
   const handleCopy = async () => {
     if (!endpoint?.url) return;
     try {
@@ -2575,14 +2584,40 @@ function CanvasWebhookFields({
   };
 
   return (
-    <div className="space-y-3 rounded-[8px] border border-brand-accent/25 bg-brand-accent/5 p-3">
-      <div className="space-y-1">
-        <p className="text-[12px] font-medium text-foreground">Send data to this Canvas webhook</p>
-        <p className="text-[11px] leading-4 text-muted-foreground">
-          Canvas receives the request and forwards the payload to this automation.
-        </p>
+    <div
+      data-testid="canvas-trigger-details"
+      className="space-y-3 rounded-[8px] border border-brand-accent/25 bg-brand-accent/5 p-3"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-[12px] font-medium text-foreground">Canvas-managed trigger</p>
+          <p className="text-[11px] leading-4 text-muted-foreground">
+            Canvas owns this trigger setup and sends JSON events to Sketch.
+          </p>
+        </div>
+        <Badge
+          className={cn(
+            "shrink-0 rounded-[5px] border px-1.5 py-0.5 text-[10px] font-semibold",
+            statusDetails.toneClass,
+          )}
+        >
+          {statusDetails.label}
+        </Badge>
       </div>
-      <Field label="Webhook URL">
+      <div
+        data-testid="canvas-trigger-setup-guidance"
+        role={statusDetails.isError ? "alert" : "status"}
+        className={cn(
+          "rounded-[6px] border px-2.5 py-2 text-[11px] leading-4",
+          statusDetails.isError
+            ? "border-destructive/25 bg-destructive/10 text-destructive"
+            : "border-border/70 bg-background/55 text-muted-foreground",
+        )}
+      >
+        <p>{statusDetails.guidance}</p>
+        {errorMessage ? <p className="mt-1 text-destructive">Canvas error: {errorMessage}</p> : null}
+      </div>
+      <Field label="Canonical URL">
         <div className="flex gap-2">
           <Input
             value={endpoint?.url ?? "Canvas endpoint is not available yet"}
@@ -2595,7 +2630,7 @@ function CanvasWebhookFields({
             variant="outline"
             size="icon"
             className="size-10 shrink-0 rounded-[8px]"
-            aria-label="Copy Canvas webhook URL"
+            aria-label="Copy canonical Canvas webhook URL"
             disabled={!endpoint?.url}
             onClick={() => void handleCopy()}
           >
@@ -2621,19 +2656,64 @@ function CanvasWebhookFields({
           />
         </Field>
       </div>
-      <Field label="Authentication">
-        <Input
-          value={endpoint?.authentication === "none" ? "None required" : "Not configured"}
-          className={builderReadOnlyInputClass}
-          readOnly
-          aria-readonly="true"
-        />
-      </Field>
-      <p className="text-[11px] leading-4 text-muted-foreground">
-        Payload: {endpoint?.payload ?? "Any JSON value"}. Use a stable event ID in your payload if the sender may retry.
-      </p>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Authentication mode">
+          <Input
+            value={endpoint?.authentication === "none" ? "None required" : "Not configured"}
+            className={builderReadOnlyInputClass}
+            readOnly
+            aria-readonly="true"
+          />
+        </Field>
+        <Field label="Payload shape">
+          <Input
+            value={endpoint?.payload ?? "Any JSON value"}
+            className={builderReadOnlyInputClass}
+            readOnly
+            aria-readonly="true"
+          />
+        </Field>
+      </div>
     </div>
   );
+}
+
+function getCanvasWebhookStatusDetails(
+  status: WorkflowTriggerConfig["status"],
+  endpoint: CanvasWebhookEndpoint | undefined,
+): { label: string; guidance: string; isError: boolean; toneClass: string } {
+  if (status === "error") {
+    return {
+      label: "Setup error",
+      guidance: "Canvas could not finish setting up this trigger. Fix the trigger in Canvas and retry setup.",
+      isError: true,
+      toneClass: "border-destructive/30 bg-destructive/10 text-destructive",
+    };
+  }
+  if (status === "pending_canvas_setup" || (!status && !endpoint)) {
+    return {
+      label: "Setup pending",
+      guidance: "Canvas is still setting up this trigger. Complete setup in Canvas before sending requests.",
+      isError: false,
+      toneClass: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    };
+  }
+  if (status === "active" && !endpoint) {
+    return {
+      label: "Active",
+      guidance:
+        "Canvas reports this trigger as active, but its canonical URL is not available yet. Refresh after setup completes.",
+      isError: false,
+      toneClass: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    };
+  }
+  return {
+    label: "Active",
+    guidance:
+      "Canvas setup is complete. Send POST requests with JSON to the canonical URL above; no authentication is required.",
+    isError: false,
+    toneClass: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  };
 }
 
 function Field({ label, children, grow = false }: { label: string; children: ReactNode; grow?: boolean }) {

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -36,6 +36,7 @@ import {
   CheckCircleIcon,
   CircleIcon,
   CodeIcon,
+  CopySimpleIcon,
   EnvelopeSimpleIcon,
   EyeIcon,
   GitBranchIcon,
@@ -2513,7 +2514,12 @@ function NodeInputPanel({
 function TriggerFields({ draft }: { draft: DraftAutomation }) {
   const triggerStep = draft.steps.find((step) => step.type === "trigger");
   const config = triggerStep?.triggerConfig ?? { type: "schedule" as const };
-  const triggerLabel = config.type === "slack_channel_message" ? "Slack channel message" : config.type;
+  const isCanvasWebhook = config.type === "canvas" && config.componentKey === "webhook-trigger";
+  const triggerLabel = isCanvasWebhook
+    ? "Canvas webhook"
+    : config.type === "slack_channel_message"
+      ? "Slack channel message"
+      : config.type;
   return (
     <>
       <Field label="Trigger type">
@@ -2524,6 +2530,7 @@ function TriggerFields({ draft }: { draft: DraftAutomation }) {
           <Input value={config.channelId ?? ""} className={builderReadOnlyInputClass} readOnly aria-readonly="true" />
         </Field>
       ) : null}
+      {isCanvasWebhook ? <CanvasWebhookFields endpoint={config.canvasEndpoint} /> : null}
       {config.type === "schedule" ? (
         <>
           <Field label="Schedule type">
@@ -2543,6 +2550,89 @@ function TriggerFields({ draft }: { draft: DraftAutomation }) {
         </>
       ) : null}
     </>
+  );
+}
+
+function CanvasWebhookFields({
+  endpoint,
+}: {
+  endpoint?: {
+    url: string;
+    method: "POST";
+    authentication: "none";
+    contentType: "application/json";
+    payload: string;
+  };
+}) {
+  const handleCopy = async () => {
+    if (!endpoint?.url) return;
+    try {
+      await navigator.clipboard.writeText(endpoint.url);
+      toast.success("Canvas webhook URL copied");
+    } catch {
+      toast.error("Unable to copy Canvas webhook URL");
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-[8px] border border-brand-accent/25 bg-brand-accent/5 p-3">
+      <div className="space-y-1">
+        <p className="text-[12px] font-medium text-foreground">Send data to this Canvas webhook</p>
+        <p className="text-[11px] leading-4 text-muted-foreground">
+          Canvas receives the request and forwards the payload to this automation.
+        </p>
+      </div>
+      <Field label="Webhook URL">
+        <div className="flex gap-2">
+          <Input
+            value={endpoint?.url ?? "Canvas endpoint is not available yet"}
+            className={cn(builderReadOnlyInputClass, "min-w-0 flex-1")}
+            readOnly
+            aria-readonly="true"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="size-10 shrink-0 rounded-[8px]"
+            aria-label="Copy Canvas webhook URL"
+            disabled={!endpoint?.url}
+            onClick={() => void handleCopy()}
+          >
+            <CopySimpleIcon size={15} />
+          </Button>
+        </div>
+      </Field>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Method">
+          <Input
+            value={endpoint?.method ?? "POST"}
+            className={builderReadOnlyInputClass}
+            readOnly
+            aria-readonly="true"
+          />
+        </Field>
+        <Field label="Content type">
+          <Input
+            value={endpoint?.contentType ?? "application/json"}
+            className={builderReadOnlyInputClass}
+            readOnly
+            aria-readonly="true"
+          />
+        </Field>
+      </div>
+      <Field label="Authentication">
+        <Input
+          value={endpoint?.authentication === "none" ? "None required" : "Not configured"}
+          className={builderReadOnlyInputClass}
+          readOnly
+          aria-readonly="true"
+        />
+      </Field>
+      <p className="text-[11px] leading-4 text-muted-foreground">
+        Payload: {endpoint?.payload ?? "Any JSON value"}. Use a stable event ID in your payload if the sender may retry.
+      </p>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- add native Sketch webhook trigger support alongside the existing scheduled-task trigger contract
- expose a stable URL, method, content type, authentication, and payload metadata in automation definitions and the builder
- show Canvas-managed triggers in the builder with canonical URL, POST/auth/content/payload details, and pending/active/error setup guidance
- mount a bounded public webhook route that validates trigger ownership/state and enqueues the automation safely
- keep Canvas-managed webhook deployment metadata distinct from native Sketch webhook scheduling

This is the first layer above PR #467 and is intended to be consumed by the Canvas AI contract PR.

## Validation

- Sketch webhook unit/API tests
- 39-case isolated automation-builder suite on the final top branch
- full top-of-stack typecheck, lint, test, and build gates

Linear: SKE-375