### PR TITLE
fix: consolidate the four file-visibility implementations and close two access bugs

### DIFF
--- a/packages/server/src/agent/tools/file-visibility-e2e.integration.test.ts
+++ b/packages/server/src/agent/tools/file-visibility-e2e.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * D4 is observable only through publicMcp.userPrincipals because every other entry point resolves through
+ * viewerPrincipals, which canonicalized phone and LID principals before PR-C. The branch point is
+ * agent/tools/search.ts:97-111.
+ */
+import type { Kysely } from "kysely";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AccessPrincipalInput } from "../../connectors/types";
+import { createUserRepository } from "../../db/repositories/users";
+import type { DB } from "../../db/schema";
+import { createTestPgDb } from "../../test-utils";
+import {
+  VISIBILITY_QUERY,
+  allVisibilityFileIds,
+  seedFileVisibilityFixture,
+  visibilityFiles,
+  visibilityUsers,
+} from "../../test/file-visibility-e2e-fixture";
+import { handleGetFileContent, handleSearch } from "./search";
+import type { SketchMcpDeps, ToolResult } from "./types";
+
+describe("file visibility through the agent tools", () => {
+  let db: Kysely<DB>;
+
+  beforeAll(async () => {
+    db = await createTestPgDb();
+    await seedFileVisibilityFixture(db);
+  }, 30_000);
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  function depsForUser(userId: string): SketchMcpDeps {
+    return {
+      db,
+      currentUserId: userId,
+      userRepo: createUserRepository(db),
+      slackEntitySyncEnabled: true,
+    } as unknown as SketchMcpDeps;
+  }
+
+  function depsForPublicPrincipals(principals: AccessPrincipalInput[]): SketchMcpDeps {
+    return {
+      db,
+      publicMcp: { userPrincipals: principals },
+      slackEntitySyncEnabled: true,
+    } as unknown as SketchMcpDeps;
+  }
+
+  function resultText(result: ToolResult): string {
+    const first = result.content[0];
+    return first && first.type === "text" ? first.text : "";
+  }
+
+  async function searchedFileIds(userId: string): Promise<string[]> {
+    const result = await handleSearch({ query: VISIBILITY_QUERY, limit: 50 }, depsForUser(userId));
+    return [...resultText(result).matchAll(/sketchId: (\S+)/gu)].map((match) => match[1]).sort();
+  }
+
+  async function canRead(userId: string, fileId: string): Promise<boolean> {
+    const result = await handleGetFileContent({ fileId }, depsForUser(userId));
+    return !resultText(result).includes(`File ${fileId} not found.`);
+  }
+
+  it.each([
+    [
+      `keeps Search and GetFileContent aligned for ${visibilityUsers.scopeMember.id}`,
+      visibilityUsers.scopeMember.id,
+      [visibilityFiles.private, visibilityFiles.propagated],
+    ],
+    [
+      `keeps Search and GetFileContent aligned for ${visibilityUsers.fileGrant.id}`,
+      visibilityUsers.fileGrant.id,
+      [visibilityFiles.fileGrant, visibilityFiles.propagated],
+    ],
+    [
+      `keeps Search and GetFileContent aligned for ${visibilityUsers.shareTarget.id}`,
+      visibilityUsers.shareTarget.id,
+      [visibilityFiles.manualShare, visibilityFiles.propagated],
+    ],
+    [
+      `keeps Search and GetFileContent aligned for ${visibilityUsers.stranger.id}`,
+      visibilityUsers.stranger.id,
+      [visibilityFiles.propagated],
+    ],
+    [
+      `keeps Search and GetFileContent aligned for ${visibilityUsers.slackOnly.id}`,
+      visibilityUsers.slackOnly.id,
+      [visibilityFiles.propagated],
+    ],
+    [
+      "reaches a phone-scoped file through aligned Search and GetFileContent for a user whose stored number is punctuated",
+      visibilityUsers.messyPhone.id,
+      [visibilityFiles.phoneScope, visibilityFiles.propagated],
+    ],
+  ])("%s", async (_name, userId, expectedFileIds) => {
+    const searched = await searchedFileIds(userId);
+    expect(searched).toEqual([...expectedFileIds].sort());
+
+    const readable: string[] = [];
+    for (const fileId of allVisibilityFileIds) {
+      if (await canRead(userId, fileId)) readable.push(fileId);
+    }
+    expect(readable.sort()).toEqual(searched);
+  });
+
+  it("keeps a private scoped file hidden while propagating an org-wide entity share", async () => {
+    const searched = await searchedFileIds(visibilityUsers.stranger.id);
+    expect(searched).not.toContain(visibilityFiles.private);
+    expect(await canRead(visibilityUsers.stranger.id, visibilityFiles.private)).toBe(false);
+    expect(searched).toContain(visibilityFiles.propagated);
+    expect(await canRead(visibilityUsers.stranger.id, visibilityFiles.propagated)).toBe(true);
+  });
+
+  it("does not leak another email's entity share to a Slack-only agent", async () => {
+    await expect(searchedFileIds(visibilityUsers.slackOnly.id)).resolves.not.toContain(
+      visibilityFiles.individualEntityShare,
+    );
+    await expect(canRead(visibilityUsers.slackOnly.id, visibilityFiles.individualEntityShare)).resolves.toBe(false);
+  });
+
+  it("reaches a phone-scoped file through Search and GetFileContent for a user whose stored number is punctuated", async () => {
+    await expect(searchedFileIds(visibilityUsers.messyPhone.id)).resolves.toContain(visibilityFiles.phoneScope);
+    await expect(canRead(visibilityUsers.messyPhone.id, visibilityFiles.phoneScope)).resolves.toBe(true);
+  });
+
+  /** This is the sole D4 regression test because it exercises caller-supplied public MCP principals. */
+  it("normalizes a raw public-MCP phone principal for Search and GetFileContent", async () => {
+    const deps = depsForPublicPrincipals([{ type: "phone", value: visibilityUsers.messyPhone.whatsappNumber }]);
+    const searchResult = await handleSearch({ query: VISIBILITY_QUERY, limit: 50 }, deps);
+    expect(resultText(searchResult)).toContain(`sketchId: ${visibilityFiles.phoneScope}`);
+
+    const contentResult = await handleGetFileContent({ fileId: visibilityFiles.phoneScope }, deps);
+    expect(resultText(contentResult)).toContain(`${VISIBILITY_QUERY} content for ${visibilityFiles.phoneScope}`);
+  });
+});

--- a/packages/server/src/agent/tools/slack-channel-history.integration.test.ts
+++ b/packages/server/src/agent/tools/slack-channel-history.integration.test.ts
@@ -4,6 +4,7 @@ import type { AccessPrincipalInput } from "../../connectors/types";
 import { createConnectorRepository } from "../../db/repositories/connectors";
 import { createConversationSlicesRepository } from "../../db/repositories/conversation-slices";
 import { createConversationRepository } from "../../db/repositories/conversations";
+import { createUserRepository } from "../../db/repositories/users";
 import type { DB } from "../../db/schema";
 import { createTestDb, createTestPgDb } from "../../test-utils";
 import { SLACK_CHANNEL_HISTORY_DENIED_TEXT, handleSlackChannelHistory } from "./slack-channel-history";
@@ -11,6 +12,15 @@ import type { SketchMcpDeps } from "./types";
 
 function depsFor(db: Kysely<DB>, principals: AccessPrincipalInput[]): SketchMcpDeps {
   return { db, publicMcp: { userPrincipals: principals } } as unknown as SketchMcpDeps;
+}
+
+function resolvedUserDeps(db: Kysely<DB>, userId: string): SketchMcpDeps {
+  return {
+    db,
+    currentUserId: userId,
+    userRepo: createUserRepository(db),
+    slackEntitySyncEnabled: true,
+  } as unknown as SketchMcpDeps;
 }
 
 function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -131,6 +141,22 @@ function runSuite(label: string, createDb: () => Promise<Kysely<DB>>) {
       expect(payload.messages[0].text).toBe("root message");
       expect(payload.messages[1].text).toBe("reply mentioning @Roopak");
       expect(payload.messages[1].sender).toBe("Roopak");
+    });
+
+    it("returns scope-only channel history through the agent's resolved caller principals", async () => {
+      const fileGrants = await db
+        .selectFrom("file_access")
+        .select("indexed_file_id")
+        .where("indexed_file_id", "=", "file-1")
+        .execute();
+      expect(fileGrants).toEqual([]);
+
+      const result = await handleSlackChannelHistory({ sliceId }, resolvedUserDeps(db, "user-admin"));
+      const payload = JSON.parse(resultText(result));
+      expect(payload.messages.map((message: { text: string }) => message.text)).toEqual([
+        "root message",
+        "reply mentioning @Roopak",
+      ]);
     });
 
     it("includes messages whose delivery lagged days behind their Slack timestamp", async () => {

--- a/packages/server/src/api/file-visibility-e2e.integration.test.ts
+++ b/packages/server/src/api/file-visibility-e2e.integration.test.ts
@@ -1,0 +1,139 @@
+/**
+ * D4 is observable only through publicMcp.userPrincipals because every other entry point resolves through
+ * viewerPrincipals, which canonicalized phone and LID principals before PR-C. The branch point is
+ * agent/tools/search.ts:97-111.
+ */
+import type { Kysely } from "kysely";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestLogger, createTestPgDb } from "../test-utils";
+import {
+  allVisibilityFileIds,
+  loginVisibilityUser,
+  seedFileVisibilityFixture,
+  visibilityFiles,
+  visibilitySessionCookie,
+  visibilityUsers,
+} from "../test/file-visibility-e2e-fixture";
+
+type FileListResponse = { files: Array<{ id: string }>; hasMore: boolean };
+
+describe("file visibility through the HTTP API", () => {
+  let db: Kysely<DB>;
+  let app: ReturnType<typeof createApp>;
+  const cookies = new Map<string, string>();
+
+  beforeAll(async () => {
+    db = await createTestPgDb();
+    await seedFileVisibilityFixture(db);
+    app = createApp(db, createTestConfig({ DB_TYPE: "postgres", SLACK_ENTITY_SYNC: true }), {
+      logger: createTestLogger(),
+    });
+
+    for (const user of [
+      visibilityUsers.admin,
+      visibilityUsers.scopeMember,
+      visibilityUsers.fileGrant,
+      visibilityUsers.shareTarget,
+      visibilityUsers.stranger,
+      visibilityUsers.messyPhone,
+    ]) {
+      cookies.set(user.id, await loginVisibilityUser(app, user.email));
+    }
+    cookies.set(visibilityUsers.slackOnly.id, await visibilitySessionCookie(db, visibilityUsers.slackOnly.id));
+  }, 30_000);
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  async function listedFileIds(userId: string): Promise<string[]> {
+    const response = await app.request("/api/connectors/all-files?limit=200", {
+      headers: { Cookie: cookies.get(userId) ?? "" },
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as FileListResponse;
+    expect(body.hasMore).toBe(false);
+    return body.files.map((file) => file.id).sort();
+  }
+
+  async function contentStatus(userId: string, fileId: string): Promise<number> {
+    const response = await app.request(`/api/connectors/files/${fileId}/content`, {
+      headers: { Cookie: cookies.get(userId) ?? "" },
+    });
+    await response.text();
+    return response.status;
+  }
+
+  it.each([
+    [
+      `keeps the list and content surfaces aligned for ${visibilityUsers.admin.id}`,
+      visibilityUsers.admin.id,
+      allVisibilityFileIds,
+    ],
+    [
+      `keeps the list and content surfaces aligned for ${visibilityUsers.scopeMember.id}`,
+      visibilityUsers.scopeMember.id,
+      [visibilityFiles.private, visibilityFiles.propagated],
+    ],
+    [
+      `keeps the list and content surfaces aligned for ${visibilityUsers.fileGrant.id}`,
+      visibilityUsers.fileGrant.id,
+      [visibilityFiles.fileGrant, visibilityFiles.propagated],
+    ],
+    [
+      `keeps the list and content surfaces aligned for ${visibilityUsers.shareTarget.id}`,
+      visibilityUsers.shareTarget.id,
+      [visibilityFiles.manualShare, visibilityFiles.propagated],
+    ],
+    [
+      `keeps the list and content surfaces aligned for ${visibilityUsers.stranger.id}`,
+      visibilityUsers.stranger.id,
+      [visibilityFiles.propagated],
+    ],
+    [
+      `keeps the list and content surfaces aligned for ${visibilityUsers.slackOnly.id}`,
+      visibilityUsers.slackOnly.id,
+      [visibilityFiles.propagated],
+    ],
+    [
+      "reaches a phone-scoped file on the aligned list and content surfaces for a user whose stored number is punctuated",
+      visibilityUsers.messyPhone.id,
+      [visibilityFiles.phoneScope, visibilityFiles.propagated],
+    ],
+  ])("%s", async (_name, userId, expectedFileIds) => {
+    const listed = await listedFileIds(userId);
+    expect(listed).toEqual([...expectedFileIds].sort());
+
+    const openable: string[] = [];
+    for (const fileId of allVisibilityFileIds) {
+      const status = await contentStatus(userId, fileId);
+      if (status === 200) openable.push(fileId);
+      else expect(status).toBe(403);
+    }
+    expect(openable.sort()).toEqual(listed);
+  });
+
+  it("keeps a private scoped file hidden from a stranger on both routes", async () => {
+    await expect(listedFileIds(visibilityUsers.stranger.id)).resolves.not.toContain(visibilityFiles.private);
+    await expect(contentStatus(visibilityUsers.stranger.id, visibilityFiles.private)).resolves.toBe(403);
+  });
+
+  it("propagates an org-wide entity share on both routes", async () => {
+    await expect(listedFileIds(visibilityUsers.stranger.id)).resolves.toContain(visibilityFiles.propagated);
+    await expect(contentStatus(visibilityUsers.stranger.id, visibilityFiles.propagated)).resolves.toBe(200);
+  });
+
+  it("does not leak another email's entity share to a Slack-only viewer", async () => {
+    await expect(listedFileIds(visibilityUsers.slackOnly.id)).resolves.not.toContain(
+      visibilityFiles.individualEntityShare,
+    );
+    await expect(contentStatus(visibilityUsers.slackOnly.id, visibilityFiles.individualEntityShare)).resolves.toBe(403);
+  });
+
+  it("reaches a phone-scoped file on both routes for a user whose stored number is punctuated", async () => {
+    await expect(listedFileIds(visibilityUsers.messyPhone.id)).resolves.toContain(visibilityFiles.phoneScope);
+    await expect(contentStatus(visibilityUsers.messyPhone.id, visibilityFiles.phoneScope)).resolves.toBe(200);
+  });
+});

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -332,7 +332,10 @@ export async function getFileContent(
             .where("entity_mentions.indexed_file_id", "=", fileId)
             .where(whereLiveEntity())
             .where((eb) =>
-              eb.or([eb("entities.share_with_everyone", "=", 1), eb("entity_share_emails.email", "is not", null)]),
+              eb.or([
+                eb("entities.share_with_everyone", "=", 1),
+                ...(emailValues.length > 0 ? [eb("entity_share_emails.email", "is not", null)] : []),
+              ]),
             )
             .limit(1)
             .execute();

--- a/packages/server/src/connectors/search.ts
+++ b/packages/server/src/connectors/search.ts
@@ -20,8 +20,8 @@ import { sql } from "kysely";
 import type { Logger } from "pino";
 import { isPg } from "../db/dialect";
 import { EMBEDDING_DIMENSIONS } from "../db/index";
-import { accessPrincipalPredicateSql } from "../db/repositories/connectors";
-import { createEntityRepository, whereLiveEntity } from "../db/repositories/entities";
+import { createEntityRepository } from "../db/repositories/entities";
+import { fileVisibilityRuleSql } from "../db/repositories/file-visibility-rule";
 import { createSettingsRepository } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
 import { parseEmailAddrJson, parseEmailAddrListJson } from "./email/envelope-metadata";
@@ -62,56 +62,11 @@ export interface SearchOptions {
 }
 
 export function fileAccessFilterSql(principalInput: AccessPrincipalInput[], slackEntitySyncEnabled = true) {
-  const principalList = normalizeAccessPrincipals(principalInput);
-  const emailValues = principalList
-    .filter((principal) => principal.type === "email")
-    .map((principal) => principal.value);
-  const emailSql =
-    emailValues.length > 0
-      ? sql.join(
-          emailValues.map((email) => sql`${email}`),
-          sql`,`,
-        )
-      : null;
-  const accessDoor = slackEntitySyncEnabled
-    ? sql`(indexed_files.source IS NULL OR indexed_files.source NOT IN ('slack', 'whatsapp'))`
-    : sql`1 = 1`;
-  return sql<SqlBool>`(
-    (${accessDoor}
-      AND indexed_files.access_scope_id IS NULL
-      AND NOT EXISTS (SELECT 1 FROM file_access WHERE file_access.indexed_file_id = indexed_files.id))
-    OR EXISTS (
-      SELECT 1 FROM access_scope_members
-      WHERE access_scope_members.access_scope_id = indexed_files.access_scope_id
-      AND ${accessPrincipalPredicateSql("access_scope_members", principalList)}
-    )
-    OR (${accessDoor}
-      AND EXISTS (
-        SELECT 1 FROM file_access
-        WHERE file_access.indexed_file_id = indexed_files.id
-        AND ${accessPrincipalPredicateSql("file_access", principalList)}
-      ))
-    OR ${
-      emailSql
-        ? sql`EXISTS (
-      SELECT 1 FROM file_share_emails
-      WHERE file_share_emails.indexed_file_id = indexed_files.id
-      AND file_share_emails.email IN (${emailSql})
-    )`
-        : sql`0 = 1`
-    }
-    OR indexed_files.share_with_everyone = 1
-    OR EXISTS (
-      SELECT 1 FROM entity_mentions em_shared
-      INNER JOIN entities ent_shared ON ent_shared.id = em_shared.entity_id
-      LEFT JOIN entity_share_emails ese
-        ON ese.entity_id = ent_shared.id ${emailSql ? sql`AND ese.email IN (${emailSql})` : sql``}
-      WHERE em_shared.indexed_file_id = indexed_files.id
-        AND ent_shared.deleted_at IS NULL
-        AND ent_shared.merged_into_entity_id IS NULL
-        AND (ent_shared.share_with_everyone = 1 OR ${emailSql ? sql`ese.email IS NOT NULL` : sql`0 = 1`})
-    )
-  )`;
+  return fileVisibilityRuleSql({
+    principals: normalizeAccessPrincipals(principalInput),
+    slackEntitySyncEnabled,
+    archived: "include",
+  });
 }
 
 /**
@@ -231,7 +186,7 @@ export async function getFileContent(
   providerUrl: string | null;
   enrichmentStatus: string;
 } | null> {
-  const file = await db
+  let query = db
     .selectFrom("indexed_files")
     .select([
       "id",
@@ -245,107 +200,17 @@ export async function getFileContent(
       "context_note",
       "provider_url",
       "enrichment_status",
-      "access_scope_id",
-      "share_with_everyone",
-      "is_archived",
     ])
-    .where("id", "=", fileId)
-    .executeTakeFirst();
-
-  if (!file) return null;
+    .where("id", "=", fileId);
 
   if (userPrincipals !== undefined) {
     const principals = normalizeAccessPrincipals(userPrincipals);
     if (principals.length === 0) return null;
-    const emailValues = principals
-      .filter((principal) => principal.type === "email")
-      .map((principal) => principal.value);
-
-    /**
-     * Archived files are denied on the RBAC path: archival severs the scope
-     * and per-file grants, which would otherwise flip the file into the
-     * unrestricted no-scope tier below. Mirrors filterAccessibleFileIds.
-     */
-    if (file.is_archived === 1) return null;
-
-    if (file.share_with_everyone !== 1) {
-      const hasScope = file.access_scope_id != null;
-      const hasFileAccess = await db
-        .selectFrom("file_access")
-        .select(["principal_type", "principal_value"])
-        .where("indexed_file_id", "=", fileId)
-        .limit(1)
-        .execute();
-
-      const isChatSource = slackEntitySyncEnabled && (file.source === "slack" || file.source === "whatsapp");
-      if (isChatSource || hasScope || hasFileAccess.length > 0) {
-        let allowed = false;
-
-        // Tier 2: scope-level access
-        if (hasScope && file.access_scope_id) {
-          const scopeMatch = await db
-            .selectFrom("access_scope_members")
-            .select(["principal_type", "principal_value"])
-            .where("access_scope_id", "=", file.access_scope_id)
-            .where(accessPrincipalPredicateSql("access_scope_members", principals))
-            .limit(1)
-            .execute();
-          if (scopeMatch.length > 0) allowed = true;
-        }
-
-        // Tier 3: per-file access
-        if (!allowed && !isChatSource && hasFileAccess.length > 0) {
-          const fileMatch = await db
-            .selectFrom("file_access")
-            .select(["principal_type", "principal_value"])
-            .where("indexed_file_id", "=", fileId)
-            .where(accessPrincipalPredicateSql("file_access", principals))
-            .limit(1)
-            .execute();
-          if (fileMatch.length > 0) allowed = true;
-        }
-
-        // Tier 4: manual share
-        if (!allowed && emailValues.length > 0) {
-          const shareMatch = await db
-            .selectFrom("file_share_emails")
-            .select("email")
-            .where("indexed_file_id", "=", fileId)
-            .where("email", "in", emailValues)
-            .limit(1)
-            .execute();
-          if (shareMatch.length > 0) allowed = true;
-        }
-
-        // Tier 5: entity-share propagation — a shared entity mentioned in
-        // this file grants read access to the file (read-time, no file_access
-        // rows written).
-        if (!allowed) {
-          const entityMatch = await db
-            .selectFrom("entity_mentions")
-            .innerJoin("entities", "entities.id", "entity_mentions.entity_id")
-            .leftJoin("entity_share_emails", (join) => {
-              const condition = join.onRef("entity_share_emails.entity_id", "=", "entities.id");
-              return emailValues.length > 0 ? condition.on("entity_share_emails.email", "in", emailValues) : condition;
-            })
-            .select("entities.id")
-            .where("entity_mentions.indexed_file_id", "=", fileId)
-            .where(whereLiveEntity())
-            .where((eb) =>
-              eb.or([
-                eb("entities.share_with_everyone", "=", 1),
-                ...(emailValues.length > 0 ? [eb("entity_share_emails.email", "is not", null)] : []),
-              ]),
-            )
-            .limit(1)
-            .execute();
-          if (entityMatch.length > 0) allowed = true;
-        }
-
-        if (!allowed) return null;
-      }
-    }
+    query = query.where(fileVisibilityRuleSql({ principals, slackEntitySyncEnabled, archived: "exclude" }));
   }
+
+  const file = await query.executeTakeFirst();
+  if (!file) return null;
 
   return {
     id: file.id,
@@ -385,132 +250,12 @@ export async function filterAccessibleFileIds(
 
   const files = await db
     .selectFrom("indexed_files")
-    .select(["id", "source", "access_scope_id", "share_with_everyone", "is_archived"])
+    .select("id")
     .where("id", "in", fileIds)
+    .where(fileVisibilityRuleSql({ principals, slackEntitySyncEnabled, archived: "exclude" }))
     .execute();
 
-  const emailValues = principals.filter((principal) => principal.type === "email").map((principal) => principal.value);
-  const [fileAccessRows, scopeMemberRows, shareRows, entityPropRows] = await Promise.all([
-    db
-      .selectFrom("file_access")
-      .select(["indexed_file_id", "principal_type", "principal_value"])
-      .where("indexed_file_id", "in", fileIds)
-      .execute(),
-    (async () => {
-      const scopeIds = files.map((f) => f.access_scope_id).filter((s): s is string => !!s);
-      if (scopeIds.length === 0) return [];
-      return db
-        .selectFrom("access_scope_members")
-        .select(["access_scope_id", "principal_type", "principal_value"])
-        .where("access_scope_id", "in", scopeIds)
-        .where(accessPrincipalPredicateSql("access_scope_members", principals))
-        .execute();
-    })(),
-    emailValues.length === 0
-      ? Promise.resolve([])
-      : db
-          .selectFrom("file_share_emails")
-          .select(["indexed_file_id", "email"])
-          .where("indexed_file_id", "in", fileIds)
-          .where("email", "in", emailValues)
-          .execute(),
-    // Entity-share propagation: a file is accessible if it mentions any entity
-    // that is shared with the viewer (or share_with_everyone). Read-time only.
-    db
-      .selectFrom("entity_mentions")
-      .innerJoin("entities", "entities.id", "entity_mentions.entity_id")
-      .leftJoin("entity_share_emails", (join) => {
-        const condition = join.onRef("entity_share_emails.entity_id", "=", "entities.id");
-        return emailValues.length > 0 ? condition.on("entity_share_emails.email", "in", emailValues) : condition;
-      })
-      .select(["entity_mentions.indexed_file_id"])
-      .where("entity_mentions.indexed_file_id", "in", fileIds)
-      .where(whereLiveEntity())
-      .where((eb) =>
-        eb.or([
-          eb("entities.share_with_everyone", "=", 1),
-          ...(emailValues.length > 0 ? [eb("entity_share_emails.email", "is not", null)] : []),
-        ]),
-      )
-      .execute(),
-  ]);
-
-  const principalSet = new Set(principals.map((principal) => `${principal.type}\0${principal.value}`));
-  const fileAccessByFile = new Map<string, Set<string>>();
-  for (const row of fileAccessRows) {
-    const set = fileAccessByFile.get(row.indexed_file_id) ?? new Set<string>();
-    set.add(`${row.principal_type}\0${row.principal_value}`);
-    fileAccessByFile.set(row.indexed_file_id, set);
-  }
-  const scopeMemberByScope = new Map<string, Set<string>>();
-  for (const row of scopeMemberRows) {
-    const set = scopeMemberByScope.get(row.access_scope_id) ?? new Set<string>();
-    set.add(`${row.principal_type}\0${row.principal_value}`);
-    scopeMemberByScope.set(row.access_scope_id, set);
-  }
-  const manualSharesByFile = new Set<string>();
-  for (const row of shareRows) {
-    manualSharesByFile.add(row.indexed_file_id);
-  }
-  const entityPropByFile = new Set<string>();
-  for (const row of entityPropRows) {
-    entityPropByFile.add(row.indexed_file_id);
-  }
-
-  const allowed = new Set<string>();
-  for (const file of files) {
-    /**
-     * Archived files are invisible regardless of tier. Archival severs the
-     * scope and per-file grants, which would otherwise flip the file into
-     * the unrestricted no-scope tier below — the opposite of the intent.
-     */
-    if (file.is_archived === 1) continue;
-
-    if (file.share_with_everyone === 1) {
-      allowed.add(file.id);
-      continue;
-    }
-
-    const perFile = fileAccessByFile.get(file.id);
-    const isChatSource = slackEntitySyncEnabled && (file.source === "slack" || file.source === "whatsapp");
-    const hasScope = file.access_scope_id != null;
-    const hasFileAccess = (perFile?.size ?? 0) > 0;
-
-    if (!isChatSource && !hasScope && !hasFileAccess) {
-      allowed.add(file.id);
-      continue;
-    }
-
-    if (hasScope && file.access_scope_id) {
-      const scopeMembers = scopeMemberByScope.get(file.access_scope_id);
-      if (scopeMembers && [...scopeMembers].some((principal) => principalSet.has(principal))) {
-        allowed.add(file.id);
-        continue;
-      }
-    }
-
-    if (!isChatSource && hasFileAccess && perFile) {
-      let matched = false;
-      for (const principal of principalSet) {
-        if (perFile.has(principal)) {
-          allowed.add(file.id);
-          matched = true;
-          break;
-        }
-      }
-      if (matched) continue;
-    }
-
-    if (manualSharesByFile.has(file.id)) {
-      allowed.add(file.id);
-      continue;
-    }
-
-    if (entityPropByFile.has(file.id)) {
-      allowed.add(file.id);
-    }
-  }
-  return allowed;
+  return new Set(files.map((file) => file.id));
 }
 
 /**

--- a/packages/server/src/connectors/types.test.ts
+++ b/packages/server/src/connectors/types.test.ts
@@ -7,4 +7,23 @@ describe("normalizeAccessPrincipals", () => {
       { type: "email", value: "alice@example.com" },
     ]);
   });
+
+  it("canonicalizes phone, Slack user, and WhatsApp LID values", () => {
+    expect(
+      normalizeAccessPrincipals([
+        { type: "phone", value: "+91 9101299347" },
+        { type: "slack_user", value: "  U-RAW  " },
+        { type: "whatsapp_lid", value: "12345:7@LID" },
+        { type: "phone", value: "+919101299347" },
+      ]),
+    ).toEqual([
+      { type: "phone", value: "+919101299347" },
+      { type: "slack_user", value: "U-RAW" },
+      { type: "whatsapp_lid", value: "12345@lid" },
+    ]);
+  });
+
+  it("drops invalid phones instead of constructing empty-string principals", () => {
+    expect(normalizeAccessPrincipals([{ type: "phone", value: "not-a-phone" }])).toEqual([]);
+  });
 });

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -9,6 +9,11 @@
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
 import type { DB } from "../db/schema";
+import {
+  normalizeSlackIdentityUserId,
+  normalizeWhatsAppIdentityLid,
+  normalizeWhatsAppIdentityPhone,
+} from "../identity-normalization";
 import type { SlackIndexingFacade } from "../slack/indexing-facade";
 import type { GeminiGenerator } from "./gemini-generate";
 
@@ -49,26 +54,28 @@ export interface AccessPrincipal {
 export type AccessPrincipalInput = AccessPrincipal | string;
 
 export function normalizeAccessPrincipals(principals: AccessPrincipalInput[]): AccessPrincipal[] {
-  const normalized = principals.map((principal) =>
-    typeof principal === "string"
-      ? { type: "email" as const, value: principal.trim().toLowerCase() }
-      : principal.type === "email"
-        ? { ...principal, value: principal.value.trim().toLowerCase() }
-        : principal,
-  );
-  return [
-    ...new Map(
-      normalized
-        .filter((principal) => principal.value)
-        .map((principal) => [`${principal.type}\0${principal.value}`, principal]),
-    ).values(),
-  ];
+  const normalized = principals.flatMap((principal): AccessPrincipal[] => {
+    if (typeof principal === "string") {
+      const value = principal.trim().toLowerCase();
+      return value ? [{ type: "email", value }] : [];
+    }
+    const value =
+      principal.type === "email"
+        ? principal.value.trim().toLowerCase()
+        : principal.type === "phone"
+          ? normalizeWhatsAppIdentityPhone(principal.value)
+          : principal.type === "slack_user"
+            ? normalizeSlackIdentityUserId(principal.value)
+            : normalizeWhatsAppIdentityLid(principal.value);
+    return value ? [{ type: principal.type, value }] : [];
+  });
+  return [...new Map(normalized.map((principal) => [`${principal.type}\0${principal.value}`, principal])).values()];
 }
 
 export function toEmailPrincipals(emails: string[]): AccessPrincipal[] {
-  return [...new Set(emails.map((email) => email.trim().toLowerCase()).filter((email) => email.length > 0))]
-    .sort()
-    .map((value) => ({ type: "email", value }));
+  return normalizeAccessPrincipals(emails).sort((left, right) =>
+    left.value < right.value ? -1 : left.value > right.value ? 1 : 0,
+  );
 }
 
 export type HierarchyTarget = "team" | "project" | "sprint" | "ignore";

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -23,6 +23,9 @@ import {
 import { normalizeSourceTimestampForStorage } from "../../timestamps";
 import { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../../whatsapp/identity-resolution";
 import type { DB } from "../schema";
+import { fileVisibilityRuleSql } from "./file-visibility-rule";
+
+export { accessPrincipalPredicateSql } from "./file-visibility-rule";
 
 /**
  * File-list viewer for RBAC. Admins bypass; others match by email.
@@ -54,22 +57,6 @@ export function viewerPrincipals(viewer: FileViewer): AccessPrincipal[] {
   const whatsappLid = normalizeWhatsAppIdentityLid(viewer.whatsappLid);
   if (whatsappLid) principals.push({ type: "whatsapp_lid", value: whatsappLid });
   return [...new Map(principals.map((principal) => [`${principal.type}\u0000${principal.value}`, principal])).values()];
-}
-
-export function accessPrincipalPredicateSql(alias: string, principals: AccessPrincipal[]) {
-  if (principals.length === 0) return sql<boolean>`0 = 1`;
-  const column = sql.raw(alias);
-  return sql<boolean>`(${sql.join(
-    principals.map(
-      (principal) =>
-        sql`${column}.principal_type = ${principal.type} AND ${column}.principal_value = ${principal.value}`,
-    ),
-    sql` OR `,
-  )})`;
-}
-
-function emailValuesForPrincipals(principals: AccessPrincipal[]): string[] {
-  return principals.filter((principal) => principal.type === "email").map((principal) => principal.value);
 }
 
 type ResolvedPrincipal = { userId: string; userName: string | null; email: string | null };
@@ -181,54 +168,12 @@ async function loadPrincipalResolution(
  * planner sees mutually-recursive EXISTS chains.
  */
 export function fileVisibilityPredicate(viewer: FileViewer, alias = "indexed_files") {
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(alias)) {
-    throw new Error(`fileVisibilityPredicate: invalid table alias "${alias}"`);
-  }
-  const t = sql.raw(alias);
-  const principals = viewerPrincipals(viewer);
-  const emailValues = emailValuesForPrincipals(principals);
-  const emailSql =
-    emailValues.length > 0
-      ? sql.join(
-          emailValues.map((email) => sql`${email}`),
-          sql`,`,
-        )
-      : null;
-  const accessDoor =
-    (viewer.slackEntitySyncEnabled ?? true)
-      ? sql`(${t}.source IS NULL OR ${t}.source NOT IN ('slack', 'whatsapp'))`
-      : sql`1 = 1`;
-  const scopeDoor = sql`EXISTS (SELECT 1 FROM access_scope_members asm
-               WHERE asm.access_scope_id = ${t}.access_scope_id
-                 AND ${accessPrincipalPredicateSql("asm", principals)})`;
-  const fileDoor = sql`EXISTS (SELECT 1 FROM file_access fa
-                   WHERE fa.indexed_file_id = ${t}.id
-                     AND ${accessPrincipalPredicateSql("fa", principals)})`;
-  const shareDoor = emailSql
-    ? sql`EXISTS (SELECT 1 FROM file_share_emails fse
-               WHERE fse.indexed_file_id = ${t}.id
-                 AND fse.email IN (${emailSql}))`
-    : sql`0 = 1`;
-  const entityShareDoor = sql`EXISTS (
-      SELECT 1 FROM entity_mentions em_shared
-      INNER JOIN entities ent_shared ON ent_shared.id = em_shared.entity_id
-      LEFT JOIN entity_share_emails ese
-        ON ese.entity_id = ent_shared.id ${emailSql ? sql`AND ese.email IN (${emailSql})` : sql``}
-      WHERE em_shared.indexed_file_id = ${t}.id
-        AND ent_shared.deleted_at IS NULL
-        AND ent_shared.merged_into_entity_id IS NULL
-        AND (ent_shared.share_with_everyone = 1 OR ${emailSql ? sql`ese.email IS NOT NULL` : sql`0 = 1`})
-    )`;
-  return sql<boolean>`(
-    (${accessDoor}
-      AND ${t}.access_scope_id IS NULL
-      AND NOT EXISTS (SELECT 1 FROM file_access fa WHERE fa.indexed_file_id = ${t}.id))
-    OR ${scopeDoor}
-    OR (${accessDoor} AND ${fileDoor})
-    OR ${shareDoor}
-    OR ${t}.share_with_everyone = 1
-    OR ${entityShareDoor}
-  )`;
+  return fileVisibilityRuleSql({
+    principals: viewerPrincipals(viewer),
+    slackEntitySyncEnabled: viewer.slackEntitySyncEnabled ?? true,
+    archived: "include",
+    alias,
+  });
 }
 
 function decodeConnectorConfigRow<T extends { credentials: string }>(row: T, encryptionKey?: string): T {

--- a/packages/server/src/db/repositories/connectors.ts
+++ b/packages/server/src/db/repositories/connectors.ts
@@ -20,8 +20,12 @@ import {
   type SyncStatus,
   normalizeAccessPrincipals,
 } from "../../connectors/types";
+import {
+  normalizeSlackIdentityUserId,
+  normalizeWhatsAppIdentityLid,
+  normalizeWhatsAppIdentityPhone,
+} from "../../identity-normalization";
 import { normalizeSourceTimestampForStorage } from "../../timestamps";
-import { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../../whatsapp/identity-resolution";
 import type { DB } from "../schema";
 import { fileVisibilityRuleSql } from "./file-visibility-rule";
 
@@ -44,19 +48,17 @@ export interface FileViewer {
 }
 
 export function viewerPrincipals(viewer: FileViewer): AccessPrincipal[] {
-  const principals: AccessPrincipal[] = [];
-  const emails = new Set([viewer.email, ...(viewer.emails ?? [])]);
-  for (const email of emails) {
-    const value = email?.trim().toLowerCase();
-    if (value) principals.push({ type: "email", value });
+  const principals: AccessPrincipalInput[] = [];
+  if (viewer.email !== null) principals.push(viewer.email);
+  principals.push(...(viewer.emails ?? []));
+  if (viewer.phone !== null && viewer.phone !== undefined) principals.push({ type: "phone", value: viewer.phone });
+  if (viewer.slackUserId !== null && viewer.slackUserId !== undefined) {
+    principals.push({ type: "slack_user", value: viewer.slackUserId });
   }
-  const phone = normalizeWhatsAppIdentityPhone(viewer.phone);
-  if (phone) principals.push({ type: "phone", value: phone });
-  const slackUserId = viewer.slackUserId?.trim();
-  if (slackUserId) principals.push({ type: "slack_user", value: slackUserId });
-  const whatsappLid = normalizeWhatsAppIdentityLid(viewer.whatsappLid);
-  if (whatsappLid) principals.push({ type: "whatsapp_lid", value: whatsappLid });
-  return [...new Map(principals.map((principal) => [`${principal.type}\u0000${principal.value}`, principal])).values()];
+  if (viewer.whatsappLid !== null && viewer.whatsappLid !== undefined) {
+    principals.push({ type: "whatsapp_lid", value: viewer.whatsappLid });
+  }
+  return normalizeAccessPrincipals(principals);
 }
 
 type ResolvedPrincipal = { userId: string; userName: string | null; email: string | null };
@@ -69,7 +71,7 @@ function principalLookupKey(type: string, value: string): string {
         ? (normalizeWhatsAppIdentityPhone(value) ?? value.trim())
         : type === "whatsapp_lid"
           ? (normalizeWhatsAppIdentityLid(value) ?? value.trim())
-          : value.trim();
+          : (normalizeSlackIdentityUserId(value) ?? "");
   return `${type}\u0000${normalized}`;
 }
 

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -7,6 +7,7 @@ import { normalizeEntityMatchName } from "../../entities/match-normalize";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../../entities/profile-facts";
 import type { ProvenanceTier } from "../../entities/provenance";
 import { resolveLiveEntity, resolveLiveEntityId, resolveSourceRefToLiveEntityId } from "../../entities/redirect";
+import { normalizePhoneLike } from "../../identity-normalization";
 import { yieldToEventLoop } from "../../lib/event-loop";
 import { parseTimestampMs } from "../../timestamps";
 import { isPg } from "../dialect";
@@ -228,16 +229,6 @@ export interface CreateMentionData {
   confidence: EntityMentionConfidence;
   source: string;
   relation: EntityMentionRelation;
-}
-
-function normalizePhoneLike(value: string): string {
-  const trimmed = value.trim();
-  const compact = trimmed.replace(/[\s().-]/g, "");
-  const withPlus = compact.startsWith("00") ? `+${compact.slice(2)}` : compact;
-  if (!/^\+[1-9]\d{7,14}$/.test(withPlus)) {
-    throw new Error("Phone contact points must be E.164, for example +14155551234");
-  }
-  return withPlus;
 }
 
 function normalizeLinkedin(value: string): string {

--- a/packages/server/src/db/repositories/file-visibility-rule.ts
+++ b/packages/server/src/db/repositories/file-visibility-rule.ts
@@ -1,0 +1,138 @@
+import type { RawBuilder } from "kysely";
+import { sql } from "kysely";
+import type { AccessPrincipal } from "../../connectors/types";
+
+export interface VisibilityRuleInput {
+  principals: AccessPrincipal[];
+  slackEntitySyncEnabled: boolean;
+  archived: "exclude" | "include";
+  alias?: string;
+}
+
+export interface EntityShareGrant {
+  entity_id: string;
+  grant_kind: "org_wide" | "email";
+}
+
+const VALID_ALIAS = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function fileAlias(input: VisibilityRuleInput): RawBuilder<unknown> {
+  const alias = input.alias ?? "indexed_files";
+  if (!VALID_ALIAS.test(alias)) {
+    throw new Error(`fileVisibilityPredicate: invalid table alias "${alias}"`);
+  }
+  return sql.raw(alias);
+}
+
+function emailSql(principals: AccessPrincipal[]): RawBuilder<unknown> | null {
+  const emails = principals.filter((principal) => principal.type === "email").map((principal) => principal.value);
+  return emails.length > 0
+    ? sql.join(
+        emails.map((email) => sql`${email}`),
+        sql`,`,
+      )
+    : null;
+}
+
+function accessDoor(input: VisibilityRuleInput, alias: RawBuilder<unknown>): RawBuilder<boolean> {
+  return input.slackEntitySyncEnabled
+    ? sql<boolean>`(${alias}.source IS NULL OR ${alias}.source NOT IN ('slack', 'whatsapp'))`
+    : sql<boolean>`1 = 1`;
+}
+
+export function accessPrincipalPredicateSql(alias: string, principals: AccessPrincipal[]): RawBuilder<boolean> {
+  if (principals.length === 0) return sql<boolean>`0 = 1`;
+  const column = sql.raw(alias);
+  return sql<boolean>`(${sql.join(
+    principals.map(
+      (principal) =>
+        sql`${column}.principal_type = ${principal.type} AND ${column}.principal_value = ${principal.value}`,
+    ),
+    sql` OR `,
+  )})`;
+}
+
+export function unrestrictedDoorSql(input: VisibilityRuleInput): RawBuilder<boolean> {
+  const alias = fileAlias(input);
+  return sql<boolean>`(${accessDoor(input, alias)}
+    AND ${alias}.access_scope_id IS NULL
+    AND NOT EXISTS (SELECT 1 FROM file_access fa WHERE fa.indexed_file_id = ${alias}.id))`;
+}
+
+export function scopeMembershipDoorSql(input: VisibilityRuleInput): RawBuilder<boolean> {
+  const alias = fileAlias(input);
+  return sql<boolean>`EXISTS (SELECT 1 FROM access_scope_members asm
+    WHERE asm.access_scope_id = ${alias}.access_scope_id
+      AND ${alias}.access_scope_id <> ''
+      AND ${accessPrincipalPredicateSql("asm", input.principals)})`;
+}
+
+export function perFileAccessDoorSql(input: VisibilityRuleInput): RawBuilder<boolean> {
+  const alias = fileAlias(input);
+  return sql<boolean>`(${accessDoor(input, alias)} AND EXISTS (SELECT 1 FROM file_access fa
+    WHERE fa.indexed_file_id = ${alias}.id
+      AND ${accessPrincipalPredicateSql("fa", input.principals)}))`;
+}
+
+export function manualShareDoorSql(input: VisibilityRuleInput): RawBuilder<boolean> {
+  const alias = fileAlias(input);
+  const emails = emailSql(input.principals);
+  return emails
+    ? sql<boolean>`EXISTS (SELECT 1 FROM file_share_emails fse
+        WHERE fse.indexed_file_id = ${alias}.id
+          AND fse.email IN (${emails}))`
+    : sql<boolean>`0 = 1`;
+}
+
+export function fileOrgWideDoorSql(input: VisibilityRuleInput): RawBuilder<boolean> {
+  const alias = fileAlias(input);
+  return sql<boolean>`${alias}.share_with_everyone = 1`;
+}
+
+export function entityShareDoorSql(input: VisibilityRuleInput): RawBuilder<boolean> {
+  const alias = fileAlias(input);
+  const emails = emailSql(input.principals);
+  return sql<boolean>`EXISTS (
+    SELECT 1 FROM entity_mentions em_shared
+    INNER JOIN entities ent_shared ON ent_shared.id = em_shared.entity_id
+    LEFT JOIN entity_share_emails ese
+      ON ese.entity_id = ent_shared.id ${emails ? sql`AND ese.email IN (${emails})` : sql``}
+    WHERE em_shared.indexed_file_id = ${alias}.id
+      AND ent_shared.deleted_at IS NULL
+      AND ent_shared.merged_into_entity_id IS NULL
+      AND (ent_shared.share_with_everyone = 1 OR ${emails ? sql`ese.email IS NOT NULL` : sql`0 = 1`})
+  )`;
+}
+
+export function entityShareGrantsSql(fileId: string): RawBuilder<EntityShareGrant> {
+  return sql<EntityShareGrant>`WITH shared_entities AS (
+    SELECT DISTINCT ent_grant.id AS entity_id, ent_grant.share_with_everyone, ese_grant.email
+    FROM entity_mentions em_grant
+    INNER JOIN entities ent_grant ON ent_grant.id = em_grant.entity_id
+    LEFT JOIN entity_share_emails ese_grant ON ese_grant.entity_id = ent_grant.id
+    WHERE em_grant.indexed_file_id = ${fileId}
+      AND ent_grant.deleted_at IS NULL
+      AND ent_grant.merged_into_entity_id IS NULL
+      AND (ent_grant.share_with_everyone = 1 OR ese_grant.email IS NOT NULL)
+  )
+  SELECT DISTINCT entity_id, 'org_wide' AS grant_kind
+  FROM shared_entities
+  WHERE share_with_everyone = 1
+  UNION
+  SELECT DISTINCT entity_id, 'email' AS grant_kind
+  FROM shared_entities
+  WHERE email IS NOT NULL`;
+}
+
+export function fileVisibilityRuleSql(input: VisibilityRuleInput): RawBuilder<boolean> {
+  const alias = fileAlias(input);
+  const doors = sql<boolean>`(
+    ${unrestrictedDoorSql(input)}
+    OR ${scopeMembershipDoorSql(input)}
+    OR ${perFileAccessDoorSql(input)}
+    OR ${manualShareDoorSql(input)}
+    OR ${fileOrgWideDoorSql(input)}
+    OR ${entityShareDoorSql(input)}
+  )`;
+  return input.archived === "exclude" ? sql<boolean>`(${alias}.is_archived = 0 AND ${doors})` : doors;
+}

--- a/packages/server/src/db/repositories/file-visibility.test.ts
+++ b/packages/server/src/db/repositories/file-visibility.test.ts
@@ -11,10 +11,21 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { fileAccessFilterSql, filterAccessibleFileIds, getFileContent } from "../../connectors/search";
+import type { AccessPrincipalInput } from "../../connectors/types";
 import { createTestDb } from "../../test-utils";
 import type { DB } from "../schema";
 import { type FileViewer, createConnectorRepository, fileVisibilityPredicate } from "./connectors";
 import { createEntityRepository } from "./entities";
+import {
+  type VisibilityRuleInput,
+  entityShareDoorSql,
+  entityShareGrantsSql,
+  fileOrgWideDoorSql,
+  manualShareDoorSql,
+  perFileAccessDoorSql,
+  scopeMembershipDoorSql,
+  unrestrictedDoorSql,
+} from "./file-visibility-rule";
 
 describe("file-visibility predicate (RBAC for file list/count)", () => {
   let db: Kysely<DB>;
@@ -98,6 +109,30 @@ describe("file-visibility predicate (RBAC for file list/count)", () => {
   const member = (email: string): FileViewer => ({ email, isAdmin: false });
   const adminViewer: FileViewer = { email: "admin@example.com", isAdmin: true };
   const nullEmail: FileViewer = { email: null, isAdmin: false };
+  const accessByEntryPoint = async (fileId: string, principalInput: AccessPrincipalInput[], viewer: FileViewer) => {
+    const slackEntitySyncEnabled = viewer.slackEntitySyncEnabled ?? true;
+    const predicateVisible = await db
+      .selectFrom("indexed_files")
+      .select("id")
+      .where(fileVisibilityPredicate(viewer))
+      .where("id", "=", fileId)
+      .executeTakeFirst();
+    const filterSqlVisible = await db
+      .selectFrom("indexed_files")
+      .select("id")
+      .where(fileAccessFilterSql(principalInput, slackEntitySyncEnabled))
+      .where("id", "=", fileId)
+      .executeTakeFirst();
+    const visibleByIds = await filterAccessibleFileIds(db, [fileId], principalInput, slackEntitySyncEnabled);
+    const visibleByContent = await getFileContent(db, fileId, principalInput, slackEntitySyncEnabled);
+
+    return {
+      fileVisibilityPredicate: predicateVisible !== undefined,
+      fileAccessFilterSql: filterSqlVisible !== undefined,
+      getFileContent: visibleByContent !== null,
+      filterAccessibleFileIds: visibleByIds.has(fileId),
+    };
+  };
 
   describe("listAllFiles", () => {
     it("admin sees every file", async () => {
@@ -438,42 +473,447 @@ describe("file-visibility predicate (RBAC for file list/count)", () => {
 
     const slackOnly = [{ type: "slack_user" as const, value: "U-NO-EMAIL" }];
     const nullEmailWebViewer: FileViewer = { email: null, slackUserId: "U-NO-EMAIL", isAdmin: false };
-    const accessByEntryPoint = async (fileId: string) => {
-      const predicateVisible = await db
-        .selectFrom("indexed_files")
-        .select("id")
-        .where(fileVisibilityPredicate(nullEmailWebViewer))
-        .where("id", "=", fileId)
-        .executeTakeFirst();
-      const filterSqlVisible = await db
-        .selectFrom("indexed_files")
-        .select("id")
-        .where(fileAccessFilterSql(slackOnly))
-        .where("id", "=", fileId)
-        .executeTakeFirst();
-      const visibleByIds = await filterAccessibleFileIds(db, [fileId], slackOnly);
-      const visibleByContent = await getFileContent(db, fileId, slackOnly);
 
-      return {
-        fileVisibilityPredicate: predicateVisible !== undefined,
-        fileAccessFilterSql: filterSqlVisible !== undefined,
-        getFileContent: visibleByContent !== null,
-        filterAccessibleFileIds: visibleByIds.has(fileId),
-      };
-    };
-
-    expect(await accessByEntryPoint("f-entity-share-individual")).toEqual({
+    expect(await accessByEntryPoint("f-entity-share-individual", slackOnly, nullEmailWebViewer)).toEqual({
       fileVisibilityPredicate: false,
       fileAccessFilterSql: false,
       getFileContent: false,
       filterAccessibleFileIds: false,
     });
-    expect(await accessByEntryPoint("f-entity-share-everyone")).toEqual({
+    expect(await accessByEntryPoint("f-entity-share-everyone", slackOnly, nullEmailWebViewer)).toEqual({
       fileVisibilityPredicate: true,
       fileAccessFilterSql: true,
       getFileContent: true,
       filterAccessibleFileIds: true,
     });
+  });
+
+  it("keeps all four entry points aligned across every visibility door and chat scope shape", async () => {
+    const now = new Date().toISOString();
+    const viewerEmail = "rule-viewer@example.com";
+    const viewer = member(viewerEmail);
+    const principals = [viewerEmail];
+    const baseFile = {
+      connector_config_id: "cfg",
+      file_name: "rule fixture",
+      file_type: "doc",
+      content_category: "document" as const,
+      source: "google_drive",
+      content: "rule fixture content",
+      is_archived: 0 as const,
+      synced_at: now,
+      share_with_everyone: 0 as const,
+    };
+
+    await db
+      .insertInto("users")
+      .values({ id: "rule-admin", name: "Rule Admin", email: "rule-admin@example.com" })
+      .execute();
+    await db
+      .insertInto("access_scopes")
+      .values([
+        {
+          id: "scope-rule-member",
+          connector_config_id: "cfg",
+          scope_type: "drive",
+          provider_scope_id: "rule-member",
+        },
+        {
+          id: "scope-rule-nonmember",
+          connector_config_id: "cfg",
+          scope_type: "drive",
+          provider_scope_id: "rule-nonmember",
+        },
+        {
+          id: "scope-rule-chat",
+          connector_config_id: "cfg",
+          scope_type: "slack_channel",
+          provider_scope_id: "rule-chat",
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("access_scope_members")
+      .values([
+        { access_scope_id: "scope-rule-member", principal_type: "email", principal_value: viewerEmail },
+        { access_scope_id: "scope-rule-nonmember", principal_type: "email", principal_value: "other@example.com" },
+        { access_scope_id: "scope-rule-chat", principal_type: "email", principal_value: viewerEmail },
+      ])
+      .execute();
+    await db
+      .insertInto("indexed_files")
+      .values([
+        {
+          id: "f-rule-unrestricted",
+          ...baseFile,
+          provider_file_id: "rule-unrestricted",
+          content_hash: "rule-unrestricted-hash",
+        },
+        {
+          id: "f-rule-scope-member",
+          ...baseFile,
+          provider_file_id: "rule-scope-member",
+          content_hash: "rule-scope-member-hash",
+          access_scope_id: "scope-rule-member",
+        },
+        {
+          id: "f-rule-scope-nonmember",
+          ...baseFile,
+          provider_file_id: "rule-scope-nonmember",
+          content_hash: "rule-scope-nonmember-hash",
+          access_scope_id: "scope-rule-nonmember",
+        },
+        {
+          id: "f-rule-per-file",
+          ...baseFile,
+          provider_file_id: "rule-per-file",
+          content_hash: "rule-per-file-hash",
+        },
+        {
+          id: "f-rule-manual",
+          ...baseFile,
+          provider_file_id: "rule-manual",
+          content_hash: "rule-manual-hash",
+          access_scope_id: "scope-rule-nonmember",
+        },
+        {
+          id: "f-rule-org-wide",
+          ...baseFile,
+          provider_file_id: "rule-org-wide",
+          content_hash: "rule-org-wide-hash",
+          access_scope_id: "scope-rule-nonmember",
+          share_with_everyone: 1,
+        },
+        {
+          id: "f-rule-entity-email",
+          ...baseFile,
+          provider_file_id: "rule-entity-email",
+          content_hash: "rule-entity-email-hash",
+          access_scope_id: "scope-rule-nonmember",
+        },
+        {
+          id: "f-rule-entity-org",
+          ...baseFile,
+          provider_file_id: "rule-entity-org",
+          content_hash: "rule-entity-org-hash",
+          access_scope_id: "scope-rule-nonmember",
+        },
+        {
+          id: "f-rule-chat-scope",
+          ...baseFile,
+          provider_file_id: "rule-chat-scope",
+          content_hash: "rule-chat-scope-hash",
+          source: "slack",
+          access_scope_id: "scope-rule-chat",
+        },
+        {
+          id: "f-rule-chat-no-scope",
+          ...baseFile,
+          provider_file_id: "rule-chat-no-scope",
+          content_hash: "rule-chat-no-scope-hash",
+          source: "slack",
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("file_access")
+      .values({ indexed_file_id: "f-rule-per-file", principal_type: "email", principal_value: viewerEmail })
+      .execute();
+    await db
+      .insertInto("file_share_emails")
+      .values({ indexed_file_id: "f-rule-manual", email: viewerEmail, granted_by_user_id: "rule-admin" })
+      .execute();
+    await db
+      .insertInto("entities")
+      .values([
+        {
+          id: "ent-rule-email",
+          name: "Rule Email Entity",
+          source_type: "manual",
+          subtype: null,
+          aliases: null,
+          metadata: null,
+          source_ref_id: null,
+          status: "confirmed",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+          share_with_everyone: 0,
+          deleted_at: null,
+          merged_into_entity_id: null,
+        },
+        {
+          id: "ent-rule-org",
+          name: "Rule Org Entity",
+          source_type: "manual",
+          subtype: null,
+          aliases: null,
+          metadata: null,
+          source_ref_id: null,
+          status: "confirmed",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+          share_with_everyone: 1,
+          deleted_at: null,
+          merged_into_entity_id: null,
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("entity_mentions")
+      .values([
+        {
+          id: "mention-rule-email",
+          entity_id: "ent-rule-email",
+          indexed_file_id: "f-rule-entity-email",
+          chunk_index: null,
+          context_snippet: null,
+          confidence: "EXTRACTED",
+          source: "test",
+          relation: "mentioned",
+          mentioned_at: now,
+        },
+        {
+          id: "mention-rule-org",
+          entity_id: "ent-rule-org",
+          indexed_file_id: "f-rule-entity-org",
+          chunk_index: null,
+          context_snippet: null,
+          confidence: "EXTRACTED",
+          source: "test",
+          relation: "mentioned",
+          mentioned_at: now,
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("entity_share_emails")
+      .values({ entity_id: "ent-rule-email", email: viewerEmail, granted_by_user_id: "rule-admin" })
+      .execute();
+
+    const fixtures = [
+      ["f-rule-unrestricted", true],
+      ["f-rule-scope-member", true],
+      ["f-rule-scope-nonmember", false],
+      ["f-rule-per-file", true],
+      ["f-rule-manual", true],
+      ["f-rule-org-wide", true],
+      ["f-rule-entity-email", true],
+      ["f-rule-entity-org", true],
+      ["f-rule-chat-scope", true],
+      ["f-rule-chat-no-scope", false],
+    ] as const;
+
+    for (const [fileId, expected] of fixtures) {
+      expect(await accessByEntryPoint(fileId, principals, viewer), fileId).toEqual({
+        fileVisibilityPredicate: expected,
+        fileAccessFilterSql: expected,
+        getFileContent: expected,
+        filterAccessibleFileIds: expected,
+      });
+    }
+
+    await expect(entityShareGrantsSql("f-rule-entity-email").execute(db)).resolves.toMatchObject({
+      rows: [{ entity_id: "ent-rule-email", grant_kind: "email" }],
+    });
+    await expect(entityShareGrantsSql("f-rule-entity-org").execute(db)).resolves.toMatchObject({
+      rows: [{ entity_id: "ent-rule-org", grant_kind: "org_wide" }],
+    });
+  });
+
+  it("preserves the archived divergence between SQL predicates and direct access paths", async () => {
+    await db
+      .insertInto("indexed_files")
+      .values({
+        id: "f-rule-archived",
+        connector_config_id: "cfg",
+        provider_file_id: "rule-archived",
+        file_name: "archived",
+        file_type: "doc",
+        content_category: "document",
+        source: "google_drive",
+        content: "archived content",
+        content_hash: "rule-archived-hash",
+        is_archived: 1,
+        synced_at: new Date().toISOString(),
+      })
+      .execute();
+
+    expect(
+      await accessByEntryPoint("f-rule-archived", ["archive-viewer@example.com"], member("archive-viewer@example.com")),
+    ).toEqual({
+      fileVisibilityPredicate: true,
+      fileAccessFilterSql: true,
+      getFileContent: false,
+      filterAccessibleFileIds: false,
+    });
+  });
+
+  it("validates aliases in every independently exported visibility door", () => {
+    const input: VisibilityRuleInput = {
+      principals: [],
+      slackEntitySyncEnabled: true,
+      archived: "include",
+      alias: "indexed-files",
+    };
+    for (const door of [
+      unrestrictedDoorSql,
+      scopeMembershipDoorSql,
+      perFileAccessDoorSql,
+      manualShareDoorSql,
+      fileOrgWideDoorSql,
+      entityShareDoorSql,
+    ]) {
+      expect(() => door(input)).toThrow('invalid table alias "indexed-files"');
+    }
+  });
+
+  it("keeps an empty scope id scoped but unmatchable across all four entry points", async () => {
+    await db
+      .insertInto("access_scopes")
+      .values({ id: "", connector_config_id: "cfg", scope_type: "drive", provider_scope_id: "empty-scope" })
+      .execute();
+    await db
+      .insertInto("access_scope_members")
+      .values({ access_scope_id: "", principal_type: "email", principal_value: "empty-scope@example.com" })
+      .execute();
+    await db
+      .insertInto("indexed_files")
+      .values({
+        id: "f-rule-empty-scope",
+        connector_config_id: "cfg",
+        provider_file_id: "rule-empty-scope",
+        file_name: "empty scope",
+        file_type: "doc",
+        content_category: "document",
+        source: "google_drive",
+        content: "empty scope content",
+        content_hash: "rule-empty-scope-hash",
+        is_archived: 0,
+        synced_at: new Date().toISOString(),
+        access_scope_id: "",
+      })
+      .execute();
+
+    await expect(
+      accessByEntryPoint("f-rule-empty-scope", ["empty-scope@example.com"], member("empty-scope@example.com")),
+    ).resolves.toEqual({
+      fileVisibilityPredicate: false,
+      fileAccessFilterSql: false,
+      getFileContent: false,
+      filterAccessibleFileIds: false,
+    });
+  });
+
+  it("preserves the empty-principal boundary divergence", async () => {
+    await expect(accessByEntryPoint("f-unrestricted", [], nullEmail)).resolves.toEqual({
+      fileVisibilityPredicate: true,
+      fileAccessFilterSql: true,
+      getFileContent: false,
+      filterAccessibleFileIds: false,
+    });
+  });
+
+  it("keeps Slack user and WhatsApp LID scope access aligned across all four entry points", async () => {
+    const now = new Date().toISOString();
+    const baseFile = {
+      connector_config_id: "cfg",
+      file_name: "typed scope fixture",
+      file_type: "doc",
+      content_category: "document" as const,
+      content: "typed scope content",
+      content_hash: "typed-scope-hash",
+      is_archived: 0 as const,
+      synced_at: now,
+    };
+    await db
+      .insertInto("access_scopes")
+      .values([
+        {
+          id: "scope-rule-slack-user",
+          connector_config_id: "cfg",
+          scope_type: "slack_channel",
+          provider_scope_id: "typed-slack",
+        },
+        {
+          id: "scope-rule-whatsapp-lid",
+          connector_config_id: "cfg",
+          scope_type: "whatsapp_group",
+          provider_scope_id: "typed-lid",
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("access_scope_members")
+      .values([
+        { access_scope_id: "scope-rule-slack-user", principal_type: "slack_user", principal_value: "U-RULE" },
+        {
+          access_scope_id: "scope-rule-whatsapp-lid",
+          principal_type: "whatsapp_lid",
+          principal_value: "98765@lid",
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("indexed_files")
+      .values([
+        {
+          id: "f-rule-slack-scoped",
+          ...baseFile,
+          provider_file_id: "rule-slack-scoped",
+          source: "slack",
+          access_scope_id: "scope-rule-slack-user",
+        },
+        {
+          id: "f-rule-whatsapp-scoped",
+          ...baseFile,
+          provider_file_id: "rule-whatsapp-scoped",
+          source: "whatsapp",
+          access_scope_id: "scope-rule-whatsapp-lid",
+        },
+        {
+          id: "f-rule-slack-unscoped",
+          ...baseFile,
+          provider_file_id: "rule-slack-unscoped",
+          source: "slack",
+        },
+      ])
+      .execute();
+
+    const slackMember = [{ type: "slack_user" as const, value: "U-RULE" }];
+    const slackNonmember = [{ type: "slack_user" as const, value: "U-OUTSIDER" }];
+    const slackMemberViewer: FileViewer = { email: null, slackUserId: "U-RULE", isAdmin: false };
+    const slackNonmemberViewer: FileViewer = { email: null, slackUserId: "U-OUTSIDER", isAdmin: false };
+    const lidMember = [{ type: "whatsapp_lid" as const, value: "98765@lid" }];
+    const lidNonmember = [{ type: "whatsapp_lid" as const, value: "11111@lid" }];
+    const lidMemberViewer: FileViewer = { email: null, whatsappLid: "98765@lid", isAdmin: false };
+    const lidNonmemberViewer: FileViewer = { email: null, whatsappLid: "11111@lid", isAdmin: false };
+    const verdict = (expected: boolean) => ({
+      fileVisibilityPredicate: expected,
+      fileAccessFilterSql: expected,
+      getFileContent: expected,
+      filterAccessibleFileIds: expected,
+    });
+
+    await expect(accessByEntryPoint("f-rule-slack-scoped", slackMember, slackMemberViewer)).resolves.toEqual(
+      verdict(true),
+    );
+    await expect(accessByEntryPoint("f-rule-slack-scoped", slackNonmember, slackNonmemberViewer)).resolves.toEqual(
+      verdict(false),
+    );
+    await expect(accessByEntryPoint("f-rule-whatsapp-scoped", lidMember, lidMemberViewer)).resolves.toEqual(
+      verdict(true),
+    );
+    await expect(accessByEntryPoint("f-rule-whatsapp-scoped", lidNonmember, lidNonmemberViewer)).resolves.toEqual(
+      verdict(false),
+    );
+    await expect(accessByEntryPoint("f-rule-slack-unscoped", slackMember, slackMemberViewer)).resolves.toEqual(
+      verdict(false),
+    );
+    await expect(accessByEntryPoint("f-rule-slack-unscoped", slackNonmember, slackNonmemberViewer)).resolves.toEqual(
+      verdict(false),
+    );
   });
 
   it("deduplicates multiple principals that resolve to one user in access summaries", async () => {

--- a/packages/server/src/db/repositories/file-visibility.test.ts
+++ b/packages/server/src/db/repositories/file-visibility.test.ts
@@ -916,6 +916,108 @@ describe("file-visibility predicate (RBAC for file list/count)", () => {
     );
   });
 
+  it("normalizes a raw phone consistently across all four entry points", async () => {
+    await db
+      .insertInto("access_scopes")
+      .values({
+        id: "scope-rule-raw-phone",
+        connector_config_id: "cfg",
+        scope_type: "whatsapp_group",
+        provider_scope_id: "raw-phone",
+      })
+      .execute();
+    await db
+      .insertInto("access_scope_members")
+      .values({
+        access_scope_id: "scope-rule-raw-phone",
+        principal_type: "phone",
+        principal_value: "+919101299347",
+      })
+      .execute();
+    await db
+      .insertInto("indexed_files")
+      .values({
+        id: "f-rule-raw-phone",
+        connector_config_id: "cfg",
+        provider_file_id: "rule-raw-phone",
+        file_name: "raw phone",
+        file_type: "doc",
+        content_category: "document",
+        source: "google_drive",
+        content: "raw phone content",
+        content_hash: "rule-raw-phone-hash",
+        is_archived: 0,
+        synced_at: new Date().toISOString(),
+        access_scope_id: "scope-rule-raw-phone",
+      })
+      .execute();
+
+    const rawPhone = "+91 9101299347";
+    await expect(
+      accessByEntryPoint("f-rule-raw-phone", [{ type: "phone", value: rawPhone }], {
+        email: null,
+        phone: rawPhone,
+        isAdmin: false,
+      }),
+    ).resolves.toEqual({
+      fileVisibilityPredicate: true,
+      fileAccessFilterSql: true,
+      getFileContent: true,
+      filterAccessibleFileIds: true,
+    });
+  });
+
+  it("normalizes an untrimmed Slack user ID consistently across all four entry points", async () => {
+    await db
+      .insertInto("access_scopes")
+      .values({
+        id: "scope-rule-raw-slack-user",
+        connector_config_id: "cfg",
+        scope_type: "slack_channel",
+        provider_scope_id: "raw-slack-user",
+      })
+      .execute();
+    await db
+      .insertInto("access_scope_members")
+      .values({
+        access_scope_id: "scope-rule-raw-slack-user",
+        principal_type: "slack_user",
+        principal_value: "U-RAW",
+      })
+      .execute();
+    await db
+      .insertInto("indexed_files")
+      .values({
+        id: "f-rule-raw-slack-user",
+        connector_config_id: "cfg",
+        provider_file_id: "rule-raw-slack-user",
+        file_name: "raw Slack user",
+        file_type: "doc",
+        content_category: "document",
+        source: "google_drive",
+        content: "raw Slack user content",
+        content_hash: "rule-raw-slack-user-hash",
+        is_archived: 0,
+        synced_at: new Date().toISOString(),
+        access_scope_id: "scope-rule-raw-slack-user",
+      })
+      .execute();
+
+    const rawSlackUserId = "  U-RAW  ";
+    await expect(
+      accessByEntryPoint("f-rule-raw-slack-user", [{ type: "slack_user", value: rawSlackUserId }], {
+        email: null,
+        slackUserId: rawSlackUserId,
+        isAdmin: false,
+      }),
+    ).resolves.toEqual({
+      fileVisibilityPredicate: true,
+      fileAccessFilterSql: true,
+      getFileContent: true,
+      filterAccessibleFileIds: true,
+    });
+  });
+
   it("deduplicates multiple principals that resolve to one user in access summaries", async () => {
     const repo = createConnectorRepository(db);
     await db

--- a/packages/server/src/db/repositories/file-visibility.test.ts
+++ b/packages/server/src/db/repositories/file-visibility.test.ts
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { fileAccessFilterSql, filterAccessibleFileIds, getFileContent } from "../../connectors/search";
 import { createTestDb } from "../../test-utils";
 import type { DB } from "../schema";
-import { type FileViewer, createConnectorRepository } from "./connectors";
+import { type FileViewer, createConnectorRepository, fileVisibilityPredicate } from "./connectors";
 import { createEntityRepository } from "./entities";
 
 describe("file-visibility predicate (RBAC for file list/count)", () => {
@@ -325,73 +325,155 @@ describe("file-visibility predicate (RBAC for file list/count)", () => {
     ).resolves.toEqual(expect.arrayContaining([expect.objectContaining({ id: "f-lid" })]));
   });
 
-  it("keeps entity share_with_everyone visible across every read gate without email", async () => {
+  it("denies another user's entity share without email while preserving org-wide entity shares", async () => {
     const now = new Date().toISOString();
+    await db.insertInto("users").values({ id: "u-admin", name: "Admin", email: "admin@example.com" }).execute();
     await db
       .insertInto("entities")
-      .values({
-        id: "ent-shared-everyone",
-        name: "Shared Entity",
-        source_type: "manual",
-        subtype: null,
-        aliases: null,
-        metadata: null,
-        source_ref_id: null,
-        status: "confirmed",
-        hotness: 0,
-        created_at: now,
-        updated_at: now,
-        share_with_everyone: 1,
-      })
+      .values([
+        {
+          id: "ent-shared-individually",
+          name: "Individually Shared Entity",
+          source_type: "manual",
+          subtype: null,
+          aliases: null,
+          metadata: null,
+          source_ref_id: null,
+          status: "confirmed",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+          share_with_everyone: 0,
+          deleted_at: null,
+          merged_into_entity_id: null,
+        },
+        {
+          id: "ent-shared-everyone",
+          name: "Shared Entity",
+          source_type: "manual",
+          subtype: null,
+          aliases: null,
+          metadata: null,
+          source_ref_id: null,
+          status: "confirmed",
+          hotness: 0,
+          created_at: now,
+          updated_at: now,
+          share_with_everyone: 1,
+          deleted_at: null,
+          merged_into_entity_id: null,
+        },
+      ])
       .execute();
     await db
       .insertInto("indexed_files")
-      .values({
-        id: "f-entity-share-everyone",
-        connector_config_id: "cfg",
-        provider_file_id: "entity-share-everyone",
-        file_name: "entity-share-everyone.txt",
-        file_type: "doc",
-        content_category: "document",
-        source: "google_drive",
-        content: "shared content",
-        content_hash: "entity-share-everyone-hash",
-        synced_at: now,
-        access_scope_id: "scope-a",
-      })
+      .values([
+        {
+          id: "f-entity-share-individual",
+          connector_config_id: "cfg",
+          provider_file_id: "entity-share-individual",
+          file_name: "entity-share-individual.txt",
+          file_type: "doc",
+          content_category: "document",
+          source: "google_drive",
+          content: "individually shared content",
+          content_hash: "entity-share-individual-hash",
+          synced_at: now,
+          access_scope_id: "scope-a",
+          is_archived: 0,
+          share_with_everyone: 0,
+        },
+        {
+          id: "f-entity-share-everyone",
+          connector_config_id: "cfg",
+          provider_file_id: "entity-share-everyone",
+          file_name: "entity-share-everyone.txt",
+          file_type: "doc",
+          content_category: "document",
+          source: "google_drive",
+          content: "shared content",
+          content_hash: "entity-share-everyone-hash",
+          synced_at: now,
+          access_scope_id: "scope-a",
+          is_archived: 0,
+          share_with_everyone: 0,
+        },
+      ])
       .execute();
     await db
       .insertInto("entity_mentions")
+      .values([
+        {
+          id: "mention-shared-individually",
+          entity_id: "ent-shared-individually",
+          indexed_file_id: "f-entity-share-individual",
+          chunk_index: null,
+          context_snippet: null,
+          confidence: "EXTRACTED",
+          source: "test",
+          relation: "mentioned",
+          mentioned_at: now,
+        },
+        {
+          id: "mention-shared-everyone",
+          entity_id: "ent-shared-everyone",
+          indexed_file_id: "f-entity-share-everyone",
+          chunk_index: null,
+          context_snippet: null,
+          confidence: "EXTRACTED",
+          source: "test",
+          relation: "mentioned",
+          mentioned_at: now,
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("entity_share_emails")
       .values({
-        id: "mention-shared-everyone",
-        entity_id: "ent-shared-everyone",
-        indexed_file_id: "f-entity-share-everyone",
-        chunk_index: null,
-        context_snippet: null,
-        confidence: "EXTRACTED",
-        source: "test",
-        relation: "mentioned",
-        mentioned_at: now,
+        entity_id: "ent-shared-individually",
+        email: "somebody-else@example.com",
+        granted_by_user_id: "u-admin",
       })
       .execute();
 
-    const phoneOnly = [{ type: "phone" as const, value: "+15550000009" }];
-    const nullEmailWebViewer: FileViewer = { email: null, phone: "+15550000009", isAdmin: false };
-    const repo = createConnectorRepository(db);
-    const filterSqlVisible = await db
-      .selectFrom("indexed_files")
-      .select("id")
-      .where(fileAccessFilterSql(phoneOnly))
-      .where("id", "=", "f-entity-share-everyone")
-      .execute();
-    const visibleByList = await repo.listAllFiles({ limit: 50, offset: 0, viewer: nullEmailWebViewer });
-    const visibleByIds = await filterAccessibleFileIds(db, ["f-entity-share-everyone"], phoneOnly);
-    const visibleByContent = await getFileContent(db, "f-entity-share-everyone", phoneOnly);
+    const slackOnly = [{ type: "slack_user" as const, value: "U-NO-EMAIL" }];
+    const nullEmailWebViewer: FileViewer = { email: null, slackUserId: "U-NO-EMAIL", isAdmin: false };
+    const accessByEntryPoint = async (fileId: string) => {
+      const predicateVisible = await db
+        .selectFrom("indexed_files")
+        .select("id")
+        .where(fileVisibilityPredicate(nullEmailWebViewer))
+        .where("id", "=", fileId)
+        .executeTakeFirst();
+      const filterSqlVisible = await db
+        .selectFrom("indexed_files")
+        .select("id")
+        .where(fileAccessFilterSql(slackOnly))
+        .where("id", "=", fileId)
+        .executeTakeFirst();
+      const visibleByIds = await filterAccessibleFileIds(db, [fileId], slackOnly);
+      const visibleByContent = await getFileContent(db, fileId, slackOnly);
 
-    expect(filterSqlVisible.map((file) => file.id)).toEqual(["f-entity-share-everyone"]);
-    expect(visibleByList.map((file) => file.id)).toContain("f-entity-share-everyone");
-    expect(visibleByIds).toEqual(new Set(["f-entity-share-everyone"]));
-    expect(visibleByContent?.id).toBe("f-entity-share-everyone");
+      return {
+        fileVisibilityPredicate: predicateVisible !== undefined,
+        fileAccessFilterSql: filterSqlVisible !== undefined,
+        getFileContent: visibleByContent !== null,
+        filterAccessibleFileIds: visibleByIds.has(fileId),
+      };
+    };
+
+    expect(await accessByEntryPoint("f-entity-share-individual")).toEqual({
+      fileVisibilityPredicate: false,
+      fileAccessFilterSql: false,
+      getFileContent: false,
+      filterAccessibleFileIds: false,
+    });
+    expect(await accessByEntryPoint("f-entity-share-everyone")).toEqual({
+      fileVisibilityPredicate: true,
+      fileAccessFilterSql: true,
+      getFileContent: true,
+      filterAccessibleFileIds: true,
+    });
   });
 
   it("deduplicates multiple principals that resolve to one user in access summaries", async () => {

--- a/packages/server/src/identity-normalization.ts
+++ b/packages/server/src/identity-normalization.ts
@@ -1,0 +1,32 @@
+export function normalizePhoneLike(value: string): string {
+  const trimmed = value.trim();
+  const compact = trimmed.replace(/[\s().-]/g, "");
+  const withPlus = compact.startsWith("00") ? `+${compact.slice(2)}` : compact;
+  if (!/^\+[1-9]\d{7,14}$/.test(withPlus)) {
+    throw new Error("Phone contact points must be E.164, for example +14155551234");
+  }
+  return withPlus;
+}
+
+export function normalizeWhatsAppIdentityPhone(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    return normalizePhoneLike(value);
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeWhatsAppIdentityLid(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim().toLowerCase();
+  const withoutSuffix = trimmed.endsWith("@lid") ? trimmed.slice(0, -4) : trimmed;
+  const deviceSeparator = withoutSuffix.indexOf(":");
+  const bare = deviceSeparator === -1 ? withoutSuffix : withoutSuffix.slice(0, deviceSeparator);
+  return bare.length > 0 ? `${bare}@lid` : null;
+}
+
+export function normalizeSlackIdentityUserId(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}

--- a/packages/server/src/scripts/audit-file-visibility.ts
+++ b/packages/server/src/scripts/audit-file-visibility.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import pino from "pino";
+import { signJwt } from "../auth/jwt";
+import { loadConfig, validateConfig } from "../config";
+import { createDatabase } from "../db";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createApp } from "../http";
+
+interface AllFilesResponse {
+  files: Array<{ id: string }>;
+  hasMore: boolean;
+}
+
+const PAGE_SIZE = 200;
+
+async function listVisibleFileIds(app: ReturnType<typeof createApp>, cookie: string): Promise<string[]> {
+  const fileIds = new Set<string>();
+  let offset = 0;
+
+  while (true) {
+    const response = await app.request(`/api/connectors/all-files?limit=${PAGE_SIZE}&offset=${offset}`, {
+      headers: { Cookie: cookie },
+    });
+    if (response.status !== 200) {
+      throw new Error(`all-files returned ${response.status}: ${await response.text()}`);
+    }
+
+    const body = (await response.json()) as AllFilesResponse;
+    for (const file of body.files) fileIds.add(file.id);
+    if (!body.hasMore) break;
+    offset += PAGE_SIZE;
+  }
+
+  return [...fileIds].sort();
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  validateConfig(config);
+  const db = await createDatabase(config);
+
+  try {
+    const settings = await createSettingsRepository(db, config.ENCRYPTION_KEY).get();
+    if (!settings?.jwt_secret) throw new Error("The database has no JWT secret");
+
+    const app = createApp(db, config, { logger: pino({ level: "silent" }) });
+    const users = await db.selectFrom("users").select(["id", "name", "auth_role"]).orderBy("id", "asc").execute();
+
+    for (const user of users) {
+      const role = user.auth_role === "admin" ? "admin" : "member";
+      const token = await signJwt(user.id, role, settings.jwt_secret);
+      const fileIds = await listVisibleFileIds(app, `sketch_session=${token}`);
+      const digest = createHash("sha256").update(fileIds.join("\n")).digest("hex");
+      console.log(`${user.id}\t${JSON.stringify(user.name)}\t${fileIds.length}\t${digest}`);
+    }
+  } finally {
+    await db.destroy();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/packages/server/src/test/file-visibility-e2e-fixture.ts
+++ b/packages/server/src/test/file-visibility-e2e-fixture.ts
@@ -1,0 +1,309 @@
+import type { Kysely } from "kysely";
+import { signJwt } from "../auth/jwt";
+import { hashPassword } from "../auth/password";
+import { createConnectorRepository } from "../db/repositories/connectors";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import type { createApp } from "../http";
+
+export const VISIBILITY_PASSWORD = "visibility-test-password";
+export const VISIBILITY_QUERY = "visibilitysentinel";
+
+export const visibilityUsers = {
+  admin: { id: "visibility-user-admin", email: "admin@test" },
+  scopeMember: { id: "visibility-user-scope-member", email: "scope-member@test" },
+  fileGrant: { id: "visibility-user-file-grant", email: "file-grant@test" },
+  shareTarget: { id: "visibility-user-share-target", email: "share-target@test" },
+  stranger: { id: "visibility-user-stranger", email: "stranger@test" },
+  slackOnly: { id: "visibility-user-slack-only", email: null, slackUserId: "U-VISIBILITY-SLACK-ONLY" },
+  messyPhone: {
+    id: "visibility-user-messy-phone",
+    email: "messy-phone@test",
+    whatsappNumber: "+91 9101299347",
+  },
+} as const;
+
+export const visibilityFiles = {
+  propagated: "file-propagated",
+  private: "file-private",
+  fileGrant: "file-grant",
+  manualShare: "file-manual-share",
+  individualEntityShare: "file-individual-entity-share",
+  phoneScope: "file-phone-scope",
+} as const;
+
+export const allVisibilityFileIds = Object.values(visibilityFiles);
+
+const NOW = "2026-08-08T08:00:00.000Z";
+
+export async function seedFileVisibilityFixture(db: Kysely<DB>): Promise<void> {
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  const passwordHash = await hashPassword(VISIBILITY_PASSWORD);
+  await settings.create();
+
+  await users.create({
+    id: visibilityUsers.admin.id,
+    name: "Visibility Admin",
+    email: visibilityUsers.admin.email,
+    emailVerified: true,
+    passwordHash,
+    authRole: "admin",
+    skipEntityLinking: true,
+  });
+  await users.create({
+    id: visibilityUsers.scopeMember.id,
+    name: "Scope Member",
+    email: visibilityUsers.scopeMember.email,
+    emailVerified: true,
+    passwordHash,
+    authRole: "member",
+    skipEntityLinking: true,
+  });
+  await users.create({
+    id: visibilityUsers.fileGrant.id,
+    name: "File Grant",
+    email: visibilityUsers.fileGrant.email,
+    emailVerified: true,
+    passwordHash,
+    authRole: "member",
+    skipEntityLinking: true,
+  });
+  await users.create({
+    id: visibilityUsers.shareTarget.id,
+    name: "Share Target",
+    email: visibilityUsers.shareTarget.email,
+    emailVerified: true,
+    passwordHash,
+    authRole: "member",
+    skipEntityLinking: true,
+  });
+  await users.create({
+    id: visibilityUsers.stranger.id,
+    name: "Stranger",
+    email: visibilityUsers.stranger.email,
+    emailVerified: true,
+    passwordHash,
+    authRole: "member",
+    skipEntityLinking: true,
+  });
+  await users.create({
+    id: visibilityUsers.slackOnly.id,
+    name: "Slack Only",
+    email: null,
+    slackUserId: visibilityUsers.slackOnly.slackUserId,
+    passwordHash,
+    authRole: "member",
+    skipEntityLinking: true,
+  });
+  await users.create({
+    id: visibilityUsers.messyPhone.id,
+    name: "Messy Phone",
+    email: visibilityUsers.messyPhone.email,
+    emailVerified: true,
+    whatsappNumber: visibilityUsers.messyPhone.whatsappNumber,
+    passwordHash,
+    authRole: "member",
+    skipEntityLinking: true,
+  });
+
+  await settings.update({
+    onboardingCompletedAt: NOW,
+    adminCanReadAllFiles: true,
+  });
+
+  const connector = await createConnectorRepository(db).createConfig({
+    connectorType: "google_drive",
+    authType: "system",
+    credentials: JSON.stringify({ type: "system" }),
+    createdBy: visibilityUsers.admin.id,
+  });
+
+  await db
+    .insertInto("access_scopes")
+    .values([
+      {
+        id: "visibility-scope-main",
+        connector_config_id: connector.id,
+        scope_type: "drive",
+        provider_scope_id: "visibility-main",
+        label: "Visibility main scope",
+      },
+      {
+        id: "visibility-scope-locked",
+        connector_config_id: connector.id,
+        scope_type: "drive",
+        provider_scope_id: "visibility-locked",
+        label: "Visibility locked scope",
+      },
+      {
+        id: "visibility-scope-phone",
+        connector_config_id: connector.id,
+        scope_type: "whatsapp_group",
+        provider_scope_id: "visibility-phone",
+        label: "Visibility phone scope",
+      },
+    ])
+    .execute();
+
+  await db
+    .insertInto("access_scope_members")
+    .values([
+      {
+        access_scope_id: "visibility-scope-main",
+        principal_type: "email",
+        principal_value: visibilityUsers.scopeMember.email,
+      },
+      {
+        access_scope_id: "visibility-scope-locked",
+        principal_type: "email",
+        principal_value: "scope-lock-holder@test",
+      },
+      {
+        access_scope_id: "visibility-scope-phone",
+        principal_type: "phone",
+        principal_value: "+919101299347",
+      },
+    ])
+    .execute();
+
+  await db
+    .insertInto("indexed_files")
+    .values([
+      fixtureFile(connector.id, visibilityFiles.propagated, "visibility-scope-main"),
+      fixtureFile(connector.id, visibilityFiles.private, "visibility-scope-main"),
+      fixtureFile(connector.id, visibilityFiles.fileGrant, "visibility-scope-locked"),
+      fixtureFile(connector.id, visibilityFiles.manualShare, "visibility-scope-locked"),
+      fixtureFile(connector.id, visibilityFiles.individualEntityShare, "visibility-scope-locked"),
+      fixtureFile(connector.id, visibilityFiles.phoneScope, "visibility-scope-phone"),
+    ])
+    .execute();
+
+  await db
+    .insertInto("file_access")
+    .values({
+      indexed_file_id: visibilityFiles.fileGrant,
+      principal_type: "email",
+      principal_value: visibilityUsers.fileGrant.email,
+    })
+    .execute();
+  await db
+    .insertInto("file_share_emails")
+    .values({
+      indexed_file_id: visibilityFiles.manualShare,
+      email: visibilityUsers.shareTarget.email,
+      granted_by_user_id: visibilityUsers.admin.id,
+    })
+    .execute();
+
+  await db
+    .insertInto("entities")
+    .values([
+      {
+        id: "visibility-entity-org-wide",
+        name: "Org-wide visibility entity",
+        source_type: "manual",
+        subtype: null,
+        aliases: null,
+        metadata: null,
+        source_ref_id: null,
+        status: "confirmed",
+        hotness: 0,
+        created_at: NOW,
+        updated_at: NOW,
+        share_with_everyone: 1,
+        deleted_at: null,
+        merged_into_entity_id: null,
+      },
+      {
+        id: "visibility-entity-individual",
+        name: "Individually shared visibility entity",
+        source_type: "manual",
+        subtype: null,
+        aliases: null,
+        metadata: null,
+        source_ref_id: null,
+        status: "confirmed",
+        hotness: 0,
+        created_at: NOW,
+        updated_at: NOW,
+        share_with_everyone: 0,
+        deleted_at: null,
+        merged_into_entity_id: null,
+      },
+    ])
+    .execute();
+  await db
+    .insertInto("entity_mentions")
+    .values([
+      fixtureMention("visibility-mention-org-wide", "visibility-entity-org-wide", visibilityFiles.propagated),
+      fixtureMention(
+        "visibility-mention-individual",
+        "visibility-entity-individual",
+        visibilityFiles.individualEntityShare,
+      ),
+    ])
+    .execute();
+  await db
+    .insertInto("entity_share_emails")
+    .values({
+      entity_id: "visibility-entity-individual",
+      email: "someone-else@test",
+      granted_by_user_id: visibilityUsers.admin.id,
+    })
+    .execute();
+}
+
+function fixtureFile(connectorConfigId: string, id: string, accessScopeId: string) {
+  return {
+    id,
+    connector_config_id: connectorConfigId,
+    provider_file_id: id,
+    file_name: `${VISIBILITY_QUERY} ${id}`,
+    file_type: "document",
+    content_category: "document",
+    content: `${VISIBILITY_QUERY} content for ${id}`,
+    content_hash: `hash-${id}`,
+    source: "google_drive",
+    synced_at: NOW,
+    source_updated_at: NOW,
+    access_scope_id: accessScopeId,
+  };
+}
+
+function fixtureMention(id: string, entityId: string, fileId: string) {
+  return {
+    id,
+    entity_id: entityId,
+    indexed_file_id: fileId,
+    chunk_index: null,
+    context_snippet: null,
+    confidence: "EXTRACTED",
+    source: "test",
+    relation: "mentioned",
+    mentioned_at: NOW,
+  };
+}
+
+export async function loginVisibilityUser(app: ReturnType<typeof createApp>, email: string): Promise<string> {
+  const response = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: VISIBILITY_PASSWORD }),
+  });
+  if (response.status !== 200) {
+    throw new Error(`Login failed for ${email}: ${response.status} ${await response.text()}`);
+  }
+  return response.headers.get("set-cookie") ?? "";
+}
+
+export async function visibilitySessionCookie(
+  db: Kysely<DB>,
+  userId: string,
+  role: "admin" | "member" = "member",
+): Promise<string> {
+  const settings = await createSettingsRepository(db).get();
+  if (!settings?.jwt_secret) throw new Error("Visibility fixture JWT secret is missing");
+  return `sketch_session=${await signJwt(userId, role, settings.jwt_secret)}`;
+}

--- a/packages/server/src/whatsapp/identity-resolution.ts
+++ b/packages/server/src/whatsapp/identity-resolution.ts
@@ -1,13 +1,15 @@
 import { createHash } from "node:crypto";
 import { type Kysely, type Transaction, sql } from "kysely";
 import type { Logger } from "pino";
-import { normalizeContactPointValue } from "../db/repositories/entities";
 import { isUniqueConstraintError } from "../db/repositories/sub-entities";
 import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
+import { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../identity-normalization";
 import { sanitizeWhatsAppDisplayText } from "./privacy";
 import { phoneE164ToWhatsAppJid } from "./provider";
+
+export { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../identity-normalization";
 
 export type WhatsAppIdentityResolution =
   | { kind: "teammate"; userId: string; name: string }
@@ -63,24 +65,6 @@ interface BuildRosterSnapshotOptions {
 }
 
 const REF_ALPHABET = "abcdefghijklmnop";
-
-export function normalizeWhatsAppIdentityPhone(value: string | null | undefined): string | null {
-  if (!value) return null;
-  try {
-    return normalizeContactPointValue("whatsapp", value);
-  } catch {
-    return null;
-  }
-}
-
-export function normalizeWhatsAppIdentityLid(value: string | null | undefined): string | null {
-  if (!value) return null;
-  const trimmed = value.trim().toLowerCase();
-  const withoutSuffix = trimmed.endsWith("@lid") ? trimmed.slice(0, -4) : trimmed;
-  const deviceSeparator = withoutSuffix.indexOf(":");
-  const bare = deviceSeparator === -1 ? withoutSuffix : withoutSuffix.slice(0, deviceSeparator);
-  return bare.length > 0 ? `${bare}@lid` : null;
-}
 
 type WhatsAppIdentityDb = Kysely<DB> | Transaction<DB>;
 


### PR DESCRIPTION
## What & why

Four separate pieces of code answered the same question — "can this viewer see this file?" — and they had drifted. One of them was wrong. This collapses them into one expression of the rule and fixes two real bugs found on the way.

This is groundwork for task minting, which needs to ask "who can see this file?" a fifth time. Without this, it would have become a fifth copy.

The rule itself is unchanged. Six doors, any one open means yes:

1. unrestricted file (chat channels excluded)
2. access-scope membership
3. per-file grant (chat channels excluded)
4. manual share by email
5. file-level `share_with_everyone`
6. entity-share propagation — a file mentioning a shared entity becomes visible

Door 6 surprises people. It is deliberate, a design-partner requirement, documented in `ENTITY_SHARING.md` and migration 071. Two earlier attempts to "fix" it were wrong. It is not touched here.

## The three changes

**PR-A — `5d6eddbb` — guard the entity-share door for viewers with no email principal.** The real bug. `getFileContent` guarded the `LEFT JOIN` on `entity_share_emails` behind "does this viewer have an email?", but not the `WHERE` that read it. So for a viewer with no email principal — a Slack-only identity, an agent — the join produced a row and the `is not null` test passed on it. They could open any file mentioning an entity shared with anyone at all.

Only the content path was wrong. The list path had the guard, so the file never appeared in the listing — you had to already know the id. That is why it went unnoticed.

**PR-B — `a48838bb` — express the rule once, in six named doors.** New `db/repositories/file-visibility-rule.ts`, one function per door plus `fileVisibilityRuleSql` composing them. The four call sites now delegate. `search.ts` loses 284 lines; `getFileContent` goes from a five-query ladder to one query. Also exports `entityShareGrantsSql`, so the task-minting audience work reuses door 6 instead of writing a fifth copy of that join.

Intended to be a pure refactor. See the equivalence proof below.

**PR-C — `78884dfa` — canonicalize every principal type in one place.** Two normalizers did different jobs. `viewerPrincipals` canonicalized phone and WhatsApp LID and trimmed Slack ids; `normalizeAccessPrincipals` handled emails only and passed the rest through untouched. Same person, different answer depending on which entry point they came through. `normalizeAccessPrincipals` now handles all four types and `viewerPrincipals` delegates to it. `normalizePhoneLike` moved down into a new `identity-normalization.ts` rather than copied — a second copy that agrees today is how this bug happened.

This one is narrower than it looks. It is reachable through exactly one surface: public MCP with caller-supplied principals (`agent/tools/search.ts:97-111`). Every other entry point already went through `viewerPrincipals`. And it is invisible in production today — all 16,981 stored permission rows are emails, so no phone or LID principal has anything to match against yet. It activates when chat ACLs start writing non-email principals.

It widens access: raw values that matched nothing now match canonical stored rows. Intended.

## Verification

**Full suite green.** Server 5281 passed / 449 files. Web 467 passed / 51 files. Root `pnpm test` exit 0. The 20 skipped are `bedrock-live` and `openrouter-live`, which self-skip without provider credentials — pre-existing and unrelated.

**End-to-end, through the real entry points.** 21 new cases across two files, driving the HTTP routes via `createApp` + `app.request` and the `Search` / `GetFileContent` / `slack-channel-history` tool handlers. They seed their own users and files through PGlite, so they need no database and run in CI.

Seven seeded users, one per door plus a negative control, a Slack-only identity with `email: null`, and a user whose stored phone number has punctuation. The load-bearing assertion: for every one of them, the set of files listed equals the set of files openable. Four copies of a rule can drift; that property is what drift breaks.

Verified by reverting all three changes and re-running — **5 of 21 fail**, covering three distinct properties: the Slack-only alignment and leak cases on the content route (PR-A, list route was already correct), and the raw public-MCP phone principal (PR-C).

Four cases originally named as though they covered PR-C passed on the reverted code. They were renamed to what they actually pin, and both files carry a docstring recording that public MCP is the only surface where that divergence is observable, so the point is not lost again.

**PR-B's equivalence, on production-shaped data.** `scripts/audit-file-visibility.ts` sweeps every user through `/api/connectors/all-files` in-process and prints a digest per user. Run against a real snapshot before and after: **identical for all 23 users, byte for byte.** A script rather than a test, because CI has no snapshot and a test that cannot run there becomes permanently skipped.

Two caveats on that sweep, stated so it is not over-read. It exercises the list route only — the content route and the agent tools are covered by the seeded tests instead. And 5 of the 23 are admins, who bypass the rule entirely, so those rows would match regardless; the real signal is the other 18, ranging 519–996 files.

**Migration 165 on real data.** It is a rename, not a backfill, so row counts can never disagree — checked with ordered bidirectional digests instead. 95 and 16,886 rows, identical both directions, every row `principal_type = 'email'`.

## Out of scope

Deliberately left open, recorded in the plan:

- **D2** — the contract for identities with no principal at all. Three agent identities have none; two more have a Slack id or phone that currently grants nothing. The sweep shows all five landing on the same 519 files.
- **D3** — the archived-file gap when `SLACK_ENTITY_SYNC` is off. Needs confirmation that no managed tenant sets it false.
- Two user records store non-canonical phone numbers. A one-off data cleanup; new writes are canonical via `whatsappNumberSchema`.

## References

Plan and two explainers, moved to `.planning/access/implemented/` as part of this PR:

- `PR_VISIBILITY_CONSOLIDATION.md` — the plan, v5
- `ACCESS_CONTROL_EXPLAINED.html` — the six doors from scratch, assumes no knowledge of the code
- `THREE_PRS_EXPLAINED.html` — what each change does and what was verified, including two acceptance criteria I wrote that could never have failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
