### PR TITLE
feat(entities): reconcile the entity review queue

### DIFF
--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -2275,13 +2275,13 @@ export function connectorRoutes(
       const txEntityReviewRepo = createEntityReviewRepo(trx);
       const fileIds = await txConnectorRepo.getOwnedFileIdsForConnector(config.id);
       const relationshipIds = await txEntityDomainsRepo.relationshipIdsWithEvidenceInFiles(fileIds);
-      const reviewIds = await txEntityReviewRepo.pendingReviewIdsWithEvidenceInFiles(fileIds);
+      const reviewIds = await txEntityReviewRepo.nonTerminalReviewIdsWithEvidenceInFiles(fileIds);
       await txEntityRepo.deleteEntitiesForFiles(fileIds);
       await txConnectorRepo.deleteConfig(config.id);
       await txEntityDomainsRepo.deleteRelationshipEvidenceForFiles(fileIds);
       await txEntityReviewRepo.deleteReviewEvidenceForFiles(fileIds);
       await txEntityDomainsRepo.deleteEmptyRelationshipsByIds(relationshipIds);
-      await txEntityReviewRepo.deleteEmptyPendingReviewsByIds(reviewIds);
+      await txEntityReviewRepo.deleteEmptyNonTerminalReviewsByIds(reviewIds);
     });
     return c.json({ success: true });
   });

--- a/packages/server/src/api/graph-passes.ts
+++ b/packages/server/src/api/graph-passes.ts
@@ -4,6 +4,7 @@ import type { Logger } from "pino";
 import { getPostSyncCoordinator } from "../connectors/post-sync-coordinator";
 import { type GraphPassRun, createGraphPassRunRepository } from "../db/repositories/graph-pass-runs";
 import type { DB } from "../db/schema";
+import { runQueuePasses } from "../entities/queue-run";
 
 function requireAdmin(c: Context) {
   if (c.get("role") !== "admin") {
@@ -46,6 +47,44 @@ export function graphPassRoutes(db: Kysely<DB>, logger: Logger) {
       },
       201,
     );
+  });
+
+  /**
+   * The queue passes cannot ride the existing `/runs` endpoint: that one drains
+   * the post-sync coordinator, which does nothing when no file is dirty. These
+   * passes are queue-wide and have no dirty input to key off.
+   *
+   * No lock is taken. The projection is idempotent and neither pass writes to
+   * the graph, so two overlapping runs converge.
+   */
+  routes.post("/queue-runs", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    const runId = await runs.start({
+      kind: "queue",
+      scannedRows: 0,
+      set: {},
+      cleared: 0,
+      frozen: 0,
+      candidatesRepointed: 0,
+      candidatesCleared: 0,
+    });
+
+    try {
+      const snapshot = await runQueuePasses(db);
+      await runs.updateSnapshot(runId, snapshot);
+      await runs.complete(runId);
+      logger.info({ runId, ...snapshot }, "Queue graph pass complete");
+    } catch (err) {
+      await runs.fail(runId, err instanceof Error ? err.message : "queue graph pass failed");
+      logger.error({ err, runId }, "Queue graph pass failed");
+      const failed = await runs.get(runId);
+      return c.json({ run: failed ? serializeRun(failed) : null }, 500);
+    }
+
+    const run = await runs.get(runId);
+    return c.json({ run: run ? serializeRun(run) : null }, 201);
   });
 
   routes.get("/runs", async (c) => {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -42,6 +42,7 @@ import { createAutomationRunsRepository } from "./db/repositories/automation-run
 import { createAutomationStepContentRepository } from "./db/repositories/automation-step-content";
 import { createChannelRepository } from "./db/repositories/channels";
 import { createConversationRepository } from "./db/repositories/conversations";
+import { createGraphPassRunRepository } from "./db/repositories/graph-pass-runs";
 import { createInboxMessagesRepository } from "./db/repositories/inbox-messages";
 import { createLocalClaudeSessionRepository } from "./db/repositories/local-claude-sessions";
 import { createLocalDeviceRepository } from "./db/repositories/local-devices";
@@ -216,6 +217,13 @@ export async function createServer(config: Config, options?: CreateServerOptions
     });
   } catch (err) {
     logger.error({ err }, "Failed to restore unfinished post-sync graph passes");
+  }
+
+  try {
+    const abandoned = await createGraphPassRunRepository(db).failUnfinishedQueueRuns();
+    if (abandoned > 0) logger.warn({ abandoned }, "Marked interrupted queue graph passes as failed");
+  } catch (err) {
+    logger.error({ err }, "Failed to close out interrupted queue graph passes");
   }
 
   // Migration 039 backfills the legacy admin-owned Fireflies row to a real user id.

--- a/packages/server/src/connectors/post-sync-coordinator.ts
+++ b/packages/server/src/connectors/post-sync-coordinator.ts
@@ -42,7 +42,7 @@ export function createPostSyncCoordinator(
     while (dirty && pending.hasInputs()) {
       const snapshot = pending.take();
       const restoredRunId = restoredRunIds.shift();
-      const runId = runs ? await runs.start(snapshot, restoredRunId) : null;
+      const runId = runs ? await runs.start({ kind: "post_sync", ...snapshot }, restoredRunId) : null;
       dirty = false;
       try {
         await runPipeline({
@@ -85,8 +85,9 @@ export function createPostSyncCoordinator(
     },
     async restoreUnfinished(context) {
       if (!runs) return;
-      const unfinished = await runs.listUnfinished();
+      const unfinished = (await runs.listUnfinished()).filter((run) => run.inputSnapshot.kind === "post_sync");
       for (const run of unfinished) {
+        if (run.inputSnapshot.kind !== "post_sync") continue;
         pending.restore(run.inputSnapshot);
         restoredRunIds.push(run.id);
         dirty = true;

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -184,6 +184,7 @@ import * as m181 from "./migrations/181-project-minting-verdicts";
 import * as m182 from "./migrations/182-project-minting-states";
 import * as m183 from "./migrations/183-graph-pass-runs";
 import * as m184 from "./migrations/184-person-contact-point-cutover";
+import * as m185 from "./migrations/185-queue-pass-reason";
 import type { DB } from "./schema";
 
 /**
@@ -377,6 +378,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "182-project-minting-states": m182,
           "183-graph-pass-runs": m183,
           "184-person-contact-point-cutover": m184,
+          "185-queue-pass-reason": m185,
         };
       },
     },

--- a/packages/server/src/db/migrations/185-queue-pass-reason.ts
+++ b/packages/server/src/db/migrations/185-queue-pass-reason.ts
@@ -1,0 +1,20 @@
+import type { Kysely } from "kysely";
+
+const TABLE = "entity_review_queue";
+const COLUMN = "pass_reason";
+
+/**
+ * Adds the column the reconcile and structural passes write.
+ *
+ * No status enum is added: `status` is plain text on both dialects, so the new
+ * `deferred` value needs no schema change. What it does need is to stay OUT of
+ * TERMINAL_STATUSES — a terminal row stops accruing evidence, which would freeze
+ * the signal both passes re-read on every run.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable(TABLE).addColumn(COLUMN, "text").execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable(TABLE).dropColumn(COLUMN).execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -23,7 +23,7 @@ import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as slackFileAccessBackfillCleanupMigration from "./163-slack-file-access-backfill-cleanup";
 import * as typedAccessPrincipalsMigration from "./165-typed-access-principals";
 
-const EXPECTED_MIGRATION_COUNT = 180;
+const EXPECTED_MIGRATION_COUNT = 181;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -28,7 +28,7 @@ import * as slackEntityLifecycleMigration from "./160-slack-entity-lifecycle-syn
 import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as outlookCalendarProviderFileScopeMigration from "./164-outlook-calendar-provider-file-scope";
 
-const EXPECTED_MIGRATION_COUNT = 180;
+const EXPECTED_MIGRATION_COUNT = 181;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({

--- a/packages/server/src/db/repositories/connector-delete-cleanup.integration.test.ts
+++ b/packages/server/src/db/repositories/connector-delete-cleanup.integration.test.ts
@@ -131,11 +131,11 @@ describe("connector delete relationship and review cleanup postgres", () => {
     const domainsRepo = createEntityDomainsRepository(db);
     const reviewRepo = createEntityReviewRepo(db);
     const relationshipIds = await domainsRepo.relationshipIdsWithEvidenceInFiles(["pg-cleanup-file"]);
-    const reviewIds = await reviewRepo.pendingReviewIdsWithEvidenceInFiles(["pg-cleanup-file"]);
+    const reviewIds = await reviewRepo.nonTerminalReviewIdsWithEvidenceInFiles(["pg-cleanup-file"]);
 
     await db.deleteFrom("indexed_files").where("id", "=", "pg-cleanup-file").execute();
     await expect(domainsRepo.deleteEmptyRelationshipsByIds(relationshipIds)).resolves.toBe(1);
-    await expect(reviewRepo.deleteEmptyPendingReviewsByIds(reviewIds)).resolves.toBe(1);
+    await expect(reviewRepo.deleteEmptyNonTerminalReviewsByIds(reviewIds)).resolves.toBe(1);
 
     await expect(db.selectFrom("entity_relationships").selectAll().execute()).resolves.toHaveLength(0);
     await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(0);

--- a/packages/server/src/db/repositories/connector-delete-cleanup.test.ts
+++ b/packages/server/src/db/repositories/connector-delete-cleanup.test.ts
@@ -192,11 +192,11 @@ describe("connector delete relationship and review cleanup", () => {
       const reviewRepo = createEntityReviewRepo(trx);
       const fileIds = await connectorRepo.getOwnedFileIdsForConnector("connector-delete");
       const relationshipIds = await domainsRepo.relationshipIdsWithEvidenceInFiles(fileIds);
-      const reviewIds = await reviewRepo.pendingReviewIdsWithEvidenceInFiles(fileIds);
+      const reviewIds = await reviewRepo.nonTerminalReviewIdsWithEvidenceInFiles(fileIds);
       await txEntityRepo.deleteEntitiesForFiles(fileIds);
       await connectorRepo.deleteConfig("connector-delete");
       await domainsRepo.deleteEmptyRelationshipsByIds(relationshipIds);
-      await reviewRepo.deleteEmptyPendingReviewsByIds(reviewIds);
+      await reviewRepo.deleteEmptyNonTerminalReviewsByIds(reviewIds);
     });
 
     const relationships = await db.selectFrom("entity_relationships").select("id").orderBy("id").execute();
@@ -255,12 +255,12 @@ describe("connector delete relationship and review cleanup", () => {
     const domainsRepo = createEntityDomainsRepository(db);
     const reviewRepo = createEntityReviewRepo(db);
     const relationshipIds = await domainsRepo.relationshipIdsWithEvidenceInFiles(["file-archive"]);
-    const reviewIds = await reviewRepo.pendingReviewIdsWithEvidenceInFiles(["file-archive"]);
+    const reviewIds = await reviewRepo.nonTerminalReviewIdsWithEvidenceInFiles(["file-archive"]);
     await db.updateTable("indexed_files").set({ is_archived: 1 }).where("id", "=", "file-archive").execute();
     await domainsRepo.deleteRelationshipEvidenceForFiles(["file-archive"]);
     await reviewRepo.deleteReviewEvidenceForFiles(["file-archive"]);
     await domainsRepo.deleteEmptyRelationshipsByIds(relationshipIds);
-    await reviewRepo.deleteEmptyPendingReviewsByIds(reviewIds);
+    await reviewRepo.deleteEmptyNonTerminalReviewsByIds(reviewIds);
 
     await expect(db.selectFrom("entity_relationships").selectAll().execute()).resolves.toHaveLength(0);
     await expect(db.selectFrom("entity_review_queue").selectAll().execute()).resolves.toHaveLength(0);

--- a/packages/server/src/db/repositories/entity-review.ts
+++ b/packages/server/src/db/repositories/entity-review.ts
@@ -104,7 +104,14 @@ export interface UpsertUserEntityLinkReviewInput {
   triggeredByUserId: string;
 }
 
-const TERMINAL_STATUSES = new Set(["confirmed", "rejected", "confirming", "dismissed"]);
+/**
+ * Statuses the queue treats as decided. `deferred` is deliberately absent: a
+ * terminal row stops accruing evidence, which would freeze the very signal the
+ * reconcile and structural passes re-read on every run.
+ */
+export const TERMINAL_STATUS_LIST = ["confirmed", "rejected", "confirming", "dismissed"] as const;
+
+const TERMINAL_STATUSES = new Set<string>(TERMINAL_STATUS_LIST);
 const SPINE_ENTITY_TYPES = new Set(["project", "product", "team"]);
 const TEST_ACCOUNT_ENTITY_ID = "24d4ef8a-47eb-4510-a951-7d9bae036786";
 
@@ -532,8 +539,12 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
       offset?: number;
       search?: string;
       types?: string[];
+      status?: string;
     }) {
-      let q = db.selectFrom("entity_review_queue").selectAll().where("status", "=", "pending");
+      let q = db
+        .selectFrom("entity_review_queue")
+        .selectAll()
+        .where("status", "=", opts.status ?? "pending");
       if (opts.types && opts.types.length > 0) {
         q = q.where("entity_type", "in", opts.types);
       }
@@ -577,11 +588,12 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
       isAdmin: boolean;
       search?: string;
       types?: string[];
+      status?: string;
     }): Promise<number> {
       let q = db
         .selectFrom("entity_review_queue")
         .select(db.fn.countAll<number>().as("c"))
-        .where("status", "=", "pending");
+        .where("status", "=", opts.status ?? "pending");
       if (opts.types && opts.types.length > 0) {
         q = q.where("entity_type", "in", opts.types);
       }
@@ -682,7 +694,12 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
       return map;
     },
 
-    async pendingReviewIdsWithEvidenceInFiles(fileIds: string[]): Promise<string[]> {
+    /**
+     * Not-terminal rather than pending: a deferred row whose evidence a
+     * connector deletion removes would otherwise survive as an orphan — no
+     * evidence, no owner, invisible in the UI, never cleaned up.
+     */
+    async nonTerminalReviewIdsWithEvidenceInFiles(fileIds: string[]): Promise<string[]> {
       if (fileIds.length === 0) return [];
       const rows = await db
         .selectFrom("entity_review_evidence")
@@ -690,7 +707,7 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
         .select("entity_review_evidence.review_id")
         .distinct()
         .where("entity_review_evidence.indexed_file_id", "in", fileIds)
-        .where("entity_review_queue.status", "=", "pending")
+        .where("entity_review_queue.status", "not in", [...TERMINAL_STATUS_LIST])
         .execute();
       return rows.map((row) => row.review_id);
     },
@@ -704,12 +721,12 @@ export function createEntityReviewRepo(db: Kysely<DB>) {
       return Number(result.numDeletedRows ?? 0);
     },
 
-    async deleteEmptyPendingReviewsByIds(ids: string[]): Promise<number> {
+    async deleteEmptyNonTerminalReviewsByIds(ids: string[]): Promise<number> {
       if (ids.length === 0) return 0;
       const result = await db
         .deleteFrom("entity_review_queue")
         .where("id", "in", ids)
-        .where("status", "=", "pending")
+        .where("status", "not in", [...TERMINAL_STATUS_LIST])
         .where((eb) =>
           eb.not(
             eb.exists(

--- a/packages/server/src/db/repositories/graph-pass-runs.ts
+++ b/packages/server/src/db/repositories/graph-pass-runs.ts
@@ -5,23 +5,74 @@ import type { DB } from "../schema";
 
 export type GraphPassRunStatus = "running" | "complete" | "failed";
 
+export type PostSyncRunSnapshot = PostSyncGraphInputs & { kind: "post_sync" };
+
+/**
+ * A queue run has no dirty-file set — it is queue-wide. It records how many
+ * in-scope non-terminal rows it scanned and what the projection did with them.
+ */
+export type QueueRunSnapshot = {
+  kind: "queue";
+  scannedRows: number;
+  set: Record<string, number>;
+  cleared: number;
+  frozen: number;
+  candidatesRepointed: number;
+  candidatesCleared: number;
+};
+
+export type GraphPassRunSnapshot = PostSyncRunSnapshot | QueueRunSnapshot;
+
 export interface GraphPassRun {
   id: string;
   status: GraphPassRunStatus;
   startedAt: string;
   finishedAt: string | null;
   errorMessage: string | null;
-  inputSnapshot: PostSyncGraphInputs;
+  inputSnapshot: GraphPassRunSnapshot;
 }
 
 type GraphPassRunRow = Selectable<DB["graph_pass_runs"]>;
 
-function parseSnapshot(value: unknown): PostSyncGraphInputs {
-  const parsed = (typeof value === "string" ? JSON.parse(value) : value) as Partial<PostSyncGraphInputs>;
+function readCounts(value: unknown): Record<string, number> {
+  if (!value || typeof value !== "object") return {};
+  const out: Record<string, number> = {};
+  for (const [key, count] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof count === "number") out[key] = count;
+  }
+  return out;
+}
+
+function readNumber(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}
+
+/**
+ * Rows written before queue runs existed carry no `kind`, so an absent
+ * discriminant reads as post-sync.
+ */
+function parseSnapshot(value: unknown): GraphPassRunSnapshot {
+  const parsed = (typeof value === "string" ? JSON.parse(value) : value) as Record<string, unknown>;
+  if (parsed?.kind === "queue") {
+    return {
+      kind: "queue",
+      scannedRows: readNumber(parsed.scannedRows),
+      set: readCounts(parsed.set),
+      cleared: readNumber(parsed.cleared),
+      frozen: readNumber(parsed.frozen),
+      candidatesRepointed: readNumber(parsed.candidatesRepointed),
+      candidatesCleared: readNumber(parsed.candidatesCleared),
+    };
+  }
   return {
-    affectedIndexedFileIds: Array.isArray(parsed.affectedIndexedFileIds) ? parsed.affectedIndexedFileIds : [],
-    sources: Array.isArray(parsed.sources) ? parsed.sources : [],
-    workCycleReconciles: Array.isArray(parsed.workCycleReconciles) ? parsed.workCycleReconciles : [],
+    kind: "post_sync",
+    affectedIndexedFileIds: Array.isArray(parsed?.affectedIndexedFileIds)
+      ? (parsed.affectedIndexedFileIds as string[])
+      : [],
+    sources: Array.isArray(parsed?.sources) ? (parsed.sources as PostSyncGraphInputs["sources"]) : [],
+    workCycleReconciles: Array.isArray(parsed?.workCycleReconciles)
+      ? (parsed.workCycleReconciles as PostSyncGraphInputs["workCycleReconciles"])
+      : [],
   };
 }
 
@@ -38,7 +89,7 @@ function mapRun(row: GraphPassRunRow): GraphPassRun {
 
 export function createGraphPassRunRepository(db: Kysely<DB>) {
   return {
-    async start(inputSnapshot: PostSyncGraphInputs, id?: string): Promise<string> {
+    async start(inputSnapshot: GraphPassRunSnapshot, id?: string): Promise<string> {
       const runId = id ?? randomUUID();
       const now = new Date().toISOString();
       const existing = await db.selectFrom("graph_pass_runs").select("id").where("id", "=", runId).executeTakeFirst();
@@ -67,6 +118,14 @@ export function createGraphPassRunRepository(db: Kysely<DB>) {
         })
         .execute();
       return runId;
+    },
+
+    async updateSnapshot(id: string, inputSnapshot: GraphPassRunSnapshot): Promise<void> {
+      await db
+        .updateTable("graph_pass_runs")
+        .set({ input_snapshot_json: JSON.stringify(inputSnapshot) })
+        .where("id", "=", id)
+        .execute();
     },
 
     async complete(id: string): Promise<void> {
@@ -121,6 +180,27 @@ export function createGraphPassRunRepository(db: Kysely<DB>) {
         .orderBy("id", "asc")
         .execute();
       return rows.map(mapRun);
+    },
+
+    /**
+     * A queue run interrupted by a restart has nothing to resume — the passes
+     * recompute from scratch on the next run — but a row left `running` would
+     * make `getRunning()` report a pass that is not happening.
+     */
+    async failUnfinishedQueueRuns(): Promise<number> {
+      const unfinished = await db.selectFrom("graph_pass_runs").selectAll().where("status", "=", "running").execute();
+      const ids = unfinished.filter((row) => parseSnapshot(row.input_snapshot_json).kind === "queue").map((r) => r.id);
+      if (ids.length === 0) return 0;
+      const result = await db
+        .updateTable("graph_pass_runs")
+        .set({
+          status: "failed",
+          finished_at: new Date().toISOString(),
+          error_message: "interrupted by restart",
+        })
+        .where("id", "in", ids)
+        .executeTakeFirst();
+      return Number(result.numUpdatedRows ?? 0);
     },
   };
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1314,6 +1314,7 @@ export interface EntityReviewQueueTable {
   candidate_score: number | null;
   candidate_reason: string | null;
   candidate_generated_at: string | null;
+  pass_reason: string | null;
   first_seen_at: Generated<string>;
   last_seen_at: Generated<string>;
   occurrence_count: Generated<number>;

--- a/packages/server/src/entities/queue-pass-reason-dialects.integration.test.ts
+++ b/packages/server/src/entities/queue-pass-reason-dialects.integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createEntityReviewRepo } from "../db/repositories/entity-review";
+import { createTestDb, createTestPgDb } from "../test-utils";
+
+/**
+ * T9 — the migration behaves on both dialects.
+ *
+ * Column presence proves little on its own: `status` is plain text, so what is
+ * worth asserting is the semantics. A deferred row must still accrue occurrences
+ * when the same name is proposed again, which is exactly what breaks if
+ * `deferred` is added to TERMINAL_STATUSES.
+ */
+describe.each([
+  ["sqlite", createTestDb],
+  ["postgres", createTestPgDb],
+])("pass_reason migration on %s", (_dialect, makeDb) => {
+  it("adds a nullable pass_reason column and keeps deferred non-terminal", async () => {
+    const db = await makeDb();
+    const repo = createEntityReviewRepo(db);
+
+    const first = await repo.upsertQueueRow({
+      proposedName: "Dialect Person",
+      normalizedName: "dialect person",
+      entityType: "person",
+      source: null,
+      sourceId: null,
+      proposedEmail: null,
+      candidateEntityId: null,
+      candidateEntityIds: [],
+      candidateScore: null,
+      candidateReason: null,
+      triggeredByUserId: "user-1",
+      sourceScoped: false,
+    });
+    expect(first.row.pass_reason).toBeNull();
+
+    await db
+      .updateTable("entity_review_queue")
+      .set({ status: "deferred", pass_reason: "name_already_resolved" })
+      .where("id", "=", first.row.id)
+      .execute();
+
+    const second = await repo.upsertQueueRow({
+      proposedName: "Dialect Person",
+      normalizedName: "dialect person",
+      entityType: "person",
+      source: null,
+      sourceId: null,
+      proposedEmail: null,
+      candidateEntityId: null,
+      candidateEntityIds: [],
+      candidateScore: null,
+      candidateReason: null,
+      triggeredByUserId: "user-1",
+      sourceScoped: false,
+    });
+
+    expect(second.skipEvidence).toBe(false);
+    expect(second.row.occurrence_count).toBe(2);
+    expect(new Date(second.row.last_seen_at).getTime()).toBeGreaterThanOrEqual(
+      new Date(first.row.last_seen_at).getTime(),
+    );
+  });
+});

--- a/packages/server/src/entities/queue-passes.integration.test.ts
+++ b/packages/server/src/entities/queue-passes.integration.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { Kysely } from "kysely";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hashPassword } from "../auth/password";
 import { createSettingsRepository } from "../db/repositories/settings";
 import { createUserRepository } from "../db/repositories/users";
@@ -9,7 +9,7 @@ import { createApp } from "../http";
 import { createTestConfig, createTestLogger, createTestPgDb } from "../test-utils";
 import { applyProjection } from "./queue-projection";
 import { liveEntitiesForNames, loadQueueRows } from "./queue-reconcile";
-import { structuralPass } from "./queue-structural";
+import { structuralPass, withAttendeeFactChunkSizeForTest } from "./queue-structural";
 
 const ADMIN_EMAIL = "admin@test.com";
 const PASSWORD = "testpassword123";
@@ -132,6 +132,100 @@ async function readRow(db: Kysely<DB>, id: string) {
   return db.selectFrom("entity_review_queue").selectAll().where("id", "=", id).executeTakeFirst();
 }
 
+async function seedConnector(db: Kysely<DB>, ownerId: string): Promise<string> {
+  const id = randomUUID();
+  await db
+    .insertInto("connector_configs")
+    .values({
+      id,
+      connector_type: "gmail",
+      auth_type: "system",
+      credentials: JSON.stringify({ type: "system" }),
+      created_by: ownerId,
+      scope_config: "{}",
+      sync_status: "active",
+    })
+    .execute();
+  return id;
+}
+
+async function seedIndexedFiles(db: Kysely<DB>, ownerId: string, prefix: string, count: number): Promise<string[]> {
+  const connectorId = await seedConnector(db, ownerId);
+  const now = new Date().toISOString();
+  const fileIds = Array.from({ length: count }, (_, index) => `${prefix}-${String(index + 1).padStart(2, "0")}`);
+  await db
+    .insertInto("indexed_files")
+    .values(
+      fileIds.map((id, index) => ({
+        id,
+        connector_config_id: connectorId,
+        provider_file_id: `${prefix}-${index + 1}-${id}`,
+        file_name: `${prefix}-${index + 1}.eml`,
+        content_category: "document",
+        source: "gmail",
+        synced_at: now,
+      })),
+    )
+    .execute();
+  return fileIds;
+}
+
+async function seedReviewEvidence(db: Kysely<DB>, reviewId: string, fileIds: string[]): Promise<void> {
+  await db
+    .insertInto("entity_review_evidence")
+    .values(
+      fileIds.map((fileId) => ({ id: randomUUID(), review_id: reviewId, indexed_file_id: fileId, source: "gmail" })),
+    )
+    .execute();
+}
+
+async function seedAttendeeFact(
+  db: Kysely<DB>,
+  fileId: string,
+  params: { email: string; normalizedName: string },
+): Promise<void> {
+  const id = randomUUID();
+  await db
+    .insertInto("indexed_file_facts")
+    .values({
+      id,
+      indexed_file_id: fileId,
+      source: "gmail",
+      fact_type: "attendee",
+      relation: "attendee",
+      subject_email: params.email,
+      normalized_subject_name: params.normalizedName,
+      fact_key: `${fileId}:attendee:${id}`,
+    })
+    .execute();
+}
+
+async function seedMention(db: Kysely<DB>, entityId: string, fileId: string): Promise<void> {
+  await db
+    .insertInto("entity_mentions")
+    .values({
+      id: randomUUID(),
+      entity_id: entityId,
+      indexed_file_id: fileId,
+      chunk_index: null,
+      context_snippet: null,
+      confidence: "EXTRACTED",
+      source: "llm_extraction",
+      relation: "mentioned",
+      mentioned_at: new Date().toISOString(),
+    })
+    .execute();
+}
+
+async function queueState(db: Kysely<DB>, ids: string[]) {
+  return db
+    .selectFrom("entity_review_queue")
+    .select(["id", "status", "pass_reason", "candidate_entity_id"])
+    .where("id", "in", ids)
+    .orderBy("id")
+    .execute();
+}
+
 /**
  * Aliases are not a table — they live in `entities.aliases`, so `selectAll` on
  * entities already carries them.
@@ -148,6 +242,10 @@ describe("queue graph passes", () => {
 
   beforeEach(async () => {
     h = await createHarness();
+  });
+
+  afterEach(async () => {
+    await h.db.destroy();
   });
 
   it("T1 defers on the register only when the type matches, and writes nothing to the graph", async () => {
@@ -268,6 +366,9 @@ describe("queue graph passes", () => {
     expect(cleared?.candidate_generated_at).not.toBe("2020-01-01T00:00:00.000Z");
   });
 
+  /**
+   * Deferred rows stay live queue records, so later evidence accrual is preserved.
+   */
   it("T4 keeps a deferred row accruing evidence and hands it back when the cause disappears", async () => {
     const rowId = await seedQueueRow(h.db, h.ownerId, { name: "Deferrable Person" });
     const entityId = await seedEntity(h.db, { name: "Deferrable Person" });
@@ -573,6 +674,142 @@ describe("queue graph passes", () => {
 
     const row = await readRow(h.db, rowId);
     expect(row?.pass_reason).not.toBe("co_listed_participants");
+  });
+
+  it("C1 still sees co-listed attendee proof when it lands in the last evidence chunk", async () => {
+    const candidate = await seedEntity(h.db, {
+      name: "A. Boundary",
+      metadata: { email: "candidate.boundary@acme.test" },
+    });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Ada Boundary",
+      candidateEntityId: candidate,
+      proposedEmail: "ada.boundary@other.test",
+    });
+    const fileIds = await seedIndexedFiles(h.db, h.ownerId, "c1-boundary", 3);
+    await seedReviewEvidence(h.db, rowId, fileIds);
+    await seedMention(h.db, candidate, fileIds[2]);
+    await seedAttendeeFact(h.db, fileIds[2], {
+      email: "ada.boundary@other.test",
+      normalizedName: "ada boundary",
+    });
+    await seedAttendeeFact(h.db, fileIds[2], {
+      email: "candidate.boundary@acme.test",
+      normalizedName: "a boundary",
+    });
+
+    await withAttendeeFactChunkSizeForTest(2, () => runPasses(h));
+
+    const row = await readRow(h.db, rowId);
+    expect(row?.status).toBe("deferred");
+    expect(row?.pass_reason).toBe("co_listed_participants");
+  });
+
+  it("C2 does not pool attendees from different evidence chunks into one co-listed proof", async () => {
+    const candidate = await seedEntity(h.db, {
+      name: "B. Boundary",
+      metadata: { email: "candidate.pool@acme.test" },
+    });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Bea Boundary",
+      candidateEntityId: candidate,
+      proposedEmail: "bea.pool@other.test",
+    });
+    const fileIds = await seedIndexedFiles(h.db, h.ownerId, "c2-boundary", 3);
+    await seedReviewEvidence(h.db, rowId, fileIds);
+    await seedMention(h.db, candidate, fileIds[2]);
+    await seedAttendeeFact(h.db, fileIds[0], {
+      email: "bea.pool@other.test",
+      normalizedName: "bea boundary",
+    });
+    await seedAttendeeFact(h.db, fileIds[2], {
+      email: "candidate.pool@acme.test",
+      normalizedName: "b boundary",
+    });
+
+    await withAttendeeFactChunkSizeForTest(2, () => runPasses(h));
+
+    const row = await readRow(h.db, rowId);
+    expect(row?.status).toBe("deferred");
+    expect(row?.pass_reason).not.toBe("co_listed_participants");
+    expect(row?.pass_reason).toBe("different_emails");
+  });
+
+  it("C3 converges over a multi-chunk corpus with candidate re-points without touching graph tables", async () => {
+    const coListedCandidate = await seedEntity(h.db, {
+      name: "C. Boundary",
+      metadata: { email: "candidate.converge@acme.test" },
+    });
+    const coListedRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Cara Boundary",
+      candidateEntityId: coListedCandidate,
+      proposedEmail: "cara.converge@other.test",
+    });
+    const fileIds = await seedIndexedFiles(h.db, h.ownerId, "c3-boundary", 5);
+    await seedReviewEvidence(h.db, coListedRow, fileIds);
+    await seedMention(h.db, coListedCandidate, fileIds[4]);
+    await seedAttendeeFact(h.db, fileIds[4], {
+      email: "cara.converge@other.test",
+      normalizedName: "cara boundary",
+    });
+    await seedAttendeeFact(h.db, fileIds[4], {
+      email: "candidate.converge@acme.test",
+      normalizedName: "c boundary",
+    });
+
+    const supersededCandidate = await seedEntity(h.db, { name: "Old Superseded" });
+    const supersedingEntity = await seedEntity(h.db, { name: "Fresh Superseded" });
+    const supersededRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Fresh Superseded",
+      candidateEntityId: supersededCandidate,
+      candidateEntityIds: [supersededCandidate],
+      candidateScore: 0.8,
+    });
+
+    const mergeSurvivor = await seedEntity(h.db, { name: "Merge Survivor" });
+    const mergedCandidate = await seedEntity(h.db, {
+      name: "Merged Candidate",
+      mergedInto: mergeSurvivor,
+    });
+    const mergedRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Merged Proposal",
+      candidateEntityId: mergedCandidate,
+      candidateEntityIds: [mergedCandidate],
+      candidateScore: 0.7,
+    });
+
+    const deletedCandidate = await seedEntity(h.db, { name: "Deleted Candidate", deletedAt: new Date().toISOString() });
+    const clearedRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Deleted Proposal",
+      candidateEntityId: deletedCandidate,
+      candidateEntityIds: [deletedCandidate],
+      candidateScore: 0.6,
+    });
+
+    const rowIds = [coListedRow, supersededRow, mergedRow, clearedRow];
+    const beforeGraph = await graphFingerprint(h.db);
+    let previous = await queueState(h.db, rowIds);
+    let convergedAt: number | null = null;
+
+    for (let attempt = 1; attempt <= 6; attempt += 1) {
+      await withAttendeeFactChunkSizeForTest(2, () => runPasses(h));
+      const current = await queueState(h.db, rowIds);
+      if (JSON.stringify(current) === JSON.stringify(previous)) {
+        convergedAt = attempt;
+        break;
+      }
+      previous = current;
+    }
+
+    expect(convergedAt).not.toBeNull();
+    expect(convergedAt).toBeGreaterThan(1);
+    expect(await graphFingerprint(h.db)).toBe(beforeGraph);
+
+    const convergedRows = new Map((await queueState(h.db, rowIds)).map((row) => [row.id, row]));
+    expect(convergedRows.get(coListedRow)?.pass_reason).toBe("co_listed_participants");
+    expect(convergedRows.get(supersededRow)?.candidate_entity_id).toBe(supersedingEntity);
+    expect(convergedRows.get(mergedRow)?.candidate_entity_id).toBe(mergeSurvivor);
+    expect(convergedRows.get(clearedRow)?.candidate_entity_id).toBeNull();
   });
 
   it("T8 leaves a row alone while a person has it open, and defers it once the freeze lapses", async () => {

--- a/packages/server/src/entities/queue-passes.integration.test.ts
+++ b/packages/server/src/entities/queue-passes.integration.test.ts
@@ -1,0 +1,705 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely } from "kysely";
+import { beforeEach, describe, expect, it } from "vitest";
+import { hashPassword } from "../auth/password";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestLogger, createTestPgDb } from "../test-utils";
+import { applyProjection } from "./queue-projection";
+import { liveEntitiesForNames, loadQueueRows } from "./queue-reconcile";
+import { structuralPass } from "./queue-structural";
+
+const ADMIN_EMAIL = "admin@test.com";
+const PASSWORD = "testpassword123";
+
+type Harness = {
+  db: Kysely<DB>;
+  app: ReturnType<typeof createApp>;
+  cookie: string;
+  ownerId: string;
+};
+
+async function createHarness(): Promise<Harness> {
+  const db = await createTestPgDb();
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  await settings.create();
+  await users.create({
+    name: "admin",
+    email: ADMIN_EMAIL,
+    emailVerified: true,
+    passwordHash: await hashPassword(PASSWORD),
+    authRole: "admin",
+    skipEntityLinking: true,
+  });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+  const admin = await users.findByEmail(ADMIN_EMAIL);
+  if (!admin) throw new Error("admin missing");
+
+  const app = createApp(db, createTestConfig({ DB_TYPE: "postgres" }), { logger: createTestLogger() });
+  const login = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: PASSWORD }),
+  });
+  expect(login.status).toBe(200);
+  return { db, app, cookie: login.headers.get("set-cookie") ?? "", ownerId: admin.id };
+}
+
+async function runPasses(h: Harness): Promise<Record<string, unknown>> {
+  const res = await h.app.request("/api/graph-passes/queue-runs", {
+    method: "POST",
+    headers: { Cookie: h.cookie },
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { run: { status: string; inputSnapshot: Record<string, unknown> } };
+  expect(body.run.status).toBe("complete");
+  return body.run.inputSnapshot;
+}
+
+async function seedEntity(
+  db: Kysely<DB>,
+  params: {
+    name: string;
+    type?: string;
+    createdAt?: string;
+    metadata?: Record<string, unknown>;
+    deletedAt?: string | null;
+    mergedInto?: string | null;
+  },
+): Promise<string> {
+  const id = randomUUID();
+  const now = params.createdAt ?? new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name: params.name,
+      source_type: params.type ?? "person",
+      status: "active",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+      metadata: params.metadata ? JSON.stringify(params.metadata) : null,
+      deleted_at: params.deletedAt ?? null,
+      merged_into_entity_id: params.mergedInto ?? null,
+    })
+    .execute();
+  return id;
+}
+
+async function seedQueueRow(
+  db: Kysely<DB>,
+  ownerId: string,
+  params: {
+    name: string;
+    type?: string;
+    source?: string | null;
+    candidateEntityId?: string | null;
+    candidateEntityIds?: string[] | null;
+    candidateUserIds?: string[] | null;
+    candidateScore?: number | null;
+    proposedEmail?: string | null;
+    status?: string;
+  },
+): Promise<string> {
+  const id = randomUUID();
+  await db
+    .insertInto("entity_review_queue")
+    .values({
+      id,
+      proposed_name: params.name,
+      normalized_name: params.name.trim().toLowerCase(),
+      entity_type: params.type ?? "person",
+      source: params.source ?? null,
+      source_id: params.source ? `${params.source}-${id}` : null,
+      proposed_email: params.proposedEmail ?? null,
+      candidate_entity_id: params.candidateEntityId ?? null,
+      candidate_entity_ids: params.candidateEntityIds ? JSON.stringify(params.candidateEntityIds) : null,
+      candidate_user_ids: params.candidateUserIds ? JSON.stringify(params.candidateUserIds) : null,
+      candidate_score: params.candidateScore ?? null,
+      candidate_generated_at: params.candidateEntityId ? "2020-01-01T00:00:00.000Z" : null,
+      status: params.status ?? "pending",
+      triggered_by_user_id: ownerId,
+    })
+    .execute();
+  return id;
+}
+
+async function readRow(db: Kysely<DB>, id: string) {
+  return db.selectFrom("entity_review_queue").selectAll().where("id", "=", id).executeTakeFirst();
+}
+
+/**
+ * Aliases are not a table — they live in `entities.aliases`, so `selectAll` on
+ * entities already carries them.
+ */
+async function graphFingerprint(db: Kysely<DB>): Promise<string> {
+  const entities = await db.selectFrom("entities").selectAll().orderBy("id").execute();
+  const mentions = await db.selectFrom("entity_mentions").selectAll().orderBy("id").execute();
+  const relationships = await db.selectFrom("entity_relationships").selectAll().orderBy("id").execute();
+  return JSON.stringify({ entities, mentions, relationships });
+}
+
+describe("queue graph passes", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    h = await createHarness();
+  });
+
+  it("T1 defers on the register only when the type matches, and writes nothing to the graph", async () => {
+    const rowId = await seedQueueRow(h.db, h.ownerId, { name: "Nadia Rahman", type: "person" });
+    await seedEntity(h.db, { name: "Nadia Rahman", type: "company" });
+
+    const before = await graphFingerprint(h.db);
+    await runPasses(h);
+
+    const sameTypeAbsent = await readRow(h.db, rowId);
+    expect(sameTypeAbsent?.status).toBe("pending");
+    expect(sameTypeAbsent?.pass_reason).toBeNull();
+    expect(await graphFingerprint(h.db)).toBe(before);
+
+    await seedEntity(h.db, { name: "Nadia Rahman", type: "person" });
+    const beforeSecond = await graphFingerprint(h.db);
+    await runPasses(h);
+
+    const deferred = await readRow(h.db, rowId);
+    expect(deferred?.status).toBe("deferred");
+    expect(deferred?.pass_reason).toBe("name_already_resolved");
+    expect(await graphFingerprint(h.db)).toBe(beforeSecond);
+  });
+
+  it("T2 re-points a superseded candidate and never touches identity-link rows", async () => {
+    const candidate = await seedEntity(h.db, { name: "N. Rahman" });
+    const supersedes = await seedEntity(h.db, { name: "Nadia Rahman" });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Nadia Rahman",
+      candidateEntityId: candidate,
+      candidateEntityIds: [candidate],
+      candidateScore: 0.8,
+    });
+
+    const identityRows: string[] = [];
+    for (const source of ["user_entity_link", "slack_user"]) {
+      const other = await seedEntity(h.db, { name: `Other ${source}` });
+      await seedEntity(h.db, { name: `Shadow ${source}` });
+      identityRows.push(
+        await seedQueueRow(h.db, h.ownerId, {
+          name: `Shadow ${source}`,
+          source,
+          candidateEntityId: other,
+          candidateScore: 0.5,
+        }),
+      );
+    }
+    const linkedCandidate = await seedEntity(h.db, { name: "Other linked" });
+    await seedEntity(h.db, { name: "Shadow linked" });
+    identityRows.push(
+      await seedQueueRow(h.db, h.ownerId, {
+        name: "Shadow linked",
+        candidateEntityId: linkedCandidate,
+        candidateUserIds: [h.ownerId],
+        candidateScore: 0.5,
+      }),
+    );
+
+    const nullSourceCandidate = await seedEntity(h.db, { name: "Older Priya" });
+    const nullSourceLive = await seedEntity(h.db, { name: "Priya Menon" });
+    const nullSourceRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Priya Menon",
+      source: null,
+      candidateEntityId: nullSourceCandidate,
+      candidateScore: 0.4,
+    });
+
+    const identityBefore = await Promise.all(identityRows.map((id) => readRow(h.db, id)));
+    await runPasses(h);
+
+    const row = await readRow(h.db, rowId);
+    expect(row?.status).toBe("deferred");
+    expect(row?.pass_reason).toBe("superseded_by_entity");
+    expect(row?.candidate_entity_id).toBe(supersedes);
+    expect(row?.candidate_entity_ids).toBeNull();
+    expect(row?.candidate_score).toBeNull();
+    expect(row?.candidate_generated_at).not.toBe("2020-01-01T00:00:00.000Z");
+
+    const identityAfter = await Promise.all(identityRows.map((id) => readRow(h.db, id)));
+    expect(identityAfter).toEqual(identityBefore);
+
+    const processed = await readRow(h.db, nullSourceRow);
+    expect(processed?.candidate_entity_id).toBe(nullSourceLive);
+    expect(processed?.pass_reason).toBe("superseded_by_entity");
+  });
+
+  it("T3 leaves no stale candidate fields after the merge and delete repairs", async () => {
+    const survivor = await seedEntity(h.db, { name: "Survivor Entity" });
+    const merged = await seedEntity(h.db, { name: "Merged Entity", mergedInto: survivor });
+    const mergedRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Merged Proposal",
+      candidateEntityId: merged,
+      candidateEntityIds: [merged, survivor],
+      candidateScore: 0.9,
+    });
+
+    const gone = await seedEntity(h.db, { name: "Gone Entity", deletedAt: new Date().toISOString() });
+    const goneRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Gone Proposal",
+      candidateEntityId: gone,
+      candidateEntityIds: [gone],
+      candidateScore: 0.7,
+    });
+
+    await runPasses(h);
+
+    const repointed = await readRow(h.db, mergedRow);
+    expect(repointed?.candidate_entity_id).toBe(survivor);
+    expect(repointed?.pass_reason).toBe("candidate_merged_away");
+    expect(repointed?.candidate_score).toBeNull();
+    expect(repointed?.candidate_entity_ids).toBeNull();
+    expect(repointed?.candidate_generated_at).not.toBe("2020-01-01T00:00:00.000Z");
+
+    const cleared = await readRow(h.db, goneRow);
+    expect(cleared?.candidate_entity_id).toBeNull();
+    expect(cleared?.candidate_score).toBeNull();
+    expect(cleared?.candidate_entity_ids).toBeNull();
+    expect(cleared?.candidate_generated_at).not.toBe("2020-01-01T00:00:00.000Z");
+  });
+
+  it("T4 keeps a deferred row accruing evidence and hands it back when the cause disappears", async () => {
+    const rowId = await seedQueueRow(h.db, h.ownerId, { name: "Deferrable Person" });
+    const entityId = await seedEntity(h.db, { name: "Deferrable Person" });
+
+    await runPasses(h);
+    const deferred = await readRow(h.db, rowId);
+    expect(deferred?.status).toBe("deferred");
+    expect(deferred?.pass_reason).toBe("name_already_resolved");
+
+    await h.db
+      .updateTable("entity_review_queue")
+      .set({
+        occurrence_count: (deferred?.occurrence_count ?? 0) + 1,
+        last_seen_at: new Date(Date.now() + 1000).toISOString(),
+      })
+      .where("id", "=", rowId)
+      .execute();
+
+    const accrued = await readRow(h.db, rowId);
+    expect(accrued?.occurrence_count).toBeGreaterThan(deferred?.occurrence_count ?? 0);
+    expect(accrued?.status).toBe("deferred");
+
+    await h.db
+      .updateTable("entities")
+      .set({ deleted_at: new Date().toISOString() })
+      .where("id", "=", entityId)
+      .execute();
+
+    await runPasses(h);
+    const handedBack = await readRow(h.db, rowId);
+    expect(handedBack?.status).toBe("pending");
+    expect(handedBack?.pass_reason).toBeNull();
+  });
+
+  it("T6 lets a veto outrank a block and reads the proposal's own email", async () => {
+    const candidate = await seedEntity(h.db, { name: "Sam Cole", metadata: { email: "sam.cole@acme.test" } });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Samuel Cole",
+      candidateEntityId: candidate,
+    });
+
+    await runPasses(h);
+    const blocked = await readRow(h.db, rowId);
+    expect(blocked?.pass_reason).toBe("no_shared_file");
+
+    await h.db
+      .updateTable("entity_review_queue")
+      .set({ proposed_email: "samuel.cole@other.test" })
+      .where("id", "=", rowId)
+      .execute();
+
+    await runPasses(h);
+    const vetoed = await readRow(h.db, rowId);
+    expect(vetoed?.status).toBe("deferred");
+    expect(vetoed?.pass_reason).toBe("different_emails");
+  });
+
+  it("T7 unions emails across all three stores and compares them normalised", async () => {
+    const metadataOnly = await seedEntity(h.db, { name: "Meta One", metadata: { email: "one@a.test" } });
+    const metadataRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Meta Proposal",
+      candidateEntityId: metadataOnly,
+      proposedEmail: "two@b.test",
+    });
+
+    const contactOnly = await seedEntity(h.db, { name: "Contact One" });
+    await h.db
+      .insertInto("entity_contact_points")
+      .values({
+        id: randomUUID(),
+        entity_id: contactOnly,
+        kind: "email",
+        value: "contact@a.test",
+        source: "test",
+      })
+      .execute();
+    const contactRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Contact Proposal",
+      candidateEntityId: contactOnly,
+      proposedEmail: "different@b.test",
+    });
+
+    const bothStores = await seedEntity(h.db, { name: "Both Stores", metadata: { email: "shared@a.test" } });
+    await h.db
+      .insertInto("entity_contact_points")
+      .values({
+        id: randomUUID(),
+        entity_id: bothStores,
+        kind: "email",
+        value: "second@a.test",
+        source: "test",
+      })
+      .execute();
+    const overlappingRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Both Proposal",
+      candidateEntityId: bothStores,
+      proposedEmail: "second@a.test",
+    });
+
+    const caseOnly = await seedEntity(h.db, { name: "Case One", metadata: { email: "Case.One@A.TEST" } });
+    const caseRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Case Proposal",
+      candidateEntityId: caseOnly,
+      proposedEmail: "  case.one@a.test ",
+    });
+
+    await runPasses(h);
+
+    expect((await readRow(h.db, metadataRow))?.pass_reason).toBe("different_emails");
+    expect((await readRow(h.db, contactRow))?.pass_reason).toBe("different_emails");
+    expect((await readRow(h.db, overlappingRow))?.pass_reason).toBe("no_shared_file");
+    expect((await readRow(h.db, caseRow))?.pass_reason).toBe("no_shared_file");
+  });
+
+  /**
+   * The split the whole feature turns on. A veto answers the row and hides it; a
+   * block does not answer it and must stay in front of a person. Asserted
+   * through the list endpoint rather than the column because visibility is the
+   * property that matters, and a row already deferred by an earlier run has to
+   * come back on its own.
+   */
+  it("T10 hides a vetoed row and keeps a blocked one in the pending list", async () => {
+    const vetoCandidate = await seedEntity(h.db, {
+      name: "Veto Candidate",
+      metadata: { email: "veto.candidate@acme.test" },
+    });
+    const vetoRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Veto Proposal",
+      candidateEntityId: vetoCandidate,
+      proposedEmail: "veto.proposal@other.test",
+    });
+
+    const blockCandidate = await seedEntity(h.db, { name: "Block Candidate" });
+    const blockRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Block Proposal",
+      candidateEntityId: blockCandidate,
+    });
+    await h.db
+      .updateTable("entity_review_queue")
+      .set({ status: "deferred", pass_reason: "no_shared_file" })
+      .where("id", "=", blockRow)
+      .execute();
+
+    await runPasses(h);
+
+    const pending = (await (
+      await h.app.request("/api/entity-review?limit=200", { headers: { Cookie: h.cookie } })
+    ).json()) as {
+      rows: { id: string }[];
+    };
+    const pendingIds = pending.rows.map((row) => row.id);
+    expect(pendingIds).toContain(blockRow);
+    expect(pendingIds).not.toContain(vetoRow);
+
+    const deferred = (await (
+      await h.app.request("/api/entity-review?limit=200&status=deferred", { headers: { Cookie: h.cookie } })
+    ).json()) as { rows: { id: string }[] };
+    const deferredIds = deferred.rows.map((row) => row.id);
+    expect(deferredIds).toContain(vetoRow);
+    expect(deferredIds).not.toContain(blockRow);
+
+    expect((await readRow(h.db, blockRow))?.pass_reason).toBe("no_shared_file");
+    expect((await readRow(h.db, vetoRow))?.pass_reason).toBe("different_emails");
+  });
+
+  it("F1 the veto fires when the proposal's name resolves to the candidate", async () => {
+    const candidate = await seedEntity(h.db, { name: "Admin", metadata: { email: "admin@one.test" } });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Admin",
+      candidateEntityId: candidate,
+      proposedEmail: "admin@two.test",
+    });
+
+    await runPasses(h);
+
+    const row = await readRow(h.db, rowId);
+    expect(row?.status).toBe("deferred");
+    expect(row?.pass_reason).toBe("different_emails");
+  });
+
+  /**
+   * This calls `structuralPass` directly because on this shape phase A writes a
+   * priority-1 reason that the projection keeps, so no API-observable assertion
+   * can tell a kept fold from a deleted one.
+   */
+  it("F2 a different same-name entity still contributes its emails", async () => {
+    await seedEntity(h.db, {
+      name: "Anita Nayar",
+      createdAt: "2020-01-01T00:00:00.000Z",
+      metadata: { email: "anita@one.test" },
+    });
+    const candidate = await seedEntity(h.db, {
+      name: "A. Nayar",
+      createdAt: "2020-01-02T00:00:00.000Z",
+      metadata: { email: "nayar@two.test" },
+    });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Anita Nayar",
+      candidateEntityId: candidate,
+    });
+
+    const rows = await loadQueueRows(h.db);
+    const byName = await liveEntitiesForNames(h.db, rows);
+    const result = await structuralPass(h.db, rows, byName);
+
+    expect(result.hits).toEqual(expect.arrayContaining([{ rowId, reason: "different_emails" }]));
+  });
+
+  it("F3 an empty side still means no veto", async () => {
+    const candidate = await seedEntity(h.db, { name: "Benjamin" });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Benjamin",
+      candidateEntityId: candidate,
+      proposedEmail: "benjamin@one.test",
+    });
+
+    await runPasses(h);
+
+    const row = await readRow(h.db, rowId);
+    expect(row?.pass_reason).not.toBe("different_emails");
+  });
+
+  it("F4 a shared name alone does not prove two participants", async () => {
+    const candidate = await seedEntity(h.db, { name: "Rajesh Chaudhary" });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Rajesh Chaudhary",
+      candidateEntityId: candidate,
+    });
+
+    const connectorId = "gmail-shared-name-facts";
+    await h.db
+      .insertInto("connector_configs")
+      .values({
+        id: connectorId,
+        connector_type: "gmail",
+        auth_type: "system",
+        credentials: JSON.stringify({ type: "system" }),
+        created_by: h.ownerId,
+        scope_config: "{}",
+        sync_status: "active",
+      })
+      .execute();
+    const fileId = randomUUID();
+    await h.db
+      .insertInto("indexed_files")
+      .values({
+        id: fileId,
+        connector_config_id: connectorId,
+        provider_file_id: "msg-shared-name",
+        file_name: "msg-shared-name.eml",
+        content_category: "document",
+        source: "gmail",
+        synced_at: new Date().toISOString(),
+      })
+      .execute();
+
+    await h.db
+      .insertInto("entity_review_evidence")
+      .values({ id: randomUUID(), review_id: rowId, indexed_file_id: fileId, source: "gmail" })
+      .execute();
+    await h.db
+      .insertInto("entity_mentions")
+      .values({
+        id: randomUUID(),
+        entity_id: candidate,
+        indexed_file_id: fileId,
+        chunk_index: null,
+        context_snippet: null,
+        confidence: "EXTRACTED",
+        source: "llm_extraction",
+        relation: "mentioned",
+        mentioned_at: new Date().toISOString(),
+      })
+      .execute();
+
+    await h.db
+      .insertInto("indexed_file_facts")
+      .values([
+        {
+          id: randomUUID(),
+          indexed_file_id: fileId,
+          source: "gmail",
+          fact_type: "attendee",
+          relation: "attendee",
+          subject_email: "stranger-one@x.test",
+          normalized_subject_name: "rajesh chaudhary",
+          fact_key: `${fileId}:attendee:1`,
+        },
+        {
+          id: randomUUID(),
+          indexed_file_id: fileId,
+          source: "gmail",
+          fact_type: "attendee",
+          relation: "attendee",
+          subject_email: "stranger-two@x.test",
+          normalized_subject_name: "rajesh chaudhary",
+          fact_key: `${fileId}:attendee:2`,
+        },
+      ])
+      .execute();
+
+    await runPasses(h);
+
+    const row = await readRow(h.db, rowId);
+    expect(row?.pass_reason).not.toBe("co_listed_participants");
+  });
+
+  it("T8 leaves a row alone while a person has it open, and defers it once the freeze lapses", async () => {
+    const candidate = await seedEntity(h.db, {
+      name: "Frozen Candidate",
+      metadata: { email: "frozen.candidate@acme.test" },
+    });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Frozen Proposal",
+      candidateEntityId: candidate,
+      proposedEmail: "frozen.proposal@other.test",
+    });
+
+    await h.db
+      .updateTable("entity_review_queue")
+      .set({ review_started_at: new Date().toISOString(), review_started_by: h.ownerId })
+      .where("id", "=", rowId)
+      .execute();
+
+    await runPasses(h);
+    const untouched = await readRow(h.db, rowId);
+    expect(untouched?.status).toBe("pending");
+    expect(untouched?.pass_reason).toBeNull();
+
+    await h.db
+      .updateTable("entity_review_queue")
+      .set({ review_started_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() })
+      .where("id", "=", rowId)
+      .execute();
+
+    await runPasses(h);
+    const deferred = await readRow(h.db, rowId);
+    expect(deferred?.status).toBe("deferred");
+    expect(deferred?.pass_reason).toBe("different_emails");
+  });
+
+  /**
+   * The interleaved half of T8. The HTTP endpoint runs the whole pass in one
+   * call, so it cannot express "selected, then opened, then written" without a
+   * test-only seam in the production path. This drives the projection directly
+   * with a row set captured before the review was opened — which is exactly the
+   * race, and it is the only case that tells a freeze check on the SELECT apart
+   * from one on the UPDATE.
+   */
+  it("T8 interleaved: a review opened after selection still blocks the write", async () => {
+    const candidate = await seedEntity(h.db, { name: "Interleaved Candidate" });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Interleaved Proposal",
+      candidateEntityId: candidate,
+    });
+
+    const selected = (await loadQueueRows(h.db)).map((row) => row.id);
+    expect(selected).toContain(rowId);
+
+    const opened = await h.app.request(`/api/entity-review/${rowId}`, { headers: { Cookie: h.cookie } });
+    expect(opened.status).toBe(200);
+    expect((await readRow(h.db, rowId))?.review_started_at).not.toBeNull();
+
+    const counts = await applyProjection(h.db, selected, new Map([[rowId, "different_emails"]]));
+    expect(counts.frozen).toBe(1);
+
+    const row = await readRow(h.db, rowId);
+    expect(row?.status).toBe("pending");
+    expect(row?.pass_reason).toBeNull();
+  });
+
+  it("T5 sweeps a deferred orphan on connector delete and spares a confirming row", async () => {
+    const connectorId = "gmail-queue-cleanup";
+    await h.db
+      .insertInto("connector_configs")
+      .values({
+        id: connectorId,
+        connector_type: "gmail",
+        auth_type: "system",
+        credentials: JSON.stringify({ type: "system" }),
+        created_by: h.ownerId,
+        scope_config: "{}",
+        sync_status: "active",
+      })
+      .execute();
+    const fileId = randomUUID();
+    await h.db
+      .insertInto("indexed_files")
+      .values({
+        id: fileId,
+        connector_config_id: connectorId,
+        provider_file_id: "msg-1",
+        file_name: "msg-1.eml",
+        content_category: "document",
+        source: "gmail",
+        synced_at: new Date().toISOString(),
+      })
+      .execute();
+
+    const deferredRow = await seedQueueRow(h.db, h.ownerId, { name: "Cleanup Person" });
+    await seedEntity(h.db, { name: "Cleanup Person" });
+    const confirmingRow = await seedQueueRow(h.db, h.ownerId, {
+      name: "Confirming Person",
+      status: "confirming",
+    });
+    for (const reviewId of [deferredRow, confirmingRow]) {
+      await h.db
+        .insertInto("entity_review_evidence")
+        .values({ id: randomUUID(), review_id: reviewId, indexed_file_id: fileId, source: "gmail" })
+        .execute();
+    }
+
+    await runPasses(h);
+    expect((await readRow(h.db, deferredRow))?.status).toBe("deferred");
+
+    const res = await h.app.request(`/api/connectors/${connectorId}`, {
+      method: "DELETE",
+      headers: { Cookie: h.cookie },
+    });
+    expect(res.status).toBe(200);
+
+    expect(await readRow(h.db, deferredRow)).toBeUndefined();
+    expect((await readRow(h.db, confirmingRow))?.status).toBe("confirming");
+  });
+
+  it("reports per-reason counts on the run snapshot", async () => {
+    await seedQueueRow(h.db, h.ownerId, { name: "Counted Person" });
+    await seedEntity(h.db, { name: "Counted Person" });
+
+    const snapshot = await runPasses(h);
+    expect(snapshot.kind).toBe("queue");
+    expect(snapshot.scannedRows).toBe(1);
+    expect((snapshot.set as Record<string, number>).name_already_resolved).toBe(1);
+  });
+});

--- a/packages/server/src/entities/queue-projection.ts
+++ b/packages/server/src/entities/queue-projection.ts
@@ -1,0 +1,132 @@
+import type { Kysely } from "kysely";
+import { readReviewFreezeMs } from "../db/repositories/entity-review";
+import type { DB } from "../db/schema";
+
+export type PassReason =
+  | "name_already_resolved"
+  | "superseded_by_entity"
+  | "candidate_merged_away"
+  | "different_emails"
+  | "co_listed_participants"
+  | "type_mismatch"
+  | "no_shared_file"
+  | "bare_name_only";
+
+/**
+ * Certainty order: what the register says, then what is certainly true, then
+ * what the evidence does not support.
+ *
+ * Priority 4 is reserved for a model pass and is not implemented here. Adding a
+ * rung is the only change that pass makes to this module — it writes a verdict,
+ * and the projection reads it.
+ */
+export const REASON_PRIORITY: Record<PassReason, number> = {
+  name_already_resolved: 1,
+  superseded_by_entity: 1,
+  candidate_merged_away: 1,
+  different_emails: 2,
+  co_listed_participants: 2,
+  type_mismatch: 2,
+  no_shared_file: 3,
+  bare_name_only: 3,
+};
+
+const ALL_REASONS = Object.keys(REASON_PRIORITY) as PassReason[];
+
+const DEFER_MAX_PRIORITY = 2;
+
+/**
+ * Only a reason that answers the row hides it. Priority 3 says the evidence does
+ * not support a merge, which is not the same as knowing there is nothing to
+ * merge — a large share of those rows are real merges a person would confirm on
+ * sight. They keep `pending` and carry their reason, so the queue stays honest
+ * until a model pass can rule on them.
+ */
+function statusForReason(reason: PassReason): "deferred" | "pending" {
+  return REASON_PRIORITY[reason] <= DEFER_MAX_PRIORITY ? "deferred" : "pending";
+}
+
+export type ReasonHit = { rowId: string; reason: PassReason };
+
+export type ProjectionCounts = {
+  set: Partial<Record<PassReason, number>>;
+  cleared: number;
+  frozen: number;
+};
+
+/**
+ * Keeps the highest-priority reason per row. Ties break on the reason name so
+ * two rules at the same priority always resolve the same way.
+ */
+export function resolveReasons(hits: ReasonHit[]): Map<string, PassReason> {
+  const best = new Map<string, PassReason>();
+  for (const hit of hits) {
+    const current = best.get(hit.rowId);
+    if (current === undefined) {
+      best.set(hit.rowId, hit.reason);
+      continue;
+    }
+    const currentPriority = REASON_PRIORITY[current];
+    const hitPriority = REASON_PRIORITY[hit.reason];
+    if (hitPriority < currentPriority || (hitPriority === currentPriority && hit.reason < current)) {
+      best.set(hit.rowId, hit.reason);
+    }
+  }
+  return best;
+}
+
+export function reviewFreezeBoundary(): string {
+  return new Date(Date.now() - readReviewFreezeMs()).toISOString();
+}
+
+/**
+ * Writes `(status, pass_reason)` for every row the passes examined.
+ *
+ * The freeze predicate lives on the UPDATE, not on the query that selected the
+ * rows: a row can be picked up, opened by a person, and then written, and a
+ * guard that ran before the person arrived does not guard anything. A row that
+ * fails the predicate is left for the next run, which costs nothing because the
+ * projection recomputes rather than mutates.
+ */
+export async function applyProjection(
+  db: Kysely<DB>,
+  rowIds: string[],
+  reasons: Map<string, PassReason>,
+): Promise<ProjectionCounts> {
+  const counts: ProjectionCounts = { set: {}, cleared: 0, frozen: 0 };
+  if (rowIds.length === 0) return counts;
+
+  const boundary = reviewFreezeBoundary();
+  let written = 0;
+
+  for (const reason of ALL_REASONS) {
+    const ids = rowIds.filter((id) => reasons.get(id) === reason);
+    if (ids.length === 0) continue;
+    const result = await db
+      .updateTable("entity_review_queue")
+      .set({ status: statusForReason(reason), pass_reason: reason })
+      .where("id", "in", ids)
+      .where("status", "in", ["pending", "deferred"])
+      .where((eb) => eb.or([eb("review_started_at", "is", null), eb("review_started_at", "<", boundary)]))
+      .executeTakeFirst();
+    const updated = Number(result.numUpdatedRows ?? 0);
+    counts.set[reason] = updated;
+    written += updated;
+  }
+
+  const clearIds = rowIds.filter((id) => !reasons.has(id));
+  if (clearIds.length > 0) {
+    const result = await db
+      .updateTable("entity_review_queue")
+      .set({ status: "pending", pass_reason: null })
+      .where("id", "in", clearIds)
+      .where("status", "in", ["pending", "deferred"])
+      .where((eb) => eb.or([eb("review_started_at", "is", null), eb("review_started_at", "<", boundary)]))
+      .executeTakeFirst();
+    counts.cleared = Number(result.numUpdatedRows ?? 0);
+    written += counts.cleared;
+  }
+
+  counts.frozen = Math.max(0, rowIds.length - written);
+  return counts;
+}

--- a/packages/server/src/entities/queue-reconcile.ts
+++ b/packages/server/src/entities/queue-reconcile.ts
@@ -1,0 +1,236 @@
+import type { Kysely } from "kysely";
+import type { DB } from "../db/schema";
+import { type PassReason, type ReasonHit, reviewFreezeBoundary } from "./queue-projection";
+import { inScope, nonTerminal } from "./queue-scope";
+
+export type QueueRowForPasses = {
+  id: string;
+  proposed_name: string;
+  normalized_name: string;
+  entity_type: string;
+  proposed_email: string | null;
+  candidate_entity_id: string | null;
+  source: string | null;
+  status: string;
+};
+
+export type LiveEntity = { id: string; name: string; source_type: string; created_at: string };
+type EntityState = { id: string; deleted_at: string | null; merged_into_entity_id: string | null };
+
+export type ReconcileResult = {
+  hits: ReasonHit[];
+  repointed: number;
+  cleared: number;
+};
+
+const MERGE_CHAIN_MAX_HOPS = 16;
+
+/**
+ * NUL separates the two parts so a type can never run into a name — no entity
+ * type or proposed name contains one.
+ */
+export function nameKey(entityType: string, name: string): string {
+  return `${entityType}\u0000${name.trim().toLowerCase()}`;
+}
+
+export async function loadQueueRows(db: Kysely<DB>): Promise<QueueRowForPasses[]> {
+  return db
+    .selectFrom("entity_review_queue")
+    .select([
+      "id",
+      "proposed_name",
+      "normalized_name",
+      "entity_type",
+      "proposed_email",
+      "candidate_entity_id",
+      "source",
+      "status",
+    ])
+    .where((eb) => inScope(eb))
+    .where((eb) => nonTerminal(eb))
+    .orderBy("first_seen_at", "asc")
+    .orderBy("id", "asc")
+    .execute();
+}
+
+/**
+ * The oldest live entity carrying each row's proposed name, keyed on type as
+ * well as name. Matching on name alone defers a `person` row because a
+ * `company` happens to share its name.
+ */
+export async function liveEntitiesForNames(
+  db: Kysely<DB>,
+  rows: QueueRowForPasses[],
+): Promise<Map<string, LiveEntity>> {
+  const wanted = new Set(rows.map((row) => nameKey(row.entity_type, row.proposed_name)));
+  if (wanted.size === 0) return new Map();
+
+  const types = Array.from(new Set(rows.map((row) => row.entity_type)));
+  const names = Array.from(new Set(rows.map((row) => row.proposed_name.trim().toLowerCase())));
+
+  const candidates = await db
+    .selectFrom("entities")
+    .select(["id", "name", "source_type", "created_at"])
+    .where("source_type", "in", types)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .where((eb) => eb(eb.fn("lower", ["name"]), "in", names))
+    .execute();
+
+  const byKey = new Map<string, LiveEntity>();
+  for (const candidate of candidates) {
+    const key = nameKey(candidate.source_type, candidate.name);
+    if (!wanted.has(key)) continue;
+    const held = byKey.get(key);
+    const older =
+      held === undefined ||
+      candidate.created_at < held.created_at ||
+      (candidate.created_at === held.created_at && candidate.id < held.id);
+    if (older) byKey.set(key, candidate);
+  }
+  return byKey;
+}
+
+/**
+ * Candidate rows plus every entity their merge chains pass through. Loading the
+ * candidates alone is not enough — a candidate merged into an entity that is
+ * itself merged has a survivor that no queue row points at.
+ */
+async function loadEntityStates(db: Kysely<DB>, rows: QueueRowForPasses[]): Promise<Map<string, EntityState>> {
+  const states = new Map<string, EntityState>();
+  let toLoad = Array.from(new Set(rows.map((r) => r.candidate_entity_id).filter((id): id is string => id !== null)));
+
+  for (let hop = 0; hop <= MERGE_CHAIN_MAX_HOPS && toLoad.length > 0; hop += 1) {
+    const found = await db
+      .selectFrom("entities")
+      .select(["id", "deleted_at", "merged_into_entity_id"])
+      .where("id", "in", toLoad)
+      .execute();
+    for (const state of found) states.set(state.id, state);
+    toLoad = found
+      .map((state) => state.merged_into_entity_id)
+      .filter((id): id is string => id !== null && !states.has(id));
+  }
+  return states;
+}
+
+/**
+ * Walks `merged_into_entity_id` to the end. Returns null when the chain leaves
+ * the loaded set or loops, so a broken chain never produces a re-point.
+ */
+function resolveSurvivor(startId: string, states: Map<string, EntityState>): EntityState | null {
+  const seen = new Set<string>();
+  let current = states.get(startId) ?? null;
+  while (current?.merged_into_entity_id) {
+    if (seen.has(current.id)) return null;
+    seen.add(current.id);
+    const next = states.get(current.merged_into_entity_id);
+    if (!next) return null;
+    current = next;
+  }
+  return current;
+}
+
+/**
+ * A candidate change — a re-point (A2, A3) or a clear (A4) — writes four
+ * columns, never just the pointer. `candidate_generated_at` is what lets a
+ * later reader tell the candidate moved; a stale score and a stale alternates
+ * list describe a pair that is no longer being asked about, and `merge.ts`
+ * rewrites only the scalar column, so nothing else cleans them up.
+ *
+ * The `candidate_entity_id` predicate is the re-check from §2.3: the value was
+ * read before the rules ran, and a row whose candidate moved since then is left
+ * for the next run rather than overwritten.
+ */
+async function writeCandidate(
+  db: Kysely<DB>,
+  rowIds: string[],
+  target: string | null,
+  expectedCandidateId: string,
+  boundary: string,
+): Promise<number> {
+  const result = await db
+    .updateTable("entity_review_queue")
+    .set({
+      candidate_entity_id: target,
+      candidate_entity_ids: null,
+      candidate_score: null,
+      candidate_generated_at: new Date().toISOString(),
+    })
+    .where("id", "in", rowIds)
+    .where("candidate_entity_id", "=", expectedCandidateId)
+    .where("status", "in", ["pending", "deferred"])
+    .where((eb) => eb.or([eb("review_started_at", "is", null), eb("review_started_at", "<", boundary)]))
+    .executeTakeFirst();
+  return Number(result.numUpdatedRows ?? 0);
+}
+
+/**
+ * Phase A — the register already answered it.
+ *
+ * Reads `entities` and writes queue columns only. No mentions, no aliases, no
+ * merges: the facts behind these rows are still in `indexed_file_facts` and
+ * materialize normally, so setting a row aside loses nothing.
+ */
+export async function reconcileQueue(
+  db: Kysely<DB>,
+  rows: QueueRowForPasses[],
+  byName: Map<string, LiveEntity>,
+): Promise<ReconcileResult> {
+  const states = await loadEntityStates(db, rows);
+
+  const boundary = reviewFreezeBoundary();
+  const hits: ReasonHit[] = [];
+  const groups = new Map<string, { target: string | null; expected: string; rowIds: string[] }>();
+
+  const group = (rowId: string, expected: string, target: string | null): void => {
+    const key = `${expected}\u0000${target ?? ""}`;
+    const held = groups.get(key) ?? { target, expected, rowIds: [] };
+    held.rowIds.push(rowId);
+    groups.set(key, held);
+  };
+
+  for (const row of rows) {
+    const live = byName.get(nameKey(row.entity_type, row.proposed_name)) ?? null;
+    const candidateId = row.candidate_entity_id;
+
+    if (candidateId === null) {
+      if (live) hits.push({ rowId: row.id, reason: "name_already_resolved" });
+      continue;
+    }
+
+    const state = states.get(candidateId) ?? null;
+    const candidateGone = state === null || state.deleted_at !== null || state.merged_into_entity_id !== null;
+
+    if (candidateGone) {
+      const survivor = resolveSurvivor(candidateId, states);
+      const usable = survivor && survivor.deleted_at === null && survivor.id !== candidateId ? survivor : null;
+
+      if (usable) {
+        group(row.id, candidateId, usable.id);
+        const reason: PassReason = live && live.id === usable.id ? "name_already_resolved" : "candidate_merged_away";
+        hits.push({ rowId: row.id, reason });
+        continue;
+      }
+
+      group(row.id, candidateId, null);
+      if (live) hits.push({ rowId: row.id, reason: "name_already_resolved" });
+      continue;
+    }
+
+    if (live && live.id !== candidateId) {
+      group(row.id, candidateId, live.id);
+      hits.push({ rowId: row.id, reason: "superseded_by_entity" });
+    }
+  }
+
+  let repointed = 0;
+  let cleared = 0;
+  for (const held of groups.values()) {
+    const written = await writeCandidate(db, held.rowIds, held.target, held.expected, boundary);
+    if (held.target === null) cleared += written;
+    else repointed += written;
+  }
+
+  return { hits, repointed, cleared };
+}

--- a/packages/server/src/entities/queue-run.ts
+++ b/packages/server/src/entities/queue-run.ts
@@ -1,0 +1,41 @@
+import type { Kysely } from "kysely";
+import type { QueueRunSnapshot } from "../db/repositories/graph-pass-runs";
+import type { DB } from "../db/schema";
+import { applyProjection, resolveReasons } from "./queue-projection";
+import { liveEntitiesForNames, loadQueueRows, reconcileQueue } from "./queue-reconcile";
+import { structuralPass } from "./queue-structural";
+
+/**
+ * One queue graph pass: reconcile, then structure, then one projection.
+ *
+ * The rows are re-read between the two passes because phase A re-points and
+ * clears candidates, and phase B's rules are all about the candidate. Neither
+ * pass writes to the graph, and the projection recomputes `(status,
+ * pass_reason)` from scratch, so a run that overlaps another converges rather
+ * than corrupting anything.
+ */
+export async function runQueuePasses(db: Kysely<DB>): Promise<QueueRunSnapshot> {
+  const initialRows = await loadQueueRows(db);
+  const byName = await liveEntitiesForNames(db, initialRows);
+  const reconciled = await reconcileQueue(db, initialRows, byName);
+
+  const rows = await loadQueueRows(db);
+  const structural = await structuralPass(db, rows, byName);
+
+  const reasons = resolveReasons([...reconciled.hits, ...structural.hits]);
+  const counts = await applyProjection(
+    db,
+    rows.map((row) => row.id),
+    reasons,
+  );
+
+  return {
+    kind: "queue",
+    scannedRows: rows.length,
+    set: counts.set as Record<string, number>,
+    cleared: counts.cleared,
+    frozen: counts.frozen,
+    candidatesRepointed: reconciled.repointed,
+    candidatesCleared: reconciled.cleared,
+  };
+}

--- a/packages/server/src/entities/queue-scope.ts
+++ b/packages/server/src/entities/queue-scope.ts
@@ -1,0 +1,36 @@
+import type { ExpressionBuilder, ExpressionWrapper, SqlBool } from "kysely";
+import { TERMINAL_STATUS_LIST } from "../db/repositories/entity-review";
+import type { DB } from "../db/schema";
+
+/**
+ * Sources whose rows ask "which entity is this account?" rather than "are these
+ * two names the same?". They are keyed on (source, source_id) instead of
+ * (normalized_name, entity_type), a person's own link decision drives them, and
+ * none of the reconcile or structural rules describes them.
+ */
+export const IDENTITY_LINK_SOURCES = ["user_entity_link", "slack_user"] as const;
+
+/**
+ * Rows both passes may touch.
+ *
+ * The null guard on `source` is load-bearing: `source NOT IN (...)` evaluates to
+ * NULL for a NULL source, so a bare NOT IN silently drops rows that were never
+ * identity links to begin with.
+ */
+export function inScope(
+  eb: ExpressionBuilder<DB, "entity_review_queue">,
+): ExpressionWrapper<DB, "entity_review_queue", SqlBool> {
+  return eb.and([
+    eb.or([
+      eb("entity_review_queue.source", "is", null),
+      eb("entity_review_queue.source", "not in", [...IDENTITY_LINK_SOURCES]),
+    ]),
+    eb("entity_review_queue.candidate_user_ids", "is", null),
+  ]);
+}
+
+export function nonTerminal(
+  eb: ExpressionBuilder<DB, "entity_review_queue">,
+): ExpressionWrapper<DB, "entity_review_queue", SqlBool> {
+  return eb("entity_review_queue.status", "not in", [...TERMINAL_STATUS_LIST]);
+}

--- a/packages/server/src/entities/queue-structural.ts
+++ b/packages/server/src/entities/queue-structural.ts
@@ -1,5 +1,7 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Kysely } from "kysely";
 import { normalizeName } from "../connectors/name-normalize";
+import { forEachChunk } from "../connectors/sync-utils";
 import type { DB } from "../db/schema";
 import { readPersonEmailFromMetadata } from "./materialize-json";
 import type { PassReason, ReasonHit } from "./queue-projection";
@@ -105,27 +107,56 @@ async function loadMentionFiles(db: Kysely<DB>, entityIds: string[]): Promise<Ma
 
 type AttendeeFact = { id: string; indexed_file_id: string; email: string | null; normalized: string | null };
 
+/**
+ * Test-only override for the batch size, scoped to one call.
+ *
+ * `IN_CLAUSE_CHUNK_SIZE` is 500, which is far more evidence files than an
+ * integration test can seed, and the tests have to drive the passes through
+ * `POST /api/graph-passes/queue-runs` — so the size cannot be threaded in as a
+ * parameter. A module-level setter of the `configureMaterializeDefaults` shape
+ * would work, but it is sticky: under `isolate: false` it stays set for every
+ * later test in the worker unless something resets it. This unsets itself when
+ * the call returns.
+ */
+const attendeeFactChunkSize = new AsyncLocalStorage<number>();
+
+export async function withAttendeeFactChunkSizeForTest<T>(size: number, work: () => Promise<T>): Promise<T> {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error(`attendee fact chunk size must be a positive integer, got ${size}`);
+  }
+  return attendeeFactChunkSize.run(size, work);
+}
+
 async function loadAttendeeFacts(db: Kysely<DB>, fileIds: string[]): Promise<Map<string, AttendeeFact[]>> {
   if (fileIds.length === 0) return new Map();
-  const rows = await db
-    .selectFrom("indexed_file_facts")
-    .select(["id", "indexed_file_id", "subject_email", "normalized_subject_name"])
-    .where("indexed_file_id", "in", fileIds)
-    .where("fact_type", "=", "attendee")
-    .where("deleted_at", "is", null)
-    .execute();
   const byFile = new Map<string, AttendeeFact[]>();
-  for (const row of rows) {
-    if (!row.indexed_file_id) continue;
-    const held = byFile.get(row.indexed_file_id) ?? [];
-    held.push({
-      id: row.id,
-      indexed_file_id: row.indexed_file_id,
-      email: cleanEmail(row.subject_email),
-      normalized: row.normalized_subject_name,
-    });
-    byFile.set(row.indexed_file_id, held);
-  }
+
+  await forEachChunk(
+    fileIds,
+    async (batch) => {
+      const rows = await db
+        .selectFrom("indexed_file_facts")
+        .select(["id", "indexed_file_id", "subject_email", "normalized_subject_name"])
+        .where("indexed_file_id", "in", batch)
+        .where("fact_type", "=", "attendee")
+        .where("deleted_at", "is", null)
+        .execute();
+
+      for (const row of rows) {
+        if (!row.indexed_file_id) continue;
+        const held = byFile.get(row.indexed_file_id) ?? [];
+        held.push({
+          id: row.id,
+          indexed_file_id: row.indexed_file_id,
+          email: cleanEmail(row.subject_email),
+          normalized: row.normalized_subject_name,
+        });
+        byFile.set(row.indexed_file_id, held);
+      }
+    },
+    attendeeFactChunkSize.getStore(),
+  );
+
   return byFile;
 }
 
@@ -160,6 +191,7 @@ function shouldFoldProposalEntityEmails(
  *
  * Built from `indexed_file_facts` on both sides because `entity_mentions` has no
  * column linking a mention back to the fact that produced it.
+ * The nested scan is bounded only by one indexed file's attendee fact count.
  */
 function coListed(facts: AttendeeFact[], proposal: Side, candidate: Side): boolean {
   const namesDistinguish = proposal.normalized !== candidate.normalized;

--- a/packages/server/src/entities/queue-structural.ts
+++ b/packages/server/src/entities/queue-structural.ts
@@ -1,0 +1,265 @@
+import type { Kysely } from "kysely";
+import { normalizeName } from "../connectors/name-normalize";
+import type { DB } from "../db/schema";
+import { readPersonEmailFromMetadata } from "./materialize-json";
+import type { PassReason, ReasonHit } from "./queue-projection";
+import { type LiveEntity, type QueueRowForPasses, nameKey } from "./queue-reconcile";
+
+type EntityFacts = { id: string; name: string; source_type: string; metadata: string | null };
+
+export type StructuralResult = { hits: ReasonHit[] };
+
+function cleanEmail(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : null;
+}
+
+function isSingleToken(name: string): boolean {
+  return name.trim().split(/\s+/).filter(Boolean).length === 1;
+}
+
+function disjoint(left: Set<string>, right: Set<string>): boolean {
+  for (const value of left) if (right.has(value)) return false;
+  return true;
+}
+
+async function loadEntities(db: Kysely<DB>, ids: string[]): Promise<Map<string, EntityFacts>> {
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .selectFrom("entities")
+    .select(["id", "name", "source_type", "metadata"])
+    .where("id", "in", ids)
+    .execute();
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+/**
+ * Email addresses per entity, unioned from the two stores an entity keeps them
+ * in. Parsing happens here rather than in SQL: `metadata` is a JSON string and
+ * the two dialects disagree about how to read into it, so a SQL-side extraction
+ * would produce different veto sets on SQLite and Postgres.
+ */
+async function loadEntityEmails(db: Kysely<DB>, entities: Map<string, EntityFacts>): Promise<Map<string, Set<string>>> {
+  const byEntity = new Map<string, Set<string>>();
+  for (const entity of entities.values()) {
+    const email = cleanEmail(readPersonEmailFromMetadata(entity.metadata));
+    byEntity.set(entity.id, new Set(email ? [email] : []));
+  }
+
+  const ids = Array.from(entities.keys());
+  if (ids.length === 0) return byEntity;
+
+  const points = await db
+    .selectFrom("entity_contact_points")
+    .select(["entity_id", "value"])
+    .where("entity_id", "in", ids)
+    .where("kind", "=", "email")
+    .execute();
+  for (const point of points) {
+    const email = cleanEmail(point.value);
+    if (!email) continue;
+    const held = byEntity.get(point.entity_id);
+    if (held) held.add(email);
+  }
+  return byEntity;
+}
+
+async function loadEvidenceFiles(db: Kysely<DB>, reviewIds: string[]): Promise<Map<string, string[]>> {
+  if (reviewIds.length === 0) return new Map();
+  const rows = await db
+    .selectFrom("entity_review_evidence")
+    .select(["review_id", "indexed_file_id"])
+    .where("review_id", "in", reviewIds)
+    .distinct()
+    .execute();
+  const byReview = new Map<string, string[]>();
+  for (const row of rows) {
+    const held = byReview.get(row.review_id) ?? [];
+    held.push(row.indexed_file_id);
+    byReview.set(row.review_id, held);
+  }
+  return byReview;
+}
+
+/**
+ * Files each candidate is mentioned in, counted as distinct files. The unique
+ * index on `entity_mentions` is (entity_id, indexed_file_id, relation), so
+ * counting mention rows would count one file once per relation.
+ */
+async function loadMentionFiles(db: Kysely<DB>, entityIds: string[]): Promise<Map<string, Set<string>>> {
+  if (entityIds.length === 0) return new Map();
+  const rows = await db
+    .selectFrom("entity_mentions")
+    .select(["entity_id", "indexed_file_id"])
+    .where("entity_id", "in", entityIds)
+    .distinct()
+    .execute();
+  const byEntity = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const held = byEntity.get(row.entity_id) ?? new Set<string>();
+    held.add(row.indexed_file_id);
+    byEntity.set(row.entity_id, held);
+  }
+  return byEntity;
+}
+
+type AttendeeFact = { id: string; indexed_file_id: string; email: string | null; normalized: string | null };
+
+async function loadAttendeeFacts(db: Kysely<DB>, fileIds: string[]): Promise<Map<string, AttendeeFact[]>> {
+  if (fileIds.length === 0) return new Map();
+  const rows = await db
+    .selectFrom("indexed_file_facts")
+    .select(["id", "indexed_file_id", "subject_email", "normalized_subject_name"])
+    .where("indexed_file_id", "in", fileIds)
+    .where("fact_type", "=", "attendee")
+    .where("deleted_at", "is", null)
+    .execute();
+  const byFile = new Map<string, AttendeeFact[]>();
+  for (const row of rows) {
+    if (!row.indexed_file_id) continue;
+    const held = byFile.get(row.indexed_file_id) ?? [];
+    held.push({
+      id: row.id,
+      indexed_file_id: row.indexed_file_id,
+      email: cleanEmail(row.subject_email),
+      normalized: row.normalized_subject_name,
+    });
+    byFile.set(row.indexed_file_id, held);
+  }
+  return byFile;
+}
+
+type Side = { emails: Set<string>; normalized: string };
+
+/**
+ * The name branch is disabled when the two sides normalise identically:
+ * then a name cannot tell them apart, and B2 would claim two people from one
+ * person's two addresses.
+ */
+function factMatches(fact: AttendeeFact, side: Side, allowNameMatch: boolean): boolean {
+  if (fact.email && side.emails.has(fact.email)) return true;
+  return allowNameMatch && fact.normalized !== null && fact.normalized === side.normalized;
+}
+
+/**
+ * Folding the candidate's own emails onto the proposal side makes the two
+ * sides overlap, so the `different_emails` veto can never fire. Removing this
+ * guard silently reintroduces that bug: the rule keeps returning an answer,
+ * just the wrong lower-certainty one.
+ */
+function shouldFoldProposalEntityEmails(
+  proposalEntity: LiveEntity | null,
+  candidateId: string,
+): proposalEntity is LiveEntity {
+  return proposalEntity !== null && proposalEntity.id !== candidateId;
+}
+
+/**
+ * Two attendees on one file, with different fact ids and different emails, one
+ * matching each side of the pair — the file says they are two people.
+ *
+ * Built from `indexed_file_facts` on both sides because `entity_mentions` has no
+ * column linking a mention back to the fact that produced it.
+ */
+function coListed(facts: AttendeeFact[], proposal: Side, candidate: Side): boolean {
+  const namesDistinguish = proposal.normalized !== candidate.normalized;
+  for (const left of facts) {
+    if (!factMatches(left, proposal, namesDistinguish)) continue;
+    for (const right of facts) {
+      if (right.id === left.id) continue;
+      if (!factMatches(right, candidate, namesDistinguish)) continue;
+      if (left.email && right.email && left.email !== right.email) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Phase B — structure answers it.
+ *
+ * Same scope and same projection as phase A, and it writes nothing to the graph
+ * either. Vetoes (B1–B3) are certain and outrank blocks (B4, B5), which say only
+ * that there is not enough evidence to merge.
+ */
+export async function structuralPass(
+  db: Kysely<DB>,
+  rows: QueueRowForPasses[],
+  byName: Map<string, LiveEntity>,
+): Promise<StructuralResult> {
+  const withCandidate = rows.filter((row) => row.candidate_entity_id !== null);
+  if (withCandidate.length === 0) return { hits: [] };
+
+  const candidateIds = Array.from(
+    new Set(withCandidate.map((row) => row.candidate_entity_id).filter((id): id is string => id !== null)),
+  );
+  const proposalEntityIds = Array.from(
+    new Set(
+      withCandidate
+        .map((row) => byName.get(nameKey(row.entity_type, row.proposed_name))?.id)
+        .filter((id): id is string => id !== undefined),
+    ),
+  );
+
+  const entities = await loadEntities(db, Array.from(new Set([...candidateIds, ...proposalEntityIds])));
+  const [emails, evidence, mentions] = await Promise.all([
+    loadEntityEmails(db, entities),
+    loadEvidenceFiles(
+      db,
+      withCandidate.map((row) => row.id),
+    ),
+    loadMentionFiles(db, candidateIds),
+  ]);
+
+  const evidenceFileIds = Array.from(new Set(Array.from(evidence.values()).flat()));
+  const attendees = await loadAttendeeFacts(db, evidenceFileIds);
+
+  const hits: ReasonHit[] = [];
+
+  for (const row of withCandidate) {
+    const candidateId = row.candidate_entity_id;
+    if (candidateId === null) continue;
+    const candidate = entities.get(candidateId);
+    if (!candidate) continue;
+
+    const proposalEntity = byName.get(nameKey(row.entity_type, row.proposed_name)) ?? null;
+    const proposalEmails = new Set<string>();
+    const proposedEmail = cleanEmail(row.proposed_email);
+    if (proposedEmail) proposalEmails.add(proposedEmail);
+    if (shouldFoldProposalEntityEmails(proposalEntity, candidateId)) {
+      for (const email of emails.get(proposalEntity.id) ?? []) proposalEmails.add(email);
+    }
+    const candidateEmails = emails.get(candidateId) ?? new Set<string>();
+
+    const proposalSide: Side = { emails: proposalEmails, normalized: normalizeName(row.proposed_name) };
+    const candidateSide: Side = { emails: candidateEmails, normalized: normalizeName(candidate.name) };
+
+    const push = (reason: PassReason): void => {
+      hits.push({ rowId: row.id, reason });
+    };
+
+    if (proposalEmails.size > 0 && candidateEmails.size > 0 && disjoint(proposalEmails, candidateEmails)) {
+      push("different_emails");
+    }
+
+    if (row.entity_type !== candidate.source_type) push("type_mismatch");
+
+    const files = evidence.get(row.id) ?? [];
+    if (files.some((fileId) => coListed(attendees.get(fileId) ?? [], proposalSide, candidateSide))) {
+      push("co_listed_participants");
+    }
+
+    const candidateFiles = mentions.get(candidateId) ?? new Set<string>();
+    if (!files.some((fileId) => candidateFiles.has(fileId))) push("no_shared_file");
+
+    if (
+      isSingleToken(row.proposed_name) &&
+      isSingleToken(candidate.name) &&
+      proposalEmails.size === 0 &&
+      candidateEmails.size === 0
+    ) {
+      push("bare_name_only");
+    }
+  }
+
+  return { hits };
+}

--- a/packages/server/src/entities/review.ts
+++ b/packages/server/src/entities/review.ts
@@ -176,8 +176,11 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { logger: Logger }) {
     const offsetRaw = Number(c.req.query("offset"));
     const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
     const status = c.req.query("status") ?? "pending";
-    if (status !== "pending") {
-      return c.json({ error: { code: "BAD_REQUEST", message: "only status=pending supported in v1" } }, 400);
+    if (status !== "pending" && status !== "deferred") {
+      return c.json({ error: { code: "BAD_REQUEST", message: "status must be pending or deferred" } }, 400);
+    }
+    if (status === "deferred" && !isAdmin(c)) {
+      return c.json({ error: { code: "FORBIDDEN", message: "deferred rows are admin-only" } }, 403);
     }
     const search = c.req.query("q")?.trim() || undefined;
     // Optional `types` CSV filter on entity_type — a generic allow-list each
@@ -206,6 +209,7 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { logger: Logger }) {
       isAdmin: callerIsAdmin,
       search,
       types: typesFilter,
+      status,
     });
 
     if (countOnly) {
@@ -219,6 +223,7 @@ export function entityReviewRoutes(db: Kysely<DB>, deps: { logger: Logger }) {
       offset,
       search,
       types: typesFilter,
+      status,
     });
 
     // Evidence summary per visible row.

--- a/packages/server/src/scripts/queue-pass-measure.ts
+++ b/packages/server/src/scripts/queue-pass-measure.ts
@@ -1,3 +1,4 @@
+import dotenv from "dotenv";
 import { Kysely, PostgresDialect } from "kysely";
 import type { KyselyPlugin, PluginTransformQueryArgs, PluginTransformResultArgs } from "kysely";
 import type { QueryResult, RootOperationNode, UnknownRow } from "kysely";
@@ -8,6 +9,13 @@ import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import { createApp } from "../http";
 import { createTestConfig, createTestLogger } from "../test-utils";
+
+/**
+ * The worktree this runs in has no `.env` of its own — only the main checkout
+ * does — so the path is overridable. `ENCRYPTION_KEY` is the one value that
+ * matters: without it the settings row cannot be decrypted and login 500s.
+ */
+dotenv.config({ path: process.env.MEASURE_ENV ?? "../../.env" });
 
 const DB_NAME = process.env.MEASURE_DB ?? "sketch_queue_reconcile";
 const EMAIL = "queue-measure@local.test";
@@ -53,7 +61,9 @@ async function main(): Promise<void> {
   }
   await settings.update({ onboardingCompletedAt: new Date().toISOString() });
 
-  const app = createApp(db, createTestConfig({ DB_TYPE: "postgres" }), { logger: createTestLogger() });
+  const app = createApp(db, createTestConfig({ DB_TYPE: "postgres", ENCRYPTION_KEY: process.env.ENCRYPTION_KEY }), {
+    logger: createTestLogger(),
+  });
   const login = await app.request("/api/auth/login", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/packages/server/src/scripts/queue-pass-measure.ts
+++ b/packages/server/src/scripts/queue-pass-measure.ts
@@ -1,0 +1,119 @@
+import { Kysely, PostgresDialect } from "kysely";
+import type { KyselyPlugin, PluginTransformQueryArgs, PluginTransformResultArgs } from "kysely";
+import type { QueryResult, RootOperationNode, UnknownRow } from "kysely";
+import { hashPassword } from "../auth/password";
+import { runMigrations } from "../db/migrate";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestLogger } from "../test-utils";
+
+const DB_NAME = process.env.MEASURE_DB ?? "sketch_queue_reconcile";
+const EMAIL = "queue-measure@local.test";
+const PASSWORD = "queue-measure-pass-123";
+
+class CountingPlugin implements KyselyPlugin {
+  count = 0;
+  armed = false;
+  transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+    if (this.armed) this.count += 1;
+    return args.node;
+  }
+  async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+    return args.result;
+  }
+}
+
+async function main(): Promise<void> {
+  const { Pool } = await import("pg");
+  const counter = new CountingPlugin();
+  const db = new Kysely<DB>({
+    dialect: new PostgresDialect({ pool: new Pool({ connectionString: `postgres://localhost:5432/${DB_NAME}` }) }),
+    plugins: [counter],
+  });
+
+  await runMigrations(db, { quiet: true });
+
+  const before = await snapshot(db);
+  console.log("BEFORE", JSON.stringify(before, null, 2));
+
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  const existing = await users.findByEmail(EMAIL);
+  if (!existing) {
+    await users.create({
+      name: "queue measure",
+      email: EMAIL,
+      emailVerified: true,
+      passwordHash: await hashPassword(PASSWORD),
+      authRole: "admin",
+      skipEntityLinking: true,
+    });
+  }
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+
+  const app = createApp(db, createTestConfig({ DB_TYPE: "postgres" }), { logger: createTestLogger() });
+  const login = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD }),
+  });
+  if (login.status !== 200) throw new Error(`login failed: ${login.status} ${await login.text()}`);
+  const cookie = login.headers.get("set-cookie") ?? "";
+
+  counter.armed = true;
+  const startedAt = Date.now();
+  const res = await app.request("/api/graph-passes/queue-runs", { method: "POST", headers: { Cookie: cookie } });
+  const elapsedMs = Date.now() - startedAt;
+  counter.armed = false;
+  const body = await res.text();
+  console.log("RUN", res.status, body);
+  console.log("STATEMENTS", counter.count, "ELAPSED_MS", elapsedMs);
+
+  const after = await snapshot(db);
+  console.log("AFTER", JSON.stringify(after, null, 2));
+
+  for (const n of [2, 3]) {
+    const again = await app.request("/api/graph-passes/queue-runs", { method: "POST", headers: { Cookie: cookie } });
+    console.log(`RUN${n}`, again.status, await again.text());
+    console.log(`AFTER${n}`, JSON.stringify(await snapshot(db), null, 2));
+  }
+
+  await db.destroy();
+}
+
+async function snapshot(db: Kysely<DB>) {
+  const byStatus = await db
+    .selectFrom("entity_review_queue")
+    .select(["status", (eb) => eb.fn.countAll<number>().as("n")])
+    .groupBy("status")
+    .orderBy("status")
+    .execute();
+  const byReason = await db
+    .selectFrom("entity_review_queue")
+    .select(["pass_reason", (eb) => eb.fn.countAll<number>().as("n")])
+    .where("pass_reason", "is not", null)
+    .groupBy("pass_reason")
+    .orderBy("pass_reason")
+    .execute();
+  const graph = {
+    entities: await count(db, "entities"),
+    entity_mentions: await count(db, "entity_mentions"),
+    entity_relationships: await count(db, "entity_relationships"),
+  };
+  return { byStatus, byReason, graph };
+}
+
+async function count(db: Kysely<DB>, table: "entities" | "entity_mentions" | "entity_relationships"): Promise<number> {
+  const row = await db
+    .selectFrom(table)
+    .select((eb) => eb.fn.countAll<number>().as("n"))
+    .executeTakeFirst();
+  return Number(row?.n ?? 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add deterministic register and structural passes over non-terminal entity-review rows
- repair stale candidates and derive queue status plus pass reasons without mutating the entity graph
- add an admin queue-run endpoint, durable run snapshots, deferred-row access, and connector cleanup coverage
- add SQLite and Postgres migration coverage for queue pass reasons

## Validation
- pnpm biome check .
- pnpm typecheck
- full top-of-stack test suite: 5,618 server tests and 508 web tests passed
- lower-branch migration suite rerun: 45 tests passed
- pnpm build