### PR TITLE
feat: enrich entity identity aliases

### DIFF
--- a/packages/server/src/connectors/whatsapp-salience.ts
+++ b/packages/server/src/connectors/whatsapp-salience.ts
@@ -406,6 +406,7 @@ async function renderSlice(db: Kysely<DB>, context: SliceContext, logger: Logger
     groupJid: context.groupJid,
     conversationId: context.conversationId,
     logger,
+    enrichEntityAliases: true,
   });
   const messages = await listSliceMessages(db, context.slice);
   const rosterBlock = renderWhatsAppRosterBlock(roster.snapshot);

--- a/packages/server/src/db/repositories/entity-aliases.ts
+++ b/packages/server/src/db/repositories/entity-aliases.ts
@@ -1,0 +1,48 @@
+import type { Kysely } from "kysely";
+import { parseAliasesString } from "../../entities/materialize-json";
+import type { DB } from "../schema";
+
+const MAX_ALIAS_MERGE_ATTEMPTS = 8;
+
+export async function mergeEntityAliases(
+  db: Kysely<DB>,
+  entityId: string,
+  candidates: Array<string | null | undefined>,
+  now = new Date().toISOString(),
+): Promise<string[]> {
+  for (let attempt = 0; attempt < MAX_ALIAS_MERGE_ATTEMPTS; attempt += 1) {
+    const entity = await db
+      .selectFrom("entities")
+      .select(["id", "name", "aliases"])
+      .where("id", "=", entityId)
+      .where("source_type", "=", "person")
+      .where("status", "!=", "archived")
+      .where("deleted_at", "is", null)
+      .where("merged_into_entity_id", "is", null)
+      .executeTakeFirst();
+    if (!entity) return [];
+
+    const aliases = parseAliasesString(entity.aliases);
+    const seen = new Set([entity.name, ...aliases].map((value) => value.trim().toLowerCase()).filter(Boolean));
+    for (const candidate of candidates) {
+      const value = candidate?.trim();
+      if (!value) continue;
+      const key = value.toLowerCase();
+      if (seen.has(key)) continue;
+      aliases.push(value);
+      seen.add(key);
+    }
+    if (aliases.length === parseAliasesString(entity.aliases).length) return aliases;
+
+    let update = db
+      .updateTable("entities")
+      .set({ aliases: JSON.stringify(aliases), updated_at: now })
+      .where("id", "=", entity.id);
+    update =
+      entity.aliases === null ? update.where("aliases", "is", null) : update.where("aliases", "=", entity.aliases);
+    const result = await update.executeTakeFirst();
+    if (result.numUpdatedRows > 0n) return aliases;
+  }
+
+  throw new Error(`Entity alias merge remained contended for ${entityId}`);
+}

--- a/packages/server/src/db/repositories/slack-entity-sync.integration.test.ts
+++ b/packages/server/src/db/repositories/slack-entity-sync.integration.test.ts
@@ -4,6 +4,7 @@ import { normalizeName } from "../../connectors/name-normalize";
 import { createTestPgDb } from "../../test-utils";
 import type { DB } from "../schema";
 import { createEntityRepository } from "./entities";
+import { mergeEntityAliases } from "./entity-aliases";
 import { isInternalSlackUser, upsertSlackPersonEntity } from "./slack-entity-sync";
 
 type SlackProfile = Parameters<typeof upsertSlackPersonEntity>[1];
@@ -680,13 +681,9 @@ describe("upsertSlackPersonEntity", () => {
       .where("id", "=", "linked-person")
       .executeTakeFirstOrThrow();
     expect(entity.name).toBe("Existing Canonical Name");
-    expect(JSON.parse(entity.aliases ?? "[]")).toEqual([
-      "Existing Alias",
-      "slack display name",
-      "deprecated.handle",
-      "Slack Real Name",
-      "linked@example.com",
-    ]);
+    expect(JSON.parse(entity.aliases ?? "[]")).toEqual(["Existing Alias", "slack display name", "Slack Real Name"]);
+    expect(entity.aliases).not.toContain("deprecated.handle");
+    expect(entity.aliases).not.toContain("linked@example.com");
     expect(JSON.parse(entity.metadata ?? "{}")).toEqual({ email: "linked@example.com", owner: "human" });
     const contactPoints = await db
       .selectFrom("entity_contact_points")
@@ -702,6 +699,39 @@ describe("upsertSlackPersonEntity", () => {
         .where("slack_user_id", "=", "U-LINKED")
         .executeTakeFirstOrThrow(),
     ).resolves.toMatchObject({ entity_created_by_sync: 0 });
+  });
+
+  it("preserves aliases added by concurrent identity writers", async () => {
+    await db
+      .insertInto("entities")
+      .values({
+        id: "concurrent-alias-person",
+        name: "Concurrent Person",
+        source_type: "person",
+        subtype: "external",
+        aliases: null,
+        metadata: null,
+        source_ref_id: null,
+        status: "confirmed",
+        provenance_tier: "human_confirmed",
+        hotness: 0,
+        created_at: "2026-08-12T00:00:00.000Z",
+        updated_at: "2026-08-12T00:00:00.000Z",
+      })
+      .execute();
+
+    await Promise.all([
+      mergeEntityAliases(db, "concurrent-alias-person", ["Slack Name"]),
+      mergeEntityAliases(db, "concurrent-alias-person", ["WhatsApp Name"]),
+      mergeEntityAliases(db, "concurrent-alias-person", ["Manual Name"]),
+    ]);
+
+    const entity = await db
+      .selectFrom("entities")
+      .select("aliases")
+      .where("id", "=", "concurrent-alias-person")
+      .executeTakeFirstOrThrow();
+    expect(JSON.parse(entity.aliases ?? "[]").sort()).toEqual(["Manual Name", "Slack Name", "WhatsApp Name"]);
   });
 
   it("demotes internal classification when a positive guest signal arrives", async () => {

--- a/packages/server/src/db/repositories/slack-entity-sync.integration.test.ts
+++ b/packages/server/src/db/repositories/slack-entity-sync.integration.test.ts
@@ -633,7 +633,7 @@ describe("upsertSlackPersonEntity", () => {
         name: "Existing Canonical Name",
         source_type: "person",
         subtype: "internal",
-        aliases: null,
+        aliases: JSON.stringify(["Existing Alias", "slack display name"]),
         metadata: JSON.stringify({ email: "linked@example.com", owner: "human" }),
         source_ref_id: null,
         status: "confirmed",
@@ -680,6 +680,13 @@ describe("upsertSlackPersonEntity", () => {
       .where("id", "=", "linked-person")
       .executeTakeFirstOrThrow();
     expect(entity.name).toBe("Existing Canonical Name");
+    expect(JSON.parse(entity.aliases ?? "[]")).toEqual([
+      "Existing Alias",
+      "slack display name",
+      "deprecated.handle",
+      "Slack Real Name",
+      "linked@example.com",
+    ]);
     expect(JSON.parse(entity.metadata ?? "{}")).toEqual({ email: "linked@example.com", owner: "human" });
     const contactPoints = await db
       .selectFrom("entity_contact_points")

--- a/packages/server/src/db/repositories/slack-entity-sync.ts
+++ b/packages/server/src/db/repositories/slack-entity-sync.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { type ExpressionBuilder, type Kysely, type Selectable, type SqlBool, sql } from "kysely";
 import { normalizeName } from "../../connectors/name-normalize";
+import { parseAliasesString } from "../../entities/materialize-json";
 import { upsertSlackIdentity } from "../../slack/upsert-identity";
 import type { DB, EntitiesTable, SlackUserSyncStateTable, UsersTable } from "../schema";
 import { createEntityRepository, isHumanSubtypeOverride, normalizeContactPointValue } from "./entities";
+import { mergeEntityAliases } from "./entity-aliases";
 import { createEntityReviewRepo } from "./entity-review";
 import { ensureUserEntityLinkForEntity } from "./user-entity-linking";
 import { createUserRepository } from "./users";
@@ -142,30 +144,6 @@ function profileName(profile: SlackUserProfile): string | null {
   return name.length > 0 ? name : null;
 }
 
-function parseAliases(raw: string | null): string[] {
-  if (!raw) return [];
-  try {
-    const value = JSON.parse(raw) as unknown;
-    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-  } catch {
-    return [];
-  }
-}
-
-function mergeAliases(raw: string | null, candidates: Array<string | null | undefined>): string[] {
-  const aliases = parseAliases(raw);
-  const normalized = new Set(aliases.map((alias) => alias.trim().toLowerCase()).filter(Boolean));
-  for (const candidate of candidates) {
-    const trimmed = candidate?.trim();
-    if (!trimmed) continue;
-    const key = trimmed.toLowerCase();
-    if (normalized.has(key)) continue;
-    aliases.push(trimmed);
-    normalized.add(key);
-  }
-  return aliases;
-}
-
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
 }
@@ -275,7 +253,6 @@ async function updateEntityFromSlackProfile(
   const metadata = parseMetadata(entity.metadata);
   if (slackOwned && email) metadata.email = email;
   const updates: Record<string, unknown> = {
-    aliases: JSON.stringify(mergeAliases(entity.aliases, [profile.name, profile.realName, profile.displayName, email])),
     updated_at: now,
   };
   if (!isHumanSubtypeOverride(entity.provenance_tier)) updates.subtype = classification;
@@ -283,6 +260,7 @@ async function updateEntityFromSlackProfile(
   if (slackOwned && email) updates.metadata = JSON.stringify(metadata);
 
   await trx.updateTable("entities").set(updates).where("id", "=", entity.id).execute();
+  await mergeEntityAliases(trx, entity.id, [profile.realName, profile.displayName], now);
   if (email) {
     await updateSlackContactPoint(trx, entity.id, "email", email, connectorConfigId, slackOwned, now);
   }
@@ -652,7 +630,7 @@ async function runUpsertBody(
     const exactCandidates = candidates.filter(
       (candidate) =>
         normalizeName(candidate.name) === normalizedProfileName ||
-        parseAliases(candidate.aliases).some((alias) => normalizeName(alias) === normalizedProfileName),
+        parseAliasesString(candidate.aliases).some((alias) => normalizeName(alias) === normalizedProfileName),
     );
     if (exactCandidates.length > 0) {
       reviewReason = {

--- a/packages/server/src/db/repositories/slack-entity-sync.ts
+++ b/packages/server/src/db/repositories/slack-entity-sync.ts
@@ -152,6 +152,20 @@ function parseAliases(raw: string | null): string[] {
   }
 }
 
+function mergeAliases(raw: string | null, candidates: Array<string | null | undefined>): string[] {
+  const aliases = parseAliases(raw);
+  const normalized = new Set(aliases.map((alias) => alias.trim().toLowerCase()).filter(Boolean));
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (normalized.has(key)) continue;
+    aliases.push(trimmed);
+    normalized.add(key);
+  }
+  return aliases;
+}
+
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
 }
@@ -261,6 +275,7 @@ async function updateEntityFromSlackProfile(
   const metadata = parseMetadata(entity.metadata);
   if (slackOwned && email) metadata.email = email;
   const updates: Record<string, unknown> = {
+    aliases: JSON.stringify(mergeAliases(entity.aliases, [profile.name, profile.realName, profile.displayName, email])),
     updated_at: now,
   };
   if (!isHumanSubtypeOverride(entity.provenance_tier)) updates.subtype = classification;

--- a/packages/server/src/whatsapp/identity-resolution.test.ts
+++ b/packages/server/src/whatsapp/identity-resolution.test.ts
@@ -304,9 +304,29 @@ describe("WhatsApp roster snapshot", () => {
       text: "provider fallback",
       receivedAt: "2026-07-07T09:02:00.000Z",
     });
-    const logger = { info: vi.fn() } as unknown as Logger;
+    const logger = { info: vi.fn(), warn: vi.fn() } as unknown as Logger;
 
-    const snapshot = await buildWhatsAppRosterSnapshot({ db, groupJid, conversationId: conversation.id, logger });
+    const snapshotWithoutEnrichment = await buildWhatsAppRosterSnapshot({
+      db,
+      groupJid,
+      conversationId: conversation.id,
+      logger,
+    });
+    expect(snapshotWithoutEnrichment.snapshot.participants[0]).toMatchObject({
+      resolutionKind: "entity",
+      entityId: "entity-aliases",
+    });
+    await expect(
+      db.selectFrom("entities").select("aliases").where("id", "=", "entity-aliases").executeTakeFirstOrThrow(),
+    ).resolves.toMatchObject({ aliases: JSON.stringify(["Existing Alias", "PUSH NAME"]) });
+
+    const snapshot = await buildWhatsAppRosterSnapshot({
+      db,
+      groupJid,
+      conversationId: conversation.id,
+      logger,
+      enrichEntityAliases: true,
+    });
     expect(snapshot.snapshot.participants[0]).toMatchObject({ resolutionKind: "entity", entityId: "entity-aliases" });
 
     const entity = await db
@@ -317,7 +337,7 @@ describe("WhatsApp roster snapshot", () => {
     expect(JSON.parse(entity.aliases ?? "[]")).toEqual([
       "Existing Alias",
       "PUSH NAME",
-      "Group Label +**********00",
+      "Group Label",
       "Second Push Name",
     ]);
     expect(entity.aliases).not.toContain("15550000901");

--- a/packages/server/src/whatsapp/identity-resolution.test.ts
+++ b/packages/server/src/whatsapp/identity-resolution.test.ts
@@ -56,7 +56,7 @@ async function seedGroup(groupJid = "120363000000001@g.us") {
   return repo;
 }
 
-async function seedEntity(args: { id: string; name: string; sourceType?: string }): Promise<void> {
+async function seedEntity(args: { id: string; name: string; sourceType?: string; aliases?: string[] }): Promise<void> {
   const now = "2026-07-07T09:00:00.000Z";
   await db
     .insertInto("entities")
@@ -65,7 +65,7 @@ async function seedEntity(args: { id: string; name: string; sourceType?: string 
       name: args.name,
       source_type: args.sourceType ?? "person",
       subtype: args.sourceType === "company" ? null : "external",
-      aliases: null,
+      aliases: args.aliases ? JSON.stringify(args.aliases) : null,
       metadata: null,
       source_ref_id: null,
       status: "confirmed",
@@ -255,6 +255,78 @@ describe("WhatsApp identity resolution", () => {
 });
 
 describe("WhatsApp roster snapshot", () => {
+  it("enriches existing entity aliases from sanitized push names and group labels", async () => {
+    const groupJid = "120363000000009@g.us";
+    const groups = await seedGroup(groupJid);
+    await seedLabeler();
+    await seedEntity({ id: "entity-aliases", name: "CRM Contact", aliases: ["Existing Alias", "PUSH NAME"] });
+    await seedContactPoint("entity-aliases", "+15550000901");
+    await seedContactPoint("entity-aliases", "+15550000902");
+    await seedContactPoint("entity-aliases", "+15550000903");
+    await groups.upsertMemberLabel({
+      groupJid,
+      phoneE164: "+15550000901",
+      displayName: "Group Label +91 99804 70200",
+      companyName: null,
+      createdBy: "labeler",
+    });
+    await groups.refreshParticipants(groupJid, [
+      { participantJid: "15550000901@s.whatsapp.net", phoneE164: "+15550000901", adminRole: null },
+      { participantJid: "15550000902@s.whatsapp.net", phoneE164: "+15550000902", adminRole: null },
+      { participantJid: "15550000903@s.whatsapp.net", phoneE164: "+15550000903", adminRole: null },
+    ]);
+    const conversation = await createConversationRepository(db).getOrCreate({
+      platform: "whatsapp",
+      kind: "group",
+      providerConversationId: groupJid,
+    });
+    await createConversationRepository(db).insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "entity-alias-push-name",
+      senderJid: "15550000901@s.whatsapp.net",
+      senderName: "Unknown",
+      text: "hello",
+      receivedAt: "2026-07-07T09:00:00.000Z",
+    });
+    await createConversationRepository(db).insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "entity-alias-second-push-name",
+      senderJid: "15550000902@s.whatsapp.net",
+      senderName: "Second Push Name",
+      text: "hello again",
+      receivedAt: "2026-07-07T09:01:00.000Z",
+    });
+    await createConversationRepository(db).insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "entity-alias-provider-id",
+      senderJid: "15550000903@s.whatsapp.net",
+      senderName: "12345",
+      text: "provider fallback",
+      receivedAt: "2026-07-07T09:02:00.000Z",
+    });
+    const logger = { info: vi.fn() } as unknown as Logger;
+
+    const snapshot = await buildWhatsAppRosterSnapshot({ db, groupJid, conversationId: conversation.id, logger });
+    expect(snapshot.snapshot.participants[0]).toMatchObject({ resolutionKind: "entity", entityId: "entity-aliases" });
+
+    const entity = await db
+      .selectFrom("entities")
+      .select("aliases")
+      .where("id", "=", "entity-aliases")
+      .executeTakeFirstOrThrow();
+    expect(JSON.parse(entity.aliases ?? "[]")).toEqual([
+      "Existing Alias",
+      "PUSH NAME",
+      "Group Label +**********00",
+      "Second Push Name",
+    ]);
+    expect(entity.aliases).not.toContain("15550000901");
+    expect(entity.aliases).not.toContain("15550000901@s.whatsapp.net");
+    expect(entity.aliases).not.toContain("@lid");
+    expect(entity.aliases).not.toContain("12345");
+    expect(entity.aliases).not.toContain("Unknown");
+  });
+
   it("serializes display context without raw phone numbers or phone JIDs", async () => {
     const groupJid = "120363000000004@g.us";
     const groups = await seedGroup(groupJid);

--- a/packages/server/src/whatsapp/identity-resolution.ts
+++ b/packages/server/src/whatsapp/identity-resolution.ts
@@ -5,6 +5,7 @@ import { createUserWhatsAppLidRepository } from "../db/repositories/user-whatsap
 import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
+import { parseAliasesString } from "../entities/materialize-json";
 import { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../identity-normalization";
 import { safeWhatsAppErrorFields, sanitizeWhatsAppDisplayText } from "./privacy";
 import { phoneE164ToWhatsAppJid } from "./provider";
@@ -129,7 +130,81 @@ function unresolvedDisplayName(phoneE164: string | null): string {
 function safePushName(value: string | undefined): string | undefined {
   if (!value) return undefined;
   const sanitized = sanitizeWhatsAppDisplayText(value);
-  return sanitized.length > 0 ? sanitized : undefined;
+  return isHumanReadableAlias(value, sanitized) ? sanitized : undefined;
+}
+
+function isHumanReadableAlias(raw: string, sanitized: string): boolean {
+  if (!sanitized || sanitized.includes("[whatsapp-id]")) return false;
+  const trimmed = raw.trim();
+  if (/^(?:unknown|unknown group|unresolved whatsapp participant)$/iu.test(trimmed)) return false;
+  if (/^\+?\d+$/u.test(trimmed)) return false;
+  return normalizeWhatsAppIdentityPhone(trimmed) === null && !/@(?:lid|s\.whatsapp\.net)$/iu.test(trimmed);
+}
+
+function mergeAliases(existing: string | null, additions: Array<string | undefined>): string[] {
+  const aliases = parseAliasesString(existing);
+  const seen = new Set(aliases.map((alias) => alias.trim().toLowerCase()));
+  for (const addition of additions) {
+    if (!addition) continue;
+    const value = addition.trim();
+    const key = value.toLowerCase();
+    if (!value || seen.has(key)) continue;
+    aliases.push(value);
+    seen.add(key);
+  }
+  return aliases;
+}
+
+async function enrichResolvedEntityAliases(
+  db: Kysely<DB>,
+  groupJid: string,
+  participants: Array<{ phone_e164: string | null; resolution: WhatsAppIdentityResolution; pushName?: string }>,
+): Promise<void> {
+  const candidates = participants.filter(
+    (
+      participant,
+    ): participant is typeof participant & { resolution: Extract<WhatsAppIdentityResolution, { kind: "entity" }> } =>
+      participant.resolution.kind === "entity",
+  );
+  if (candidates.length === 0) return;
+
+  const labels = await createWhatsAppGroupRepository(db).listMemberLabels(groupJid);
+  const labelByPhone = new Map(
+    labels.map((label) => [normalizeWhatsAppIdentityPhone(label.phone_e164), safePushName(label.display_name)]),
+  );
+  const additionsByEntityId = new Map<string, string[]>();
+  for (const candidate of candidates) {
+    const phone = normalizeWhatsAppIdentityPhone(candidate.phone_e164);
+    const additions = additionsByEntityId.get(candidate.resolution.entityId) ?? [];
+    additions.push(candidate.pushName ?? "", phone ? (labelByPhone.get(phone) ?? "") : "");
+    additionsByEntityId.set(candidate.resolution.entityId, additions);
+  }
+
+  for (const [entityId, additions] of additionsByEntityId) {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const entity = await db
+        .selectFrom("entities")
+        .select(["id", "aliases"])
+        .where("id", "=", entityId)
+        .where("source_type", "=", "person")
+        .where("status", "!=", "archived")
+        .where("deleted_at", "is", null)
+        .executeTakeFirst();
+      if (!entity) break;
+
+      const aliases = mergeAliases(entity.aliases, additions);
+      if (aliases.length === parseAliasesString(entity.aliases).length) break;
+
+      let update = db
+        .updateTable("entities")
+        .set({ aliases: JSON.stringify(aliases), updated_at: new Date().toISOString() })
+        .where("id", "=", entity.id);
+      update =
+        entity.aliases === null ? update.where("aliases", "is", null) : update.where("aliases", "=", entity.aliases);
+      const result = await update.executeTakeFirst();
+      if (result.numUpdatedRows > 0n) break;
+    }
+  }
 }
 
 function displayNameForResolution(
@@ -441,14 +516,24 @@ export async function buildWhatsAppRosterSnapshot({
   const pushNamesBySenderJid = await loadPushNamesBySenderJid(db, conversationId);
   const counts = emptyCounts(participants.length);
 
-  const snapshotParticipants = participants.map((participant) => {
+  const snapshotInputs = participants.map((participant) => {
     const resolution = resolutions.get(participant.participant_jid) ?? { kind: "unresolved" };
-    incrementCount(counts, resolution.kind);
-    return snapshotParticipant(
-      participant,
+    const pushName = pushNameForParticipant(pushNamesBySenderJid, participant.participant_jid, participant.phone_e164);
+    return { participant, resolution, pushName };
+  });
+  await enrichResolvedEntityAliases(
+    db,
+    groupJid,
+    snapshotInputs.map(({ participant, resolution, pushName }) => ({
+      phone_e164: participant.phone_e164,
       resolution,
-      pushNameForParticipant(pushNamesBySenderJid, participant.participant_jid, participant.phone_e164),
-    );
+      pushName,
+    })),
+  );
+
+  const snapshotParticipants = snapshotInputs.map(({ participant, resolution, pushName }) => {
+    incrementCount(counts, resolution.kind);
+    return snapshotParticipant(participant, resolution, pushName);
   });
 
   logger.info(

--- a/packages/server/src/whatsapp/identity-resolution.ts
+++ b/packages/server/src/whatsapp/identity-resolution.ts
@@ -1,13 +1,13 @@
 import { createHash } from "node:crypto";
 import { type Kysely, sql } from "kysely";
 import type { Logger } from "pino";
+import { mergeEntityAliases } from "../db/repositories/entity-aliases";
 import { createUserWhatsAppLidRepository } from "../db/repositories/user-whatsapp-lids";
 import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
-import { parseAliasesString } from "../entities/materialize-json";
 import { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../identity-normalization";
-import { safeWhatsAppErrorFields, sanitizeWhatsAppDisplayText } from "./privacy";
+import { safeWhatsAppErrorFields, sanitizeWhatsAppDisplayText, stripPersonalNumberTokens } from "./privacy";
 import { phoneE164ToWhatsAppJid } from "./provider";
 
 export { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../identity-normalization";
@@ -64,6 +64,7 @@ interface BuildRosterSnapshotOptions {
   groupJid: string;
   conversationId: number;
   logger: Logger;
+  enrichEntityAliases?: boolean;
 }
 
 const REF_ALPHABET = "abcdefghijklmnop";
@@ -133,6 +134,16 @@ function safePushName(value: string | undefined): string | undefined {
   return isHumanReadableAlias(value, sanitized) ? sanitized : undefined;
 }
 
+function safeEntityAlias(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const withoutControls = value
+    .replace(/[\p{Cc}\p{Cf}]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  const sanitized = stripPersonalNumberTokens(withoutControls).slice(0, 160).trim();
+  return isHumanReadableAlias(withoutControls, sanitized) ? sanitized : undefined;
+}
+
 function isHumanReadableAlias(raw: string, sanitized: string): boolean {
   if (!sanitized || sanitized.includes("[whatsapp-id]")) return false;
   const trimmed = raw.trim();
@@ -141,24 +152,10 @@ function isHumanReadableAlias(raw: string, sanitized: string): boolean {
   return normalizeWhatsAppIdentityPhone(trimmed) === null && !/@(?:lid|s\.whatsapp\.net)$/iu.test(trimmed);
 }
 
-function mergeAliases(existing: string | null, additions: Array<string | undefined>): string[] {
-  const aliases = parseAliasesString(existing);
-  const seen = new Set(aliases.map((alias) => alias.trim().toLowerCase()));
-  for (const addition of additions) {
-    if (!addition) continue;
-    const value = addition.trim();
-    const key = value.toLowerCase();
-    if (!value || seen.has(key)) continue;
-    aliases.push(value);
-    seen.add(key);
-  }
-  return aliases;
-}
-
 async function enrichResolvedEntityAliases(
   db: Kysely<DB>,
   groupJid: string,
-  participants: Array<{ phone_e164: string | null; resolution: WhatsAppIdentityResolution; pushName?: string }>,
+  participants: Array<{ phone_e164: string | null; resolution: WhatsAppIdentityResolution; aliasName?: string }>,
 ): Promise<void> {
   const candidates = participants.filter(
     (
@@ -170,40 +167,18 @@ async function enrichResolvedEntityAliases(
 
   const labels = await createWhatsAppGroupRepository(db).listMemberLabels(groupJid);
   const labelByPhone = new Map(
-    labels.map((label) => [normalizeWhatsAppIdentityPhone(label.phone_e164), safePushName(label.display_name)]),
+    labels.map((label) => [normalizeWhatsAppIdentityPhone(label.phone_e164), safeEntityAlias(label.display_name)]),
   );
   const additionsByEntityId = new Map<string, string[]>();
   for (const candidate of candidates) {
     const phone = normalizeWhatsAppIdentityPhone(candidate.phone_e164);
     const additions = additionsByEntityId.get(candidate.resolution.entityId) ?? [];
-    additions.push(candidate.pushName ?? "", phone ? (labelByPhone.get(phone) ?? "") : "");
+    additions.push(candidate.aliasName ?? "", phone ? (labelByPhone.get(phone) ?? "") : "");
     additionsByEntityId.set(candidate.resolution.entityId, additions);
   }
 
   for (const [entityId, additions] of additionsByEntityId) {
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      const entity = await db
-        .selectFrom("entities")
-        .select(["id", "aliases"])
-        .where("id", "=", entityId)
-        .where("source_type", "=", "person")
-        .where("status", "!=", "archived")
-        .where("deleted_at", "is", null)
-        .executeTakeFirst();
-      if (!entity) break;
-
-      const aliases = mergeAliases(entity.aliases, additions);
-      if (aliases.length === parseAliasesString(entity.aliases).length) break;
-
-      let update = db
-        .updateTable("entities")
-        .set({ aliases: JSON.stringify(aliases), updated_at: new Date().toISOString() })
-        .where("id", "=", entity.id);
-      update =
-        entity.aliases === null ? update.where("aliases", "is", null) : update.where("aliases", "=", entity.aliases);
-      const result = await update.executeTakeFirst();
-      if (result.numUpdatedRows > 0n) break;
-    }
+    await mergeEntityAliases(db, entityId, additions);
   }
 }
 
@@ -484,16 +459,16 @@ async function loadPushNamesBySenderJid(db: Kysely<DB>, conversationId: number):
   return out;
 }
 
-function pushNameForParticipant(
+function rawPushNameForParticipant(
   pushNamesBySenderJid: Map<string, string>,
   participantJid: string,
   phoneE164: string | null,
 ): string | undefined {
   const direct = pushNamesBySenderJid.get(participantJid);
-  if (direct) return safePushName(direct);
+  if (direct) return direct;
   const normalizedPhone = normalizeWhatsAppIdentityPhone(phoneE164);
   if (!normalizedPhone) return undefined;
-  return safePushName(pushNamesBySenderJid.get(phoneE164ToWhatsAppJid(normalizedPhone)));
+  return pushNamesBySenderJid.get(phoneE164ToWhatsAppJid(normalizedPhone));
 }
 
 export async function buildWhatsAppRosterSnapshot({
@@ -501,6 +476,7 @@ export async function buildWhatsAppRosterSnapshot({
   groupJid,
   conversationId,
   logger,
+  enrichEntityAliases = false,
 }: BuildRosterSnapshotOptions): Promise<WhatsAppRosterBuildResult> {
   const participantRepo = createWhatsAppGroupRepository(db);
   const participants = await participantRepo.listParticipants(groupJid);
@@ -518,18 +494,31 @@ export async function buildWhatsAppRosterSnapshot({
 
   const snapshotInputs = participants.map((participant) => {
     const resolution = resolutions.get(participant.participant_jid) ?? { kind: "unresolved" };
-    const pushName = pushNameForParticipant(pushNamesBySenderJid, participant.participant_jid, participant.phone_e164);
-    return { participant, resolution, pushName };
+    const rawPushName = rawPushNameForParticipant(
+      pushNamesBySenderJid,
+      participant.participant_jid,
+      participant.phone_e164,
+    );
+    return { participant, resolution, pushName: safePushName(rawPushName), aliasName: safeEntityAlias(rawPushName) };
   });
-  await enrichResolvedEntityAliases(
-    db,
-    groupJid,
-    snapshotInputs.map(({ participant, resolution, pushName }) => ({
-      phone_e164: participant.phone_e164,
-      resolution,
-      pushName,
-    })),
-  );
+  if (enrichEntityAliases) {
+    try {
+      await enrichResolvedEntityAliases(
+        db,
+        groupJid,
+        snapshotInputs.map(({ participant, resolution, aliasName }) => ({
+          phone_e164: participant.phone_e164,
+          resolution,
+          aliasName,
+        })),
+      );
+    } catch (err) {
+      logger.warn(
+        { ...safeWhatsAppErrorFields(err), groupJid },
+        "WhatsApp entity alias enrichment failed without blocking roster resolution",
+      );
+    }
+  }
 
   const snapshotParticipants = snapshotInputs.map(({ participant, resolution, pushName }) => {
     incrementCount(counts, resolution.kind);


### PR DESCRIPTION
## Summary

- enrich person entities with Slack real/display-name aliases
- enrich entities with sanitized WhatsApp push-name and member-label aliases only for indexed groups
- preserve concurrent alias updates with a portable compare-and-swap helper
- keep email, phone, Slack IDs, and WhatsApp IDs as structured identity data instead of aliases

## Safety

- no schema migration or destructive rewrite
- alias enrichment failures cannot block roster or ACL reconciliation
- unresolved WhatsApp participants still do not create entities
- archived, deleted, and merged entities are not enriched

## Verification

- Biome and TypeScript checks passed
- server: 5,449 passed; 20 live-provider tests skipped
- web: 506 passed
- production build passed

## Rollback

Revert the three commits. No data migration is required.

Linear: https://linear.app/sketch-ai/issue/SKE-389/enrich-person-entities-with-slack-and-whatsapp-name-aliases
Planning: `.planning/knowledge/implemented/SKE-389.md`