### PR TITLE
feat(dev-tools): add stage-by-stage enrichment trace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,10 @@ LOG_LEVEL=info          # debug | info | warn | error
 # TEAMS_MAX_INFLIGHT=4
 # TEAMS_PROCESSING_LAG_MS=7200000
 
+# Internal pipeline-debugging surface: /api/dev routes plus the /dev-tools page.
+# Admin-only on top of this flag. Leave off on tenant deployments.
+# DEV_TOOLS_ENABLED=false
+
 # Visual analysis tool for text-only LLM deployments
 # VISION_ENABLED=false
 # VISION_MODEL=xiaomi/mimo-v2.5

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -37,6 +37,7 @@ import {
   resolveOpenRouterEnrichmentConfig,
 } from "../connectors/enrichment-providers";
 import { buildCredentialHint } from "../connectors/fireflies";
+import type { GeminiGenerator } from "../connectors/gemini-generate";
 import { ensureValidToken, listFolderContents, listMyDriveFolders, listSharedDrives } from "../connectors/google-drive";
 import { browseNotionRootPages, getBrowseStatus, startNotionBrowse } from "../connectors/notion";
 import { buildOtterCredentialHint } from "../connectors/otter";
@@ -420,6 +421,10 @@ export function connectorRoutes(
       | "SLACK_ENTITY_SYNC"
     >
   >,
+  deps?: {
+    /** Overrides the settings-derived model, so tests can drive the per-file enrich route. */
+    enrichmentGenerator?: GeminiGenerator;
+  },
 ) {
   const routes = new Hono();
   const fileSharesRepo = createFileSharesRepository(db);
@@ -2519,7 +2524,7 @@ export function connectorRoutes(
     const settings = await createSettingsRepository(db, appConfig?.ENCRYPTION_KEY).get();
     const providerConfig = buildEnrichmentProviderConfig(settings, appConfig, logger);
     const embeddingProvider = createEnrichmentEmbeddingProvider(providerConfig);
-    const generator = createEnrichmentGenerator(providerConfig);
+    const generator = deps?.enrichmentGenerator ?? createEnrichmentGenerator(providerConfig);
 
     // Enrich only this specific file.
     // This endpoint is the per-file "Enrich File" debug surface — always dump

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -2525,6 +2525,16 @@ export function connectorRoutes(
     // This endpoint is the per-file "Enrich File" debug surface — always dump
     // LLM calls to disk for inspection. Each call gets its own dated subdir
     // under data/llm-dumps/ so runs don't clobber each other.
+    //
+    // Clear summary_status first. Smart enrichment — extraction, dedup and
+    // fact materialisation — is gated on it being unresolved
+    // (enrichment.ts `summaryAlreadyResolved`), so on an already-enriched file
+    // this endpoint would re-embed, report success, and silently skip the
+    // half a caller actually asked for. runEnrichment's fileIds path already
+    // treats an explicit rerun as a manual override for embedding_status;
+    // this makes summary_status agree.
+    await db.updateTable("indexed_files").set({ summary_status: "pending" }).where("id", "=", fileId).execute();
+
     const dumpStamp = new Date().toISOString().replace(/[:.]/g, "-");
     const debugDumpDir = `data/llm-dumps/${fileId}__${dumpStamp}`;
     runEnrichment({

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -31,6 +31,7 @@ import { parseEmailAddrJson, parseEmailAddrListJson } from "../connectors/email/
 import type { EmailAddr } from "../connectors/email/normalized-email";
 import { isEnrichmentActive, runEnrichment } from "../connectors/enrichment";
 import {
+  buildEnrichmentProviderConfig,
   createEnrichmentEmbeddingProvider,
   createEnrichmentGenerator,
   resolveOpenRouterEnrichmentConfig,
@@ -2516,15 +2517,7 @@ export function connectorRoutes(
     if (denied) return denied;
 
     const settings = await createSettingsRepository(db, appConfig?.ENCRYPTION_KEY).get();
-    const openRouterConfig = resolveOpenRouterEnrichmentConfig(settings, appConfig?.OPENROUTER_API_KEY);
-    const providerConfig = {
-      geminiApiKey: settings?.gemini_api_key,
-      embeddingProvider: settings?.embedding_provider,
-      geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
-      geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
-      logger,
-      ...openRouterConfig,
-    };
+    const providerConfig = buildEnrichmentProviderConfig(settings, appConfig, logger);
     const embeddingProvider = createEnrichmentEmbeddingProvider(providerConfig);
     const generator = createEnrichmentGenerator(providerConfig);
 

--- a/packages/server/src/api/dev-enrichment.test.ts
+++ b/packages/server/src/api/dev-enrichment.test.ts
@@ -1,21 +1,21 @@
-/**
- * The failure mode this file exists for: the debug surface reaching a tenant.
- *
- * Two independent gates have to hold — the routes must not mount at all without
- * `DEV_TOOLS_ENABLED`, and with the flag on they must still refuse a non-admin.
- * A regression in either one leaks internal pipeline behaviour to a customer,
- * which is the reason the surface is separate from the product in the first place.
- */
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Kysely } from "kysely";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hashPassword } from "../auth/password";
+import type { GeminiGenerator, GenerateOptions } from "../connectors/gemini-generate";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
+import { clearTraceRuns } from "../dev/enrichment-trace";
 import { createApp } from "../http";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
 
 const logger = createTestLogger();
+const ADMIN_ID = "admin-user";
+const MEMBER_ID = "member-user";
 const ADMIN_EMAIL = "admin@test.com";
 const MEMBER_EMAIL = "member@test.com";
 const PASSWORD = "testpassword123";
@@ -25,8 +25,16 @@ async function seedUsers(db: Kysely<DB>) {
   const users = createUserRepository(db);
   const hash = await hashPassword(PASSWORD);
   await settings.create();
-  await users.create({ name: "admin", email: ADMIN_EMAIL, emailVerified: true, passwordHash: hash, authRole: "admin" });
   await users.create({
+    id: ADMIN_ID,
+    name: "admin",
+    email: ADMIN_EMAIL,
+    emailVerified: true,
+    passwordHash: hash,
+    authRole: "admin",
+  });
+  await users.create({
+    id: MEMBER_ID,
     name: "member",
     email: MEMBER_EMAIL,
     emailVerified: true,
@@ -45,63 +53,271 @@ async function login(app: ReturnType<typeof createApp>, email: string): Promise<
   return res.headers.get("set-cookie") ?? "";
 }
 
+async function seedTraceFile(db: Kysely<DB>, fileId = `file-${randomUUID()}`): Promise<string> {
+  const productNames = Array.from({ length: 25 }, (_, index) => `Trace Product ${String(index).padStart(2, "0")}`);
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id: "trace-connector",
+      connector_type: "google_drive",
+      auth_type: "oauth",
+      credentials: "{}",
+      created_by: ADMIN_ID,
+    })
+    .onConflict((oc) => oc.doNothing())
+    .execute();
+  await db
+    .insertInto("entities")
+    .values(
+      productNames.map((name, index) => ({
+        id: `product-${index}`,
+        name,
+        source_type: "product",
+        subtype: null,
+        aliases: null,
+        metadata: null,
+        source_ref_id: `product-${index}`,
+        status: "confirmed",
+        provenance_tier: "declared",
+        hotness: 100 - index,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })),
+    )
+    .execute();
+  const content = `${productNames.join(" ")} ${Array.from({ length: 130 }, (_, index) => `context${index}`).join(" ")}`;
+  await db
+    .insertInto("indexed_files")
+    .values({
+      id: fileId,
+      connector_config_id: "trace-connector",
+      provider_file_id: fileId,
+      provider_url: null,
+      file_name: "Trace Product Notes",
+      file_type: "text",
+      content_category: "document",
+      source: "google_drive",
+      source_path: "My Drive/Trace Product Notes",
+      content,
+      summary: null,
+      context_note: null,
+      content_hash: `hash-${fileId}`,
+      source_created_at: new Date().toISOString(),
+      source_updated_at: new Date().toISOString(),
+      synced_at: new Date().toISOString(),
+      access_scope_id: null,
+    })
+    .execute();
+  return fileId;
+}
+
+function dumpWritingGenerator(opts: { throwOnEntityFacts?: boolean } = {}): GeminiGenerator {
+  async function writeDump(prompt: string, options: GenerateOptions | undefined, text: string) {
+    if (!options?.dumpDir) return;
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const safeLabel = (options.label ?? "unlabeled").replace(/[^a-zA-Z0-9_-]/g, "_");
+    await mkdir(options.dumpDir, { recursive: true });
+    await writeFile(
+      join(options.dumpDir, `${ts}__${safeLabel}.json`),
+      JSON.stringify(
+        {
+          label: options.label ?? "unlabeled",
+          prompt,
+          systemPrompt: options.systemPrompt,
+          maxTokens: options.maxTokens ?? 8192,
+          text,
+          finishReason: "STOP",
+          promptTokens: 11,
+          candidatesTokens: 7,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+  }
+
+  return {
+    async generate(prompt, options) {
+      const text = "Trace Product Notes discusses Trace Product 00.";
+      await writeDump(prompt, options, text);
+      return text;
+    },
+    async generateJSON<T>(prompt: string, options?: Omit<GenerateOptions, "responseMimeType">) {
+      if (options?.label?.startsWith("extractEntityFacts") && opts.throwOnEntityFacts) {
+        throw new Error("entity facts exploded");
+      }
+      const value = options?.label?.startsWith("extractEntities")
+        ? {
+            mentions: [{ mention: "Trace Product 00", type: "product", variations: [], confidence: 0.97 }],
+            relations: [],
+          }
+        : options?.label?.startsWith("dedupAdjudicate")
+          ? [{ mention: "M1", matchesKnown: "K1" }]
+          : {};
+      await writeDump(prompt, options, JSON.stringify(value));
+      return value as T;
+    },
+  };
+}
+
+async function startRun(app: ReturnType<typeof createApp>, cookie: string, fileId: string): Promise<string> {
+  const start = await app.request("/api/dev/enrichment-runs", {
+    method: "POST",
+    headers: { Cookie: cookie, "Content-Type": "application/json" },
+    body: JSON.stringify({ fileId }),
+  });
+  expect(start.status).toBe(201);
+  return ((await start.json()) as { runId: string }).runId;
+}
+
+async function waitForRun(app: ReturnType<typeof createApp>, cookie: string, runId: string) {
+  await vi.waitFor(
+    async () => {
+      const res = await app.request(`/api/dev/enrichment-runs/${runId}`, { headers: { Cookie: cookie } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        run: { status: string };
+        stageReports: Array<{ stage: string; status: string; error?: string }>;
+      };
+      expect(body.run.status).not.toBe("running");
+    },
+    { timeout: 10_000, interval: 25 },
+  );
+  const res = await app.request(`/api/dev/enrichment-runs/${runId}`, { headers: { Cookie: cookie } });
+  expect(res.status).toBe(200);
+  return (await res.json()) as {
+    run: { status: string };
+    stageReports: Array<{ stage: string; status: string; error?: string }>;
+  };
+}
+
 describe("Dev enrichment trace routes", () => {
   let db: Kysely<DB>;
+  let dataDir: string;
 
   beforeEach(async () => {
     db = await createTestDb();
+    dataDir = join(tmpdir(), `sketch-dev-enrichment-${randomUUID()}`);
+    clearTraceRuns();
     await seedUsers(db);
   });
 
   afterEach(async () => {
+    clearTraceRuns();
     try {
       await db.destroy();
     } catch {}
   });
 
-  it("does not mount without DEV_TOOLS_ENABLED, even for an admin", async () => {
-    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: false }), { logger });
+  it("serves a model stage with its prompt, output, parsed JSON, and capped context report", async () => {
+    const fileId = await seedTraceFile(db);
+    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: true, DATA_DIR: dataDir }), {
+      logger,
+      enrichmentGenerator: dumpWritingGenerator(),
+    });
     const cookie = await login(app, ADMIN_EMAIL);
 
-    const list = await app.request("/api/dev/enrichment-runs", { headers: { Cookie: cookie } });
-    const start = await app.request("/api/dev/enrichment-runs", {
-      method: "POST",
-      headers: { Cookie: cookie, "Content-Type": "application/json" },
-      body: JSON.stringify({ fileId: "anything" }),
-    });
+    const runId = await startRun(app, cookie, fileId);
+    const runBody = await waitForRun(app, cookie, runId);
 
-    expect(list.status).toBe(404);
-    expect(start.status).toBe(404);
+    const callsRes = await app.request(`/api/dev/enrichment-runs/${runId}/calls`, { headers: { Cookie: cookie } });
+    expect(callsRes.status).toBe(200);
+    const callsBody = (await callsRes.json()) as { calls: Array<{ seq: number; stage: string; promptChars: number }> };
+    const extractCall = callsBody.calls.find((call) => call.stage === "extractEntities");
+    expect(extractCall).toBeTruthy();
+    for (const call of callsBody.calls) {
+      expect(Object.keys(call)).not.toContain("prompt");
+      expect(Object.keys(call)).not.toContain("text");
+      expect(Object.keys(call)).not.toContain("systemPrompt");
+    }
+
+    const callRes = await app.request(`/api/dev/enrichment-runs/${runId}/calls/${extractCall?.seq}`, {
+      headers: { Cookie: cookie },
+    });
+    expect(callRes.status).toBe(200);
+    const callBody = (await callRes.json()) as {
+      call: { prompt: string; text: string; parsed: { mentions: unknown[] }; promptChars: number };
+    };
+    const runHeader = await app.request(`/api/dev/enrichment-runs/${runId}`, { headers: { Cookie: cookie } });
+    const { run } = (await runHeader.json()) as { run: { dumpDir: string } };
+    const dumpFiles = (await readdir(run.dumpDir)).filter((name) => name.includes("extractEntities")).sort();
+    const onDisk = JSON.parse(await readFile(join(run.dumpDir, dumpFiles[0]), "utf8")) as { prompt: string };
+    expect(callBody.call.prompt).toBe(onDisk.prompt);
+    expect(callBody.call.promptChars).toBe(Buffer.byteLength(onDisk.prompt, "utf8"));
+    expect(callBody.call.text).toContain("Trace Product 00");
+
+    const facts = await db
+      .selectFrom("indexed_file_facts")
+      .select("id")
+      .where("indexed_file_id", "=", fileId)
+      .where("fact_type", "=", "llm_extracted")
+      .where("deleted_at", "is", null)
+      .execute();
+    expect(callBody.call.parsed.mentions).toHaveLength(facts.length);
+
+    const extractReport = runBody.stageReports.find((report) => report.stage === "extractEntities") as
+      | { context?: Array<{ key: string; total: number; items: string[]; truncated?: boolean }> }
+      | undefined;
+    const knownBlock = extractReport?.context?.find((block) => block.key === "knownEntities");
+    expect(knownBlock?.total).toBeGreaterThan(knownBlock?.items.length ?? 0);
+    expect(knownBlock?.truncated).toBe(true);
   });
 
-  it("refuses a non-admin once the flag is on", async () => {
-    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: true }), { logger });
-    const cookie = await login(app, MEMBER_EMAIL);
-
-    const list = await app.request("/api/dev/enrichment-runs", { headers: { Cookie: cookie } });
-    const start = await app.request("/api/dev/enrichment-runs", {
-      method: "POST",
-      headers: { Cookie: cookie, "Content-Type": "application/json" },
-      body: JSON.stringify({ fileId: "anything" }),
+  it("does not expose call payloads through either dev-tools gate", async () => {
+    const hiddenApp = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: false }), { logger });
+    const adminCookie = await login(hiddenApp, ADMIN_EMAIL);
+    const hiddenList = await hiddenApp.request("/api/dev/enrichment-runs/run/calls", {
+      headers: { Cookie: adminCookie },
     });
+    const hiddenBody = await hiddenApp.request("/api/dev/enrichment-runs/run/calls/1", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(hiddenList.status).toBe(404);
+    expect(hiddenBody.status).toBe(404);
 
-    expect(list.status).toBe(403);
-    expect(start.status).toBe(403);
+    const flaggedApp = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: true }), { logger });
+    const memberCookie = await login(flaggedApp, MEMBER_EMAIL);
+    const forbiddenList = await flaggedApp.request("/api/dev/enrichment-runs/run/calls", {
+      headers: { Cookie: memberCookie },
+    });
+    const forbiddenBody = await flaggedApp.request("/api/dev/enrichment-runs/run/calls/1", {
+      headers: { Cookie: memberCookie },
+    });
+    expect(forbiddenList.status).toBe(403);
+    expect(forbiddenBody.status).toBe(403);
   });
 
-  it("serves an admin the run list and rejects an unknown file", async () => {
-    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: true }), { logger });
+  it("keeps a run readable when a later model stage throws without writing a dump", async () => {
+    const fileId = await seedTraceFile(db);
+    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: true, DATA_DIR: dataDir }), {
+      logger,
+      enrichmentGenerator: dumpWritingGenerator({ throwOnEntityFacts: true }),
+    });
     const cookie = await login(app, ADMIN_EMAIL);
 
-    const list = await app.request("/api/dev/enrichment-runs", { headers: { Cookie: cookie } });
-    expect(list.status).toBe(200);
-    expect(await list.json()).toHaveProperty("runs");
-
-    const start = await app.request("/api/dev/enrichment-runs", {
-      method: "POST",
-      headers: { Cookie: cookie, "Content-Type": "application/json" },
-      body: JSON.stringify({ fileId: "does-not-exist" }),
+    const runId = await startRun(app, cookie, fileId);
+    const runBody = await waitForRun(app, cookie, runId);
+    expect(runBody.run.status).toBe("failed");
+    expect(runBody.stageReports.find((report) => report.stage === "extractEntityFacts")).toMatchObject({
+      status: "failed",
+      error: "entity facts exploded",
     });
-    expect(start.status).toBe(404);
+    expect(runBody.stageReports.find((report) => report.stage === "engagementFloor")).toMatchObject({
+      status: "skipped",
+    });
+    expect(runBody.stageReports.find((report) => report.stage === "materialize")).toMatchObject({ status: "skipped" });
+
+    const callsRes = await app.request(`/api/dev/enrichment-runs/${runId}/calls`, { headers: { Cookie: cookie } });
+    const callsBody = (await callsRes.json()) as { calls: Array<{ seq: number; stage: string }> };
+    expect(callsBody.calls.some((call) => call.stage === "extractEntityFacts")).toBe(false);
+    const extractCall = callsBody.calls.find((call) => call.stage === "extractEntities");
+    expect(extractCall).toBeTruthy();
+
+    const callRes = await app.request(`/api/dev/enrichment-runs/${runId}/calls/${extractCall?.seq}`, {
+      headers: { Cookie: cookie },
+    });
+    expect(callRes.status).toBe(200);
+    expect(((await callRes.json()) as { call: { prompt: string } }).call.prompt).toContain("Trace Product Notes");
   });
 });

--- a/packages/server/src/api/dev-enrichment.test.ts
+++ b/packages/server/src/api/dev-enrichment.test.ts
@@ -161,6 +161,29 @@ function dumpWritingGenerator(opts: { throwOnEntityFacts?: boolean } = {}): Gemi
   };
 }
 
+/**
+ * Records the label of every model call, which is how a test tells "extraction
+ * ran" from "the endpoint returned success and skipped it".
+ */
+function labelRecordingGenerator(labels: string[]): GeminiGenerator {
+  return {
+    async generate(_prompt, options) {
+      labels.push(options?.label ?? "unlabeled");
+      return "Trace Product Notes discusses Trace Product 00.";
+    },
+    async generateJSON<T>(_prompt: string, options?: Omit<GenerateOptions, "responseMimeType">) {
+      labels.push(options?.label ?? "unlabeled");
+      const value = options?.label?.startsWith("extractEntities")
+        ? {
+            mentions: [{ mention: "Trace Product 00", type: "product", variations: [], confidence: 0.97 }],
+            relations: [],
+          }
+        : {};
+      return value as T;
+    },
+  };
+}
+
 async function startRun(app: ReturnType<typeof createApp>, cookie: string, fileId: string): Promise<string> {
   const start = await app.request("/api/dev/enrichment-runs", {
     method: "POST",
@@ -319,5 +342,47 @@ describe("Dev enrichment trace routes", () => {
     });
     expect(callRes.status).toBe(200);
     expect(((await callRes.json()) as { call: { prompt: string } }).call.prompt).toContain("Trace Product Notes");
+  });
+  it("re-extracts through the per-file enrich endpoint when the summary is already resolved", async () => {
+    const fileId = await seedTraceFile(db);
+    const labels: string[] = [];
+    const app = createApp(db, createTestConfig({ DATA_DIR: dataDir }), {
+      logger,
+      enrichmentGenerator: labelRecordingGenerator(labels),
+    });
+    const cookie = await login(app, ADMIN_EMAIL);
+
+    for (const status of ["done", "skipped"] as const) {
+      labels.length = 0;
+      await db.updateTable("indexed_files").set({ summary_status: status }).where("id", "=", fileId).execute();
+
+      const res = await app.request(`/api/connectors/files/${fileId}/enrichments`, {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+
+      await vi.waitFor(() => expect(labels.some((label) => label.startsWith("extractEntities"))).toBe(true), {
+        timeout: 10_000,
+        interval: 25,
+      });
+
+      /**
+       * The endpoint answers before enrichment finishes. Wait for the run to
+       * settle rather than tearing the database down underneath it — these
+       * tests share a worker, so work that outlives its test fails another one.
+       */
+      await vi.waitFor(
+        async () => {
+          const row = await db
+            .selectFrom("indexed_files")
+            .select("summary_status")
+            .where("id", "=", fileId)
+            .executeTakeFirst();
+          expect(row?.summary_status).not.toBe("pending");
+        },
+        { timeout: 10_000, interval: 25 },
+      );
+    }
   });
 });

--- a/packages/server/src/api/dev-enrichment.test.ts
+++ b/packages/server/src/api/dev-enrichment.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The failure mode this file exists for: the debug surface reaching a tenant.
+ *
+ * Two independent gates have to hold — the routes must not mount at all without
+ * `DEV_TOOLS_ENABLED`, and with the flag on they must still refuse a non-admin.
+ * A regression in either one leaks internal pipeline behaviour to a customer,
+ * which is the reason the surface is separate from the product in the first place.
+ */
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hashPassword } from "../auth/password";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+
+const logger = createTestLogger();
+const ADMIN_EMAIL = "admin@test.com";
+const MEMBER_EMAIL = "member@test.com";
+const PASSWORD = "testpassword123";
+
+async function seedUsers(db: Kysely<DB>) {
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  const hash = await hashPassword(PASSWORD);
+  await settings.create();
+  await users.create({ name: "admin", email: ADMIN_EMAIL, emailVerified: true, passwordHash: hash, authRole: "admin" });
+  await users.create({
+    name: "member",
+    email: MEMBER_EMAIL,
+    emailVerified: true,
+    passwordHash: hash,
+    authRole: "member",
+  });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+}
+
+async function login(app: ReturnType<typeof createApp>, email: string): Promise<string> {
+  const res = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  });
+  return res.headers.get("set-cookie") ?? "";
+}
+
+describe("Dev enrichment trace routes", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await seedUsers(db);
+  });
+
+  afterEach(async () => {
+    try {
+      await db.destroy();
+    } catch {}
+  });
+
+  it("does not mount without DEV_TOOLS_ENABLED, even for an admin", async () => {
+    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: false }), { logger });
+    const cookie = await login(app, ADMIN_EMAIL);
+
+    const list = await app.request("/api/dev/enrichment-runs", { headers: { Cookie: cookie } });
+    const start = await app.request("/api/dev/enrichment-runs", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ fileId: "anything" }),
+    });
+
+    expect(list.status).toBe(404);
+    expect(start.status).toBe(404);
+  });
+
+  it("refuses a non-admin once the flag is on", async () => {
+    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: true }), { logger });
+    const cookie = await login(app, MEMBER_EMAIL);
+
+    const list = await app.request("/api/dev/enrichment-runs", { headers: { Cookie: cookie } });
+    const start = await app.request("/api/dev/enrichment-runs", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ fileId: "anything" }),
+    });
+
+    expect(list.status).toBe(403);
+    expect(start.status).toBe(403);
+  });
+
+  it("serves an admin the run list and rejects an unknown file", async () => {
+    const app = createApp(db, createTestConfig({ DEV_TOOLS_ENABLED: true }), { logger });
+    const cookie = await login(app, ADMIN_EMAIL);
+
+    const list = await app.request("/api/dev/enrichment-runs", { headers: { Cookie: cookie } });
+    expect(list.status).toBe(200);
+    expect(await list.json()).toHaveProperty("runs");
+
+    const start = await app.request("/api/dev/enrichment-runs", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ fileId: "does-not-exist" }),
+    });
+    expect(start.status).toBe(404);
+  });
+});

--- a/packages/server/src/api/dev-enrichment.ts
+++ b/packages/server/src/api/dev-enrichment.ts
@@ -1,0 +1,130 @@
+/**
+ * Dev-only enrichment trace routes.
+ *
+ * Mounted only when `DEV_TOOLS_ENABLED` is set, and admin-gated on top of that,
+ * so a tenant deployment has no route to find. Everything it returns is
+ * captured in memory for the life of the process — see `dev/enrichment-trace.ts`.
+ *
+ * Running a trace runs the real pipeline: it writes facts and can mint entities,
+ * exactly as the Enrich File button does. It is an observation window on a real
+ * run, not a simulation of one.
+ */
+import { type Context, Hono } from "hono";
+import type { Kysely } from "kysely";
+import type { Logger } from "pino";
+import { z } from "zod";
+import { runEnrichment } from "../connectors/enrichment";
+import {
+  buildEnrichmentProviderConfig,
+  createEnrichmentEmbeddingProvider,
+  createEnrichmentGenerator,
+} from "../connectors/enrichment-providers";
+import { createSettingsRepository } from "../db/repositories/settings";
+import type { DB } from "../db/schema";
+import { createTracedLogger, finishTraceRun, getTraceRun, listTraceRuns, startTraceRun } from "../dev/enrichment-trace";
+
+const startRunSchema = z.object({ fileId: z.string().min(1) });
+
+function requireAdmin(c: Context) {
+  if (c.get("role") !== "admin") {
+    return { error: { code: "FORBIDDEN", message: "Admin access required" } };
+  }
+  return null;
+}
+
+export function devEnrichmentRoutes(
+  db: Kysely<DB>,
+  logger: Logger,
+  appConfig?: {
+    ENCRYPTION_KEY?: string;
+    GEMINI_MAX_RPM?: number;
+    GEMINI_MAX_RETRIES?: number;
+    OPENROUTER_API_KEY?: string;
+  },
+) {
+  const routes = new Hono();
+
+  /** Starts one traced enrichment of a single file and returns immediately. */
+  routes.post("/enrichment-runs", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    const parsed = startRunSchema.safeParse(await c.req.json().catch(() => ({})));
+    if (!parsed.success) {
+      return c.json({ error: { code: "INVALID_BODY", message: "fileId is required" } }, 400);
+    }
+
+    const file = await db
+      .selectFrom("indexed_files")
+      .select(["id", "file_name"])
+      .where("id", "=", parsed.data.fileId)
+      .executeTakeFirst();
+    if (!file) {
+      return c.json({ error: { code: "NOT_FOUND", message: "File not found" } }, 404);
+    }
+
+    const settings = await createSettingsRepository(db, appConfig?.ENCRYPTION_KEY).get();
+    const providerConfig = buildEnrichmentProviderConfig(settings, appConfig, logger);
+    const generator = createEnrichmentGenerator(providerConfig);
+    if (!generator) {
+      return c.json(
+        { error: { code: "LLM_NOT_CONFIGURED", message: "Configure an enrichment model before tracing a run" } },
+        503,
+      );
+    }
+    const embeddingProvider = createEnrichmentEmbeddingProvider(providerConfig);
+
+    const dumpStamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const dumpDir = `data/llm-dumps/${file.id}__${dumpStamp}`;
+    const run = startTraceRun({ fileId: file.id, fileName: file.file_name, dumpDir });
+
+    runEnrichment({
+      db,
+      logger: createTracedLogger(logger.child({ component: "enrichment", fileId: file.id }), run),
+      embeddingProvider,
+      generator,
+      geminiApiKey: settings?.gemini_api_key,
+      geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
+      geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
+      fileIds: [file.id],
+      debugDumpDir: dumpDir,
+    })
+      .then((result) => {
+        const failure = result.errors[0];
+        if (failure) finishTraceRun(run, "failed", failure.error);
+        else finishTraceRun(run, "done");
+      })
+      .catch((err) => {
+        finishTraceRun(run, "failed", err);
+        logger.error({ err, fileId: file.id }, "Traced enrichment run failed");
+      });
+
+    return c.json({ runId: run.id, fileId: file.id, fileName: file.file_name }, 201);
+  });
+
+  routes.get("/enrichment-runs", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+    return c.json({ runs: listTraceRuns() });
+  });
+
+  /** `since` returns only steps after that sequence number, so the client can poll cheaply. */
+  routes.get("/enrichment-runs/:id", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    const run = getTraceRun(c.req.param("id"));
+    if (!run) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Run not found or evicted" } }, 404);
+    }
+
+    const since = Number(c.req.query("since") ?? 0) || 0;
+    const { steps, ...header } = run;
+    return c.json({
+      run: { ...header, stepCount: steps.length },
+      steps: since > 0 ? steps.filter((step) => step.seq > since) : steps,
+    });
+  });
+
+  return routes;
+}

--- a/packages/server/src/api/dev-enrichment.ts
+++ b/packages/server/src/api/dev-enrichment.ts
@@ -19,9 +19,18 @@ import {
   createEnrichmentEmbeddingProvider,
   createEnrichmentGenerator,
 } from "../connectors/enrichment-providers";
+import type { GeminiGenerator } from "../connectors/gemini-generate";
 import { createSettingsRepository } from "../db/repositories/settings";
 import type { DB } from "../db/schema";
-import { createTracedLogger, finishTraceRun, getTraceRun, listTraceRuns, startTraceRun } from "../dev/enrichment-trace";
+import {
+  appendTraceStageReport,
+  createTracedLogger,
+  finishTraceRun,
+  getTraceRun,
+  listTraceRuns,
+  startTraceRun,
+} from "../dev/enrichment-trace";
+import { listLlmDumpHeaders, readLlmDumpBody } from "../dev/llm-dump-reader";
 
 const startRunSchema = z.object({ fileId: z.string().min(1) });
 
@@ -40,7 +49,9 @@ export function devEnrichmentRoutes(
     GEMINI_MAX_RPM?: number;
     GEMINI_MAX_RETRIES?: number;
     OPENROUTER_API_KEY?: string;
+    DATA_DIR?: string;
   },
+  deps: { enrichmentGenerator?: GeminiGenerator } = {},
 ) {
   const routes = new Hono();
 
@@ -65,7 +76,7 @@ export function devEnrichmentRoutes(
 
     const settings = await createSettingsRepository(db, appConfig?.ENCRYPTION_KEY).get();
     const providerConfig = buildEnrichmentProviderConfig(settings, appConfig, logger);
-    const generator = createEnrichmentGenerator(providerConfig);
+    const generator = deps.enrichmentGenerator ?? createEnrichmentGenerator(providerConfig);
     if (!generator) {
       return c.json(
         { error: { code: "LLM_NOT_CONFIGURED", message: "Configure an enrichment model before tracing a run" } },
@@ -75,29 +86,38 @@ export function devEnrichmentRoutes(
     const embeddingProvider = createEnrichmentEmbeddingProvider(providerConfig);
 
     const dumpStamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const dumpDir = `data/llm-dumps/${file.id}__${dumpStamp}`;
+    const dumpDir = `${appConfig?.DATA_DIR ?? "data"}/llm-dumps/${file.id}__${dumpStamp}`;
     const run = startTraceRun({ fileId: file.id, fileName: file.file_name, dumpDir });
 
-    runEnrichment({
-      db,
-      logger: createTracedLogger(logger.child({ component: "enrichment", fileId: file.id }), run),
-      embeddingProvider,
-      generator,
-      geminiApiKey: settings?.gemini_api_key,
-      geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
-      geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
-      fileIds: [file.id],
-      debugDumpDir: dumpDir,
-    })
-      .then((result) => {
+    void (async () => {
+      try {
+        const result = await runEnrichment({
+          db,
+          logger: createTracedLogger(logger.child({ component: "enrichment", fileId: file.id }), run),
+          embeddingProvider,
+          generator,
+          geminiApiKey: settings?.gemini_api_key,
+          geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
+          geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
+          fileIds: [file.id],
+          debugDumpDir: dumpDir,
+          forceSmartEnrichment: true,
+          stageReport: (report) => appendTraceStageReport(run, report),
+        });
         const failure = result.errors[0];
-        if (failure) finishTraceRun(run, "failed", failure.error);
-        else finishTraceRun(run, "done");
-      })
-      .catch((err) => {
-        finishTraceRun(run, "failed", err);
+        const failedStage = run.stageReports.find((report) => report.status === "failed");
+        if (run.status === "running") {
+          if (failure) finishTraceRun(run, "failed", failure.error);
+          else if (failedStage) finishTraceRun(run, "failed", failedStage.error ?? `${failedStage.label} failed`);
+          else finishTraceRun(run, "done");
+        }
+      } catch (err) {
+        if (run.status === "running") finishTraceRun(run, "failed", err);
         logger.error({ err, fileId: file.id }, "Traced enrichment run failed");
-      });
+      } finally {
+        if (run.status === "running") finishTraceRun(run, "failed", "Trace promise settled without a terminal result");
+      }
+    })();
 
     return c.json({ runId: run.id, fileId: file.id, fileName: file.file_name }, 201);
   });
@@ -119,11 +139,44 @@ export function devEnrichmentRoutes(
     }
 
     const since = Number(c.req.query("since") ?? 0) || 0;
-    const { steps, ...header } = run;
+    const { steps, stageReports, ...header } = run;
     return c.json({
       run: { ...header, stepCount: steps.length },
       steps: since > 0 ? steps.filter((step) => step.seq > since) : steps,
+      stageReports,
     });
+  });
+
+  routes.get("/enrichment-runs/:id/calls", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    const run = getTraceRun(c.req.param("id"));
+    if (!run) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Run not found or evicted" } }, 404);
+    }
+
+    return c.json({ calls: await listLlmDumpHeaders(run.dumpDir) });
+  });
+
+  routes.get("/enrichment-runs/:id/calls/:seq", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    const run = getTraceRun(c.req.param("id"));
+    if (!run) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Run not found or evicted" } }, 404);
+    }
+
+    const seq = Number(c.req.param("seq"));
+    if (!Number.isInteger(seq) || seq < 1) {
+      return c.json({ error: { code: "INVALID_SEQ", message: "Call sequence must be a positive integer" } }, 400);
+    }
+    const call = await readLlmDumpBody(run.dumpDir, seq);
+    if (!call) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Call not found" } }, 404);
+    }
+    return c.json({ call });
   });
 
   return routes;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -56,6 +56,15 @@ export const configSchema = z.object({
     .enum(["true", "false", "1", "0"])
     .default("false")
     .transform((v) => v === "true" || v === "1"),
+  /**
+   * Mounts the internal pipeline-debugging routes under /api/dev and the
+   * /dev-tools page. Off everywhere except our own deployments — a tenant
+   * should have no route to find.
+   */
+  DEV_TOOLS_ENABLED: z
+    .enum(["true", "false", "1", "0"])
+    .default("false")
+    .transform((v) => v === "true" || v === "1"),
   VISION_MODEL: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   OPENROUTER_API_KEY: z.preprocess((v) => (v === "" ? undefined : v), z.string().optional()),
   OPENROUTER_PRICE_TTL_HOURS: z.coerce.number().min(1).default(12),

--- a/packages/server/src/connectors/enrichment-providers.ts
+++ b/packages/server/src/connectors/enrichment-providers.ts
@@ -35,6 +35,32 @@ export function resolveOpenRouterEnrichmentConfig(
   };
 }
 
+/**
+ * Assembles the provider config an enrichment run needs from stored settings
+ * plus env. Shared by the per-file enrich endpoint and the dev trace endpoint
+ * so the two always run against the same model and embedding provider.
+ */
+export function buildEnrichmentProviderConfig(
+  settings: {
+    gemini_api_key?: string | null;
+    embedding_provider?: string | null;
+    llm_provider?: string | null;
+    anthropic_api_key?: string | null;
+    model_id?: string | null;
+  } | null,
+  appConfig: { GEMINI_MAX_RPM?: number; GEMINI_MAX_RETRIES?: number; OPENROUTER_API_KEY?: string } | undefined,
+  logger: Logger,
+): EnrichmentProviderConfig {
+  return {
+    geminiApiKey: settings?.gemini_api_key,
+    embeddingProvider: settings?.embedding_provider,
+    geminiMaxRpm: appConfig?.GEMINI_MAX_RPM,
+    geminiMaxRetries: appConfig?.GEMINI_MAX_RETRIES,
+    logger,
+    ...resolveOpenRouterEnrichmentConfig(settings ?? null, appConfig?.OPENROUTER_API_KEY),
+  };
+}
+
 export function resolveEmbeddingProviderName(provider?: string | null): EmbeddingProviderName | null {
   if (provider == null || provider.trim() === "") return "openrouter";
   if (provider === "openrouter" || provider === "gemini") return provider;

--- a/packages/server/src/connectors/enrichment-stage-report.ts
+++ b/packages/server/src/connectors/enrichment-stage-report.ts
@@ -1,0 +1,37 @@
+import type { MintContextBlock } from "./mint-context";
+
+export type EnrichmentStageKey =
+  | "extractEntities"
+  | "dedupAdjudicate"
+  | "reconcileFacts"
+  | "matchEntities"
+  | "generateSummary"
+  | "extractEntityFacts"
+  | "engagementFloor"
+  | "materialize";
+
+export type EnrichmentStageKind = "model" | "code";
+export type EnrichmentStageStatus = "done" | "failed" | "skipped";
+
+export type StageOutcome = {
+  subject: string;
+  kind: string;
+  result: "kept" | "dropped" | "created" | "linked" | "queued" | "suppressed" | "deferred";
+  reason?: string;
+};
+
+export interface StageReport {
+  stage: EnrichmentStageKey;
+  label: string;
+  kind: EnrichmentStageKind;
+  status: EnrichmentStageStatus;
+  context?: MintContextBlock[];
+  outcomes?: StageOutcome[];
+  error?: string;
+  parallelGroup?: string;
+  summary?: Record<string, unknown>;
+}
+
+export type StageReporter = (report: StageReport) => void;
+
+export type { MintContextBlock } from "./mint-context";

--- a/packages/server/src/connectors/enrichment.ts
+++ b/packages/server/src/connectors/enrichment.ts
@@ -28,6 +28,7 @@ import { type DocumentFactContext, emitDocumentDerivedFacts, sortDocumentParentR
 import { ensureEmailThreadSummary, rebuildEmailThreadSummary } from "./email/thread-summary";
 import type { EmbeddingProvider } from "./embeddings/types";
 import { applyEngagementFloor } from "./engagement-floor";
+import type { StageReport, StageReporter } from "./enrichment-stage-report";
 import { type KnownEntityForPrompt, buildFileScopedKnownEntities } from "./file-scope-context";
 import { type GeminiGenerator, createGeminiGenerator } from "./gemini-generate";
 import { buildParticipantBlock } from "./participant-block";
@@ -401,6 +402,12 @@ export interface EnrichmentDeps {
    * the per-file "Enrich File" debug endpoint; never set in bulk runs.
    */
   debugDumpDir?: string;
+  stageReport?: StageReporter;
+  /**
+   * Re-runs the LLM stages on a file that already has a summary. Set only by the
+   * dev trace route, where the caller named one file and expects work to happen.
+   */
+  forceSmartEnrichment?: boolean;
   maxFilesPerRun?: number;
   timeBudgetMs?: number;
   now?: () => number;
@@ -610,6 +617,7 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
                   knownEntities,
                   participantBlock,
                   debugDumpDir: deps.debugDumpDir,
+                  stageReport: deps.stageReport,
                   ensureFresh: () => ensureFileFresh(db, file.id, fileVersion),
                 },
                 {
@@ -637,16 +645,25 @@ async function runEnrichmentInner(deps: EnrichmentDeps): Promise<EnrichmentResul
                   contentHash: file.content_hash,
                 },
               );
+              deps.stageReport?.({
+                stage: "engagementFloor",
+                label: "Engagement floor",
+                kind: "code",
+                status: "done",
+                summary: { ...floor },
+              });
               await ensureFileFresh(db, file.id, fileVersion);
               if (floor.emitted > 0) {
                 await materializeUnmaterializedFacts(db, logger, {
                   embeddingProvider: deps.embeddingProvider,
                   factTypes: ["llm_relation"],
+                  stageReport: deps.stageReport,
                 });
               }
               await resetSummaryRetry(db, file.id, fileVersion);
             } catch (err) {
               if (err instanceof StaleEnrichmentError) throw err;
+              reportPostSmartSkipped(deps.stageReport, err);
               logger.warn(
                 {
                   err,
@@ -870,7 +887,14 @@ async function enrichTextDocument(
   const wordCount = file.content.split(/\s+/).filter(Boolean).length;
   let usedSmartEnrichment = false;
   let smartEnrichmentFailed = false;
-  const summaryAlreadyResolved = file.summary_status === "done" || file.summary_status === "skipped";
+  /**
+   * A file that already has a summary normally skips every LLM stage, which is
+   * right for a sync but useless for a deliberate per-file re-run: the caller
+   * asked for this file by id and gets silence. `forceSmartEnrichment` is set
+   * only by the dev trace route.
+   */
+  const summaryAlreadyResolved =
+    !deps.forceSmartEnrichment && (file.summary_status === "done" || file.summary_status === "skipped");
   const minWordsForSummary = minWordsForSmartEnrichment(file.file_type, threadContext);
   const generator =
     deps.generator ??
@@ -903,6 +927,7 @@ async function enrichTextDocument(
           knownEntities,
           participantBlock,
           debugDumpDir: deps.debugDumpDir,
+          stageReport: deps.stageReport,
           ensureFresh: () => ensureFileFresh(db, file.id, fileVersion),
         },
         {
@@ -930,20 +955,38 @@ async function enrichTextDocument(
           contentHash: file.content_hash,
         },
       );
+      deps.stageReport?.({
+        stage: "engagementFloor",
+        label: "Engagement floor",
+        kind: "code",
+        status: "done",
+        summary: { ...floor },
+      });
       await ensureFileFresh(db, file.id, fileVersion);
       if (floor.emitted > 0) {
         await materializeUnmaterializedFacts(db, logger, {
           embeddingProvider,
           factTypes: ["llm_relation"],
+          stageReport: deps.stageReport,
         });
       }
       await resetSummaryRetry(db, file.id, fileVersion);
       usedSmartEnrichment = true;
     } catch (err) {
       if (err instanceof StaleEnrichmentError) throw err;
+      reportPostSmartSkipped(deps.stageReport, err);
       smartEnrichmentFailed = true;
       logger.warn({ err, fileId: file.id }, "Smart enrichment failed");
     }
+  }
+
+  if (!usedSmartEnrichment && !smartEnrichmentFailed) {
+    reportSmartEnrichmentSkipped(deps.stageReport, {
+      summaryAlreadyResolved,
+      hasGenerator: Boolean(generator),
+      wordCount,
+      minWordsForSummary,
+    });
   }
 
   if (!summaryAlreadyResolved && !usedSmartEnrichment) {
@@ -1009,6 +1052,55 @@ async function enrichTextDocument(
       logger.warn({ err, fileId: file.id }, "Embedding storage failed, entity linking still saved");
     }
   }
+}
+
+/**
+ * Says why no LLM stage ran. Without this a re-run of an already-summarised file
+ * reports "done" with eight untouched stages and no reason anywhere, which reads
+ * as a broken page rather than as a pipeline that decided to do nothing.
+ */
+function reportSmartEnrichmentSkipped(
+  stageReport: StageReporter | undefined,
+  facts: { summaryAlreadyResolved: boolean; hasGenerator: boolean; wordCount: number; minWordsForSummary: number },
+): void {
+  if (!stageReport) return;
+  const reason = facts.summaryAlreadyResolved
+    ? "The file already has a summary, so every LLM stage was skipped. Re-run with force to redo them."
+    : !facts.hasGenerator
+      ? "No enrichment model is configured, so no LLM stage could run."
+      : `The file has ${facts.wordCount} words and this file type needs at least ${facts.minWordsForSummary} before any LLM stage runs.`;
+
+  for (const stage of SMART_ENRICHMENT_STAGES) {
+    stageReport({ ...stage, status: "skipped", error: reason });
+  }
+}
+
+const SMART_ENRICHMENT_STAGES = [
+  { stage: "extractEntities", label: "Extract entities", kind: "model" },
+  { stage: "dedupAdjudicate", label: "Adjudicate known matches", kind: "model" },
+  { stage: "reconcileFacts", label: "Reconcile facts", kind: "code" },
+  { stage: "matchEntities", label: "Match entities", kind: "code" },
+  { stage: "generateSummary", label: "Summary", kind: "model" },
+  { stage: "extractEntityFacts", label: "Entity facts", kind: "model" },
+  { stage: "engagementFloor", label: "Engagement floor", kind: "code" },
+  { stage: "materialize", label: "Materialise", kind: "code" },
+] as const satisfies ReadonlyArray<Pick<StageReport, "stage" | "label" | "kind">>;
+
+function reportPostSmartSkipped(stageReport: StageReporter | undefined, err: unknown): void {
+  stageReport?.({
+    stage: "engagementFloor",
+    label: "Engagement floor",
+    kind: "code",
+    status: "skipped",
+    error: err instanceof Error ? err.message : String(err),
+  });
+  stageReport?.({
+    stage: "materialize",
+    label: "Materialise",
+    kind: "code",
+    status: "skipped",
+    error: err instanceof Error ? err.message : String(err),
+  });
 }
 
 /**

--- a/packages/server/src/connectors/mint-context.ts
+++ b/packages/server/src/connectors/mint-context.ts
@@ -1,0 +1,9 @@
+export interface MintContextBlock {
+  key: string;
+  label: string;
+  selection: string;
+  total: number;
+  items: string[];
+  truncated?: boolean;
+  via: "prompt" | "tool";
+}

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -62,6 +62,7 @@ import {
 } from "./embeddings/trunk-name-embeddings";
 import type { EmbeddingProvider } from "./embeddings/types";
 import { isGenericEngagementName } from "./engagement-name-filter";
+import type { MintContextBlock, StageOutcome, StageReporter } from "./enrichment-stage-report";
 import { isCodeShapedFeatureName } from "./feature-name-filter";
 import type { KnownEntityForPrompt } from "./file-scope-context";
 import type { GeminiGenerator } from "./gemini-generate";
@@ -216,6 +217,7 @@ interface SmartEnrichmentDeps {
    * "Enrich File" debug path; never set in bulk sync/reset/reenrich runs.
    */
   debugDumpDir?: string;
+  stageReport?: StageReporter;
   ensureFresh?: () => Promise<void>;
 }
 
@@ -319,6 +321,71 @@ function renderKnown(e: KnownEntityForPrompt, index: number): string {
   if (e.recentlyActive) tags.push("active in last 2 weeks");
   if (tags.length > 0) parts.push(` · ${tags.join(" · ")}`);
   return parts.join("");
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function extractionContextBlocks(
+  file: FileContext,
+  knownEntities: KnownEntityForPrompt[] | undefined,
+  participantBlock: string | undefined,
+  personCandidateBlock: string | undefined,
+): MintContextBlock[] {
+  const knownItems = (knownEntities ?? []).slice(0, 20).map(renderKnown);
+  const blocks: MintContextBlock[] = [
+    {
+      key: "knownEntities",
+      label: "Known entities",
+      selection:
+        "Known entities likely to appear in this file, selected by file anchors, adjacency, verbatim baseline matches, and pending proposals; display capped at 20.",
+      total: knownEntities?.length ?? 0,
+      items: knownItems,
+      truncated: (knownEntities?.length ?? 0) > knownItems.length,
+      via: "prompt",
+    },
+    {
+      key: "content",
+      label: "Content",
+      selection: `First ${MAX_CONTENT_CHARS} characters of file content sent to the extraction model.`,
+      total: file.content.length,
+      items: [`${Math.min(file.content.length, MAX_CONTENT_CHARS)} characters sent`],
+      truncated: file.content.length > MAX_CONTENT_CHARS,
+      via: "prompt",
+    },
+  ];
+  if (participantBlock) {
+    blocks.push({
+      key: "participants",
+      label: "Participant block",
+      selection: "Meeting or message participants resolved from connector facts for this file.",
+      total: participantBlock.split("\n").filter(Boolean).length,
+      items: participantBlock.split("\n").filter(Boolean).slice(0, 20),
+      truncated: participantBlock.split("\n").filter(Boolean).length > 20,
+      via: "prompt",
+    });
+  }
+  if (personCandidateBlock) {
+    blocks.push({
+      key: "personCandidates",
+      label: "Person candidates",
+      selection: "Person-like names detected from file content and participant context.",
+      total: personCandidateBlock.split("\n").filter(Boolean).length,
+      items: personCandidateBlock.split("\n").filter(Boolean).slice(0, 20),
+      truncated: personCandidateBlock.split("\n").filter(Boolean).length > 20,
+      via: "prompt",
+    });
+  }
+  return blocks;
+}
+
+function outcomeForMention(
+  mention: Pick<ExtractedMention, "mention" | "type">,
+  result: StageOutcome["result"],
+  reason?: string,
+): StageOutcome {
+  return { subject: mention.mention, kind: mention.type, result, ...(reason ? { reason } : {}) };
 }
 
 // ── Entity Extraction ────────────────────────────────────────────────────
@@ -1273,9 +1340,25 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
       validExtractionTypes,
     );
   } catch (err) {
+    deps.stageReport?.({
+      stage: "extractEntities",
+      label: "Extract entities",
+      kind: "model",
+      status: "failed",
+      context: extractionContextBlocks(file, deps.knownEntities, deps.participantBlock, deps.personCandidateBlock),
+      error: errorMessage(err),
+    });
     logger.error({ ...fileMeta, stage: "extractEntities", err }, "smartEnrichFile: stage failed");
     throw err;
   }
+  deps.stageReport?.({
+    stage: "extractEntities",
+    label: "Extract entities",
+    kind: "model",
+    status: "done",
+    context: extractionContextBlocks(file, deps.knownEntities, deps.participantBlock, deps.personCandidateBlock),
+    summary: { mentionCount: extraction.mentions.length, relationCount: extraction.relations.length },
+  });
   logger.info(
     {
       fileId: file.id,
@@ -1301,6 +1384,25 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
     logger,
     rejectedKnownMatchPairs,
   });
+  deps.stageReport?.({
+    stage: "dedupAdjudicate",
+    label: "Adjudicate known matches",
+    kind: "model",
+    status: "done",
+    context: [
+      {
+        key: "knownCandidates",
+        label: "Known candidates",
+        selection:
+          "Known project and product candidates from the file-scoped list plus retrieved name-dedup candidates; display capped at 20.",
+        total: widenedKnown.length,
+        items: widenedKnown.slice(0, 20).map(renderKnown),
+        truncated: widenedKnown.length > 20,
+        via: "prompt",
+      },
+    ],
+    summary: { rewriteCount: canonicalRewriteMap.size },
+  });
   resolveKnownMatches(extraction.mentions, widenedKnown);
   applyCanonicalRewriteMap(extraction, canonicalRewriteMap);
 
@@ -1323,6 +1425,19 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
 
   const matchableMentions = extraction.mentions.filter((mention) => !isFeatureMention(mention));
   const { matched, unmatched } = await matchEntities(db, matchableMentions);
+  deps.stageReport?.({
+    stage: "matchEntities",
+    label: "Match entities",
+    kind: "code",
+    status: "done",
+    outcomes: [
+      ...matched.map(({ mention, entity }) =>
+        outcomeForMention(mention, "linked", `matched existing ${entity.sourceType} entity ${entity.name}`),
+      ),
+      ...unmatched.map((mention) => outcomeForMention(mention, "deferred", "no existing entity matched")),
+    ],
+    summary: { matchedCount: matched.length, unmatchedCount: unmatched.length },
+  });
   const allMatched = matched.map((m) => m.entity);
   logger.debug(
     { fileId: file.id, matchedCount: matched.length, unmatchedCount: unmatched.length },
@@ -1352,9 +1467,34 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
   const factsMap = factsResult.status === "fulfilled" ? factsResult.value.facts : new Map<string, LearnedFact[]>();
 
   if (summaryResult.status === "rejected") {
+    deps.stageReport?.({
+      stage: "generateSummary",
+      label: "Summary",
+      kind: "model",
+      status: "failed",
+      parallelGroup: "summaryAndFacts",
+      error: errorMessage(summaryResult.reason),
+    });
     logger.error({ ...fileMeta, stage: "generateSummary", err: summaryResult.reason }, "smartEnrichFile: stage failed");
+  } else {
+    deps.stageReport?.({
+      stage: "generateSummary",
+      label: "Summary",
+      kind: "model",
+      status: "done",
+      parallelGroup: "summaryAndFacts",
+      summary: { summaryLength: summaryResult.value.length },
+    });
   }
   if (factsResult.status === "rejected") {
+    deps.stageReport?.({
+      stage: "extractEntityFacts",
+      label: "Entity facts",
+      kind: "model",
+      status: "failed",
+      parallelGroup: "summaryAndFacts",
+      error: errorMessage(factsResult.reason),
+    });
     logger.warn(
       { ...fileMeta, stage: "extractEntityFacts", matchedEntityCount: allMatched.length, err: factsResult.reason },
       "smartEnrichFile: stage failed (continuing without entity facts)",
@@ -1363,10 +1503,25 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
       await markConversationalFactsPending(db, file, fileVersion);
       throw factsResult.reason;
     }
+  } else {
+    deps.stageReport?.({
+      stage: "extractEntityFacts",
+      label: "Entity facts",
+      kind: "model",
+      status: "done",
+      parallelGroup: "summaryAndFacts",
+      summary: {
+        entityCount: factsMap.size,
+        factCount: [...factsMap.values()].reduce((sum, facts) => sum + facts.length, 0),
+      },
+    });
   }
 
   if (!summary) {
     throw summaryResult.status === "rejected" ? summaryResult.reason : new Error("smartEnrichFile: empty summary");
+  }
+  if (deps.stageReport && factsResult.status === "rejected") {
+    throw factsResult.reason;
   }
 
   logger.info(
@@ -1505,6 +1660,7 @@ async function reconcileLlmExtractionFacts(
   const emittedFeatureKeys: string[] = [];
   const writtenFactKeys: string[] = [];
   let materializeDeps: MaterializeDeps | null = null;
+  const outcomes: StageOutcome[] = [];
 
   try {
     for (const rawMention of extraction.mentions) {
@@ -1513,6 +1669,7 @@ async function reconcileLlmExtractionFacts(
         type: coerceMentionType(rawMention.mention, rawMention.type),
       };
       if (!allowedTypes.has(mention.type)) {
+        outcomes.push(outcomeForMention(mention, "dropped", "type not allowed for this file type"));
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention, entityType: mention.type },
           "Dropped LLM mention with unsupported type",
@@ -1520,6 +1677,7 @@ async function reconcileLlmExtractionFacts(
         continue;
       }
       if (mention.type === "company" && isEmailProviderName(mention.mention)) {
+        outcomes.push(outcomeForMention(mention, "dropped", "email-provider company name"));
         deps.logger.info({ fileId: file.id, displayName: mention.mention }, "Dropped email-provider company mention");
         continue;
       }
@@ -1527,14 +1685,19 @@ async function reconcileLlmExtractionFacts(
         mention.type === "project" &&
         normalizeDocumentTitle(mention.mention) === normalizeDocumentTitle(file.fileName)
       ) {
+        outcomes.push(outcomeForMention(mention, "dropped", "project name matching the document title"));
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention },
           "Dropped project mention matching document title",
         );
         continue;
       }
-      if (mention.mention.length < MIN_ENTITY_NAME_LENGTH) continue;
+      if (mention.mention.length < MIN_ENTITY_NAME_LENGTH) {
+        outcomes.push(outcomeForMention(mention, "dropped", `shorter than ${MIN_ENTITY_NAME_LENGTH} characters`));
+        continue;
+      }
       if ((mention.type === "project" || mention.type === "product") && isGenericEngagementName(mention.mention)) {
+        outcomes.push(outcomeForMention(mention, "dropped", "generic engagement name"));
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention, reason: "generic_engagement_name" },
           "Dropped generic engagement-name mention",
@@ -1550,6 +1713,7 @@ async function reconcileLlmExtractionFacts(
         source: "llm_extraction",
       });
       if (!validation.ok) {
+        outcomes.push(outcomeForMention(mention, "dropped", validation.reason));
         deps.logger.info(
           { fileId: file.id, displayName: mention.mention, reason: validation.reason },
           "Dropped invalid LLM mention",
@@ -1634,6 +1798,7 @@ async function reconcileLlmExtractionFacts(
       emittedMentionKeys.push(factKey);
       await deps.ensureFresh?.();
       await factRepo.upsertFact(input);
+      outcomes.push(outcomeForMention(mention, "kept", "llm_extracted fact written"));
       writtenFactKeys.push(factKey);
       await yieldToEventLoop();
     }
@@ -1701,8 +1866,28 @@ async function reconcileLlmExtractionFacts(
       embeddingProvider: deps.embeddingProvider,
       factTypes: ["llm_extracted", "llm_relation", "feature"],
     });
+    deps.stageReport?.({
+      stage: "reconcileFacts",
+      label: "Reconcile facts",
+      kind: "code",
+      status: "done",
+      outcomes,
+      summary: {
+        mentionCount: extraction.mentions.length,
+        kept: outcomes.filter((outcome) => outcome.result === "kept").length,
+        dropped: outcomes.filter((outcome) => outcome.result === "dropped").length,
+      },
+    });
     return writtenFactKeys;
   } catch (err) {
+    deps.stageReport?.({
+      stage: "reconcileFacts",
+      label: "Reconcile facts",
+      kind: "code",
+      status: "failed",
+      outcomes,
+      error: errorMessage(err),
+    });
     if (isStaleEnrichmentError(err)) {
       await tombstoneWrittenLlmFacts(deps, writtenFactKeys);
     }

--- a/packages/server/src/connectors/smart-enrichment.ts
+++ b/packages/server/src/connectors/smart-enrichment.ts
@@ -331,7 +331,6 @@ function extractionContextBlocks(
   file: FileContext,
   knownEntities: KnownEntityForPrompt[] | undefined,
   participantBlock: string | undefined,
-  personCandidateBlock: string | undefined,
 ): MintContextBlock[] {
   const knownItems = (knownEntities ?? []).slice(0, 20).map(renderKnown);
   const blocks: MintContextBlock[] = [
@@ -363,17 +362,6 @@ function extractionContextBlocks(
       total: participantBlock.split("\n").filter(Boolean).length,
       items: participantBlock.split("\n").filter(Boolean).slice(0, 20),
       truncated: participantBlock.split("\n").filter(Boolean).length > 20,
-      via: "prompt",
-    });
-  }
-  if (personCandidateBlock) {
-    blocks.push({
-      key: "personCandidates",
-      label: "Person candidates",
-      selection: "Person-like names detected from file content and participant context.",
-      total: personCandidateBlock.split("\n").filter(Boolean).length,
-      items: personCandidateBlock.split("\n").filter(Boolean).slice(0, 20),
-      truncated: personCandidateBlock.split("\n").filter(Boolean).length > 20,
       via: "prompt",
     });
   }
@@ -1345,7 +1333,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
       label: "Extract entities",
       kind: "model",
       status: "failed",
-      context: extractionContextBlocks(file, deps.knownEntities, deps.participantBlock, deps.personCandidateBlock),
+      context: extractionContextBlocks(file, deps.knownEntities, deps.participantBlock),
       error: errorMessage(err),
     });
     logger.error({ ...fileMeta, stage: "extractEntities", err }, "smartEnrichFile: stage failed");
@@ -1356,7 +1344,7 @@ export async function smartEnrichFile(deps: SmartEnrichmentDeps, file: FileConte
     label: "Extract entities",
     kind: "model",
     status: "done",
-    context: extractionContextBlocks(file, deps.knownEntities, deps.participantBlock, deps.personCandidateBlock),
+    context: extractionContextBlocks(file, deps.knownEntities, deps.participantBlock),
     summary: { mentionCount: extraction.mentions.length, relationCount: extraction.relations.length },
   });
   logger.info(

--- a/packages/server/src/dev/enrichment-trace.test.ts
+++ b/packages/server/src/dev/enrichment-trace.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Three failure modes this surface can have, and nothing else:
+ *
+ * 1. The capture silently loses the pipeline. Everything downstream of the
+ *    route uses `logger.child(...)`, so a wrapper that stops propagating
+ *    through children would produce an empty-looking but "successful" trace.
+ * 2. The capture grows without bound. Runs are held in process memory, so a
+ *    long run or a busy afternoon must not be able to hold the heap.
+ * 3. The trace turns into a record. Runs must be evicted, so the surface stays
+ *    a window and never becomes something anyone depends on.
+ */
+import pino from "pino";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  type DevTraceRun,
+  clearTraceRuns,
+  createTracedLogger,
+  finishTraceRun,
+  getTraceRun,
+  listTraceRuns,
+  startTraceRun,
+} from "./enrichment-trace";
+
+function silentLogger() {
+  return pino({ level: "silent" });
+}
+
+function newRun(fileName = "meeting.md"): DevTraceRun {
+  return startTraceRun({ fileId: `file-${fileName}`, fileName, dumpDir: "data/llm-dumps/x" });
+}
+
+beforeEach(() => {
+  clearTraceRuns();
+});
+
+describe("createTracedLogger", () => {
+  it("captures calls made through nested child loggers", () => {
+    const run = newRun();
+    const traced = createTracedLogger(silentLogger(), run);
+
+    traced.info({ fileId: "f1" }, "smartEnrichFile: start");
+    const child = traced.child({ component: "enrichment" });
+    const grandchild = child.child({ stage: "materialize" });
+    grandchild.warn({ displayName: "Canvasx" }, "Dropped email-provider company mention");
+
+    expect(run.steps).toHaveLength(2);
+    expect(run.steps[0]).toMatchObject({ seq: 1, level: "info", msg: "smartEnrichFile: start" });
+    expect(run.steps[1]).toMatchObject({
+      seq: 2,
+      level: "warn",
+      msg: "Dropped email-provider company mention",
+      fields: { displayName: "Canvasx" },
+    });
+  });
+
+  it("records levels the logger itself would not print", () => {
+    const run = newRun();
+    createTracedLogger(pino({ level: "error" }), run).debug({ matchedCount: 3 }, "entity match results");
+
+    expect(run.steps).toHaveLength(1);
+    expect(run.steps[0].level).toBe("debug");
+  });
+
+  it("truncates long strings and large arrays instead of holding the payload", () => {
+    const run = newRun();
+    const traced = createTracedLogger(silentLogger(), run);
+
+    traced.info({ content: "x".repeat(5000), mentions: Array.from({ length: 400 }, (_, i) => `m${i}`) }, "extracted");
+
+    const fields = run.steps[0].fields as { content: string; mentions: unknown[] };
+    expect(fields.content.length).toBeLessThan(700);
+    expect(fields.content.endsWith("…")).toBe(true);
+    expect(fields.mentions.length).toBeLessThan(30);
+    expect(String(fields.mentions.at(-1))).toContain("more");
+  });
+
+  it("stops appending once a run hits the step cap and says so", () => {
+    const run = newRun();
+    const traced = createTracedLogger(silentLogger(), run);
+
+    for (let i = 0; i < 4100; i++) traced.info({ i }, "step");
+
+    expect(run.truncated).toBe(true);
+    expect(run.steps.length).toBeLessThanOrEqual(4000);
+  });
+});
+
+describe("trace run store", () => {
+  it("evicts the oldest runs so the window never becomes a record", () => {
+    const created: DevTraceRun[] = [];
+    for (let i = 0; i < 25; i++) {
+      const run = startTraceRun({ fileId: `f${i}`, fileName: `file-${i}`, dumpDir: "data/llm-dumps/x" });
+      created.push(run);
+      finishTraceRun(run, "done");
+    }
+
+    const listed = listTraceRuns();
+    expect(listed).toHaveLength(20);
+    expect(listed[0].fileName).toBe("file-24");
+    expect(getTraceRun(created[0].id)).toBeUndefined();
+    expect(getTraceRun(created[4].id)).toBeUndefined();
+    expect(getTraceRun(created[5].id)).toBeDefined();
+  });
+
+  it("reports a failed run with its message", () => {
+    const run = newRun();
+    finishTraceRun(run, "failed", new Error("Gemini rate limited"));
+
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("Gemini rate limited");
+    expect(run.finishedAt).not.toBeNull();
+  });
+});

--- a/packages/server/src/dev/enrichment-trace.ts
+++ b/packages/server/src/dev/enrichment-trace.ts
@@ -1,0 +1,187 @@
+/**
+ * In-memory capture of a single enrichment run, for the dev-only trace surface.
+ *
+ * Nothing is persisted and nothing new is instrumented. The pipeline already
+ * reports every stage and every drop through pino, so the capture is a logger
+ * wrapper: hand `runEnrichment` a traced logger and every downstream
+ * `logger.child(...)` — extraction, fact reconciliation, entity proposal,
+ * materialisation — reports into the same run.
+ *
+ * Runs live in a bounded ring and are lost on restart. That is deliberate:
+ * this is a debugging window for the team that owns the pipeline, not a record,
+ * so it needs no table, no retention policy and no tenant-facing surface.
+ *
+ * Prompt and response bodies are never captured here. They already go to
+ * `data/llm-dumps/`, which stays on the server's disk.
+ */
+import { randomUUID } from "node:crypto";
+import type { Logger } from "pino";
+
+/** Level methods intercepted on the wrapped logger. */
+const LEVEL_METHODS = new Set(["trace", "debug", "info", "warn", "error", "fatal"]);
+
+const MAX_RUNS = 20;
+const MAX_STEPS_PER_RUN = 4000;
+const MAX_STRING_CHARS = 600;
+const MAX_ARRAY_ITEMS = 25;
+const MAX_FIELD_DEPTH = 3;
+
+export type DevTraceRunStatus = "running" | "done" | "failed";
+
+export interface DevTraceStep {
+  /** 1-based, monotonic within a run. Clients poll with `since` to fetch only new steps. */
+  seq: number;
+  at: string;
+  level: string;
+  msg: string;
+  /** The structured fields pino was given, truncated for display. */
+  fields: Record<string, unknown>;
+}
+
+export interface DevTraceRun {
+  id: string;
+  fileId: string;
+  fileName: string;
+  startedAt: string;
+  finishedAt: string | null;
+  status: DevTraceRunStatus;
+  error: string | null;
+  /** Server-side directory holding the raw prompts and responses for this run. */
+  dumpDir: string;
+  steps: DevTraceStep[];
+  /** Set once the run exceeded `MAX_STEPS_PER_RUN` and later steps were dropped. */
+  truncated: boolean;
+}
+
+const runs = new Map<string, DevTraceRun>();
+
+export function startTraceRun(input: { fileId: string; fileName: string; dumpDir: string }): DevTraceRun {
+  const run: DevTraceRun = {
+    id: randomUUID(),
+    fileId: input.fileId,
+    fileName: input.fileName,
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+    status: "running",
+    error: null,
+    dumpDir: input.dumpDir,
+    steps: [],
+    truncated: false,
+  };
+  runs.set(run.id, run);
+  evictOldest();
+  return run;
+}
+
+export function finishTraceRun(run: DevTraceRun, status: Exclude<DevTraceRunStatus, "running">, error?: unknown): void {
+  run.status = status;
+  run.finishedAt = new Date().toISOString();
+  run.error = error ? errorMessage(error) : null;
+}
+
+export function getTraceRun(id: string): DevTraceRun | undefined {
+  return runs.get(id);
+}
+
+/**
+ * Newest first, without step bodies — the list view only needs the headers.
+ * Ordering follows insertion, not `startedAt`, so runs started in the same
+ * millisecond still come back in the order they were started.
+ */
+export function listTraceRuns(): Array<Omit<DevTraceRun, "steps"> & { stepCount: number }> {
+  return [...runs.values()].reverse().map(({ steps, ...rest }) => ({ ...rest, stepCount: steps.length }));
+}
+
+export function clearTraceRuns(): void {
+  runs.clear();
+}
+
+/**
+ * Wraps a pino logger so every call also lands in `run`. Child loggers stay
+ * wrapped, which is what makes a single call site capture the whole pipeline.
+ *
+ * Steps are recorded regardless of the logger's own level, so `debug` lines the
+ * server would not print still show up in the trace.
+ */
+export function createTracedLogger(base: Logger, run: DevTraceRun): Logger {
+  return new Proxy(base, {
+    get(target, prop) {
+      if (prop === "child") {
+        const child = Reflect.get(target, prop, target) as unknown as (
+          bindings: Record<string, unknown>,
+          options?: unknown,
+        ) => Logger;
+        return (bindings: Record<string, unknown>, options?: unknown) =>
+          createTracedLogger(child.call(target, bindings, options), run);
+      }
+      if (typeof prop === "string" && LEVEL_METHODS.has(prop)) {
+        const original = Reflect.get(target, prop, target) as (...args: unknown[]) => void;
+        return (...args: unknown[]) => {
+          original.apply(target, args);
+          appendStep(run, prop, args);
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+    },
+  }) as Logger;
+}
+
+/**
+ * Records one pino call. Handles both `log(obj, msg)` and `log(msg)` forms.
+ */
+function appendStep(run: DevTraceRun, level: string, args: unknown[]): void {
+  if (run.steps.length >= MAX_STEPS_PER_RUN) {
+    run.truncated = true;
+    return;
+  }
+  const [first, second] = args;
+  const hasFields = typeof first === "object" && first !== null;
+  run.steps.push({
+    seq: run.steps.length + 1,
+    at: new Date().toISOString(),
+    level,
+    msg: hasFields ? (typeof second === "string" ? second : "") : typeof first === "string" ? first : "",
+    fields: hasFields ? (safeValue(first, MAX_FIELD_DEPTH) as Record<string, unknown>) : {},
+  });
+}
+
+/**
+ * Truncating serializer. Fields reaching here are log payloads, which can hold
+ * whole mention arrays and error objects; the caps keep one run's capture bounded.
+ */
+function safeValue(value: unknown, depth: number): unknown {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Error) return { name: value.name, message: value.message };
+  const type = typeof value;
+  if (type === "string") {
+    const text = value as string;
+    return text.length > MAX_STRING_CHARS ? `${text.slice(0, MAX_STRING_CHARS)}…` : text;
+  }
+  if (type === "number" || type === "boolean") return value;
+  if (type !== "object") return String(value);
+  if (Array.isArray(value)) {
+    if (depth <= 0) return `[${value.length} items]`;
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((item) => safeValue(item, depth - 1));
+    return value.length > MAX_ARRAY_ITEMS ? [...items, `… ${value.length - MAX_ARRAY_ITEMS} more`] : items;
+  }
+  if (depth <= 0) return "{…}";
+  const out: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = safeValue(nested, depth - 1);
+  }
+  return out;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Map iteration is insertion-ordered, so the first key is the oldest run. */
+function evictOldest(): void {
+  while (runs.size > MAX_RUNS) {
+    const oldest = runs.keys().next();
+    if (oldest.done) return;
+    runs.delete(oldest.value);
+  }
+}

--- a/packages/server/src/dev/enrichment-trace.ts
+++ b/packages/server/src/dev/enrichment-trace.ts
@@ -16,6 +16,7 @@
  */
 import { randomUUID } from "node:crypto";
 import type { Logger } from "pino";
+import type { StageReport } from "../connectors/enrichment-stage-report";
 
 /** Level methods intercepted on the wrapped logger. */
 const LEVEL_METHODS = new Set(["trace", "debug", "info", "warn", "error", "fatal"]);
@@ -25,6 +26,16 @@ const MAX_STEPS_PER_RUN = 4000;
 const MAX_STRING_CHARS = 600;
 const MAX_ARRAY_ITEMS = 25;
 const MAX_FIELD_DEPTH = 3;
+const STAGE_ORDER = new Map([
+  ["extractEntities", 1],
+  ["dedupAdjudicate", 2],
+  ["reconcileFacts", 3],
+  ["matchEntities", 4],
+  ["generateSummary", 5],
+  ["extractEntityFacts", 6],
+  ["engagementFloor", 7],
+  ["materialize", 8],
+]);
 
 export type DevTraceRunStatus = "running" | "done" | "failed";
 
@@ -48,6 +59,7 @@ export interface DevTraceRun {
   error: string | null;
   /** Server-side directory holding the raw prompts and responses for this run. */
   dumpDir: string;
+  stageReports: StageReport[];
   steps: DevTraceStep[];
   /** Set once the run exceeded `MAX_STEPS_PER_RUN` and later steps were dropped. */
   truncated: boolean;
@@ -65,6 +77,7 @@ export function startTraceRun(input: { fileId: string; fileName: string; dumpDir
     status: "running",
     error: null,
     dumpDir: input.dumpDir,
+    stageReports: [],
     steps: [],
     truncated: false,
   };
@@ -77,6 +90,28 @@ export function finishTraceRun(run: DevTraceRun, status: Exclude<DevTraceRunStat
   run.status = status;
   run.finishedAt = new Date().toISOString();
   run.error = error ? errorMessage(error) : null;
+}
+
+export function appendTraceStageReport(run: DevTraceRun, report: StageReport): void {
+  const existingIndex = run.stageReports.findIndex((item) => item.stage === report.stage);
+  if (existingIndex >= 0) {
+    const existing = run.stageReports[existingIndex];
+    run.stageReports[existingIndex] = {
+      ...existing,
+      ...report,
+      context: report.context ?? existing.context,
+      outcomes: [...(existing.outcomes ?? []), ...(report.outcomes ?? [])],
+      summary: { ...(existing.summary ?? {}), ...(report.summary ?? {}) },
+    };
+    sortStageReports(run);
+    return;
+  }
+  run.stageReports.push(report);
+  sortStageReports(run);
+}
+
+function sortStageReports(run: DevTraceRun): void {
+  run.stageReports.sort((a, b) => (STAGE_ORDER.get(a.stage) ?? 999) - (STAGE_ORDER.get(b.stage) ?? 999));
 }
 
 export function getTraceRun(id: string): DevTraceRun | undefined {

--- a/packages/server/src/dev/llm-dump-reader.ts
+++ b/packages/server/src/dev/llm-dump-reader.ts
@@ -1,0 +1,195 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+export type LlmDumpStage = "extractEntities" | "dedupAdjudicate" | "generateSummary" | "extractEntityFacts" | "unknown";
+
+export interface LlmDumpHeader {
+  seq: number;
+  label: string;
+  stage: LlmDumpStage;
+  at: string | null;
+  model: string;
+  promptChars: number | null;
+  promptTokens: number | null;
+  completionTokens: number | null;
+  costUsd: number | null;
+  finishReason: string | null;
+  unreadable?: { reason: string };
+}
+
+export interface LlmDumpBody extends LlmDumpHeader {
+  prompt: string | null;
+  systemPrompt: string | null;
+  text: string | null;
+  parsed?: unknown;
+}
+
+interface DumpPayload {
+  label?: unknown;
+  prompt?: unknown;
+  systemPrompt?: unknown;
+  text?: unknown;
+  finishReason?: unknown;
+  promptTokens?: unknown;
+  candidatesTokens?: unknown;
+  completionTokens?: unknown;
+  costUsd?: unknown;
+}
+
+interface ParsedFilename {
+  at: string | null;
+  safeLabel: string;
+  model: string;
+}
+
+export async function listLlmDumpHeaders(dumpDir: string): Promise<LlmDumpHeader[]> {
+  const files = await listDumpFiles(dumpDir);
+  return Promise.all(files.map((file, index) => readDumpHeader(dumpDir, file, index + 1)));
+}
+
+export async function readLlmDumpBody(dumpDir: string, seq: number): Promise<LlmDumpBody | null> {
+  const files = await listDumpFiles(dumpDir);
+  const file = files[seq - 1];
+  if (!file) return null;
+  return readDumpBody(dumpDir, file, seq);
+}
+
+/**
+ * A missing directory is the normal state for a run whose first call has not
+ * returned yet, or whose only call threw before the writer ran.
+ */
+async function listDumpFiles(dumpDir: string): Promise<string[]> {
+  try {
+    return (await readdir(dumpDir)).filter((name) => name.endsWith(".json")).sort();
+  } catch {
+    return [];
+  }
+}
+
+async function readDumpHeader(dumpDir: string, filename: string, seq: number): Promise<LlmDumpHeader> {
+  const meta = parseDumpFilename(filename);
+  const fallback = fallbackHeader(seq, meta);
+  try {
+    const payload = parsePayload(await readFile(join(dumpDir, filename), "utf8"));
+    return headerFromPayload(seq, meta, payload);
+  } catch (err) {
+    return { ...fallback, unreadable: { reason: err instanceof Error ? err.message : String(err) } };
+  }
+}
+
+async function readDumpBody(dumpDir: string, filename: string, seq: number): Promise<LlmDumpBody> {
+  const meta = parseDumpFilename(filename);
+  const fallback = fallbackHeader(seq, meta);
+  try {
+    const payload = parsePayload(await readFile(join(dumpDir, filename), "utf8"));
+    const header = headerFromPayload(seq, meta, payload);
+    const text = stringOrNull(payload.text);
+    const parsed = text ? parseJsonText(text) : undefined;
+    return {
+      ...header,
+      prompt: stringOrNull(payload.prompt),
+      systemPrompt: stringOrNull(payload.systemPrompt),
+      text,
+      ...(parsed === undefined ? {} : { parsed }),
+    };
+  } catch (err) {
+    return {
+      ...fallback,
+      prompt: null,
+      systemPrompt: null,
+      text: null,
+      unreadable: { reason: err instanceof Error ? err.message : String(err) },
+    };
+  }
+}
+
+function fallbackHeader(seq: number, meta: ParsedFilename): LlmDumpHeader {
+  return {
+    seq,
+    label: meta.safeLabel,
+    stage: stageFromLabel(meta.safeLabel),
+    at: meta.at,
+    model: meta.model,
+    promptChars: null,
+    promptTokens: null,
+    completionTokens: null,
+    costUsd: null,
+    finishReason: null,
+  };
+}
+
+function headerFromPayload(seq: number, meta: ParsedFilename, payload: DumpPayload): LlmDumpHeader {
+  const label = stringOrNull(payload.label) ?? meta.safeLabel;
+  return {
+    seq,
+    label,
+    stage: stageFromLabel(label),
+    at: meta.at,
+    model: meta.model,
+    promptChars: typeof payload.prompt === "string" ? Buffer.byteLength(payload.prompt, "utf8") : null,
+    promptTokens: numberOrNull(payload.promptTokens),
+    completionTokens: numberOrNull(payload.completionTokens ?? payload.candidatesTokens),
+    costUsd: numberOrNull(payload.costUsd),
+    finishReason: stringOrNull(payload.finishReason),
+  };
+}
+
+function parsePayload(raw: string): DumpPayload {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Dump JSON was not an object");
+  return parsed as DumpPayload;
+}
+
+function parseDumpFilename(filename: string): ParsedFilename {
+  const stem = filename.endsWith(".json") ? filename.slice(0, -5) : filename;
+  const separator = stem.indexOf("__");
+  if (separator < 0) return { at: null, safeLabel: stem, model: "unknown" };
+  const stamp = stem.slice(0, separator);
+  const rest = stem.slice(separator + 2);
+  const openRouter = rest.startsWith("openrouter_");
+  return {
+    at: parseDumpTimestamp(stamp),
+    safeLabel: openRouter ? rest.slice("openrouter_".length) : rest,
+    model: openRouter ? "openrouter" : "gemini-2.5-flash",
+  };
+}
+
+function parseDumpTimestamp(stamp: string): string | null {
+  if (!stamp) return null;
+  if (!Number.isNaN(Date.parse(stamp))) return new Date(stamp).toISOString();
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})-(\d{3}Z)$/.exec(stamp);
+  if (!match) return null;
+  const restored = `${match[1]}:${match[2]}:${match[3]}.${match[4]}`;
+  return Number.isNaN(Date.parse(restored)) ? null : new Date(restored).toISOString();
+}
+
+function stageFromLabel(label: string): LlmDumpStage {
+  const safe = label.replace(/[^a-zA-Z0-9_-]/g, "_");
+  if (safe.startsWith("extractEntities_") || label.startsWith("extractEntities:")) return "extractEntities";
+  if (safe.startsWith("dedupAdjudicate_") || label.startsWith("dedupAdjudicate:")) return "dedupAdjudicate";
+  if (safe.startsWith("generateSummary_") || label.startsWith("generateSummary:")) return "generateSummary";
+  if (safe.startsWith("extractEntityFacts_") || label.startsWith("extractEntityFacts:")) return "extractEntityFacts";
+  return "unknown";
+}
+
+function parseJsonText(text: string): unknown {
+  try {
+    return JSON.parse(stripJsonFence(text));
+  } catch {
+    return undefined;
+  }
+}
+
+function stripJsonFence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1].trim() : trimmed;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Logger } from "pino";
+import type { StageOutcome } from "../connectors/enrichment-stage-report";
 import { createEntityDomainsRepository } from "../db/repositories/entity-domains";
 import type { DB } from "../db/schema";
 import { yieldToEventLoop } from "../lib/event-loop";
@@ -413,6 +414,13 @@ async function materializeUnmaterializedFactsInner(
     summary.factsRead++;
     try {
       const result = await materializeFromFact(deps, fact);
+      opts.stageReport?.({
+        stage: "materialize",
+        label: "Materialise",
+        kind: "code",
+        status: "done",
+        outcomes: [materializeOutcome(fact, result, deps.llmPromotionThreshold)],
+      });
       accumulate(summary, result);
       if (result.kind === "deferred_below_threshold") {
         summary.deferredBelowThreshold++;
@@ -453,6 +461,21 @@ async function materializeUnmaterializedFactsInner(
         .execute();
       summary.skipped++;
       summary.deferred++;
+      opts.stageReport?.({
+        stage: "materialize",
+        label: "Materialise",
+        kind: "code",
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+        outcomes: [
+          {
+            subject: fact.subject_name ?? fact.fact_key,
+            kind: fact.mention_type ?? fact.fact_type,
+            result: "deferred",
+            reason: err instanceof Error ? err.message : String(err),
+          },
+        ],
+      });
     }
     completed++;
     opts.onProgress?.({ phase: "materialize", completed, total });
@@ -495,6 +518,33 @@ async function materializeUnmaterializedFactsInner(
   await cleanupEmptyRelationships(db);
   logger.info({ summary, ...heapStats(startHeapMb) }, "Source-fact materialization complete");
   return summary;
+}
+
+function materializeOutcome(
+  fact: IndexedFileFactRow,
+  result: MaterializeResult,
+  llmPromotionThreshold: number,
+): StageOutcome {
+  const subject = fact.subject_name ?? fact.fact_key;
+  const kind = fact.mention_type ?? fact.fact_type;
+  if (result.kind === "entity_created") return { subject, kind, result: "created" };
+  if (result.kind === "entity_linked") return { subject, kind, result: "linked" };
+  if (result.kind === "queued") return { subject, kind, result: "queued" };
+  if (result.kind === "queued_held") return { subject, kind, result: "queued", reason: result.reason };
+  if (result.kind === "deferred_below_threshold") {
+    return {
+      subject,
+      kind,
+      result: "deferred",
+      reason: `${result.reason}; seen count below threshold, needs ${llmPromotionThreshold}`,
+    };
+  }
+  if (result.kind === "skipped" || result.kind === "skipped_missing_owner") {
+    return { subject, kind, result: "suppressed", reason: result.reason };
+  }
+  if (result.kind === "relationship_materialized") return { subject, kind, result: "linked" };
+  if (result.kind === "structural") return { subject, kind, result: "linked" };
+  return { subject, kind, result: "created" };
 }
 
 export function shouldMarkMaterialized(result: MaterializeResult): boolean {

--- a/packages/server/src/entities/materialize-types.ts
+++ b/packages/server/src/entities/materialize-types.ts
@@ -1,6 +1,7 @@
 import type { Kysely, Selectable } from "kysely";
 import type { Logger } from "pino";
 import type { EmbeddingProvider } from "../connectors/embeddings/types";
+import type { StageReporter } from "../connectors/enrichment-stage-report";
 import type { createEntityRepository } from "../db/repositories/entities";
 import type { EntityDomainsRepository } from "../db/repositories/entity-domains";
 import type { createEntityReviewRepo } from "../db/repositories/entity-review";
@@ -181,4 +182,5 @@ export interface MaterializeUnmaterializedOptions {
    */
   onProgress?: (progress: MaterializeProgress) => void;
   shouldCancel?: () => boolean;
+  stageReport?: StageReporter;
 }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -20,6 +20,7 @@ import { apiTokenRoutes } from "./api/api-tokens";
 import { type MagicLinkSender, authRoutes } from "./api/auth";
 import { channelRoutes } from "./api/channels";
 import { connectorRoutes } from "./api/connectors";
+import { devEnrichmentRoutes } from "./api/dev-enrichment";
 import { entityRoutes } from "./api/entities";
 import { healthRoutes } from "./api/health";
 import { localClaudeSessionEventRoutes } from "./api/local-claude-sessions";
@@ -476,6 +477,9 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
     }),
   );
   app.route("/api/settings", settingsRoutes(settings, db, deps?.logger, config));
+  if (config.DEV_TOOLS_ENABLED) {
+    app.route("/api/dev", devEnrichmentRoutes(db, logger, config));
+  }
   app.route("/api/skills", skillsRoutes(config));
   app.route(
     "/api/users",

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -36,6 +36,7 @@ import { settingsRoutes } from "./api/settings";
 import { setupRoutes } from "./api/setup";
 import { skillsRoutes } from "./api/skills";
 import { verifyJwt } from "./auth/jwt";
+import type { GeminiGenerator } from "./connectors/gemini-generate";
 import { entityReviewRoutes } from "./entities/review";
 
 import { oauthRoutes, resolveOrigin } from "./api/oauth";
@@ -152,6 +153,8 @@ interface AppDeps {
   onWhatsAppSocketStateChange?: (change: WhatsAppSocketStateChange) => Promise<void> | void;
   getWhatsAppHealth?: () => { missingProviderIdEvents: number };
   reconcileManagedMembers?: () => Promise<ManagedMemberReconciliationResult>;
+  /** Injected so the dev trace route, and its tests, can drive a specific model. */
+  enrichmentGenerator?: GeminiGenerator;
 }
 
 /**
@@ -631,7 +634,12 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   });
 
   if (deps?.logger) {
-    app.route("/api/connectors", connectorRoutes(connectors, db, deps.logger, users, config));
+    app.route(
+      "/api/connectors",
+      connectorRoutes(connectors, db, deps.logger, users, config, {
+        enrichmentGenerator: deps.enrichmentGenerator,
+      }),
+    );
   }
 
   app.route("/api/identities", providerIdentityRoutes(identities, users));

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -478,7 +478,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
   );
   app.route("/api/settings", settingsRoutes(settings, db, deps?.logger, config));
   if (config.DEV_TOOLS_ENABLED) {
-    app.route("/api/dev", devEnrichmentRoutes(db, logger, config));
+    app.route("/api/dev", devEnrichmentRoutes(db, logger, config, { enrichmentGenerator: deps?.enrichmentGenerator }));
   }
   app.route("/api/skills", skillsRoutes(config));
   app.route(

--- a/packages/server/src/test-utils.ts
+++ b/packages/server/src/test-utils.ts
@@ -182,6 +182,7 @@ export function createTestConfig(overrides: Partial<Config> = {}): Config {
     MAX_FILE_SIZE_MB: 20,
     MAX_UPLOAD_SIZE_MB: 50,
     BIRTH_GATE_DRY_RUN: true,
+    DEV_TOOLS_ENABLED: false,
     LLM_PROMOTION_THRESHOLD: 2,
     LLM_TASK_CORROBORATION_THRESHOLD: 2,
     FEATURE_AUTO_MINT_THRESHOLD: 1,

--- a/packages/web/src/components/context-block-row.tsx
+++ b/packages/web/src/components/context-block-row.tsx
@@ -1,0 +1,62 @@
+/**
+ * One block of context handed to a model, stated so a reader can judge it.
+ *
+ * The row's job is the three facts a raw prompt cannot show: the rule that
+ * selected the items, how many the rule matched *before* any cap, and how many
+ * actually went. `total > items.length` is why truncation reads as a visible
+ * fact rather than as items nobody notices are missing.
+ *
+ * Shared by the mint-tasks dialog and the dev-tools enrichment trace.
+ */
+import type { MintContextBlock } from "@/lib/api";
+import { CaretRightIcon } from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
+import { useState } from "react";
+
+export function ContextBlockRow({ block }: { block: MintContextBlock }) {
+  const [expanded, setExpanded] = useState(false);
+  const empty = block.items.length === 0;
+
+  return (
+    <div className="rounded-md border border-border">
+      <button
+        type="button"
+        onClick={() => !empty && setExpanded((v) => !v)}
+        disabled={empty}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left disabled:cursor-default"
+      >
+        <CaretRightIcon
+          size={12}
+          className={`shrink-0 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""} ${
+            empty ? "opacity-0" : ""
+          }`}
+        />
+        <span className="text-sm font-medium">{block.label}</span>
+        <span className={`text-xs ${empty ? "text-muted-foreground" : ""}`}>
+          {block.truncated ? `${block.items.length} of ${block.total}` : block.total}
+        </span>
+        {block.via === "tool" && (
+          <Badge variant="outline" className="text-[10px]">
+            fetched by model
+          </Badge>
+        )}
+        <span className="ml-auto truncate text-xs text-muted-foreground">{block.selection}</span>
+      </button>
+
+      {expanded && (
+        <ul className="border-t border-border px-3 py-2 space-y-1">
+          {block.items.map((item) => (
+            <li key={item} className="text-xs text-muted-foreground break-words whitespace-pre-wrap">
+              {item}
+            </li>
+          ))}
+          {block.truncated && (
+            <li className="text-xs italic text-muted-foreground">
+              {block.total - block.items.length} more matched the rule but were not sent.
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1060,8 +1060,6 @@ export interface MintContextBlock {
   via?: "prompt" | "tool";
 }
 
-
-
 /**
  * One captured pino call from a traced enrichment run. Prompt and response
  * bodies are never included — those stay in the server-side dump directory.

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1074,6 +1074,61 @@ export interface DevTraceStep {
   fields: Record<string, unknown>;
 }
 
+/** The eight stages a single-file enrichment runs, in the order the server reports them. */
+export type DevStageKey =
+  | "extractEntities"
+  | "dedupAdjudicate"
+  | "reconcileFacts"
+  | "matchEntities"
+  | "generateSummary"
+  | "extractEntityFacts"
+  | "engagementFloor"
+  | "materialize";
+
+/** What one stage decided about one thing, and the rule that decided it. */
+export interface DevStageOutcome {
+  subject: string;
+  kind: string;
+  result: "kept" | "dropped" | "created" | "linked" | "queued" | "suppressed" | "deferred";
+  reason?: string;
+}
+
+export interface DevStageReport {
+  stage: DevStageKey;
+  label: string;
+  kind: "model" | "code";
+  status: "done" | "failed" | "skipped";
+  context?: MintContextBlock[];
+  outcomes?: DevStageOutcome[];
+  error?: string;
+  parallelGroup?: string;
+  summary?: Record<string, unknown>;
+}
+
+/** One LLM call's header. Never carries the prompt — those are ~19,000 chars each. */
+export interface DevLlmCallHeader {
+  seq: number;
+  label: string;
+  stage: DevStageKey | "unknown";
+  at: string | null;
+  model: string;
+  promptChars: number | null;
+  promptTokens: number | null;
+  completionTokens: number | null;
+  costUsd: number | null;
+  finishReason: string | null;
+  /** Set when the dump is missing or malformed — normal for a call that threw. */
+  unreadable?: { reason: string };
+}
+
+export interface DevLlmCallBody extends DevLlmCallHeader {
+  prompt: string | null;
+  systemPrompt: string | null;
+  text: string | null;
+  /** The response re-parsed as JSON, so a silent empty parse is visible. */
+  parsed?: unknown;
+}
+
 export interface DevTraceRunHeader {
   id: string;
   fileId: string;
@@ -3092,7 +3147,16 @@ export const api = {
     /** `since` fetches only steps after that sequence number, for incremental polling. */
     enrichmentRun(runId: string, since = 0) {
       const qs = since > 0 ? `?since=${since}` : "";
-      return request<{ run: DevTraceRunHeader; steps: DevTraceStep[] }>(`/api/dev/enrichment-runs/${runId}${qs}`);
+      return request<{ run: DevTraceRunHeader; steps: DevTraceStep[]; stageReports: DevStageReport[] }>(
+        `/api/dev/enrichment-runs/${runId}${qs}`,
+      );
+    },
+    enrichmentCalls(runId: string) {
+      return request<{ calls: DevLlmCallHeader[] }>(`/api/dev/enrichment-runs/${runId}/calls`);
+    },
+    /** Fetched per call on expand — the prompt bodies are far too large for the list. */
+    enrichmentCall(runId: string, seq: number) {
+      return request<{ call: DevLlmCallBody }>(`/api/dev/enrichment-runs/${runId}/calls/${seq}`);
     },
   },
   workspace: {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1040,6 +1040,54 @@ export interface FileContent {
   emailThread?: { connectorId: string; threadKey: string };
 }
 
+/**
+ * One group of context handed to the extraction model, as the server assembled it.
+ *
+ * Modelled as an ordered list rather than named fields so the same renderer serves both
+ * shapes of run: today every block is stuffed into the prompt up front, and a later
+ * tool-calling extractor emits the same blocks as the model fetches them. `via`
+ * distinguishes the two.
+ */
+export interface MintContextBlock {
+  key: string;
+  label: string;
+  /** The rule that chose these items, stated for a reader — e.g. "open tasks on the 3 projects above". */
+  selection: string;
+  /** How many items the rule matched, before any cap. Differs from items.length when truncated. */
+  total: number;
+  items: string[];
+  truncated?: boolean;
+  via?: "prompt" | "tool";
+}
+
+
+
+/**
+ * One captured pino call from a traced enrichment run. Prompt and response
+ * bodies are never included — those stay in the server-side dump directory.
+ */
+export interface DevTraceStep {
+  seq: number;
+  at: string;
+  level: string;
+  msg: string;
+  fields: Record<string, unknown>;
+}
+
+export interface DevTraceRunHeader {
+  id: string;
+  fileId: string;
+  fileName: string;
+  startedAt: string;
+  finishedAt: string | null;
+  status: "running" | "done" | "failed";
+  error: string | null;
+  dumpDir: string;
+  stepCount: number;
+  /** Set once the run exceeded the capture cap and later steps were dropped. */
+  truncated: boolean;
+}
+
 export interface EmailAddr {
   name?: string | null;
   email: string;
@@ -3025,6 +3073,26 @@ export const api = {
         method: "PATCH",
         body: JSON.stringify({ status }),
       });
+    },
+  },
+  /**
+   * Internal pipeline-debugging endpoints. Present only when the server was
+   * started with DEV_TOOLS_ENABLED; every call 404s otherwise.
+   */
+  dev: {
+    startEnrichmentRun(fileId: string) {
+      return request<{ runId: string; fileId: string; fileName: string }>("/api/dev/enrichment-runs", {
+        method: "POST",
+        body: JSON.stringify({ fileId }),
+      });
+    },
+    enrichmentRuns() {
+      return request<{ runs: DevTraceRunHeader[] }>("/api/dev/enrichment-runs");
+    },
+    /** `since` fetches only steps after that sequence number, for incremental polling. */
+    enrichmentRun(runId: string, since = 0) {
+      const qs = since > 0 ? `?since=${since}` : "";
+      return request<{ run: DevTraceRunHeader; steps: DevTraceStep[] }>(`/api/dev/enrichment-runs/${runId}${qs}`);
     },
   },
   workspace: {

--- a/packages/web/src/router.ts
+++ b/packages/web/src/router.ts
@@ -5,6 +5,7 @@ import { channelsRoute } from "./routes/channels";
 import { chatIndexRoute, chatRoute } from "./routes/chat";
 import { connectionsCallbackRoute, connectionsRoute } from "./routes/connections";
 import { dashboardRoute } from "./routes/dashboard";
+import { devToolsRoute } from "./routes/dev-tools";
 import { filesRoute } from "./routes/files";
 import { homeRoute } from "./routes/home";
 import { indexRoute } from "./routes/index";
@@ -41,6 +42,7 @@ const routeTree = rootRoute.addChildren([
     connectionsRoute.addChildren([connectionsCallbackRoute]),
     usageRoute,
     settingsRoute,
+    devToolsRoute,
   ]),
 ]);
 

--- a/packages/web/src/routes/dev-tools/enrichment-trace.tsx
+++ b/packages/web/src/routes/dev-tools/enrichment-trace.tsx
@@ -1,0 +1,225 @@
+/**
+ * One enrichment run as master-detail: all eight stages in a rail on the left,
+ * one stage open on the right.
+ *
+ * A rail rather than an accordion because the stage bodies are large — a
+ * 19,000-character prompt or a hundred-row outcome list — and expanding one
+ * inline would push the rest of the run off screen just when the reader needs
+ * to compare it against the others.
+ */
+import { type DevLlmCallHeader, type DevStageReport, type DevTraceRunHeader, type DevTraceStep, api } from "@/lib/api";
+import { CaretRightIcon, SpinnerGapIcon } from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
+import { useEffect, useRef, useState } from "react";
+import { StageDetail } from "./stage-detail";
+import { type RailSelection, StageRail } from "./stage-rail";
+import { STAGES } from "./stages";
+
+export function EnrichmentTrace({ runId }: { runId: string }) {
+  const [header, setHeader] = useState<DevTraceRunHeader | null>(null);
+  const [stageReports, setStageReports] = useState<DevStageReport[]>([]);
+  const [steps, setSteps] = useState<DevTraceStep[]>([]);
+  const [calls, setCalls] = useState<DevLlmCallHeader[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [selection, setSelection] = useState<RailSelection>({ kind: "stage", stage: STAGES[0].stage });
+  /** Once the reader picks a stage, the run stops moving the selection under them. */
+  const pinned = useRef(false);
+  const lastSeq = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    lastSeq.current = 0;
+    pinned.current = false;
+    setSteps([]);
+    setStageReports([]);
+    setCalls([]);
+    setHeader(null);
+    setError(null);
+    setSelection({ kind: "stage", stage: STAGES[0].stage });
+
+    async function poll() {
+      if (cancelled) return;
+      try {
+        const [runData, callData] = await Promise.all([
+          api.dev.enrichmentRun(runId, lastSeq.current),
+          api.dev.enrichmentCalls(runId),
+        ]);
+        if (cancelled) return;
+        setHeader(runData.run);
+        setStageReports(runData.stageReports);
+        setCalls(callData.calls);
+        if (runData.steps.length > 0) {
+          lastSeq.current = runData.steps[runData.steps.length - 1].seq;
+          setSteps((prev) => [...prev, ...runData.steps]);
+        }
+        if (!pinned.current) {
+          const latest = latestReportedStage(runData.stageReports);
+          if (latest) setSelection({ kind: "stage", stage: latest });
+        }
+        if (runData.run.status === "running") setTimeout(poll, 1000);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load run");
+      }
+    }
+    poll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  const reportByStage = new Map(stageReports.map((report) => [report.stage, report]));
+  const callByStage = new Map(calls.map((call) => [call.stage, call]));
+  const ranCount = stageReports.filter((report) => report.status === "done").length;
+  const skippedAll = stageReports.length > 0 && stageReports.every((report) => report.status === "skipped");
+  const totals = callTotals(calls);
+  const running = header?.status === "running";
+
+  const activeIndex = selection.kind === "stage" ? STAGES.findIndex((s) => s.stage === selection.stage) : -1;
+  const activeDefinition = activeIndex >= 0 ? STAGES[activeIndex] : null;
+
+  function select(next: RailSelection) {
+    pinned.current = true;
+    setSelection(next);
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border px-5 py-2.5">
+        {header && <RunStatusBadge status={header.status} />}
+        <span className="text-xs text-muted-foreground">
+          {ranCount} of {STAGES.length} stages ran
+          {totals.tokens > 0 && ` · ${totals.tokens.toLocaleString()} tok`}
+          {totals.cost > 0 && ` · $${totals.cost.toFixed(4)}`}
+        </span>
+        {header && (
+          <span className="ml-auto truncate font-mono text-[10px] text-muted-foreground">{header.dumpDir}</span>
+        )}
+      </div>
+
+      {(header?.error || error || skippedAll) && (
+        <div className="border-b border-border px-5 py-2">
+          {header?.error && <p className="text-[13px] text-destructive">{header.error}</p>}
+          {error && <p className="text-[13px] text-destructive">{error}</p>}
+          {skippedAll && <p className="text-[13px]">{stageReports[0]?.error ?? "Nothing ran."}</p>}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        <StageRail
+          stages={STAGES}
+          reportByStage={reportByStage}
+          callByStage={callByStage}
+          selected={selection}
+          onSelect={select}
+          logLineCount={steps.length}
+          running={running}
+        />
+        {activeDefinition ? (
+          <StageDetail
+            key={activeDefinition.stage}
+            runId={runId}
+            definition={activeDefinition}
+            report={reportByStage.get(activeDefinition.stage)}
+            call={callByStage.get(activeDefinition.stage)}
+            position={activeIndex + 1}
+          />
+        ) : (
+          <LogPane steps={steps} truncated={header?.truncated ?? false} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** The furthest stage the run has reported, so a live run follows itself down the rail. */
+function latestReportedStage(reports: DevStageReport[]): string | null {
+  let best: { stage: string; index: number } | null = null;
+  for (const report of reports) {
+    const index = STAGES.findIndex((stage) => stage.stage === report.stage);
+    if (index >= 0 && (!best || index > best.index)) best = { stage: report.stage, index };
+  }
+  return best?.stage ?? null;
+}
+
+function callTotals(calls: DevLlmCallHeader[]) {
+  return calls.reduce(
+    (acc, call) => ({
+      tokens: acc.tokens + (call.promptTokens ?? 0) + (call.completionTokens ?? 0),
+      cost: acc.cost + (call.costUsd ?? 0),
+    }),
+    { tokens: 0, cost: 0 },
+  );
+}
+
+/**
+ * The raw pino stream. The fallback for a failure no stage report anticipated.
+ */
+function LogPane({ steps, truncated }: { steps: DevTraceStep[]; truncated: boolean }) {
+  return (
+    <div className="flex h-full min-w-0 flex-1 flex-col">
+      <div className="border-b border-border px-5 py-3">
+        <h3 className="text-[15px] font-medium">Log timeline</h3>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          Every line the pipeline logged, in order{truncated && " · capture cap reached"}
+        </p>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {steps.length === 0 ? (
+          <p className="px-5 py-4 text-[13px] text-muted-foreground">Nothing logged yet.</p>
+        ) : (
+          steps.map((step) => <LogRow key={step.seq} step={step} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LogRow({ step }: { step: DevTraceStep }) {
+  const [expanded, setExpanded] = useState(false);
+  const fieldKeys = Object.keys(step.fields);
+
+  return (
+    <div className="border-b border-border">
+      <button
+        type="button"
+        onClick={() => fieldKeys.length > 0 && setExpanded((v) => !v)}
+        disabled={fieldKeys.length === 0}
+        className="flex w-full items-center gap-2 px-5 py-1.5 text-left disabled:cursor-default"
+      >
+        <CaretRightIcon
+          size={11}
+          className={`shrink-0 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""} ${
+            fieldKeys.length === 0 ? "opacity-0" : ""
+          }`}
+        />
+        <span className="w-8 shrink-0 font-mono text-[10px] text-muted-foreground">{step.seq}</span>
+        <span className="w-10 shrink-0 font-mono text-[9px] uppercase text-muted-foreground">{step.level}</span>
+        <span className="min-w-0 flex-1 truncate text-[13px]">{step.msg || "(no message)"}</span>
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{step.at.slice(11, 19)}</span>
+      </button>
+
+      {expanded && (
+        <pre className="overflow-x-auto border-t border-border px-5 py-2 font-mono text-[11px] leading-relaxed">
+          {JSON.stringify(step.fields, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function RunStatusBadge({ status }: { status: DevTraceRunHeader["status"] }) {
+  if (status === "running") {
+    return (
+      <Badge variant="secondary" className="gap-1 text-[10px]">
+        <SpinnerGapIcon size={11} className="animate-spin" />
+        running
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant={status === "failed" ? "destructive" : "outline"} className="text-[10px]">
+      {status}
+    </Badge>
+  );
+}

--- a/packages/web/src/routes/dev-tools/index.tsx
+++ b/packages/web/src/routes/dev-tools/index.tsx
@@ -3,19 +3,23 @@
  * mounted unless the server ran with DEV_TOOLS_ENABLED, so a tenant never
  * reaches it.
  *
- * The surface is one traced enrichment of one file: every log line the pipeline
- * emits — extraction, fact reconciliation, entity matching, materialisation —
- * lands here in order, including the drops that are otherwise invisible.
+ * The surface is one file's journey through enrichment as eight stages: what
+ * was sent to each model call, what came back, and what the code then did with
+ * it — including the drops that leave no trace in the database.
  */
-import { type DevTraceRunHeader, type DevTraceStep, type UnifiedFile, api } from "@/lib/api";
-import { CaretRightIcon, SpinnerGapIcon, WarningIcon } from "@phosphor-icons/react";
-import { Badge } from "@sketch/ui/components/badge";
+import { ConnectorLogo } from "@/components/connector-logos";
+import { type DevTraceRunHeader, type UnifiedFile, api } from "@/lib/api";
+import { type IntegrationType, getIntegration } from "@/lib/integrations";
+import { FileDetailSheet } from "@/routes/files/file-detail-sheet";
+import { WarningIcon } from "@phosphor-icons/react";
 import { Button } from "@sketch/ui/components/button";
 import { Input } from "@sketch/ui/components/input";
 import { useQuery } from "@tanstack/react-query";
 import { createRoute } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
-import { dashboardRoute } from "../dashboard";
+import { useState } from "react";
+import { dashboardRoute, useDashboardAuth } from "../dashboard";
+import { RunStatusBadge } from "./enrichment-trace";
+import { TraceDialog } from "./trace-dialog";
 
 export const devToolsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
@@ -23,91 +27,126 @@ export const devToolsRoute = createRoute({
   component: DevToolsPage,
 });
 
-/** Log messages worth surfacing on their own — the pipeline's silent rejections. */
-const DROP_PATTERN = /drop|skip|suppress|reject|deferred|quarantin/i;
-
-function isDrop(step: DevTraceStep) {
-  return DROP_PATTERN.test(step.msg);
-}
-
 function DevToolsPage() {
-  const [runId, setRunId] = useState<string | null>(null);
+  const auth = useDashboardAuth();
+  const [traceFile, setTraceFile] = useState<{ id: string; name: string } | null>(null);
+  const [openRunId, setOpenRunId] = useState<string | null>(null);
+  const isAdmin = auth.role === "admin";
+
+  /**
+   * The probe is the gate. `/api/dev` is only mounted when the server ran with
+   * DEV_TOOLS_ENABLED, so a failing list call is how this page learns the
+   * surface is off — nothing about it is advertised anywhere a tenant can read.
+   */
+  const runsQuery = useQuery({
+    queryKey: ["dev-tools", "runs"],
+    queryFn: () => api.dev.enrichmentRuns(),
+    enabled: isAdmin,
+    retry: false,
+    refetchInterval: 5000,
+  });
+  const mounted = isAdmin && !runsQuery.isError;
+
+  function closeDialog() {
+    setTraceFile(null);
+    setOpenRunId(null);
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto box-content max-w-4xl px-10 py-8">
+        <h1 className="text-[22px] font-medium">Not available</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">This page does not exist for your account.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto box-content max-w-4xl px-10 py-8">
       <div>
         <h1 className="text-[22px] font-medium">Pipeline debug</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
-          Runs enrichment on one file and shows every step the pipeline logged, in order. Internal only — this is not
-          part of the product.
+          One file through enrichment, stage by stage. Every model call, in and out. Internal only — not part of the
+          product.
         </p>
       </div>
 
-      <div className="mt-5 flex gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[13px]">
-        <WarningIcon size={15} className="mt-0.5 shrink-0" />
-        <span>
-          This runs the real pipeline. It writes facts and can create entities, exactly as the Enrich File button does.
-          Prompts and model responses are not shown here — they stay in the server's dump directory.
-        </span>
-      </div>
+      {mounted ? (
+        <>
+          <div className="mt-5 flex gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[13px]">
+            <WarningIcon size={15} className="mt-0.5 shrink-0" />
+            <span>
+              This runs the real pipeline and re-runs stages the file has already been through, so it writes facts and
+              can create entities. Prompts embed the file body, so this page shows raw customer content.
+            </span>
+          </div>
 
-      <FilePicker onStarted={setRunId} />
-      {runId && <RunTrace runId={runId} />}
-      <PastRuns activeRunId={runId} onSelect={setRunId} />
+          <FilePicker onTrace={setTraceFile} />
+          <PastRuns runs={runsQuery.data?.runs ?? []} onSelect={setOpenRunId} />
+          <TraceDialog file={traceFile} existingRunId={openRunId} onOpenChange={(next) => !next && closeDialog()} />
+        </>
+      ) : (
+        <p className="mt-5 rounded-md border border-border bg-muted/40 px-3 py-2 text-[13px]">
+          Dev tools are off on this deployment. Start the server with <code>DEV_TOOLS_ENABLED=true</code> to mount the
+          debug routes.
+        </p>
+      )}
     </div>
   );
 }
 
 /**
- * Recent files, filtered in the browser. A file id can also be pasted directly,
- * which is how a file found in logs or the DB gets here.
+ * Files filtered by connector, then by name. The source filter matters because
+ * a pipeline bug is usually specific to one connector's shape of content, and
+ * the flat recent-files list buries everything but the noisiest source.
  */
-function FilePicker({ onStarted }: { onStarted: (runId: string) => void }) {
+function FilePicker({ onTrace }: { onTrace: (file: { id: string; name: string }) => void }) {
+  const [source, setSource] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
-  const [starting, setStarting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [inspectFileId, setInspectFileId] = useState<string | null>(null);
 
+  const countsQuery = useQuery({
+    queryKey: ["dev-tools", "file-counts"],
+    queryFn: () => api.integrations.fileCountsBySource(),
+  });
   const filesQuery = useQuery({
-    queryKey: ["dev-tools", "files"],
-    queryFn: () => api.integrations.allFiles({ limit: 200 }),
+    queryKey: ["dev-tools", "files", source],
+    queryFn: () => api.integrations.allFiles({ limit: 200, ...(source ? { source } : {}) }),
   });
 
   const trimmed = filter.trim();
   const matches = (filesQuery.data?.files ?? [])
     .filter((file) => (trimmed ? matchesFile(file, trimmed) : true))
-    .slice(0, 12);
-
-  async function start(fileId: string) {
-    setStarting(true);
-    setError(null);
-    try {
-      const { runId } = await api.dev.startEnrichmentRun(fileId);
-      onStarted(runId);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to start run");
-    } finally {
-      setStarting(false);
-    }
-  }
+    .slice(0, 15);
 
   return (
     <section className="mt-7">
-      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Pick a file</h2>
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pick a file</h2>
+
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        <SourceChip label="All sources" active={source === null} onClick={() => setSource(null)} />
+        {(countsQuery.data?.counts ?? []).map((entry) => (
+          <SourceChip
+            key={entry.source}
+            label={sourceLabel(entry.source)}
+            count={entry.count}
+            source={entry.source}
+            active={source === entry.source}
+            onClick={() => setSource(entry.source)}
+          />
+        ))}
+      </div>
+
       <div className="flex gap-2">
         <Input
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          placeholder="Filter recent files, or paste a file id"
+          placeholder="Filter by name, or paste a file id"
           className="flex-1"
         />
-        {looksLikeId(trimmed) && (
-          <Button onClick={() => start(trimmed)} disabled={starting}>
-            Run on this id
-          </Button>
-        )}
+        {looksLikeId(trimmed) && <Button onClick={() => onTrace({ id: trimmed, name: trimmed })}>Trace this id</Button>}
       </div>
 
-      {error && <p className="mt-2 text-[13px] text-destructive">{error}</p>}
       {filesQuery.isError && (
         <p className="mt-2 text-[13px] text-muted-foreground">Could not load files: {String(filesQuery.error)}</p>
       )}
@@ -119,22 +158,65 @@ function FilePicker({ onStarted }: { onStarted: (runId: string) => void }) {
           </p>
         ) : (
           matches.map((file) => (
-            <div key={file.id} className="flex items-center gap-3 px-3 py-2">
-              <div className="min-w-0 flex-1">
+            <div key={file.id} className="flex items-center gap-2 px-3 py-2">
+              <ConnectorLogo type={file.source as IntegrationType} size={14} className="shrink-0" />
+              <button
+                type="button"
+                onClick={() => setInspectFileId(file.id)}
+                className="min-w-0 flex-1 text-left"
+                title="Open the file to check it is the right one"
+              >
                 <p className="truncate text-sm">{file.fileName}</p>
                 <p className="truncate font-mono text-[11px] text-muted-foreground">
-                  {file.source} · {file.id}
+                  {file.summaryStatus === "done" ? "enriched" : file.summaryStatus} · {file.id}
                 </p>
-              </div>
-              <Button size="sm" variant="outline" disabled={starting} onClick={() => start(file.id)}>
-                {starting ? <SpinnerGapIcon size={13} className="animate-spin" /> : "Trace"}
+              </button>
+              <Button size="sm" variant="outline" onClick={() => onTrace({ id: file.id, name: file.fileName })}>
+                Trace
               </Button>
             </div>
           ))
         )}
       </div>
+      <p className="mt-1.5 text-[11px] text-muted-foreground">
+        Click a file name to open it and confirm you picked the right one. Trace runs the pipeline.
+      </p>
+
+      <FileDetailSheet fileId={inspectFileId} onClose={() => setInspectFileId(null)} />
     </section>
   );
+}
+
+function SourceChip({
+  label,
+  count,
+  source,
+  active,
+  onClick,
+}: {
+  label: string;
+  count?: number;
+  source?: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] ${
+        active ? "border-foreground/30 bg-muted font-medium" : "border-border text-muted-foreground"
+      }`}
+    >
+      {source && <ConnectorLogo type={source as IntegrationType} size={12} />}
+      {label}
+      {count !== undefined && <span className="font-mono text-[10px] text-muted-foreground">{count}</span>}
+    </button>
+  );
+}
+
+function sourceLabel(source: string): string {
+  return getIntegration(source as IntegrationType)?.name ?? source;
 }
 
 function matchesFile(file: UnifiedFile, needle: string) {
@@ -147,172 +229,22 @@ function looksLikeId(value: string) {
 }
 
 /**
- * Polls one run, accumulating steps by sequence number so a long run streams in
- * rather than refetching its whole body each tick.
- */
-function RunTrace({ runId }: { runId: string }) {
-  const [header, setHeader] = useState<DevTraceRunHeader | null>(null);
-  const [steps, setSteps] = useState<DevTraceStep[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [dropsOnly, setDropsOnly] = useState(false);
-  const lastSeq = useRef(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    lastSeq.current = 0;
-    setSteps([]);
-    setHeader(null);
-    setError(null);
-
-    async function poll() {
-      if (cancelled) return;
-      try {
-        const data = await api.dev.enrichmentRun(runId, lastSeq.current);
-        if (cancelled) return;
-        setHeader(data.run);
-        if (data.steps.length > 0) {
-          lastSeq.current = data.steps[data.steps.length - 1].seq;
-          setSteps((prev) => [...prev, ...data.steps]);
-        }
-        if (data.run.status === "running") {
-          setTimeout(poll, 1000);
-        }
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load run");
-      }
-    }
-    poll();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [runId]);
-
-  const shown = dropsOnly ? steps.filter(isDrop) : steps;
-  const dropCount = steps.filter(isDrop).length;
-
-  return (
-    <section className="mt-8">
-      <div className="flex flex-wrap items-center gap-2">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Trace</h2>
-        {header && <RunStatusBadge status={header.status} />}
-        <span className="text-xs text-muted-foreground">
-          {steps.length} steps · {dropCount} drops
-          {header?.truncated && " · capture cap reached"}
-        </span>
-        {dropCount > 0 && (
-          <Button size="sm" variant="ghost" className="ml-auto" onClick={() => setDropsOnly((v) => !v)}>
-            {dropsOnly ? "Show all steps" : "Drops only"}
-          </Button>
-        )}
-      </div>
-
-      {header && (
-        <p className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
-          {header.fileName} · raw calls: {header.dumpDir}
-        </p>
-      )}
-      {header?.error && <p className="mt-2 text-[13px] text-destructive">{header.error}</p>}
-      {error && <p className="mt-2 text-[13px] text-destructive">{error}</p>}
-
-      <div className="mt-2 divide-y divide-border rounded-md border border-border">
-        {shown.length === 0 ? (
-          <p className="px-3 py-3 text-[13px] text-muted-foreground">
-            {header?.status === "running" ? "Waiting for the first step…" : "No steps to show."}
-          </p>
-        ) : (
-          shown.map((step) => <StepRow key={step.seq} step={step} />)
-        )}
-      </div>
-    </section>
-  );
-}
-
-function StepRow({ step }: { step: DevTraceStep }) {
-  const [expanded, setExpanded] = useState(false);
-  const fieldKeys = Object.keys(step.fields);
-  const drop = isDrop(step);
-
-  return (
-    <div className={drop ? "bg-destructive/5" : undefined}>
-      <button
-        type="button"
-        onClick={() => fieldKeys.length > 0 && setExpanded((v) => !v)}
-        disabled={fieldKeys.length === 0}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left disabled:cursor-default"
-      >
-        <CaretRightIcon
-          size={11}
-          className={`shrink-0 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""} ${
-            fieldKeys.length === 0 ? "opacity-0" : ""
-          }`}
-        />
-        <span className="w-8 shrink-0 font-mono text-[10px] text-muted-foreground">{step.seq}</span>
-        <LevelBadge level={step.level} />
-        <span className="min-w-0 flex-1 truncate text-[13px]">{step.msg || "(no message)"}</span>
-        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{step.at.slice(11, 19)}</span>
-      </button>
-
-      {expanded && (
-        <pre className="overflow-x-auto border-t border-border px-3 py-2 font-mono text-[11px] leading-relaxed">
-          {JSON.stringify(step.fields, null, 2)}
-        </pre>
-      )}
-    </div>
-  );
-}
-
-function LevelBadge({ level }: { level: string }) {
-  const variant = level === "error" || level === "fatal" ? "destructive" : level === "warn" ? "default" : "secondary";
-  return (
-    <Badge variant={variant} className="w-14 shrink-0 justify-center font-mono text-[9px] uppercase">
-      {level}
-    </Badge>
-  );
-}
-
-function RunStatusBadge({ status }: { status: DevTraceRunHeader["status"] }) {
-  if (status === "running") {
-    return (
-      <Badge variant="secondary" className="gap-1 text-[10px]">
-        <SpinnerGapIcon size={11} className="animate-spin" />
-        running
-      </Badge>
-    );
-  }
-  return (
-    <Badge variant={status === "failed" ? "destructive" : "outline"} className="text-[10px]">
-      {status}
-    </Badge>
-  );
-}
-
-/**
  * Runs are held in memory and evicted, so this list is short by design and
  * empties on a server restart.
  */
-function PastRuns({ activeRunId, onSelect }: { activeRunId: string | null; onSelect: (runId: string) => void }) {
-  const runsQuery = useQuery({
-    queryKey: ["dev-tools", "runs", activeRunId],
-    queryFn: () => api.dev.enrichmentRuns(),
-    refetchInterval: 5000,
-  });
-
-  const runs = runsQuery.data?.runs ?? [];
+function PastRuns({ runs, onSelect }: { runs: DevTraceRunHeader[]; onSelect: (runId: string) => void }) {
   if (runs.length === 0) return null;
 
   return (
     <section className="mt-8">
-      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Recent runs</h2>
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Recent runs</h2>
       <div className="divide-y divide-border rounded-md border border-border">
         {runs.map((run) => (
           <button
             key={run.id}
             type="button"
             onClick={() => onSelect(run.id)}
-            className={`flex w-full items-center gap-3 px-3 py-2 text-left ${
-              run.id === activeRunId ? "bg-muted/50" : ""
-            }`}
+            className="flex w-full items-center gap-3 px-3 py-2 text-left"
           >
             <RunStatusBadge status={run.status} />
             <span className="min-w-0 flex-1 truncate text-[13px]">{run.fileName}</span>

--- a/packages/web/src/routes/dev-tools/index.tsx
+++ b/packages/web/src/routes/dev-tools/index.tsx
@@ -1,0 +1,327 @@
+/**
+ * /dev-tools — internal pipeline debugging. Not linked from the nav and not
+ * mounted unless the server ran with DEV_TOOLS_ENABLED, so a tenant never
+ * reaches it.
+ *
+ * The surface is one traced enrichment of one file: every log line the pipeline
+ * emits — extraction, fact reconciliation, entity matching, materialisation —
+ * lands here in order, including the drops that are otherwise invisible.
+ */
+import { type DevTraceRunHeader, type DevTraceStep, type UnifiedFile, api } from "@/lib/api";
+import { CaretRightIcon, SpinnerGapIcon, WarningIcon } from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
+import { Button } from "@sketch/ui/components/button";
+import { Input } from "@sketch/ui/components/input";
+import { useQuery } from "@tanstack/react-query";
+import { createRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+import { dashboardRoute } from "../dashboard";
+
+export const devToolsRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: "/dev-tools",
+  component: DevToolsPage,
+});
+
+/** Log messages worth surfacing on their own — the pipeline's silent rejections. */
+const DROP_PATTERN = /drop|skip|suppress|reject|deferred|quarantin/i;
+
+function isDrop(step: DevTraceStep) {
+  return DROP_PATTERN.test(step.msg);
+}
+
+function DevToolsPage() {
+  const [runId, setRunId] = useState<string | null>(null);
+
+  return (
+    <div className="mx-auto box-content max-w-4xl px-10 py-8">
+      <div>
+        <h1 className="text-[22px] font-medium">Pipeline debug</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">
+          Runs enrichment on one file and shows every step the pipeline logged, in order. Internal only — this is not
+          part of the product.
+        </p>
+      </div>
+
+      <div className="mt-5 flex gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[13px]">
+        <WarningIcon size={15} className="mt-0.5 shrink-0" />
+        <span>
+          This runs the real pipeline. It writes facts and can create entities, exactly as the Enrich File button does.
+          Prompts and model responses are not shown here — they stay in the server's dump directory.
+        </span>
+      </div>
+
+      <FilePicker onStarted={setRunId} />
+      {runId && <RunTrace runId={runId} />}
+      <PastRuns activeRunId={runId} onSelect={setRunId} />
+    </div>
+  );
+}
+
+/**
+ * Recent files, filtered in the browser. A file id can also be pasted directly,
+ * which is how a file found in logs or the DB gets here.
+ */
+function FilePicker({ onStarted }: { onStarted: (runId: string) => void }) {
+  const [filter, setFilter] = useState("");
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filesQuery = useQuery({
+    queryKey: ["dev-tools", "files"],
+    queryFn: () => api.integrations.allFiles({ limit: 200 }),
+  });
+
+  const trimmed = filter.trim();
+  const matches = (filesQuery.data?.files ?? [])
+    .filter((file) => (trimmed ? matchesFile(file, trimmed) : true))
+    .slice(0, 12);
+
+  async function start(fileId: string) {
+    setStarting(true);
+    setError(null);
+    try {
+      const { runId } = await api.dev.startEnrichmentRun(fileId);
+      onStarted(runId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start run");
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  return (
+    <section className="mt-7">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Pick a file</h2>
+      <div className="flex gap-2">
+        <Input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter recent files, or paste a file id"
+          className="flex-1"
+        />
+        {looksLikeId(trimmed) && (
+          <Button onClick={() => start(trimmed)} disabled={starting}>
+            Run on this id
+          </Button>
+        )}
+      </div>
+
+      {error && <p className="mt-2 text-[13px] text-destructive">{error}</p>}
+      {filesQuery.isError && (
+        <p className="mt-2 text-[13px] text-muted-foreground">Could not load files: {String(filesQuery.error)}</p>
+      )}
+
+      <div className="mt-2 divide-y divide-border rounded-md border border-border">
+        {matches.length === 0 ? (
+          <p className="px-3 py-3 text-[13px] text-muted-foreground">
+            {filesQuery.isLoading ? "Loading files…" : "No files match."}
+          </p>
+        ) : (
+          matches.map((file) => (
+            <div key={file.id} className="flex items-center gap-3 px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm">{file.fileName}</p>
+                <p className="truncate font-mono text-[11px] text-muted-foreground">
+                  {file.source} · {file.id}
+                </p>
+              </div>
+              <Button size="sm" variant="outline" disabled={starting} onClick={() => start(file.id)}>
+                {starting ? <SpinnerGapIcon size={13} className="animate-spin" /> : "Trace"}
+              </Button>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function matchesFile(file: UnifiedFile, needle: string) {
+  const lower = needle.toLowerCase();
+  return file.fileName.toLowerCase().includes(lower) || file.id.toLowerCase().includes(lower);
+}
+
+function looksLikeId(value: string) {
+  return /^[0-9a-f-]{20,}$/i.test(value);
+}
+
+/**
+ * Polls one run, accumulating steps by sequence number so a long run streams in
+ * rather than refetching its whole body each tick.
+ */
+function RunTrace({ runId }: { runId: string }) {
+  const [header, setHeader] = useState<DevTraceRunHeader | null>(null);
+  const [steps, setSteps] = useState<DevTraceStep[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [dropsOnly, setDropsOnly] = useState(false);
+  const lastSeq = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    lastSeq.current = 0;
+    setSteps([]);
+    setHeader(null);
+    setError(null);
+
+    async function poll() {
+      if (cancelled) return;
+      try {
+        const data = await api.dev.enrichmentRun(runId, lastSeq.current);
+        if (cancelled) return;
+        setHeader(data.run);
+        if (data.steps.length > 0) {
+          lastSeq.current = data.steps[data.steps.length - 1].seq;
+          setSteps((prev) => [...prev, ...data.steps]);
+        }
+        if (data.run.status === "running") {
+          setTimeout(poll, 1000);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load run");
+      }
+    }
+    poll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  const shown = dropsOnly ? steps.filter(isDrop) : steps;
+  const dropCount = steps.filter(isDrop).length;
+
+  return (
+    <section className="mt-8">
+      <div className="flex flex-wrap items-center gap-2">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Trace</h2>
+        {header && <RunStatusBadge status={header.status} />}
+        <span className="text-xs text-muted-foreground">
+          {steps.length} steps · {dropCount} drops
+          {header?.truncated && " · capture cap reached"}
+        </span>
+        {dropCount > 0 && (
+          <Button size="sm" variant="ghost" className="ml-auto" onClick={() => setDropsOnly((v) => !v)}>
+            {dropsOnly ? "Show all steps" : "Drops only"}
+          </Button>
+        )}
+      </div>
+
+      {header && (
+        <p className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
+          {header.fileName} · raw calls: {header.dumpDir}
+        </p>
+      )}
+      {header?.error && <p className="mt-2 text-[13px] text-destructive">{header.error}</p>}
+      {error && <p className="mt-2 text-[13px] text-destructive">{error}</p>}
+
+      <div className="mt-2 divide-y divide-border rounded-md border border-border">
+        {shown.length === 0 ? (
+          <p className="px-3 py-3 text-[13px] text-muted-foreground">
+            {header?.status === "running" ? "Waiting for the first step…" : "No steps to show."}
+          </p>
+        ) : (
+          shown.map((step) => <StepRow key={step.seq} step={step} />)
+        )}
+      </div>
+    </section>
+  );
+}
+
+function StepRow({ step }: { step: DevTraceStep }) {
+  const [expanded, setExpanded] = useState(false);
+  const fieldKeys = Object.keys(step.fields);
+  const drop = isDrop(step);
+
+  return (
+    <div className={drop ? "bg-destructive/5" : undefined}>
+      <button
+        type="button"
+        onClick={() => fieldKeys.length > 0 && setExpanded((v) => !v)}
+        disabled={fieldKeys.length === 0}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left disabled:cursor-default"
+      >
+        <CaretRightIcon
+          size={11}
+          className={`shrink-0 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""} ${
+            fieldKeys.length === 0 ? "opacity-0" : ""
+          }`}
+        />
+        <span className="w-8 shrink-0 font-mono text-[10px] text-muted-foreground">{step.seq}</span>
+        <LevelBadge level={step.level} />
+        <span className="min-w-0 flex-1 truncate text-[13px]">{step.msg || "(no message)"}</span>
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{step.at.slice(11, 19)}</span>
+      </button>
+
+      {expanded && (
+        <pre className="overflow-x-auto border-t border-border px-3 py-2 font-mono text-[11px] leading-relaxed">
+          {JSON.stringify(step.fields, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function LevelBadge({ level }: { level: string }) {
+  const variant = level === "error" || level === "fatal" ? "destructive" : level === "warn" ? "default" : "secondary";
+  return (
+    <Badge variant={variant} className="w-14 shrink-0 justify-center font-mono text-[9px] uppercase">
+      {level}
+    </Badge>
+  );
+}
+
+function RunStatusBadge({ status }: { status: DevTraceRunHeader["status"] }) {
+  if (status === "running") {
+    return (
+      <Badge variant="secondary" className="gap-1 text-[10px]">
+        <SpinnerGapIcon size={11} className="animate-spin" />
+        running
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant={status === "failed" ? "destructive" : "outline"} className="text-[10px]">
+      {status}
+    </Badge>
+  );
+}
+
+/**
+ * Runs are held in memory and evicted, so this list is short by design and
+ * empties on a server restart.
+ */
+function PastRuns({ activeRunId, onSelect }: { activeRunId: string | null; onSelect: (runId: string) => void }) {
+  const runsQuery = useQuery({
+    queryKey: ["dev-tools", "runs", activeRunId],
+    queryFn: () => api.dev.enrichmentRuns(),
+    refetchInterval: 5000,
+  });
+
+  const runs = runsQuery.data?.runs ?? [];
+  if (runs.length === 0) return null;
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Recent runs</h2>
+      <div className="divide-y divide-border rounded-md border border-border">
+        {runs.map((run) => (
+          <button
+            key={run.id}
+            type="button"
+            onClick={() => onSelect(run.id)}
+            className={`flex w-full items-center gap-3 px-3 py-2 text-left ${
+              run.id === activeRunId ? "bg-muted/50" : ""
+            }`}
+          >
+            <RunStatusBadge status={run.status} />
+            <span className="min-w-0 flex-1 truncate text-[13px]">{run.fileName}</span>
+            <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+              {run.stepCount} steps · {run.startedAt.slice(11, 19)}
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/routes/dev-tools/stage-detail.tsx
+++ b/packages/web/src/routes/dev-tools/stage-detail.tsx
@@ -1,0 +1,264 @@
+/**
+ * The right pane of a run: one stage with the mint-tasks anatomy — what was
+ * sent, what came back, and what the code then did with it.
+ *
+ * A model stage gets four tabs. A code stage has no prompt, so it opens straight
+ * on its outcomes, which is the half of the pipeline that leaves no trace
+ * anywhere else.
+ */
+import { ContextBlockRow } from "@/components/context-block-row";
+import { type DevLlmCallHeader, type DevStageOutcome, type DevStageReport, api } from "@/lib/api";
+import { SpinnerGapIcon } from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
+import { Button } from "@sketch/ui/components/button";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import type { StageDefinition } from "./stages";
+
+type StageTab = "context" | "prompt" | "response" | "parsed" | "outcomes";
+
+/** Results that mean the pipeline declined to act, which is what a reader is usually hunting. */
+const NEGATIVE_RESULTS = new Set(["dropped", "suppressed", "deferred"]);
+
+const MODEL_TABS: Array<{ id: StageTab; label: string }> = [
+  { id: "context", label: "Context sent" },
+  { id: "prompt", label: "Full prompt" },
+  { id: "response", label: "Raw response" },
+  { id: "parsed", label: "Parsed" },
+  { id: "outcomes", label: "Outcomes" },
+];
+
+export function StageDetail({
+  runId,
+  definition,
+  report,
+  call,
+  position,
+}: {
+  runId: string;
+  definition: StageDefinition;
+  report?: DevStageReport;
+  call?: DevLlmCallHeader;
+  position: number;
+}) {
+  const [tab, setTab] = useState<StageTab>(definition.kind === "model" ? "context" : "outcomes");
+  const activeTab = definition.kind === "model" ? tab : "outcomes";
+
+  return (
+    <div className="flex h-full min-w-0 flex-1 flex-col">
+      <div className="border-b border-border px-5 py-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[11px] text-muted-foreground">{position}</span>
+          <h3 className="text-[15px] font-medium">{definition.label}</h3>
+          <Badge variant="secondary" className="font-mono text-[9px] uppercase">
+            {definition.kind}
+          </Badge>
+          <StageStatus status={report?.status} />
+          {definition.parallelWith && (
+            <span className="text-[11px] text-muted-foreground">runs with {definition.parallelWith}</span>
+          )}
+        </div>
+        {call && (
+          <p className="mt-1 font-mono text-[11px] text-muted-foreground">
+            {call.model}
+            {call.promptChars !== null && ` · ${call.promptChars.toLocaleString()} chars in`}
+            {call.promptTokens !== null && ` · ${call.promptTokens.toLocaleString()} tok`}
+            {call.costUsd !== null && ` · $${call.costUsd.toFixed(4)}`}
+            {call.finishReason && ` · ${call.finishReason}`}
+          </p>
+        )}
+        {report?.error && <p className="mt-1.5 text-[13px] text-destructive">{report.error}</p>}
+
+        {definition.kind === "model" && (
+          <div className="mt-2.5 flex flex-wrap gap-1">
+            {MODEL_TABS.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                onClick={() => setTab(entry.id)}
+                className={`rounded-md px-2.5 py-1 text-[12px] ${
+                  tab === entry.id ? "bg-muted font-medium text-foreground" : "text-muted-foreground"
+                }`}
+              >
+                {entry.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+        {activeTab === "context" ? (
+          <ContextPane report={report} />
+        ) : activeTab === "outcomes" ? (
+          <OutcomesPane report={report} definition={definition} />
+        ) : (
+          <CallPane runId={runId} call={call} view={activeTab} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ContextPane({ report }: { report?: DevStageReport }) {
+  if (!report?.context || report.context.length === 0) {
+    return <Empty text="This stage declared no context blocks." />;
+  }
+  return (
+    <>
+      <div className="space-y-1.5">
+        {report.context.map((block) => (
+          <ContextBlockRow key={block.key} block={block} />
+        ))}
+      </div>
+      <p className="mt-3 text-[11px] text-muted-foreground">
+        Each block states the rule that selected it and the count it matched before any cap.
+      </p>
+    </>
+  );
+}
+
+function OutcomesPane({ report, definition }: { report?: DevStageReport; definition: StageDefinition }) {
+  const outcomes = report?.outcomes ?? [];
+  if (outcomes.length === 0) {
+    return (
+      <Empty
+        text={
+          definition.kind === "model"
+            ? "This stage records its decisions on the code stage that consumes it."
+            : "This stage recorded no per-item outcomes."
+        }
+      />
+    );
+  }
+
+  const negative = outcomes.filter((outcome) => NEGATIVE_RESULTS.has(outcome.result));
+  const positive = outcomes.filter((outcome) => !NEGATIVE_RESULTS.has(outcome.result));
+
+  return (
+    <div className="space-y-4">
+      {negative.length > 0 && <OutcomeGroup title={`Not acted on (${negative.length})`} outcomes={negative} negative />}
+      {positive.length > 0 && <OutcomeGroup title={`Acted on (${positive.length})`} outcomes={positive} />}
+    </div>
+  );
+}
+
+function OutcomeGroup({
+  title,
+  outcomes,
+  negative,
+}: {
+  title: string;
+  outcomes: DevStageOutcome[];
+  negative?: boolean;
+}) {
+  return (
+    <div>
+      <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</p>
+      <div className={`overflow-hidden rounded-md border border-border ${negative ? "bg-destructive/5" : ""}`}>
+        {outcomes.map((outcome, index) => (
+          <div
+            key={`${outcome.subject}-${outcome.result}-${index}`}
+            className="grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-3 gap-y-0.5 border-b border-border px-3 py-1.5 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_5rem_5rem_minmax(0,14rem)]"
+          >
+            <span className="truncate text-[13px]">{outcome.subject}</span>
+            <span className="font-mono text-[10px] text-muted-foreground">{outcome.kind}</span>
+            <span className="font-mono text-[10px]">{outcome.result}</span>
+            <span className="col-span-2 text-[11px] text-muted-foreground sm:col-span-1">{outcome.reason ?? ""}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Prompt and response bodies load only when their tab is opened — an extraction
+ * prompt runs to roughly 19,000 characters.
+ */
+function CallPane({
+  runId,
+  call,
+  view,
+}: {
+  runId: string;
+  call?: DevLlmCallHeader;
+  view: "prompt" | "response" | "parsed";
+}) {
+  const bodyQuery = useQuery({
+    queryKey: ["dev-tools", "call", runId, call?.seq],
+    queryFn: () => api.dev.enrichmentCall(runId, call?.seq ?? 0),
+    enabled: Boolean(call),
+  });
+
+  if (!call) {
+    return (
+      <Empty text="No dump was written for this stage. Dumps are saved after a response arrives, so a call that threw leaves nothing behind." />
+    );
+  }
+  if (bodyQuery.isLoading) {
+    return (
+      <p className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
+        <SpinnerGapIcon size={13} className="animate-spin" />
+        Loading the call…
+      </p>
+    );
+  }
+  if (bodyQuery.isError) return <p className="text-[13px] text-destructive">{String(bodyQuery.error)}</p>;
+
+  const body = bodyQuery.data?.call;
+  if (view === "prompt") {
+    return (
+      <div className="space-y-3">
+        {body?.systemPrompt && <Payload label="System prompt" text={body.systemPrompt} />}
+        {body?.prompt ? <Payload label="Prompt" text={body.prompt} /> : <Empty text="No prompt recorded." />}
+      </div>
+    );
+  }
+  if (view === "parsed") {
+    return body?.parsed === undefined ? (
+      <Empty text="The response did not parse as JSON." />
+    ) : (
+      <Payload label="Parsed" text={JSON.stringify(body.parsed, null, 2)} />
+    );
+  }
+  return body?.text ? <Payload label="Response" text={body.text} /> : <Empty text="No response text." />;
+}
+
+function Payload({ label, text }: { label: string; text: string }) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</span>
+        <span className="text-[11px] text-muted-foreground">{text.length.toLocaleString()} chars</span>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 text-[11px]"
+          onClick={() => navigator.clipboard.writeText(text)}
+        >
+          Copy
+        </Button>
+      </div>
+      <pre className="whitespace-pre-wrap rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-[11px] leading-relaxed">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+function Empty({ text }: { text: string }) {
+  return <p className="text-[13px] text-muted-foreground">{text}</p>;
+}
+
+function StageStatus({ status }: { status?: DevStageReport["status"] }) {
+  if (!status) return <span className="font-mono text-[10px] text-muted-foreground">not started</span>;
+  return (
+    <Badge
+      variant={status === "failed" ? "destructive" : status === "skipped" ? "secondary" : "outline"}
+      className="text-[10px]"
+    >
+      {status}
+    </Badge>
+  );
+}

--- a/packages/web/src/routes/dev-tools/stage-rail.tsx
+++ b/packages/web/src/routes/dev-tools/stage-rail.tsx
@@ -1,0 +1,111 @@
+/**
+ * The left rail of a run: all eight stages at once, so the shape of the run
+ * stays visible while one stage is being read on the right.
+ */
+import type { DevLlmCallHeader, DevStageReport } from "@/lib/api";
+import { SpinnerGapIcon } from "@phosphor-icons/react";
+import type { StageDefinition } from "./stages";
+
+export type RailSelection = { kind: "stage"; stage: string } | { kind: "log" };
+
+export function StageRail({
+  stages,
+  reportByStage,
+  callByStage,
+  selected,
+  onSelect,
+  logLineCount,
+  running,
+}: {
+  stages: StageDefinition[];
+  reportByStage: Map<string, DevStageReport>;
+  callByStage: Map<string, DevLlmCallHeader>;
+  selected: RailSelection;
+  onSelect: (selection: RailSelection) => void;
+  logLineCount: number;
+  running: boolean;
+}) {
+  return (
+    <nav className="flex h-full w-60 shrink-0 flex-col overflow-y-auto border-r border-border bg-muted/20">
+      {stages.map((definition, index) => {
+        const report = reportByStage.get(definition.stage);
+        const call = callByStage.get(definition.stage);
+        const active = selected.kind === "stage" && selected.stage === definition.stage;
+        return (
+          <button
+            key={definition.stage}
+            type="button"
+            onClick={() => onSelect({ kind: "stage", stage: definition.stage })}
+            className={`flex items-start gap-2.5 border-b border-border px-3 py-2.5 text-left ${
+              active ? "bg-background" : "hover:bg-background/60"
+            }`}
+          >
+            <StatusDot status={report?.status} running={running} />
+            <span className="min-w-0 flex-1">
+              <span className="flex items-baseline gap-1.5">
+                <span className="font-mono text-[10px] text-muted-foreground">{index + 1}</span>
+                <span className={`truncate text-[13px] ${active ? "font-medium" : ""}`}>{definition.label}</span>
+              </span>
+              <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                {railLine(definition, report, call)}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+
+      <button
+        type="button"
+        onClick={() => onSelect({ kind: "log" })}
+        className={`mt-auto flex items-center gap-2.5 border-t border-border px-3 py-2.5 text-left ${
+          selected.kind === "log" ? "bg-background" : "hover:bg-background/60"
+        }`}
+      >
+        <span className="h-2 w-2 shrink-0 rounded-full border border-border" />
+        <span className="min-w-0 flex-1">
+          <span className={`block truncate text-[13px] ${selected.kind === "log" ? "font-medium" : ""}`}>
+            Log timeline
+          </span>
+          <span className="mt-0.5 block text-[11px] text-muted-foreground">{logLineCount} lines</span>
+        </span>
+      </button>
+    </nav>
+  );
+}
+
+/**
+ * The rail's one line per stage: its own counts if it ran, its cost if it called
+ * a model, and the reason it did not run if it was skipped.
+ */
+function railLine(definition: StageDefinition, report?: DevStageReport, call?: DevLlmCallHeader): string {
+  if (!report) return definition.kind === "model" ? "model call" : "not started";
+  if (report.status === "skipped") return "skipped";
+  if (report.status === "failed") return "failed";
+
+  const parts: string[] = [];
+  if (report.summary) {
+    for (const [key, value] of Object.entries(report.summary)) parts.push(`${humanizeKey(key)} ${String(value)}`);
+  }
+  if (call?.promptTokens != null) parts.push(`${call.promptTokens.toLocaleString()} tok`);
+  return parts.length > 0 ? parts.join(" · ") : "done";
+}
+
+function humanizeKey(key: string): string {
+  return key
+    .replace(/([A-Z])/g, " $1")
+    .toLowerCase()
+    .trim();
+}
+
+function StatusDot({ status, running }: { status?: DevStageReport["status"]; running: boolean }) {
+  if (!status) {
+    return running ? (
+      <SpinnerGapIcon size={9} className="mt-1.5 shrink-0 animate-spin text-muted-foreground" />
+    ) : (
+      <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full border border-border" />
+    );
+  }
+  const tone =
+    status === "failed" ? "bg-destructive" : status === "skipped" ? "bg-muted-foreground/40" : "bg-foreground/70";
+  return <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${tone}`} />;
+}

--- a/packages/web/src/routes/dev-tools/stages.ts
+++ b/packages/web/src/routes/dev-tools/stages.ts
@@ -1,0 +1,27 @@
+/**
+ * The eight stages of a single-file enrichment, in run order.
+ *
+ * Listed here rather than derived from what the server has reported so far, so a
+ * run in flight shows the stages it has not reached yet instead of growing a
+ * list from nothing.
+ */
+import type { DevStageKey } from "@/lib/api";
+
+export interface StageDefinition {
+  stage: DevStageKey;
+  label: string;
+  kind: "model" | "code";
+  /** Set when this stage runs concurrently with another, so the list does not imply an order that does not exist. */
+  parallelWith?: string;
+}
+
+export const STAGES: StageDefinition[] = [
+  { stage: "extractEntities", label: "Extract entities", kind: "model" },
+  { stage: "dedupAdjudicate", label: "Adjudicate known matches", kind: "model" },
+  { stage: "reconcileFacts", label: "Reconcile facts", kind: "code" },
+  { stage: "matchEntities", label: "Match entities", kind: "code" },
+  { stage: "generateSummary", label: "Summary", kind: "model", parallelWith: "entity facts" },
+  { stage: "extractEntityFacts", label: "Entity facts", kind: "model", parallelWith: "summary" },
+  { stage: "engagementFloor", label: "Engagement floor", kind: "code" },
+  { stage: "materialize", label: "Materialise", kind: "code" },
+];

--- a/packages/web/src/routes/dev-tools/trace-dialog.tsx
+++ b/packages/web/src/routes/dev-tools/trace-dialog.tsx
@@ -1,0 +1,101 @@
+/**
+ * Runs one file through the pipeline and shows every stage as it happens.
+ *
+ * Lives inside /dev-tools only. It exposes prompts, and prompts embed the file
+ * body, so it has no place on a product surface.
+ */
+import { api } from "@/lib/api";
+import { SparkleIcon, SpinnerGapIcon, WarningIcon } from "@phosphor-icons/react";
+import { Button } from "@sketch/ui/components/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@sketch/ui/components/dialog";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { EnrichmentTrace } from "./enrichment-trace";
+
+export function TraceDialog({
+  file,
+  existingRunId,
+  onOpenChange,
+}: {
+  /** Set to start a fresh run for this file. */
+  file: { id: string; name: string } | null;
+  /** Set to reopen a run that already happened. */
+  existingRunId: string | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [runId, setRunId] = useState<string | null>(existingRunId);
+
+  const startMutation = useMutation({
+    mutationFn: (fileId: string) => api.dev.startEnrichmentRun(fileId),
+    onSuccess: (data) => setRunId(data.runId),
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  useEffect(() => {
+    setRunId(existingRunId);
+  }, [existingRunId]);
+
+  const open = Boolean(file || existingRunId);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setRunId(null);
+      startMutation.reset();
+    }
+    onOpenChange(next);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="flex h-[88vh] w-[96vw] max-w-[1180px] flex-col gap-0 overflow-hidden p-0 sm:max-w-[1180px]">
+        <DialogHeader className="shrink-0 border-b border-border px-5 py-3">
+          <DialogTitle>Trace enrichment</DialogTitle>
+          <DialogDescription>
+            {file ? (
+              <>
+                Runs the pipeline against <span className="font-medium text-foreground">{file.name}</span> and shows
+                each stage as it happens.
+              </>
+            ) : (
+              "An earlier run, replayed from what the server still holds in memory."
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        {runId ? (
+          <div className="min-h-0 flex-1">
+            <EnrichmentTrace runId={runId} />
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center px-5 py-6 text-center">
+            <div className="mb-4 flex max-w-md gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-left text-xs">
+              <WarningIcon size={14} className="mt-0.5 shrink-0" />
+              <span>
+                This writes facts and can create entities. Stages the file has already been through are re-run, so the
+                graph changes.
+              </span>
+            </div>
+            <Button
+              onClick={() => file && startMutation.mutate(file.id)}
+              disabled={startMutation.isPending || !file}
+              className="gap-1.5"
+            >
+              {startMutation.isPending ? (
+                <>
+                  <SpinnerGapIcon size={14} className="animate-spin" />
+                  Starting...
+                </>
+              ) : (
+                <>
+                  <SparkleIcon size={14} />
+                  Run enrichment
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## What Changed

- Add an admin-only enrichment trace API and /dev-tools UI behind DEV_TOOLS_ENABLED.
- Capture model-stage prompts, outputs, parsed JSON, context reports, and pipeline stage metadata for inspection.
- Make per-file enrichment rerun extraction when summary status is already done or skipped.
- Add regression coverage with deterministic model injection and wait for background enrichment before teardown.

## Why

Enrichment failures and skipped stages were difficult to diagnose from the final materialized result alone. This adds an internal trace surface for following a run stage by stage and fixes the per-file rerun path uncovered while validating it.

## How to Test

1. Set DEV_TOOLS_ENABLED=true and start Sketch.
2. Open /dev-tools as an admin.
3. Select a file, start an enrichment run, and inspect each recorded stage and model call.
4. Trigger per-file enrichment for files whose summary status is done and skipped; confirm extraction runs again.

## Checklist

- [x] pnpm lint passes
- [x] pnpm typecheck passes
- [x] pnpm test passes
- [x] pnpm build succeeds