### PR TITLE
feat(entities): drain deterministic entity duplicates

### DIFF
--- a/packages/server/src/api/entities/merge-routes.ts
+++ b/packages/server/src/api/entities/merge-routes.ts
@@ -60,12 +60,17 @@ export function createEntityMergeRoutes(db: Kysely<DB>) {
     const denied = denyIfNotMergeAdmin(c);
     if (denied) return denied;
     const entityId = c.req.query("entityId");
-    if (!entityId) return c.json({ error: { code: "BAD_REQUEST", message: "entityId is required" } }, 400);
+    const groupId = c.req.query("groupId");
+    if (!entityId && !groupId) {
+      return c.json({ error: { code: "BAD_REQUEST", message: "entityId or groupId is required" } }, 400);
+    }
 
-    const merges = await db
+    let query = db
       .selectFrom("entity_merges")
       .select([
         "id",
+        "group_id",
+        "merged_by",
         "survivor_entity_id",
         "merged_entity_id",
         "entity_type",
@@ -73,10 +78,15 @@ export function createEntityMergeRoutes(db: Kysely<DB>) {
         "unmerged_at",
         "unmerged_by_user_id",
       ])
-      .where((eb) => eb.or([eb("survivor_entity_id", "=", entityId), eb("merged_entity_id", "=", entityId)]))
       .orderBy("merged_at", "desc")
-      .orderBy("id", "desc")
-      .execute();
+      .orderBy("id", "desc");
+    if (entityId) {
+      query = query.where((eb) =>
+        eb.or([eb("survivor_entity_id", "=", entityId), eb("merged_entity_id", "=", entityId)]),
+      );
+    }
+    if (groupId) query = query.where("group_id", "=", groupId);
+    const merges = await query.execute();
 
     return c.json({ merges });
   });
@@ -84,7 +94,11 @@ export function createEntityMergeRoutes(db: Kysely<DB>) {
   routes.post("/merges", async (c) => {
     const denied = denyIfNotMergeAdmin(c);
     if (denied) return denied;
-    const body = (await c.req.json().catch(() => ({}))) as { survivorId?: string; loserId?: string };
+    const body = (await c.req.json().catch(() => ({}))) as {
+      survivorId?: string;
+      loserId?: string;
+      groupId?: string;
+    };
     if (!body.survivorId || !body.loserId) {
       return c.json({ error: { code: "BAD_REQUEST", message: "survivorId and loserId are required" } }, 400);
     }
@@ -94,8 +108,36 @@ export function createEntityMergeRoutes(db: Kysely<DB>) {
         survivorId: body.survivorId,
         loserId: body.loserId,
         userId: c.get("sub"),
+        groupId: body.groupId,
       });
       return c.json({ mergeId: result.mergeId, moves: result.moves.map(redactMove) });
+    } catch (err) {
+      return handleMergeError(c, err);
+    }
+  });
+
+  routes.delete("/merges/groups/:groupId", async (c) => {
+    const denied = denyIfNotMergeAdmin(c);
+    if (denied) return denied;
+
+    const groupId = c.req.param("groupId");
+    const merges = await db
+      .selectFrom("entity_merges")
+      .select(["id"])
+      .where("group_id", "=", groupId)
+      .where("unmerged_at", "is", null)
+      .orderBy("merged_at", "desc")
+      .orderBy("id", "desc")
+      .execute();
+    if (merges.length === 0) {
+      return c.json({ error: { code: "MERGE_NOT_FOUND", message: "active merge group not found" } }, 404);
+    }
+
+    try {
+      for (const merge of merges) {
+        await unmergeEntities(db, { mergeId: merge.id, userId: c.get("sub") });
+      }
+      return c.json({ ok: true, reversed: merges.length });
     } catch (err) {
       return handleMergeError(c, err);
     }

--- a/packages/server/src/api/graph-passes.ts
+++ b/packages/server/src/api/graph-passes.ts
@@ -4,6 +4,7 @@ import type { Logger } from "pino";
 import { getPostSyncCoordinator } from "../connectors/post-sync-coordinator";
 import { type GraphPassRun, createGraphPassRunRepository } from "../db/repositories/graph-pass-runs";
 import type { DB } from "../db/schema";
+import { runDuplicateDrain } from "../entities/duplicate-drain";
 import { runQueuePasses } from "../entities/queue-run";
 
 function requireAdmin(c: Context) {
@@ -85,6 +86,22 @@ export function graphPassRoutes(db: Kysely<DB>, logger: Logger) {
 
     const run = await runs.get(runId);
     return c.json({ run: run ? serializeRun(run) : null }, 201);
+  });
+
+  routes.post("/duplicate-drain-runs", async (c) => {
+    const forbidden = requireAdmin(c);
+    if (forbidden) return c.json(forbidden, 403);
+
+    try {
+      const snapshot = await runDuplicateDrain(db, { logger });
+      const run = await runs.get("duplicate-drain:v1");
+      logger.info(snapshot, "Duplicate drain graph pass complete");
+      return c.json({ run: run ? serializeRun(run) : null }, 201);
+    } catch (err) {
+      logger.error({ err }, "Duplicate drain graph pass failed");
+      const run = await runs.get("duplicate-drain:v1");
+      return c.json({ run: run ? serializeRun(run) : null }, 500);
+    }
   });
 
   routes.get("/runs", async (c) => {

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -60,6 +60,7 @@ import { createWhatsAppInboundEventsRepository } from "./db/repositories/whatsap
 import { createWhatsAppProviderEventRepository } from "./db/repositories/whatsapp-provider-events";
 import { createWhatsAppTemplateMappingRepository } from "./db/repositories/whatsapp-template-mappings";
 import type { DB } from "./db/schema";
+import { startDuplicateDrain } from "./entities/duplicate-drain";
 import { configureMaterializeDefaults } from "./entities/materialize";
 import { startNormalizationBackfill } from "./entities/normalization-backfill";
 import { isPersonalOrSharedDomain } from "./entities/personal-domains";
@@ -878,6 +879,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   // for pre-migration rows in the background; readers stay on the legacy path
   // until it completes, so this must not block startup readiness.
   const normalizationBackfill = backgroundWork ? startNormalizationBackfill(db, logger) : null;
+  const duplicateDrain = backgroundWork ? startDuplicateDrain(db, logger) : null;
   const whatsappWindowKeepAliveJob =
     backgroundWork && config.WHATSAPP_WINDOW_KEEPALIVE_ENABLED
       ? startWhatsAppWindowKeepAliveJob({
@@ -1262,6 +1264,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     }
     whatsappInboundRetention?.stop();
     normalizationBackfill?.stop();
+    duplicateDrain?.stop();
     await managedMemberReconciliationPromise?.catch(() => undefined);
     await telemetry.shutdown();
     await syncScheduler?.stop();

--- a/packages/server/src/connectors/post-sync.ts
+++ b/packages/server/src/connectors/post-sync.ts
@@ -4,6 +4,7 @@ import { createTaskRepository } from "../db/repositories/tasks";
 import { reconcileWorkCycles } from "../db/repositories/work-cycles";
 import type { DB } from "../db/schema";
 import { sweepCoMentionContributesTo } from "../entities/co-mention-sweep";
+import { runDuplicateDrain } from "../entities/duplicate-drain";
 import { materializeUnmaterializedFacts } from "../entities/materialize";
 import { reconcileStructuralAssigneeContributesTo } from "../entities/structural-assignee";
 import { floorRetryForDomains } from "./engagement-floor";
@@ -134,6 +135,10 @@ export async function runPostSyncGraphPipeline({
       domainSweep.promotedDomains,
       { maxFilesPerDomain: floorRetryMaxFilesPerDomain },
     );
+  }
+  const duplicateDrain = await runDuplicateDrain(db, { logger: syncLogger.child({ component: "duplicate-drain" }) });
+  if (duplicateDrain.merged > 0 || duplicateDrain.aliasOnlyQueued > 0) {
+    syncLogger.info({ duplicateDrain }, "Post-sync duplicate drain complete");
   }
 
   await sweepCoMentionContributesTo(db, syncLogger.child({ component: "co-mention-sweep" }), {

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -185,6 +185,7 @@ import * as m182 from "./migrations/182-project-minting-states";
 import * as m183 from "./migrations/183-graph-pass-runs";
 import * as m184 from "./migrations/184-person-contact-point-cutover";
 import * as m185 from "./migrations/185-queue-pass-reason";
+import * as m186 from "./migrations/186-entity-merge-groups";
 import type { DB } from "./schema";
 
 /**
@@ -379,6 +380,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "183-graph-pass-runs": m183,
           "184-person-contact-point-cutover": m184,
           "185-queue-pass-reason": m185,
+          "186-entity-merge-groups": m186,
         };
       },
     },

--- a/packages/server/src/db/migrations/186-entity-merge-groups.ts
+++ b/packages/server/src/db/migrations/186-entity-merge-groups.ts
@@ -1,0 +1,127 @@
+import { type Kysely, sql } from "kysely";
+import { isPg } from "../dialect";
+
+const ENTITY_MERGE_COLUMNS = [
+  "id",
+  "survivor_entity_id",
+  "merged_entity_id",
+  "entity_type",
+  "moves",
+  "merged_by_user_id",
+  "merged_at",
+  "unmerged_at",
+  "unmerged_by_user_id",
+  "group_id",
+  "merged_by",
+] as const;
+
+async function hasColumn(db: Kysely<unknown>, tableName: string, columnName: string): Promise<boolean> {
+  const tables = await db.introspection.getTables();
+  return tables.some((table) => table.name === tableName && table.columns.some((column) => column.name === columnName));
+}
+
+async function createLedgerIndexes(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE INDEX IF NOT EXISTS entity_merges_survivor_idx ON entity_merges(survivor_entity_id)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS entity_merges_merged_idx ON entity_merges(merged_entity_id)`.execute(db);
+}
+
+async function createIndexes(db: Kysely<unknown>): Promise<void> {
+  await createLedgerIndexes(db);
+  await sql`CREATE INDEX IF NOT EXISTS entity_merges_group_idx ON entity_merges(group_id)`.execute(db);
+}
+
+async function rebuildSqlite(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS entity_merges_171_old`.execute(db);
+  await sql`DROP INDEX IF EXISTS entity_merges_survivor_idx`.execute(db);
+  await sql`DROP INDEX IF EXISTS entity_merges_merged_idx`.execute(db);
+  await sql`DROP INDEX IF EXISTS entity_merges_group_idx`.execute(db);
+
+  const hasGroupId = await hasColumn(db, "entity_merges", "group_id");
+  const hasMergedBy = await hasColumn(db, "entity_merges", "merged_by");
+  await sql`ALTER TABLE entity_merges RENAME TO entity_merges_171_old`.execute(db);
+  await db.schema
+    .createTable("entity_merges")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("survivor_entity_id", "text", (col) => col.notNull().references("entities.id").onDelete("restrict"))
+    .addColumn("merged_entity_id", "text", (col) => col.notNull().references("entities.id").onDelete("restrict"))
+    .addColumn("entity_type", "text", (col) => col.notNull())
+    .addColumn("moves", "text", (col) => col.notNull())
+    .addColumn("merged_by_user_id", "text", (col) => col.references("users.id").onDelete("restrict"))
+    .addColumn("merged_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("unmerged_at", "text")
+    .addColumn("unmerged_by_user_id", "text", (col) => col.references("users.id").onDelete("restrict"))
+    .addColumn("group_id", "text")
+    .addColumn("merged_by", "text")
+    .execute();
+
+  const columnList = sql.raw(ENTITY_MERGE_COLUMNS.join(", "));
+  const groupIdSelect = hasGroupId ? sql.raw("group_id") : sql`NULL`;
+  const mergedBySelect = hasMergedBy ? sql.raw("merged_by") : sql`NULL`;
+  await sql`INSERT INTO entity_merges (${columnList})
+    SELECT id, survivor_entity_id, merged_entity_id, entity_type, moves, merged_by_user_id, merged_at,
+      unmerged_at, unmerged_by_user_id, ${groupIdSelect}, ${mergedBySelect}
+    FROM entity_merges_171_old`.execute(db);
+
+  await sql`DROP TABLE IF EXISTS entity_merges_171_old`.execute(db);
+  await createIndexes(db);
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (isPg(db)) {
+    await db.schema.alterTable("entity_merges").addColumn("group_id", "text").execute();
+    await db.schema.alterTable("entity_merges").addColumn("merged_by", "text").execute();
+    await sql`ALTER TABLE entity_merges ALTER COLUMN merged_by_user_id DROP NOT NULL`.execute(db);
+    await createIndexes(db);
+    return;
+  }
+
+  await rebuildSqlite(db);
+}
+
+/**
+ * Restoring `merged_by_user_id NOT NULL` discards every machine-authored merge —
+ * the correction pass writes them with a null user by design, so there is no value
+ * to keep them under. `unmergeEntities` reads the ledger to reverse a merge, so a
+ * down migration also gives up the ability to reverse those merges. Reverse them
+ * through `DELETE /api/entities/merges/groups/:groupId` first if that matters.
+ *
+ * The SQLite branch rebuilds without `group_id`, so it recreates only the two
+ * ledger indexes. Calling `createIndexes` here would try to index a column that
+ * no longer exists and the migration would throw.
+ */
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS entity_merges_group_idx`.execute(db);
+  if (isPg(db)) {
+    await sql`ALTER TABLE entity_merges ALTER COLUMN merged_by_user_id SET NOT NULL`.execute(db);
+    await db.schema.alterTable("entity_merges").dropColumn("merged_by").execute();
+    await db.schema.alterTable("entity_merges").dropColumn("group_id").execute();
+    return;
+  }
+
+  await sql`DROP TABLE IF EXISTS entity_merges_171_old`.execute(db);
+  await sql`DROP INDEX IF EXISTS entity_merges_survivor_idx`.execute(db);
+  await sql`DROP INDEX IF EXISTS entity_merges_merged_idx`.execute(db);
+  await sql`ALTER TABLE entity_merges RENAME TO entity_merges_171_old`.execute(db);
+  await db.schema
+    .createTable("entity_merges")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("survivor_entity_id", "text", (col) => col.notNull().references("entities.id").onDelete("restrict"))
+    .addColumn("merged_entity_id", "text", (col) => col.notNull().references("entities.id").onDelete("restrict"))
+    .addColumn("entity_type", "text", (col) => col.notNull())
+    .addColumn("moves", "text", (col) => col.notNull())
+    .addColumn("merged_by_user_id", "text", (col) => col.notNull().references("users.id").onDelete("restrict"))
+    .addColumn("merged_at", "text", (col) => col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`))
+    .addColumn("unmerged_at", "text")
+    .addColumn("unmerged_by_user_id", "text", (col) => col.references("users.id").onDelete("restrict"))
+    .execute();
+  await sql`INSERT INTO entity_merges (
+      id, survivor_entity_id, merged_entity_id, entity_type, moves, merged_by_user_id, merged_at,
+      unmerged_at, unmerged_by_user_id
+    )
+    SELECT id, survivor_entity_id, merged_entity_id, entity_type, moves, merged_by_user_id, merged_at,
+      unmerged_at, unmerged_by_user_id
+    FROM entity_merges_171_old
+    WHERE merged_by_user_id IS NOT NULL`.execute(db);
+  await sql`DROP TABLE IF EXISTS entity_merges_171_old`.execute(db);
+  await createLedgerIndexes(db);
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -23,7 +23,7 @@ import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as slackFileAccessBackfillCleanupMigration from "./163-slack-file-access-backfill-cleanup";
 import * as typedAccessPrincipalsMigration from "./165-typed-access-principals";
 
-const EXPECTED_MIGRATION_COUNT = 181;
+const EXPECTED_MIGRATION_COUNT = 182;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;
@@ -981,7 +981,9 @@ describe("runMigrations on Postgres — full sequence", () => {
         expect.objectContaining({ column_name: "merged_entity_id", data_type: "text", is_nullable: "NO" }),
         expect.objectContaining({ column_name: "entity_type", data_type: "text", is_nullable: "NO" }),
         expect.objectContaining({ column_name: "moves", data_type: "text", is_nullable: "NO" }),
-        expect.objectContaining({ column_name: "merged_by_user_id", data_type: "text", is_nullable: "NO" }),
+        expect.objectContaining({ column_name: "merged_by_user_id", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "group_id", data_type: "text", is_nullable: "YES" }),
+        expect.objectContaining({ column_name: "merged_by", data_type: "text", is_nullable: "YES" }),
         expect.objectContaining({ column_name: "merged_at", data_type: "text", is_nullable: "NO" }),
         expect.objectContaining({ column_name: "unmerged_at", data_type: "text", is_nullable: "YES" }),
         expect.objectContaining({ column_name: "unmerged_by_user_id", data_type: "text", is_nullable: "YES" }),
@@ -1047,7 +1049,7 @@ describe("runMigrations on Postgres — full sequence", () => {
         AND tablename = 'entity_merges'
     `.execute(db);
     expect(indexes.rows.map((row) => row.indexname)).toEqual(
-      expect.arrayContaining(["entity_merges_survivor_idx", "entity_merges_merged_idx"]),
+      expect.arrayContaining(["entity_merges_survivor_idx", "entity_merges_merged_idx", "entity_merges_group_idx"]),
     );
   });
 

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -27,8 +27,9 @@ import * as combinedDurabilityReseedMigration from "./152-reseed-combined-durabi
 import * as slackEntityLifecycleMigration from "./160-slack-entity-lifecycle-sync";
 import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as outlookCalendarProviderFileScopeMigration from "./164-outlook-calendar-provider-file-scope";
+import * as entityMergeGroupsMigration from "./186-entity-merge-groups";
 
-const EXPECTED_MIGRATION_COUNT = 181;
+const EXPECTED_MIGRATION_COUNT = 182;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -1191,7 +1192,9 @@ describe("runMigrations — full sequence", () => {
         expect.objectContaining({ name: "merged_entity_id", type: "TEXT", notnull: 1 }),
         expect.objectContaining({ name: "entity_type", type: "TEXT", notnull: 1 }),
         expect.objectContaining({ name: "moves", type: "TEXT", notnull: 1 }),
-        expect.objectContaining({ name: "merged_by_user_id", type: "TEXT", notnull: 1 }),
+        expect.objectContaining({ name: "merged_by_user_id", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "group_id", type: "TEXT", notnull: 0 }),
+        expect.objectContaining({ name: "merged_by", type: "TEXT", notnull: 0 }),
         expect.objectContaining({ name: "merged_at", type: "TEXT", notnull: 1, dflt_value: "CURRENT_TIMESTAMP" }),
         expect.objectContaining({ name: "unmerged_at", type: "TEXT", notnull: 0 }),
         expect.objectContaining({ name: "unmerged_by_user_id", type: "TEXT", notnull: 0 }),
@@ -1215,8 +1218,26 @@ describe("runMigrations — full sequence", () => {
 
     const indexes = await sql<{ name: string }>`PRAGMA index_list(entity_merges)`.execute(db);
     expect(indexes.rows.map((row) => row.name)).toEqual(
-      expect.arrayContaining(["entity_merges_survivor_idx", "entity_merges_merged_idx"]),
+      expect.arrayContaining(["entity_merges_survivor_idx", "entity_merges_merged_idx", "entity_merges_group_idx"]),
     );
+  });
+
+  it("migration 171 down restores the NOT NULL ledger without indexing a dropped column", async () => {
+    await runMigrations(db, { quiet: true });
+
+    await entityMergeGroupsMigration.down(db as unknown as Kysely<unknown>);
+
+    const columns = await sql<{ name: string; notnull: number }>`PRAGMA table_info(entity_merges)`.execute(db);
+    expect(columns.rows.map((row) => row.name)).not.toContain("group_id");
+    expect(columns.rows.map((row) => row.name)).not.toContain("merged_by");
+    expect(columns.rows).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "merged_by_user_id", notnull: 1 })]),
+    );
+
+    const indexes = await sql<{ name: string }>`PRAGMA index_list(entity_merges)`.execute(db);
+    const names = indexes.rows.map((row) => row.name);
+    expect(names).toEqual(expect.arrayContaining(["entity_merges_survivor_idx", "entity_merges_merged_idx"]));
+    expect(names).not.toContain("entity_merges_group_idx");
   });
 
   it("creates the users table", async () => {

--- a/packages/server/src/db/repositories/graph-pass-runs.ts
+++ b/packages/server/src/db/repositories/graph-pass-runs.ts
@@ -21,7 +21,22 @@ export type QueueRunSnapshot = {
   candidatesCleared: number;
 };
 
-export type GraphPassRunSnapshot = PostSyncRunSnapshot | QueueRunSnapshot;
+export type DuplicateDrainRunSnapshot = {
+  kind: "duplicate_drain";
+  passId: "duplicate-drain";
+  version: 1;
+  status: "running" | "complete";
+  cursorCreatedAt: string | null;
+  cursorId: string | null;
+  scannedEntities: number;
+  merged: number;
+  groupIds: string[];
+  m5SkippedPassReason: number;
+  m3EmailVetoes: number;
+  aliasOnlyQueued: number;
+};
+
+export type GraphPassRunSnapshot = PostSyncRunSnapshot | QueueRunSnapshot | DuplicateDrainRunSnapshot;
 
 export interface GraphPassRun {
   id: string;
@@ -64,6 +79,24 @@ function parseSnapshot(value: unknown): GraphPassRunSnapshot {
       candidatesCleared: readNumber(parsed.candidatesCleared),
     };
   }
+  if (parsed?.kind === "duplicate_drain") {
+    return {
+      kind: "duplicate_drain",
+      passId: "duplicate-drain",
+      version: 1,
+      status: parsed.status === "complete" ? "complete" : "running",
+      cursorCreatedAt: typeof parsed.cursorCreatedAt === "string" ? parsed.cursorCreatedAt : null,
+      cursorId: typeof parsed.cursorId === "string" ? parsed.cursorId : null,
+      scannedEntities: readNumber(parsed.scannedEntities),
+      merged: readNumber(parsed.merged),
+      groupIds: Array.isArray(parsed.groupIds)
+        ? (parsed.groupIds as string[]).filter((id) => typeof id === "string")
+        : [],
+      m5SkippedPassReason: readNumber(parsed.m5SkippedPassReason),
+      m3EmailVetoes: readNumber(parsed.m3EmailVetoes),
+      aliasOnlyQueued: readNumber(parsed.aliasOnlyQueued),
+    };
+  }
   return {
     kind: "post_sync",
     affectedIndexedFileIds: Array.isArray(parsed?.affectedIndexedFileIds)
@@ -85,6 +118,10 @@ function mapRun(row: GraphPassRunRow): GraphPassRun {
     errorMessage: row.error_message,
     inputSnapshot: parseSnapshot(row.input_snapshot_json),
   };
+}
+
+function isPostSyncRun(row: GraphPassRunRow): boolean {
+  return parseSnapshot(row.input_snapshot_json).kind === "post_sync";
 }
 
 export function createGraphPassRunRepository(db: Kysely<DB>) {
@@ -150,13 +187,14 @@ export function createGraphPassRunRepository(db: Kysely<DB>) {
     },
 
     async getRunning(): Promise<GraphPassRun | null> {
-      const row = await db
+      const rows = await db
         .selectFrom("graph_pass_runs")
         .selectAll()
         .where("status", "=", "running")
         .orderBy("started_at", "desc")
         .orderBy("id", "desc")
-        .executeTakeFirst();
+        .execute();
+      const row = rows.find(isPostSyncRun);
       return row ? mapRun(row) : null;
     },
 
@@ -166,9 +204,9 @@ export function createGraphPassRunRepository(db: Kysely<DB>) {
         .selectAll()
         .orderBy("started_at", "desc")
         .orderBy("id", "desc")
-        .limit(limit)
+        .limit(Math.max(limit * 2, limit))
         .execute();
-      return rows.map(mapRun);
+      return rows.filter(isPostSyncRun).slice(0, limit).map(mapRun);
     },
 
     async listUnfinished(): Promise<GraphPassRun[]> {
@@ -179,7 +217,7 @@ export function createGraphPassRunRepository(db: Kysely<DB>) {
         .orderBy("started_at", "asc")
         .orderBy("id", "asc")
         .execute();
-      return rows.map(mapRun);
+      return rows.filter(isPostSyncRun).map(mapRun);
     },
 
     /**

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1090,7 +1090,9 @@ export interface EntityMergesTable {
   merged_entity_id: string;
   entity_type: string;
   moves: string;
-  merged_by_user_id: string;
+  merged_by_user_id: string | null;
+  group_id: string | null;
+  merged_by: string | null;
   merged_at: Generated<string>;
   unmerged_at: string | null;
   unmerged_by_user_id: string | null;

--- a/packages/server/src/entities/company-dedup-groups.ts
+++ b/packages/server/src/entities/company-dedup-groups.ts
@@ -130,8 +130,11 @@ function collectEdges(members: CompanyDedupMember[]): CompanyDedupEdge[] {
  * including singletons, so callers can use it as a complete partition of the
  * input. Members and groups are ordered deterministically.
  */
-export function buildCompanyDedupGroups(members: CompanyDedupMember[]): CompanyDedupGroup[] {
-  const edges = collectEdges(members);
+export function buildCompanyDedupGroups(
+  members: CompanyDedupMember[],
+  allowedEdgeKinds?: ReadonlySet<CompanyDedupEdgeKind>,
+): CompanyDedupGroup[] {
+  const edges = collectEdges(members).filter((edge) => !allowedEdgeKinds || allowedEdgeKinds.has(edge.kind));
   const uf = createUnionFind(members.map((member) => member.entityId));
   for (const edge of edges) {
     for (let i = 1; i < edge.entityIds.length; i += 1) uf.union(edge.entityIds[0], edge.entityIds[i]);

--- a/packages/server/src/entities/duplicate-drain.integration.test.ts
+++ b/packages/server/src/entities/duplicate-drain.integration.test.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+import { hashPassword } from "../auth/password";
+import { createSettingsRepository } from "../db/repositories/settings";
+import { createUserRepository } from "../db/repositories/users";
+import type { DB } from "../db/schema";
+import { createApp } from "../http";
+import { createTestConfig, createTestLogger, createTestPgDb } from "../test-utils";
+import { duplicateDrainActor, duplicateDrainStateRowId } from "./duplicate-drain";
+import { parseAliasesString } from "./materialize-json";
+
+const ADMIN_EMAIL = "admin@test.com";
+const PASSWORD = "testpassword123";
+
+type Harness = {
+  db: Kysely<DB>;
+  app: ReturnType<typeof createApp>;
+  cookie: string;
+  ownerId: string;
+};
+
+async function createHarness(): Promise<Harness> {
+  const db = await createTestPgDb();
+  const settings = createSettingsRepository(db);
+  const users = createUserRepository(db);
+  await settings.create();
+  await users.create({
+    name: "admin",
+    email: ADMIN_EMAIL,
+    emailVerified: true,
+    passwordHash: await hashPassword(PASSWORD),
+    authRole: "admin",
+    skipEntityLinking: true,
+  });
+  await settings.update({ onboardingCompletedAt: new Date().toISOString() });
+  const admin = await users.findByEmail(ADMIN_EMAIL);
+  if (!admin) throw new Error("admin missing");
+
+  const app = createApp(db, createTestConfig({ DB_TYPE: "postgres" }), { logger: createTestLogger() });
+  const login = await app.request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: PASSWORD }),
+  });
+  expect(login.status).toBe(200);
+  return { db, app, cookie: login.headers.get("set-cookie") ?? "", ownerId: admin.id };
+}
+
+async function triggerDuplicateDrain(h: Harness) {
+  const res = await h.app.request("/api/graph-passes/duplicate-drain-runs", {
+    method: "POST",
+    headers: { Cookie: h.cookie },
+  });
+  expect(res.status).toBe(201);
+  return (await res.json()) as { run: { status: string; inputSnapshot: Record<string, unknown> } | null };
+}
+
+async function seedEntity(
+  db: Kysely<DB>,
+  id: string,
+  params: {
+    name: string;
+    type?: string;
+    createdAt?: string;
+    email?: string;
+    aliases?: string[];
+  },
+): Promise<string> {
+  const now = params.createdAt ?? new Date().toISOString();
+  await db
+    .insertInto("entities")
+    .values({
+      id,
+      name: params.name,
+      source_type: params.type ?? "person",
+      status: "active",
+      hotness: 0,
+      created_at: now,
+      updated_at: now,
+      metadata: params.email ? JSON.stringify({ email: params.email }) : null,
+      aliases: params.aliases ? JSON.stringify(params.aliases) : null,
+    })
+    .execute();
+  return id;
+}
+
+async function seedSourceRef(db: Kysely<DB>, entityId: string, sourceId: string): Promise<void> {
+  await db
+    .insertInto("entity_source_refs")
+    .values({
+      id: randomUUID(),
+      entity_id: entityId,
+      source: "test",
+      source_id: sourceId,
+      source_url: null,
+      last_seen_at: "2026-08-13T00:00:00.000Z",
+    })
+    .execute();
+}
+
+async function seedDomain(db: Kysely<DB>, entityId: string, domain: string): Promise<void> {
+  await db
+    .insertInto("entity_domains")
+    .values({
+      id: randomUUID(),
+      entity_id: entityId,
+      domain,
+      kind: "corporate",
+      is_primary: 1,
+      confidence: 1,
+      source: "test",
+    })
+    .execute();
+}
+
+async function seedQueueRow(
+  db: Kysely<DB>,
+  ownerId: string,
+  params: {
+    proposedName: string;
+    type?: string;
+    candidateEntityId: string;
+    status?: string;
+    passReason?: string | null;
+  },
+): Promise<string> {
+  const id = randomUUID();
+  await db
+    .insertInto("entity_review_queue")
+    .values({
+      id,
+      proposed_name: params.proposedName,
+      normalized_name: params.proposedName.trim().toLowerCase(),
+      entity_type: params.type ?? "person",
+      candidate_entity_id: params.candidateEntityId,
+      candidate_score: 1,
+      candidate_reason: "test",
+      candidate_generated_at: "2026-08-13T00:00:00.000Z",
+      status: params.status ?? "pending",
+      pass_reason: params.passReason ?? null,
+      triggered_by_user_id: ownerId,
+    })
+    .execute();
+  return id;
+}
+
+async function liveCount(db: Kysely<DB>, ids: string[]): Promise<number> {
+  const row = await db
+    .selectFrom("entities")
+    .select((eb) => eb.fn.countAll<number>().as("count"))
+    .where("id", "in", ids)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+async function mergeCount(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entity_merges")
+    .select((eb) => eb.fn.countAll<number>().as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
+describe("duplicate drain", () => {
+  let harness: Harness | null = null;
+
+  afterEach(async () => {
+    if (harness) await harness.db.destroy();
+    harness = null;
+  });
+
+  it("never fuses things the graph already knows are different", async () => {
+    harness = await createHarness();
+    const { db, ownerId } = harness;
+
+    await seedEntity(db, "abhishek-moonshot", {
+      name: "Abhishek Sharma",
+      email: "abhinav.sharma@moonshotcom.com",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "abhishek-ow", {
+      name: "Sharma, Abhishek",
+      email: "abhishek.sharma@oliverwyman.com",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    await seedEntity(db, "abhishek-onestop", {
+      name: "Abhishek Sharma",
+      email: "abhishek.sharma@onestop.ai",
+      createdAt: "2026-01-03T00:00:00.000Z",
+    });
+
+    await seedEntity(db, "cecilia-work", {
+      name: "Cecilia Montessoro",
+      email: "cecilia@oliverwyman.com",
+      createdAt: "2026-02-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "cecilia-gmail", {
+      name: "Montessoro, Cecilia",
+      email: "cecilia@gmail.com",
+      createdAt: "2026-02-02T00:00:00.000Z",
+    });
+    const vetoedRow = await seedQueueRow(db, ownerId, {
+      proposedName: "Montessoro, Cecilia",
+      candidateEntityId: "cecilia-work",
+      passReason: "different_emails",
+    });
+
+    await seedEntity(db, "meta", {
+      name: "Meta",
+      type: "company",
+      aliases: ["Facebook"],
+      createdAt: "2026-03-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "facebook", {
+      name: "Facebook",
+      type: "company",
+      createdAt: "2026-03-02T00:00:00.000Z",
+    });
+
+    await triggerDuplicateDrain(harness);
+
+    expect(await liveCount(db, ["abhishek-moonshot", "abhishek-ow", "abhishek-onestop"])).toBe(3);
+    const personMerges = await db.selectFrom("entity_merges").selectAll().where("entity_type", "=", "person").execute();
+    expect(personMerges).toHaveLength(0);
+    const row = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", vetoedRow)
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("pending");
+    expect(row.pass_reason).toBe("different_emails");
+    expect(await liveCount(db, ["meta", "facebook"])).toBe(2);
+    const aliasReview = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("proposed_name", "=", "Facebook")
+      .where("candidate_entity_id", "=", "meta")
+      .executeTakeFirst();
+    expect(aliasReview).toMatchObject({ status: "pending", triggered_by_user_id: "system" });
+  });
+
+  it("collapses known duplicates, renames the survivor reversibly, and a second run applies nothing", async () => {
+    harness = await createHarness();
+    const { db, ownerId } = harness;
+
+    await seedEntity(db, "sugarfit", {
+      name: "Sugarfit",
+      type: "company",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "sugar-fit", {
+      name: "Sugar Fit",
+      type: "company",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    await seedSourceRef(db, "sugarfit", "sugarfit-a");
+    await seedSourceRef(db, "sugar-fit", "sugarfit-b");
+
+    await seedEntity(db, "open-router", {
+      name: "Open Router",
+      type: "product",
+      createdAt: "2026-02-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "openrouter", {
+      name: "OpenRouter",
+      type: "product",
+      createdAt: "2026-02-02T00:00:00.000Z",
+    });
+
+    await seedEntity(db, "ceren-comma", {
+      name: "Gokoglu, Ceren",
+      createdAt: "2026-03-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "ceren-normal", {
+      name: "Ceren Gokoglu",
+      createdAt: "2026-03-02T00:00:00.000Z",
+    });
+
+    await seedEntity(db, "munaf-no-email", {
+      name: "Munaf",
+      createdAt: "2026-04-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "munaf-email", {
+      name: "Munaf",
+      email: "munaf@sugarfit.com",
+      createdAt: "2026-04-02T00:00:00.000Z",
+    });
+
+    await seedEntity(db, "alpha-candidate", {
+      name: "Alpha Tool",
+      type: "tool",
+      createdAt: "2026-05-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "alpha-proposal", {
+      name: "Tool Alpha",
+      type: "tool",
+      createdAt: "2026-05-02T00:00:00.000Z",
+    });
+    const m5Row = await seedQueueRow(db, ownerId, {
+      proposedName: "Tool Alpha",
+      type: "tool",
+      candidateEntityId: "alpha-candidate",
+    });
+
+    await triggerDuplicateDrain(harness);
+
+    expect(await liveCount(db, ["sugarfit", "sugar-fit"])).toBe(1);
+    const sugar = await db.selectFrom("entities").selectAll().where("id", "=", "sugarfit").executeTakeFirstOrThrow();
+    expect(sugar.name).toBe("Sugar Fit");
+    expect(parseAliasesString(sugar.aliases)).toContain("Sugarfit");
+    const refs = await db
+      .selectFrom("entity_source_refs")
+      .select("entity_id")
+      .where("entity_id", "=", "sugarfit")
+      .execute();
+    expect(refs).toHaveLength(2);
+    expect(await liveCount(db, ["open-router", "openrouter"])).toBe(1);
+    expect(await liveCount(db, ["ceren-comma", "ceren-normal"])).toBe(1);
+    expect(await liveCount(db, ["munaf-no-email", "munaf-email"])).toBe(1);
+    expect(await liveCount(db, ["alpha-candidate", "alpha-proposal"])).toBe(1);
+    const resolved = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", m5Row)
+      .executeTakeFirstOrThrow();
+    expect(resolved).toMatchObject({ status: "confirmed", resolved_by: duplicateDrainActor });
+    expect(await mergeCount(db)).toBe(5);
+
+    await triggerDuplicateDrain(harness);
+
+    expect(await mergeCount(db)).toBe(5);
+    const state = await db
+      .selectFrom("graph_pass_runs")
+      .select(["status", "input_snapshot_json"])
+      .where("id", "=", duplicateDrainStateRowId)
+      .executeTakeFirstOrThrow();
+    expect(state.status).toBe("complete");
+    expect(JSON.parse(state.input_snapshot_json)).toMatchObject({
+      kind: "duplicate_drain",
+      version: 1,
+      status: "complete",
+    });
+  });
+
+  it("reverses a chained group as a set without touching another group", async () => {
+    harness = await createHarness();
+    const { db, app, cookie } = harness;
+
+    await seedEntity(db, "a", {
+      name: "Alpha Tool",
+      type: "product",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "b", {
+      name: "AlphaTool",
+      type: "product",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    await triggerDuplicateDrain(harness);
+
+    const firstMerge = await db
+      .selectFrom("entity_merges")
+      .selectAll()
+      .where("merged_entity_id", "=", "b")
+      .executeTakeFirstOrThrow();
+    await seedEntity(db, "c", {
+      name: "Container",
+      type: "product",
+      createdAt: "2026-02-01T00:00:00.000Z",
+    });
+    const chain = await app.request("/api/entities/merges", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ survivorId: "c", loserId: "a", groupId: firstMerge.group_id }),
+    });
+    expect(chain.status).toBe(200);
+
+    await seedEntity(db, "d", {
+      name: "Other A",
+      type: "product",
+      createdAt: "2026-03-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "e", {
+      name: "Other B",
+      type: "product",
+      createdAt: "2026-03-02T00:00:00.000Z",
+    });
+    const other = await app.request("/api/entities/merges", {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ survivorId: "e", loserId: "d", groupId: "untouched-group" }),
+    });
+    expect(other.status).toBe(200);
+
+    const reversed = await app.request(`/api/entities/merges/groups/${firstMerge.group_id}`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+    expect(reversed.status).toBe(200);
+
+    expect(await liveCount(db, ["a", "b", "c"])).toBe(3);
+    const restoredA = await db.selectFrom("entities").selectAll().where("id", "=", "a").executeTakeFirstOrThrow();
+    expect(restoredA.name).toBe("Alpha Tool");
+    expect(parseAliasesString(restoredA.aliases)).toEqual([]);
+    const stillMerged = await db.selectFrom("entities").selectAll().where("id", "=", "d").executeTakeFirstOrThrow();
+    expect(stillMerged.deleted_at).not.toBeNull();
+    expect(stillMerged.merged_into_entity_id).toBe("e");
+  });
+});

--- a/packages/server/src/entities/duplicate-drain.ts
+++ b/packages/server/src/entities/duplicate-drain.ts
@@ -1,0 +1,498 @@
+import type { Kysely, Selectable } from "kysely";
+import type { Logger } from "pino";
+import { normalizeName } from "../connectors/name-normalize";
+import { createEntityReviewRepo } from "../db/repositories/entity-review";
+import type { DuplicateDrainRunSnapshot } from "../db/repositories/graph-pass-runs";
+import type { DB, EntitiesTable, EntityReviewQueueTable } from "../db/schema";
+import { yieldToEventLoop } from "../lib/event-loop";
+import {
+  type CompanyDedupGroup,
+  buildCompanyDedupGroups,
+  chooseCanonicalCompany,
+  loadCompanyDedupMembers,
+} from "./company-dedup-groups";
+import { compactEntityNameKey } from "./match-normalize";
+import { parseAliasesString, readPersonEmailFromMetadata } from "./materialize-json";
+import { withMaterializeReplayQueue } from "./materialize-replay";
+import { mergeEntities } from "./merge";
+import { normalizeStrict, normalizeTokenSet } from "./name-dedup";
+
+const PASS_ID = "duplicate-drain";
+const PASS_VERSION = 1;
+const STATE_ROW_ID = `${PASS_ID}:v${PASS_VERSION}`;
+const ACTOR = `correction:${PASS_ID}@${PASS_VERSION}`;
+const DEFAULT_PAGE_SIZE = 250;
+const HARD_COMPANY_EDGES = new Set(["domain", "name"] as const);
+
+type Entity = Selectable<EntitiesTable>;
+type QueueRow = Selectable<EntityReviewQueueTable>;
+
+export interface DuplicateDrainOptions {
+  logger?: Logger;
+  pageSize?: number;
+  shouldStop?: () => boolean;
+}
+
+export interface DuplicateDrainHandle {
+  done: Promise<void>;
+  stop: () => void;
+}
+
+export type DuplicateDrainSummary = DuplicateDrainRunSnapshot;
+
+function emptySummary(status: "running" | "complete" = "running"): DuplicateDrainSummary {
+  return {
+    kind: "duplicate_drain",
+    passId: PASS_ID,
+    version: PASS_VERSION,
+    status,
+    cursorCreatedAt: null,
+    cursorId: null,
+    scannedEntities: 0,
+    merged: 0,
+    groupIds: [],
+    m5SkippedPassReason: 0,
+    m3EmailVetoes: 0,
+    aliasOnlyQueued: 0,
+  };
+}
+
+function parseSummary(raw: string): DuplicateDrainSummary {
+  try {
+    const parsed = JSON.parse(raw) as Partial<DuplicateDrainSummary>;
+    if (parsed.kind !== "duplicate_drain" || parsed.version !== PASS_VERSION) return emptySummary();
+    return {
+      ...emptySummary(parsed.status === "complete" ? "complete" : "running"),
+      cursorCreatedAt: typeof parsed.cursorCreatedAt === "string" ? parsed.cursorCreatedAt : null,
+      cursorId: typeof parsed.cursorId === "string" ? parsed.cursorId : null,
+      scannedEntities: typeof parsed.scannedEntities === "number" ? parsed.scannedEntities : 0,
+      merged: typeof parsed.merged === "number" ? parsed.merged : 0,
+      groupIds: Array.isArray(parsed.groupIds) ? parsed.groupIds.filter((id) => typeof id === "string") : [],
+      m5SkippedPassReason: typeof parsed.m5SkippedPassReason === "number" ? parsed.m5SkippedPassReason : 0,
+      m3EmailVetoes: typeof parsed.m3EmailVetoes === "number" ? parsed.m3EmailVetoes : 0,
+      aliasOnlyQueued: typeof parsed.aliasOnlyQueued === "number" ? parsed.aliasOnlyQueued : 0,
+    };
+  } catch {
+    return emptySummary();
+  }
+}
+
+async function writeState(db: Kysely<DB>, summary: DuplicateDrainSummary): Promise<void> {
+  const now = new Date().toISOString();
+  const status = summary.status === "complete" ? "complete" : "running";
+  const row = {
+    id: STATE_ROW_ID,
+    status,
+    started_at: now,
+    finished_at: status === "complete" ? now : null,
+    error_message: null,
+    input_snapshot_json: JSON.stringify(summary),
+  };
+  await db
+    .insertInto("graph_pass_runs")
+    .values(row)
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        status,
+        finished_at: row.finished_at,
+        error_message: null,
+        input_snapshot_json: row.input_snapshot_json,
+      }),
+    )
+    .execute();
+}
+
+async function failState(db: Kysely<DB>, error: unknown): Promise<void> {
+  await db
+    .updateTable("graph_pass_runs")
+    .set({
+      status: "failed",
+      finished_at: new Date().toISOString(),
+      error_message: error instanceof Error ? error.message : "duplicate drain failed",
+    })
+    .where("id", "=", STATE_ROW_ID)
+    .execute();
+}
+
+async function readState(db: Kysely<DB>): Promise<DuplicateDrainSummary> {
+  const row = await db
+    .selectFrom("graph_pass_runs")
+    .select(["status", "input_snapshot_json"])
+    .where("id", "=", STATE_ROW_ID)
+    .executeTakeFirst();
+  if (!row) return emptySummary();
+  const summary = parseSummary(row.input_snapshot_json);
+  return row.status === "complete" ? { ...summary, status: "complete" } : summary;
+}
+
+async function loadLiveEntitiesFromCursor(
+  db: Kysely<DB>,
+  cursor: { createdAt: string; id: string },
+  limit: number,
+): Promise<Entity[]> {
+  return db
+    .selectFrom("entities")
+    .selectAll()
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .where((eb) =>
+      eb.or([
+        eb("created_at", ">", cursor.createdAt),
+        eb.and([eb("created_at", "=", cursor.createdAt), eb("id", ">", cursor.id)]),
+      ]),
+    )
+    .orderBy("created_at", "asc")
+    .orderBy("id", "asc")
+    .limit(limit)
+    .execute();
+}
+
+async function loadLiveEntities(
+  db: Kysely<DB>,
+  opts: DuplicateDrainOptions,
+  summary: DuplicateDrainSummary,
+): Promise<Entity[] | null> {
+  const entities: Entity[] = [];
+  let cursor = { createdAt: summary.cursorCreatedAt ?? "", id: summary.cursorId ?? "" };
+  for (;;) {
+    if (opts.shouldStop?.()) {
+      await writeState(db, { ...summary, status: "running" });
+      return null;
+    }
+    const rows = await loadLiveEntitiesFromCursor(db, cursor, opts.pageSize ?? DEFAULT_PAGE_SIZE);
+    if (rows.length === 0) break;
+    entities.push(...rows);
+    const last = rows[rows.length - 1];
+    cursor = { createdAt: last.created_at, id: last.id };
+    summary.cursorCreatedAt = cursor.createdAt;
+    summary.cursorId = cursor.id;
+    summary.scannedEntities += rows.length;
+    await writeState(db, summary);
+    await yieldToEventLoop();
+  }
+  return entities;
+}
+
+function emailsFromEntity(entity: Entity): Set<string> {
+  const emails = new Set<string>();
+  const metadataEmail = readPersonEmailFromMetadata(entity.metadata);
+  if (metadataEmail?.trim()) emails.add(metadataEmail.trim().toLowerCase());
+  for (const alias of parseAliasesString(entity.aliases)) {
+    if (alias.includes("@")) emails.add(alias.trim().toLowerCase());
+  }
+  return emails;
+}
+
+async function loadContactPointEmails(db: Kysely<DB>, entities: Entity[]): Promise<Map<string, Set<string>>> {
+  const byEntity = new Map<string, Set<string>>();
+  for (const entity of entities) byEntity.set(entity.id, emailsFromEntity(entity));
+  const ids = entities.map((entity) => entity.id);
+  if (ids.length === 0) return byEntity;
+  const points = await db
+    .selectFrom("entity_contact_points")
+    .select(["entity_id", "value"])
+    .where("entity_id", "in", ids)
+    .where("kind", "=", "email")
+    .execute();
+  for (const point of points) {
+    const value = point.value.trim().toLowerCase();
+    if (!value) continue;
+    byEntity.get(point.entity_id)?.add(value);
+  }
+  return byEntity;
+}
+
+function disjoint(left: Set<string>, right: Set<string>): boolean {
+  for (const value of left) if (right.has(value)) return false;
+  return true;
+}
+
+function groupEntities(entities: Entity[], keyFor: (entity: Entity) => string): Entity[][] {
+  const groups = new Map<string, Entity[]>();
+  for (const entity of entities) {
+    const key = keyFor(entity);
+    if (!key) continue;
+    const bucket = groups.get(key) ?? [];
+    bucket.push(entity);
+    groups.set(key, bucket);
+  }
+  return [...groups.values()].filter((group) => group.length > 1);
+}
+
+function chooseGenericSurvivor(group: Entity[]): Entity {
+  return [...group].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))[0];
+}
+
+function spacedCompanyName(group: CompanyDedupGroup, survivorName: string): string | undefined {
+  const compact = compactEntityNameKey("company", survivorName);
+  const choices = group.members.filter((member) => compactEntityNameKey("company", member.name) === compact);
+  if (choices.length !== group.members.length) return undefined;
+  return [...choices].sort((a, b) => {
+    const aSpaced = Number(/\s/.test(a.name));
+    const bSpaced = Number(/\s/.test(b.name));
+    if (aSpaced !== bSpaced) return bSpaced - aSpaced;
+    if (a.name.length !== b.name.length) return b.name.length - a.name.length;
+    return a.name.localeCompare(b.name);
+  })[0]?.name;
+}
+
+async function liveEntity(db: Kysely<DB>, id: string): Promise<Entity | undefined> {
+  return db
+    .selectFrom("entities")
+    .selectAll()
+    .where("id", "=", id)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .executeTakeFirst();
+}
+
+async function applyEntityGroup(
+  db: Kysely<DB>,
+  groupId: string,
+  survivorId: string,
+  loserIds: string[],
+  summary: DuplicateDrainSummary,
+  survivorName?: string,
+): Promise<void> {
+  let first = true;
+  let recordedGroup = false;
+  for (const loserId of loserIds) {
+    if (!(await liveEntity(db, survivorId)) || !(await liveEntity(db, loserId))) continue;
+    await mergeEntities(db, {
+      survivorId,
+      loserId,
+      groupId,
+      mergedBy: ACTOR,
+      survivorName: first ? survivorName : undefined,
+    });
+    if (!recordedGroup) {
+      summary.groupIds.push(groupId);
+      recordedGroup = true;
+    }
+    summary.merged++;
+    first = false;
+  }
+}
+
+async function applyCompanyHardGroups(db: Kysely<DB>, summary: DuplicateDrainSummary): Promise<void> {
+  const members = await loadCompanyDedupMembers(db);
+  const groups = buildCompanyDedupGroups(members, HARD_COMPANY_EDGES);
+  for (const group of groups.filter((candidate) => candidate.members.length > 1)) {
+    const survivor = chooseCanonicalCompany(group);
+    const survivorName = spacedCompanyName(group, survivor.name);
+    const losers = group.members
+      .filter((member) => member.entityId !== survivor.entityId)
+      .map((member) => member.entityId);
+    await applyEntityGroup(
+      db,
+      `duplicate-drain:v1:m1:${compactEntityNameKey("company", survivorName ?? survivor.name)}`,
+      survivor.entityId,
+      losers,
+      summary,
+      survivorName,
+    );
+  }
+}
+
+async function queueAliasOnlyCompanyGroups(db: Kysely<DB>, summary: DuplicateDrainSummary): Promise<void> {
+  const members = await loadCompanyDedupMembers(db);
+  const hardGroups = buildCompanyDedupGroups(members, HARD_COMPANY_EDGES).filter((group) => group.members.length > 1);
+  const hardMembers = new Set(hardGroups.flatMap((group) => group.members.map((member) => member.entityId)));
+  const aliasGroups = buildCompanyDedupGroups(members).filter(
+    (group) => group.members.length > 1 && group.edges.some((edge) => edge.kind === "name_alias"),
+  );
+  const repo = createEntityReviewRepo(db);
+  for (const group of aliasGroups) {
+    const aliasOnlyMembers = group.members.filter((member) => !hardMembers.has(member.entityId));
+    if (aliasOnlyMembers.length < 2) continue;
+    const survivor = chooseCanonicalCompany({ ...group, members: aliasOnlyMembers });
+    for (const member of aliasOnlyMembers) {
+      if (member.entityId === survivor.entityId) continue;
+      await repo.upsertQueueRow({
+        proposedName: member.name,
+        normalizedName: normalizeName(member.name),
+        entityType: "company",
+        source: PASS_ID,
+        sourceId: `v1:alias:${member.entityId}:${survivor.entityId}`,
+        candidateEntityId: survivor.entityId,
+        candidateEntityIds: aliasOnlyMembers.map((m) => m.entityId),
+        candidateScore: 1,
+        candidateReason: "name_alias",
+        triggeredByUserId: "system",
+      });
+      summary.aliasOnlyQueued++;
+    }
+  }
+}
+
+async function applyProductGroups(db: Kysely<DB>, entities: Entity[], summary: DuplicateDrainSummary): Promise<void> {
+  for (const group of groupEntities(
+    entities.filter((entity) => entity.source_type === "product"),
+    (entity) => compactEntityNameKey("product", entity.name),
+  )) {
+    const survivor = chooseGenericSurvivor(group);
+    const losers = group.filter((entity) => entity.id !== survivor.id).map((entity) => entity.id);
+    await applyEntityGroup(
+      db,
+      `duplicate-drain:v1:m2:${compactEntityNameKey("product", survivor.name)}`,
+      survivor.id,
+      losers,
+      summary,
+    );
+  }
+}
+
+async function applyPersonTokenSetGroups(
+  db: Kysely<DB>,
+  entities: Entity[],
+  emails: Map<string, Set<string>>,
+  summary: DuplicateDrainSummary,
+): Promise<void> {
+  for (const group of groupEntities(
+    entities.filter((entity) => entity.source_type === "person"),
+    (entity) => normalizeTokenSet(entity.name),
+  )) {
+    const strictKeys = new Set(group.map((entity) => normalizeStrict(entity.name)));
+    if (strictKeys.size < 2) continue;
+    let vetoed = false;
+    for (let i = 0; i < group.length && !vetoed; i += 1) {
+      for (let j = i + 1; j < group.length; j += 1) {
+        const left = emails.get(group[i].id) ?? new Set<string>();
+        const right = emails.get(group[j].id) ?? new Set<string>();
+        if (left.size > 0 && right.size > 0 && disjoint(left, right)) {
+          vetoed = true;
+          summary.m3EmailVetoes++;
+          break;
+        }
+      }
+    }
+    if (vetoed) continue;
+    const survivor = chooseGenericSurvivor(group);
+    const losers = group.filter((entity) => entity.id !== survivor.id).map((entity) => entity.id);
+    await applyEntityGroup(
+      db,
+      `duplicate-drain:v1:m3:${normalizeTokenSet(survivor.name)}`,
+      survivor.id,
+      losers,
+      summary,
+    );
+  }
+}
+
+async function applyPersonStrictGroups(
+  db: Kysely<DB>,
+  entities: Entity[],
+  emails: Map<string, Set<string>>,
+  summary: DuplicateDrainSummary,
+): Promise<void> {
+  for (const group of groupEntities(
+    entities.filter((entity) => entity.source_type === "person"),
+    (entity) => normalizeStrict(entity.name),
+  )) {
+    const withEmail = group.filter((entity) => (emails.get(entity.id)?.size ?? 0) > 0);
+    if (withEmail.length > 1) continue;
+    const survivor = chooseGenericSurvivor(group);
+    const losers = group.filter((entity) => entity.id !== survivor.id).map((entity) => entity.id);
+    await applyEntityGroup(db, `duplicate-drain:v1:m4:${normalizeStrict(survivor.name)}`, survivor.id, losers, summary);
+  }
+}
+
+async function loadM5Rows(db: Kysely<DB>): Promise<{ mergeable: QueueRow[]; skippedPassReason: number }> {
+  const rows = await db
+    .selectFrom("entity_review_queue")
+    .selectAll()
+    .where("status", "=", "pending")
+    .where("candidate_entity_id", "is not", null)
+    .execute();
+  return {
+    mergeable: rows.filter((row) => row.pass_reason === null),
+    skippedPassReason: rows.filter((row) => row.pass_reason !== null).length,
+  };
+}
+
+async function applyM5Rows(db: Kysely<DB>, summary: DuplicateDrainSummary): Promise<void> {
+  const { mergeable, skippedPassReason } = await loadM5Rows(db);
+  summary.m5SkippedPassReason += skippedPassReason;
+  for (const row of mergeable) {
+    if (!row.candidate_entity_id) continue;
+    const candidate = await liveEntity(db, row.candidate_entity_id);
+    const tokenSetKey = normalizeTokenSet(row.proposed_name);
+    if (!candidate || !tokenSetKey || tokenSetKey !== normalizeTokenSet(candidate.name)) continue;
+    const proposal = await db
+      .selectFrom("entities")
+      .selectAll()
+      .where("source_type", "=", row.entity_type)
+      .where("deleted_at", "is", null)
+      .where("merged_into_entity_id", "is", null)
+      .where("id", "!=", candidate.id)
+      .where((eb) => eb(eb.fn("lower", ["name"]), "=", row.proposed_name.trim().toLowerCase()))
+      .orderBy("created_at", "asc")
+      .orderBy("id", "asc")
+      .executeTakeFirst();
+    if (!proposal) continue;
+    const groupId = `duplicate-drain:v1:m5:${row.id}`;
+    await applyEntityGroup(db, groupId, candidate.id, [proposal.id], summary);
+    await db
+      .updateTable("entity_review_queue")
+      .set({
+        status: "confirmed",
+        resolved_by: ACTOR,
+        resolved_at: new Date().toISOString(),
+        resolved_entity_id: candidate.id,
+      })
+      .where("id", "=", row.id)
+      .where("status", "=", "pending")
+      .where("pass_reason", "is", null)
+      .execute();
+  }
+}
+
+export async function runDuplicateDrain(
+  db: Kysely<DB>,
+  opts: DuplicateDrainOptions = {},
+): Promise<DuplicateDrainSummary> {
+  return withMaterializeReplayQueue(async () => {
+    const state = await readState(db);
+    if (state.status === "complete") return state;
+    await writeState(db, state);
+    try {
+      const entities = await loadLiveEntities(db, opts, state);
+      if (!entities) return state;
+      const emails = await loadContactPointEmails(
+        db,
+        entities.filter((entity) => entity.source_type === "person"),
+      );
+      await applyCompanyHardGroups(db, state);
+      await queueAliasOnlyCompanyGroups(db, state);
+      await applyProductGroups(db, entities, state);
+      await applyPersonTokenSetGroups(db, entities, emails, state);
+      await applyPersonStrictGroups(db, entities, emails, state);
+      await applyM5Rows(db, state);
+      const complete = { ...state, status: "complete" as const, cursorCreatedAt: null, cursorId: null };
+      await writeState(db, complete);
+      opts.logger?.info(complete, "duplicate drain complete");
+      return complete;
+    } catch (err) {
+      await failState(db, err);
+      throw err;
+    }
+  });
+}
+
+export function startDuplicateDrain(db: Kysely<DB>, logger?: Logger): DuplicateDrainHandle {
+  let stopped = false;
+  const done = runDuplicateDrain(db, { logger, shouldStop: () => stopped })
+    .then(() => undefined)
+    .catch((err) => {
+      logger?.error({ err }, "duplicate drain failed");
+    });
+  return {
+    done,
+    stop: () => {
+      stopped = true;
+    },
+  };
+}
+
+export const duplicateDrainActor = ACTOR;
+export const duplicateDrainStateRowId = STATE_ROW_ID;

--- a/packages/server/src/entities/materialize-replay.ts
+++ b/packages/server/src/entities/materialize-replay.ts
@@ -344,17 +344,21 @@ export async function replaySourceFacts(
 
 let materializeQueue: Promise<void> = Promise.resolve();
 
-export async function materializeUnmaterializedFacts(
-  db: Kysely<DB>,
-  logger: Logger,
-  opts: MaterializeUnmaterializedOptions = {},
-): Promise<MaterializeFactsSummary> {
-  const run = materializeQueue.then(() => materializeUnmaterializedFactsInner(db, logger, opts));
+export async function withMaterializeReplayQueue<T>(work: () => Promise<T>): Promise<T> {
+  const run = materializeQueue.then(work);
   materializeQueue = run.then(
     () => undefined,
     () => undefined,
   );
   return run;
+}
+
+export async function materializeUnmaterializedFacts(
+  db: Kysely<DB>,
+  logger: Logger,
+  opts: MaterializeUnmaterializedOptions = {},
+): Promise<MaterializeFactsSummary> {
+  return withMaterializeReplayQueue(() => materializeUnmaterializedFactsInner(db, logger, opts));
 }
 
 export async function cleanupRelationshipEvidenceForFacts(db: Kysely<DB>, sourceFactIds: string[]): Promise<number> {

--- a/packages/server/src/entities/merge.ts
+++ b/packages/server/src/entities/merge.ts
@@ -47,7 +47,10 @@ export type EntityMergeMove =
   | {
       table: "entities";
       rowId: string;
-      colChanges: { subtype: { before: string | null; after: string } };
+      colChanges: Partial<{
+        subtype: { before: string | null; after: string | null };
+        name: { before: string | null; after: string | null };
+      }>;
     }
   | { kind: "alias_added"; value: string; normalizedKey: string };
 
@@ -74,12 +77,15 @@ export class EntityMergeError extends Error {
 export interface MergeEntitiesInput {
   survivorId: string;
   loserId: string;
-  userId: string;
+  userId?: string;
+  groupId?: string;
+  mergedBy?: string;
+  survivorName?: string;
 }
 
 export interface UnmergeEntitiesInput {
   mergeId: string;
-  userId: string;
+  userId?: string;
 }
 
 export interface MergeEntitiesResult {
@@ -756,6 +762,55 @@ async function carryLoserAliasesToSurvivor(
     .execute();
 }
 
+async function addAliasIfAbsent(
+  db: Kysely<DB>,
+  entityId: string,
+  aliasesRaw: string | null,
+  value: string,
+  moves: EntityMergeMove[],
+): Promise<string | null> {
+  const trimmed = value.trim();
+  const normalizedKey = normalizeStrict(trimmed);
+  if (!trimmed || !normalizedKey) return aliasesRaw;
+  const aliases = parseAliasesString(aliasesRaw);
+  if (aliases.some((alias) => normalizeStrict(alias) === normalizedKey)) return aliasesRaw;
+  aliases.push(trimmed);
+  moves.push({ kind: "alias_added", value: trimmed, normalizedKey });
+  const next = JSON.stringify(aliases);
+  await db
+    .updateTable("entities")
+    .set({ aliases: next, updated_at: new Date().toISOString() })
+    .where("id", "=", entityId)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .execute();
+  return next;
+}
+
+async function renameSurvivorIfRequested(
+  db: Kysely<DB>,
+  survivor: Entity,
+  input: MergeEntitiesInput,
+  moves: EntityMergeMove[],
+): Promise<Entity> {
+  const name = input.survivorName?.trim();
+  if (!name || name === survivor.name) return survivor;
+  const aliases = await addAliasIfAbsent(db, survivor.id, survivor.aliases, survivor.name, moves);
+  moves.push({
+    table: "entities",
+    rowId: survivor.id,
+    colChanges: { name: { before: survivor.name, after: name } },
+  });
+  await db
+    .updateTable("entities")
+    .set({ name, aliases, updated_at: new Date().toISOString() })
+    .where("id", "=", survivor.id)
+    .where("deleted_at", "is", null)
+    .where("merged_into_entity_id", "is", null)
+    .execute();
+  return { ...survivor, name, aliases };
+}
+
 function emptyMergePreview(
   input: { survivorId: string; loserId: string },
   blocked?: EntityMergeErrorCode,
@@ -902,9 +957,11 @@ async function reverseMove(db: Kysely<DB>, move: EntityMergeMove): Promise<void>
     return;
   }
   if (move.table === "entities" && "colChanges" in move) {
+    const updates: Record<string, string | null> = {};
+    for (const [column, change] of Object.entries(move.colChanges)) updates[column] = change.before;
     await db
       .updateTable("entities")
-      .set({ subtype: move.colChanges.subtype.before })
+      .set({ ...updates, updated_at: new Date().toISOString() })
       .where("id", "=", move.rowId)
       .execute();
     return;
@@ -1052,11 +1109,12 @@ export async function mergeEntitiesInTransaction(
   db: Kysely<DB>,
   input: MergeEntitiesInput,
 ): Promise<MergeEntitiesResult> {
-  const survivor = await fetchRawEntity(db, input.survivorId);
+  let survivor = await fetchRawEntity(db, input.survivorId);
   const loser = await fetchRawEntity(db, input.loserId);
   assertMergeable(survivor, loser, input);
 
   const moves: EntityMergeMove[] = [];
+  if (survivor) survivor = await renameSurvivorIfRequested(db, survivor, input, moves);
   if (survivor?.source_type === "person" && loser?.source_type === "person") {
     const internalSubtype = survivor.subtype === "internal" || loser.subtype === "internal";
     if (internalSubtype && survivor.subtype !== "internal") {
@@ -1103,7 +1161,9 @@ export async function mergeEntitiesInTransaction(
       merged_entity_id: input.loserId,
       entity_type: survivor?.source_type ?? "",
       moves: JSON.stringify(moves),
-      merged_by_user_id: input.userId,
+      merged_by_user_id: input.userId ?? null,
+      group_id: input.groupId ?? null,
+      merged_by: input.mergedBy ?? null,
     })
     .execute();
 


### PR DESCRIPTION
## Summary
- add a resumable deterministic duplicate drain for companies, products, people, and eligible review-queue matches
- protect ambiguous company aliases and conflicting person emails from automatic merges
- group system merges in the ledger and make whole groups reversible in newest-first order
- run the drain at startup and after post-sync domain promotion, with an admin manual-run endpoint

## Stack
- stacked on #506
- contains two commits beyond feat/queue-reconcile
- retarget to main after #506 merges

## Validation
- pnpm biome check .
- pnpm typecheck
- full test suite: 5,618 server tests and 508 web tests passed
- pnpm build