### PR TITLE
fix: make the learned_facts append idempotent

### DIFF
--- a/packages/server/src/connectors/smart-enrichment.test.ts
+++ b/packages/server/src/connectors/smart-enrichment.test.ts
@@ -24,6 +24,7 @@ import {
   projectProductMentionNames,
   smartEnrichFile,
 } from "./smart-enrichment";
+import { recoverStaleEnrichments } from "./sync";
 
 const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
 
@@ -375,6 +376,128 @@ describe("smartEnrichFile — LLM extraction facts", () => {
     } catch {
       // already destroyed
     }
+  });
+
+  async function readLearnedFacts(entityId: string): Promise<unknown[]> {
+    const row = await db.selectFrom("entities").select("metadata").where("id", "=", entityId).executeTakeFirstOrThrow();
+    const metadata = JSON.parse(row.metadata ?? "{}");
+    return metadata.learned_facts ?? [];
+  }
+
+  function factGenerator(entityId: string, facts: string[]): GeminiGenerator {
+    return {
+      generate: async () => "Sarah Chen owns the launch plan.",
+      generateJSON: async <T>(_prompt: string, opts?: { label?: string }) => {
+        if (opts?.label?.startsWith("extractEntities")) {
+          return {
+            mentions: [{ mention: "Sarah Chen", type: "person", variations: ["Sarah"], confidence: 0.95 }],
+          } as T;
+        }
+        if (opts?.label?.startsWith("extractEntityFacts")) {
+          return { [entityId]: facts.map((fact) => ({ fact })) } as T;
+        }
+        return {} as T;
+      },
+    } as GeminiGenerator;
+  }
+
+  it("does not change learned facts when re-enrichment returns the same facts", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, { content: "Sarah Chen owns the launch plan.", contentHash: "hash-idempotent" });
+    const entity = await createEntityRepository(db).upsertEntityFromTool({
+      name: "Sarah Chen",
+      sourceType: "person",
+      source: "google_drive",
+      sourceId: "person:sarah-chen-idempotent",
+    });
+    const file = smartFileContext(fileId, "hash-idempotent", { content: "Sarah Chen owns the launch plan." });
+
+    await smartEnrichFile(
+      {
+        db,
+        logger: createTestLogger(),
+        generator: factGenerator(entity.id, ["Owns the launch plan"]),
+        embeddingProvider: null,
+      },
+      file,
+    );
+    const firstFacts = await readLearnedFacts(entity.id);
+
+    await smartEnrichFile(
+      {
+        db,
+        logger: createTestLogger(),
+        generator: factGenerator(entity.id, ["  owns   the launch plan  "]),
+        embeddingProvider: null,
+      },
+      file,
+    );
+
+    expect(await readLearnedFacts(entity.id)).toEqual(firstFacts);
+  });
+
+  it("appends only new learned facts and preserves existing entries", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, { content: "Sarah Chen owns the launch plan.", contentHash: "hash-partial" });
+    const entity = await createEntityRepository(db).upsertEntityFromTool({
+      name: "Sarah Chen",
+      sourceType: "person",
+      source: "google_drive",
+      sourceId: "person:sarah-chen-partial",
+    });
+    const file = smartFileContext(fileId, "hash-partial", { content: "Sarah Chen owns the launch plan." });
+
+    await smartEnrichFile(
+      {
+        db,
+        logger: createTestLogger(),
+        generator: factGenerator(entity.id, ["Owns the launch plan", "Works at Acme"]),
+        embeddingProvider: null,
+      },
+      file,
+    );
+    const existingFacts = await readLearnedFacts(entity.id);
+
+    await smartEnrichFile(
+      {
+        db,
+        logger: createTestLogger(),
+        generator: factGenerator(entity.id, ["owns the launch plan", "Works at Acme", "Leads sales"]),
+        embeddingProvider: null,
+      },
+      file,
+    );
+
+    expect(await readLearnedFacts(entity.id)).toEqual([
+      ...existingFacts,
+      { fact: "Leads sales", source_file_id: fileId, learned_at: expect.any(String) },
+    ]);
+  });
+
+  it("does not duplicate learned facts when stale recovery retries enrichment after a crash", async () => {
+    const fileId = randomUUID();
+    await seedFile(db, fileId, { content: "Sarah Chen owns the launch plan.", contentHash: "hash-crash-retry" });
+    const entity = await createEntityRepository(db).upsertEntityFromTool({
+      name: "Sarah Chen",
+      sourceType: "person",
+      source: "google_drive",
+      sourceId: "person:sarah-chen-crash-retry",
+    });
+    const file = smartFileContext(fileId, "hash-crash-retry", { content: "Sarah Chen owns the launch plan." });
+    const generator = factGenerator(entity.id, ["Owns the launch plan"]);
+
+    await smartEnrichFile({ db, logger: createTestLogger(), generator, embeddingProvider: null }, file);
+    const firstFacts = await readLearnedFacts(entity.id);
+
+    await db
+      .updateTable("indexed_files")
+      .set({ embedding_status: "processing", synced_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() })
+      .where("id", "=", fileId)
+      .execute();
+    await recoverStaleEnrichments(db, createTestLogger());
+    await smartEnrichFile({ db, logger: createTestLogger(), generator, embeddingProvider: null }, file);
+
+    expect(await readLearnedFacts(entity.id)).toEqual(firstFacts);
   });
 
   it("persists LLM facts on first sighting, defers materialization, and promotes once threshold reached", async () => {

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -1269,17 +1269,26 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
       if (newFacts.length === 0) continue;
 
       await deps.ensureFresh?.();
-      const updated = await withFreshFileWriteLock(db, file.id, fileVersion, async (trx) => {
+      const appendedCount = await withFreshFileWriteLock(db, file.id, fileVersion, async (trx) => {
         const txEntityRepo = createEntityRepository(trx);
         const currentEntity = await txEntityRepo.getEntity(entityId);
-        if (!currentEntity) return false;
+        if (!currentEntity) return 0;
         const currentMetadata = parseEntityMetadata(currentEntity.metadata);
-        currentMetadata.learned_facts = [...(currentMetadata.learned_facts ?? []), ...newFacts];
+        const existingFacts = currentMetadata.learned_facts ?? [];
+        const existingKeys = new Set(existingFacts.map(learnedFactKey).filter((key): key is string => key !== null));
+        const factsToAppend = newFacts.filter((fact) => {
+          const key = learnedFactKey(fact);
+          if (!key || existingKeys.has(key)) return false;
+          existingKeys.add(key);
+          return true;
+        });
+        if (factsToAppend.length === 0) return 0;
+        currentMetadata.learned_facts = [...existingFacts, ...factsToAppend];
         await txEntityRepo.updateEntity(entityId, { metadata: JSON.stringify(currentMetadata) });
-        return true;
+        return factsToAppend.length;
       });
 
-      if (updated) logger.debug({ entityId, newFactCount: facts.length }, "Updated entity definition");
+      if (appendedCount > 0) logger.debug({ entityId, newFactCount: appendedCount }, "Updated entity definition");
       await yieldToEventLoop();
     }
   } catch (err) {
@@ -1711,6 +1720,19 @@ interface EntityMetadata {
   definition?: string;
   learned_facts?: Array<{ fact: string; source_file_id?: string; learned_at?: string }>;
   [key: string]: unknown;
+}
+
+function normalizeLearnedFactContent(value: string): string {
+  return value.normalize("NFKC").replace(/\s+/gu, " ").trim().toLowerCase();
+}
+
+function learnedFactKey(entry: { fact?: unknown; source_file_id?: unknown }): string | null {
+  if (typeof entry.fact !== "string" || typeof entry.source_file_id !== "string" || entry.source_file_id.length === 0) {
+    return null;
+  }
+  const normalizedFact = normalizeLearnedFactContent(entry.fact);
+  const factHash = createHash("sha256").update(normalizedFact).digest("hex");
+  return `${entry.source_file_id}:${factHash}`;
 }
 
 function parseEntityMetadata(raw: string | null): EntityMetadata {


### PR DESCRIPTION
## What

`extractEntityFacts` results are written to **two** places. `indexed_file_facts` is safe — `UNIQUE(fact_key)` with an upsert. But the same results were also appended to `entities.metadata.learned_facts` with **no deduplication**, so any repeated enrichment of a file appended duplicates forever.

## Why it matters today

This is a live bug on **every connector**, not just WhatsApp. Two paths trigger it:

1. A crash between the append and enrichment being marked done — stale recovery retries and appends again (`sync.ts`).
2. Manual re-enrichment, which resets even unchanged files to pending (`reenrich.ts:350`).

It was found while designing WhatsApp LLM chunking, where the open chunk re-enriches many times per chunk and would make this side channel load-bearing — but the fix stands on its own and is worth landing first.

## How

Facts are keyed by `source_file_id` + a normalized (NFKC, whitespace-collapsed, lowercased) SHA-256 of the fact text. Only unseen keys are appended.

- Existing entries keep their order and content — no rewriting or churn.
- A pass that finds nothing new skips the `updateEntity` write entirely.
- Legacy entries without `source_file_id` are excluded from the dedup set rather than blocking appends.
- The reader shape is unchanged (`learned-fact-selector.ts`, `validators.ts` verified).

## Tests

Three regression tests: identical re-run is a no-op, a partial-new-facts run appends only the new ones, and the crash-then-stale-recovery retry does not duplicate.

## Not included

Existing duplicate metadata is not cleaned up. A one-off cleanup would keep the first occurrence per key and handle legacy entries without `source_file_id` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)