### PR TITLE
chore: ignore the run-canvas-sketch dev skill symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/superpowers/specs/
 # Created by ./.planning/dev-skills/link.sh — never commit these.
 .claude/skills/implement-story
 .claude/skills/remote-tenant-debugging
+.claude/skills/run-canvas-sketch


### PR DESCRIPTION
One line in `.gitignore`.

A new private dev skill — `run-canvas-sketch`, manages the combined Canvas AI + Sketch + Sketch Platform local stack — is being added to the `.planning` submodule in canvasxai/sketch-internal-planning#12. This ignores the symlink that `./.planning/dev-skills/link.sh` creates for it, so the skill content never enters this public repo.

Same pattern as `implement-story` and `remote-tenant-debugging`.

**No submodule pointer bump here.** That follows once the planning PR merges to its `main`, per the precedent in #486.

Pre-push gate (lint, typecheck, test, build) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
