### PR TITLE
fix(entities): queue the alias-only pairs the drain lost, and stop M5 fusing different people

### DIFF
--- a/packages/server/src/api/graph-passes.ts
+++ b/packages/server/src/api/graph-passes.ts
@@ -94,12 +94,12 @@ export function graphPassRoutes(db: Kysely<DB>, logger: Logger) {
 
     try {
       const snapshot = await runDuplicateDrain(db, { logger });
-      const run = await runs.get("duplicate-drain:v1");
+      const run = await runs.get("duplicate-drain:v2");
       logger.info(snapshot, "Duplicate drain graph pass complete");
       return c.json({ run: run ? serializeRun(run) : null }, 201);
     } catch (err) {
       logger.error({ err }, "Duplicate drain graph pass failed");
-      const run = await runs.get("duplicate-drain:v1");
+      const run = await runs.get("duplicate-drain:v2");
       return c.json({ run: run ? serializeRun(run) : null }, 500);
     }
   });

--- a/packages/server/src/db/repositories/graph-pass-runs.ts
+++ b/packages/server/src/db/repositories/graph-pass-runs.ts
@@ -24,7 +24,7 @@ export type QueueRunSnapshot = {
 export type DuplicateDrainRunSnapshot = {
   kind: "duplicate_drain";
   passId: "duplicate-drain";
-  version: 1;
+  version: 2;
   status: "running" | "complete";
   cursorCreatedAt: string | null;
   cursorId: string | null;
@@ -34,6 +34,7 @@ export type DuplicateDrainRunSnapshot = {
   m5SkippedPassReason: number;
   m3EmailVetoes: number;
   aliasOnlyQueued: number;
+  aliasOnlyDropped: number;
 };
 
 export type GraphPassRunSnapshot = PostSyncRunSnapshot | QueueRunSnapshot | DuplicateDrainRunSnapshot;
@@ -83,7 +84,7 @@ function parseSnapshot(value: unknown): GraphPassRunSnapshot {
     return {
       kind: "duplicate_drain",
       passId: "duplicate-drain",
-      version: 1,
+      version: 2,
       status: parsed.status === "complete" ? "complete" : "running",
       cursorCreatedAt: typeof parsed.cursorCreatedAt === "string" ? parsed.cursorCreatedAt : null,
       cursorId: typeof parsed.cursorId === "string" ? parsed.cursorId : null,
@@ -95,6 +96,7 @@ function parseSnapshot(value: unknown): GraphPassRunSnapshot {
       m5SkippedPassReason: readNumber(parsed.m5SkippedPassReason),
       m3EmailVetoes: readNumber(parsed.m3EmailVetoes),
       aliasOnlyQueued: readNumber(parsed.aliasOnlyQueued),
+      aliasOnlyDropped: readNumber(parsed.aliasOnlyDropped),
     };
   }
   return {

--- a/packages/server/src/db/repositories/graph-pass-runs.ts
+++ b/packages/server/src/db/repositories/graph-pass-runs.ts
@@ -33,6 +33,7 @@ export type DuplicateDrainRunSnapshot = {
   groupIds: string[];
   m5SkippedPassReason: number;
   m3EmailVetoes: number;
+  m5EmailVetoes: number;
   aliasOnlyQueued: number;
   aliasOnlyDropped: number;
 };
@@ -95,6 +96,7 @@ function parseSnapshot(value: unknown): GraphPassRunSnapshot {
         : [],
       m5SkippedPassReason: readNumber(parsed.m5SkippedPassReason),
       m3EmailVetoes: readNumber(parsed.m3EmailVetoes),
+      m5EmailVetoes: readNumber(parsed.m5EmailVetoes),
       aliasOnlyQueued: readNumber(parsed.aliasOnlyQueued),
       aliasOnlyDropped: readNumber(parsed.aliasOnlyDropped),
     };

--- a/packages/server/src/entities/duplicate-drain.integration.test.ts
+++ b/packages/server/src/entities/duplicate-drain.integration.test.ts
@@ -511,6 +511,51 @@ describe("duplicate drain", () => {
     expect(duplicateGreenMerge).toHaveLength(1);
   });
 
+  it("keeps M5 people pending when both sides have disjoint emails", async () => {
+    harness = await createHarness();
+    const { db, ownerId } = harness;
+
+    await seedEntity(db, "abhishek-onestop", {
+      name: "Abhishek Sharma",
+      email: "abhishek.sharma@onestop.ai",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    await seedEntity(db, "abhishek-moonshot", {
+      name: "Abhishek Sharma",
+      email: "abhinav.sharma@moonshotcom.com",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    const rowId = await seedQueueRow(db, ownerId, {
+      proposedName: "Abhishek Sharma",
+      candidateEntityId: "abhishek-onestop",
+      passReason: null,
+    });
+
+    const response = await triggerDuplicateDrain(harness);
+
+    expect(await liveCount(db, ["abhishek-onestop", "abhishek-moonshot"])).toBe(2);
+    const entities = await db
+      .selectFrom("entities")
+      .select(["id", "merged_into_entity_id"])
+      .where("id", "in", ["abhishek-onestop", "abhishek-moonshot"])
+      .execute();
+    expect(entities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "abhishek-onestop", merged_into_entity_id: null }),
+        expect.objectContaining({ id: "abhishek-moonshot", merged_into_entity_id: null }),
+      ]),
+    );
+    const row = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("id", "=", rowId)
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("pending");
+    expect(row.pass_reason).toBeNull();
+    expect(row.resolved_entity_id).toBeNull();
+    expect(response.run?.inputSnapshot).toMatchObject({ m5EmailVetoes: 1 });
+  });
+
   it("reverses a chained group as a set without touching another group", async () => {
     harness = await createHarness();
     const { db, app, cookie } = harness;

--- a/packages/server/src/entities/duplicate-drain.integration.test.ts
+++ b/packages/server/src/entities/duplicate-drain.integration.test.ts
@@ -114,6 +114,26 @@ async function seedDomain(db: Kysely<DB>, entityId: string, domain: string): Pro
     .execute();
 }
 
+async function seedRedseerShape(db: Kysely<DB>, params: { consultingDomain?: boolean } = {}): Promise<void> {
+  await seedEntity(db, "red-seer", {
+    name: "Red Seer",
+    type: "company",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+  await seedEntity(db, "redseer", {
+    name: "Redseer",
+    type: "company",
+    createdAt: "2026-01-02T00:00:00.000Z",
+  });
+  await seedEntity(db, "redseerconsulting", {
+    name: "Redseerconsulting",
+    type: "company",
+    aliases: ["RedSeer"],
+    createdAt: "2026-01-03T00:00:00.000Z",
+  });
+  if (params.consultingDomain) await seedDomain(db, "redseerconsulting", "redseerconsulting.com");
+}
+
 async function seedQueueRow(
   db: Kysely<DB>,
   ownerId: string,
@@ -154,6 +174,67 @@ async function liveCount(db: Kysely<DB>, ids: string[]): Promise<number> {
     .where("merged_into_entity_id", "is", null)
     .executeTakeFirstOrThrow();
   return Number(row.count);
+}
+
+async function seedCompletedDuplicateDrainV1(db: Kysely<DB>): Promise<void> {
+  await db
+    .insertInto("graph_pass_runs")
+    .values({
+      id: "duplicate-drain:v1",
+      status: "complete",
+      started_at: "2026-08-13T00:00:00.000Z",
+      finished_at: "2026-08-13T00:00:01.000Z",
+      error_message: null,
+      input_snapshot_json: JSON.stringify({
+        kind: "duplicate_drain",
+        passId: "duplicate-drain",
+        version: 1,
+        status: "complete",
+        cursorCreatedAt: null,
+        cursorId: null,
+        scannedEntities: 3,
+        merged: 1,
+        groupIds: ["duplicate-drain:v1:m1:greenmentor"],
+        m5SkippedPassReason: 0,
+        m3EmailVetoes: 0,
+        aliasOnlyQueued: 0,
+      }),
+    })
+    .execute();
+}
+
+async function seedAlreadyDrainedCompanyPair(db: Kysely<DB>): Promise<void> {
+  await seedEntity(db, "green-mentor", {
+    name: "Green Mentor",
+    type: "company",
+    aliases: ["Greenmentor"],
+    createdAt: "2026-02-01T00:00:00.000Z",
+  });
+  await seedEntity(db, "greenmentor", {
+    name: "Greenmentor",
+    type: "company",
+    createdAt: "2026-02-02T00:00:00.000Z",
+  });
+  await db
+    .updateTable("entities")
+    .set({ deleted_at: "2026-08-13T00:00:01.000Z", merged_into_entity_id: "green-mentor" })
+    .where("id", "=", "greenmentor")
+    .execute();
+  await db
+    .insertInto("entity_merges")
+    .values({
+      id: randomUUID(),
+      survivor_entity_id: "green-mentor",
+      merged_entity_id: "greenmentor",
+      entity_type: "company",
+      moves: "[]",
+      merged_by_user_id: null,
+      group_id: "duplicate-drain:v1:m1:greenmentor",
+      merged_by: "correction:duplicate-drain@1",
+      unmerged_at: null,
+      unmerged_by_user_id: null,
+    })
+    .execute();
 }
 
 async function mergeCount(db: Kysely<DB>): Promise<number> {
@@ -340,9 +421,94 @@ describe("duplicate drain", () => {
     expect(state.status).toBe("complete");
     expect(JSON.parse(state.input_snapshot_json)).toMatchObject({
       kind: "duplicate_drain",
-      version: 1,
+      version: 2,
       status: "complete",
     });
+  });
+
+  it("queues an alias-only company whose partner is merged in the same drain", async () => {
+    harness = await createHarness();
+    const { db } = harness;
+    await seedRedseerShape(db);
+
+    const response = await triggerDuplicateDrain(harness);
+
+    const consulting = await db
+      .selectFrom("entities")
+      .select(["deleted_at", "merged_into_entity_id"])
+      .where("id", "=", "redseerconsulting")
+      .executeTakeFirstOrThrow();
+    expect(consulting.deleted_at).toBeNull();
+    expect(consulting.merged_into_entity_id).toBeNull();
+    expect(await liveCount(db, ["red-seer", "redseer"])).toBe(1);
+    const review = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("proposed_name", "=", "Redseerconsulting")
+      .executeTakeFirstOrThrow();
+    expect(review).toMatchObject({
+      status: "pending",
+      candidate_entity_id: "red-seer",
+      candidate_reason: "name_alias",
+      triggered_by_user_id: "system",
+    });
+    expect(JSON.parse(review.candidate_entity_ids ?? "[]")).toEqual(["redseerconsulting", "red-seer"]);
+    expect(response.run?.inputSnapshot).toMatchObject({ version: 2, aliasOnlyQueued: 1, aliasOnlyDropped: 0 });
+  });
+
+  it("queues the hard-group survivor instead of the full alias group survivor", async () => {
+    harness = await createHarness();
+    const { db } = harness;
+    await seedRedseerShape(db, { consultingDomain: true });
+
+    await triggerDuplicateDrain(harness);
+
+    const review = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("proposed_name", "=", "Redseerconsulting")
+      .executeTakeFirstOrThrow();
+    expect(review.candidate_entity_id).toBe("red-seer");
+    expect(review.candidate_entity_id).not.toBe("redseerconsulting");
+    expect(await liveCount(db, ["red-seer", "redseerconsulting"])).toBe(2);
+  });
+
+  it("runs version 2 after version 1 completed without re-merging already drained pairs", async () => {
+    harness = await createHarness();
+    const { db } = harness;
+    await seedCompletedDuplicateDrainV1(db);
+    await seedAlreadyDrainedCompanyPair(db);
+    await seedRedseerShape(db);
+    const mergesBefore = await mergeCount(db);
+
+    const response = await triggerDuplicateDrain(harness);
+
+    const review = await db
+      .selectFrom("entity_review_queue")
+      .selectAll()
+      .where("proposed_name", "=", "Redseerconsulting")
+      .where("candidate_entity_id", "=", "red-seer")
+      .executeTakeFirst();
+    expect(review).toMatchObject({ status: "pending" });
+    const state = await db
+      .selectFrom("graph_pass_runs")
+      .select(["status", "input_snapshot_json"])
+      .where("id", "=", "duplicate-drain:v2")
+      .executeTakeFirstOrThrow();
+    expect(state.status).toBe("complete");
+    expect(JSON.parse(state.input_snapshot_json)).toMatchObject({
+      kind: "duplicate_drain",
+      version: 2,
+      status: "complete",
+    });
+    expect(response.run?.inputSnapshot).toMatchObject({ version: 2 });
+    expect(await mergeCount(db)).toBe(mergesBefore + 1);
+    const duplicateGreenMerge = await db
+      .selectFrom("entity_merges")
+      .selectAll()
+      .where("merged_entity_id", "=", "greenmentor")
+      .execute();
+    expect(duplicateGreenMerge).toHaveLength(1);
   });
 
   it("reverses a chained group as a set without touching another group", async () => {

--- a/packages/server/src/entities/duplicate-drain.ts
+++ b/packages/server/src/entities/duplicate-drain.ts
@@ -53,6 +53,7 @@ function emptySummary(status: "running" | "complete" = "running"): DuplicateDrai
     groupIds: [],
     m5SkippedPassReason: 0,
     m3EmailVetoes: 0,
+    m5EmailVetoes: 0,
     aliasOnlyQueued: 0,
     aliasOnlyDropped: 0,
   };
@@ -71,6 +72,7 @@ function parseSummary(raw: string): DuplicateDrainSummary {
       groupIds: Array.isArray(parsed.groupIds) ? parsed.groupIds.filter((id) => typeof id === "string") : [],
       m5SkippedPassReason: typeof parsed.m5SkippedPassReason === "number" ? parsed.m5SkippedPassReason : 0,
       m3EmailVetoes: typeof parsed.m3EmailVetoes === "number" ? parsed.m3EmailVetoes : 0,
+      m5EmailVetoes: typeof parsed.m5EmailVetoes === "number" ? parsed.m5EmailVetoes : 0,
       aliasOnlyQueued: typeof parsed.aliasOnlyQueued === "number" ? parsed.aliasOnlyQueued : 0,
       aliasOnlyDropped: typeof parsed.aliasOnlyDropped === "number" ? parsed.aliasOnlyDropped : 0,
     };
@@ -207,6 +209,14 @@ async function loadContactPointEmails(db: Kysely<DB>, entities: Entity[]): Promi
 function disjoint(left: Set<string>, right: Set<string>): boolean {
   for (const value of left) if (right.has(value)) return false;
   return true;
+}
+
+function hasDisjointEmails(left: Set<string>, right: Set<string>): boolean {
+  return left.size > 0 && right.size > 0 && disjoint(left, right);
+}
+
+function emailsForEntity(entity: Entity, emails: Map<string, Set<string>>): Set<string> {
+  return emails.get(entity.id) ?? emailsFromEntity(entity);
 }
 
 function groupEntities(entities: Entity[], keyFor: (entity: Entity) => string): Entity[][] {
@@ -388,9 +398,7 @@ async function applyPersonTokenSetGroups(
     let vetoed = false;
     for (let i = 0; i < group.length && !vetoed; i += 1) {
       for (let j = i + 1; j < group.length; j += 1) {
-        const left = emails.get(group[i].id) ?? new Set<string>();
-        const right = emails.get(group[j].id) ?? new Set<string>();
-        if (left.size > 0 && right.size > 0 && disjoint(left, right)) {
+        if (hasDisjointEmails(emailsForEntity(group[i], emails), emailsForEntity(group[j], emails))) {
           vetoed = true;
           summary.m3EmailVetoes++;
           break;
@@ -441,7 +449,11 @@ async function loadM5Rows(db: Kysely<DB>): Promise<{ mergeable: QueueRow[]; skip
   };
 }
 
-async function applyM5Rows(db: Kysely<DB>, summary: DuplicateDrainSummary): Promise<void> {
+async function applyM5Rows(
+  db: Kysely<DB>,
+  emails: Map<string, Set<string>>,
+  summary: DuplicateDrainSummary,
+): Promise<void> {
   const { mergeable, skippedPassReason } = await loadM5Rows(db);
   summary.m5SkippedPassReason += skippedPassReason;
   for (const row of mergeable) {
@@ -461,6 +473,14 @@ async function applyM5Rows(db: Kysely<DB>, summary: DuplicateDrainSummary): Prom
       .orderBy("id", "asc")
       .executeTakeFirst();
     if (!proposal) continue;
+    if (
+      candidate.source_type === "person" &&
+      proposal.source_type === "person" &&
+      hasDisjointEmails(emailsForEntity(candidate, emails), emailsForEntity(proposal, emails))
+    ) {
+      summary.m5EmailVetoes++;
+      continue;
+    }
     const groupId = `duplicate-drain:v2:m5:${row.id}`;
     await applyEntityGroup(db, groupId, candidate.id, [proposal.id], summary);
     await db
@@ -498,7 +518,7 @@ export async function runDuplicateDrain(
       await applyProductGroups(db, entities, state);
       await applyPersonTokenSetGroups(db, entities, emails, state);
       await applyPersonStrictGroups(db, entities, emails, state);
-      await applyM5Rows(db, state);
+      await applyM5Rows(db, emails, state);
       const complete = { ...state, status: "complete" as const, cursorCreatedAt: null, cursorId: null };
       await writeState(db, complete);
       opts.logger?.info(complete, "duplicate drain complete");

--- a/packages/server/src/entities/duplicate-drain.ts
+++ b/packages/server/src/entities/duplicate-drain.ts
@@ -18,7 +18,7 @@ import { mergeEntities } from "./merge";
 import { normalizeStrict, normalizeTokenSet } from "./name-dedup";
 
 const PASS_ID = "duplicate-drain";
-const PASS_VERSION = 1;
+const PASS_VERSION = 2;
 const STATE_ROW_ID = `${PASS_ID}:v${PASS_VERSION}`;
 const ACTOR = `correction:${PASS_ID}@${PASS_VERSION}`;
 const DEFAULT_PAGE_SIZE = 250;
@@ -54,6 +54,7 @@ function emptySummary(status: "running" | "complete" = "running"): DuplicateDrai
     m5SkippedPassReason: 0,
     m3EmailVetoes: 0,
     aliasOnlyQueued: 0,
+    aliasOnlyDropped: 0,
   };
 }
 
@@ -71,6 +72,7 @@ function parseSummary(raw: string): DuplicateDrainSummary {
       m5SkippedPassReason: typeof parsed.m5SkippedPassReason === "number" ? parsed.m5SkippedPassReason : 0,
       m3EmailVetoes: typeof parsed.m3EmailVetoes === "number" ? parsed.m3EmailVetoes : 0,
       aliasOnlyQueued: typeof parsed.aliasOnlyQueued === "number" ? parsed.aliasOnlyQueued : 0,
+      aliasOnlyDropped: typeof parsed.aliasOnlyDropped === "number" ? parsed.aliasOnlyDropped : 0,
     };
   } catch {
     return emptySummary();
@@ -279,13 +281,13 @@ async function applyCompanyHardGroups(db: Kysely<DB>, summary: DuplicateDrainSum
   const groups = buildCompanyDedupGroups(members, HARD_COMPANY_EDGES);
   for (const group of groups.filter((candidate) => candidate.members.length > 1)) {
     const survivor = chooseCanonicalCompany(group);
-    const survivorName = spacedCompanyName(group, survivor.name);
+    const survivorName = group.ownOrg ? undefined : spacedCompanyName(group, survivor.name);
     const losers = group.members
       .filter((member) => member.entityId !== survivor.entityId)
       .map((member) => member.entityId);
     await applyEntityGroup(
       db,
-      `duplicate-drain:v1:m1:${compactEntityNameKey("company", survivorName ?? survivor.name)}`,
+      `duplicate-drain:v2:m1:${compactEntityNameKey("company", survivorName ?? survivor.name)}`,
       survivor.entityId,
       losers,
       summary,
@@ -297,25 +299,54 @@ async function applyCompanyHardGroups(db: Kysely<DB>, summary: DuplicateDrainSum
 async function queueAliasOnlyCompanyGroups(db: Kysely<DB>, summary: DuplicateDrainSummary): Promise<void> {
   const members = await loadCompanyDedupMembers(db);
   const hardGroups = buildCompanyDedupGroups(members, HARD_COMPANY_EDGES).filter((group) => group.members.length > 1);
-  const hardMembers = new Set(hardGroups.flatMap((group) => group.members.map((member) => member.entityId)));
+  const hardSurvivorByMember = new Map<string, string>();
+  for (const group of hardGroups) {
+    const survivor = chooseCanonicalCompany(group);
+    for (const member of group.members) hardSurvivorByMember.set(member.entityId, survivor.entityId);
+  }
   const aliasGroups = buildCompanyDedupGroups(members).filter(
     (group) => group.members.length > 1 && group.edges.some((edge) => edge.kind === "name_alias"),
   );
   const repo = createEntityReviewRepo(db);
   for (const group of aliasGroups) {
-    const aliasOnlyMembers = group.members.filter((member) => !hardMembers.has(member.entityId));
-    if (aliasOnlyMembers.length < 2) continue;
-    const survivor = chooseCanonicalCompany({ ...group, members: aliasOnlyMembers });
-    for (const member of aliasOnlyMembers) {
-      if (member.entityId === survivor.entityId) continue;
+    const memberById = new Map(group.members.map((member) => [member.entityId, member]));
+    const rows = new Map<string, { member: (typeof group.members)[number]; candidateEntityId: string }>();
+    for (const edge of group.edges.filter((candidate) => candidate.kind === "name_alias")) {
+      const candidateIds = [
+        ...new Set(
+          edge.entityIds.map((entityId) => hardSurvivorByMember.get(entityId)).filter((id) => id !== undefined),
+        ),
+      ];
+      for (const entityId of edge.entityIds) {
+        if (hardSurvivorByMember.has(entityId)) continue;
+        const member = memberById.get(entityId);
+        if (!member) continue;
+        for (const candidateEntityId of candidateIds) {
+          rows.set(`${entityId}:${candidateEntityId}`, { member, candidateEntityId });
+        }
+      }
+    }
+    if (rows.size === 0 && !group.members.some((member) => hardSurvivorByMember.has(member.entityId))) {
+      const survivor = chooseCanonicalCompany(group);
+      for (const member of group.members) {
+        if (member.entityId !== survivor.entityId)
+          rows.set(`${member.entityId}:${survivor.entityId}`, { member, candidateEntityId: survivor.entityId });
+      }
+    }
+    for (const { member, candidateEntityId } of rows.values()) {
+      const candidateEntityIds = [...new Set([member.entityId, candidateEntityId])];
+      if (candidateEntityIds.length < 2) {
+        summary.aliasOnlyDropped++;
+        continue;
+      }
       await repo.upsertQueueRow({
         proposedName: member.name,
         normalizedName: normalizeName(member.name),
         entityType: "company",
         source: PASS_ID,
-        sourceId: `v1:alias:${member.entityId}:${survivor.entityId}`,
-        candidateEntityId: survivor.entityId,
-        candidateEntityIds: aliasOnlyMembers.map((m) => m.entityId),
+        sourceId: `v2:alias:${member.entityId}:${candidateEntityId}`,
+        candidateEntityId,
+        candidateEntityIds,
         candidateScore: 1,
         candidateReason: "name_alias",
         triggeredByUserId: "system",
@@ -334,7 +365,7 @@ async function applyProductGroups(db: Kysely<DB>, entities: Entity[], summary: D
     const losers = group.filter((entity) => entity.id !== survivor.id).map((entity) => entity.id);
     await applyEntityGroup(
       db,
-      `duplicate-drain:v1:m2:${compactEntityNameKey("product", survivor.name)}`,
+      `duplicate-drain:v2:m2:${compactEntityNameKey("product", survivor.name)}`,
       survivor.id,
       losers,
       summary,
@@ -371,7 +402,7 @@ async function applyPersonTokenSetGroups(
     const losers = group.filter((entity) => entity.id !== survivor.id).map((entity) => entity.id);
     await applyEntityGroup(
       db,
-      `duplicate-drain:v1:m3:${normalizeTokenSet(survivor.name)}`,
+      `duplicate-drain:v2:m3:${normalizeTokenSet(survivor.name)}`,
       survivor.id,
       losers,
       summary,
@@ -393,7 +424,7 @@ async function applyPersonStrictGroups(
     if (withEmail.length > 1) continue;
     const survivor = chooseGenericSurvivor(group);
     const losers = group.filter((entity) => entity.id !== survivor.id).map((entity) => entity.id);
-    await applyEntityGroup(db, `duplicate-drain:v1:m4:${normalizeStrict(survivor.name)}`, survivor.id, losers, summary);
+    await applyEntityGroup(db, `duplicate-drain:v2:m4:${normalizeStrict(survivor.name)}`, survivor.id, losers, summary);
   }
 }
 
@@ -430,7 +461,7 @@ async function applyM5Rows(db: Kysely<DB>, summary: DuplicateDrainSummary): Prom
       .orderBy("id", "asc")
       .executeTakeFirst();
     if (!proposal) continue;
-    const groupId = `duplicate-drain:v1:m5:${row.id}`;
+    const groupId = `duplicate-drain:v2:m5:${row.id}`;
     await applyEntityGroup(db, groupId, candidate.id, [proposal.id], summary);
     await db
       .updateTable("entity_review_queue")
@@ -462,8 +493,8 @@ export async function runDuplicateDrain(
         db,
         entities.filter((entity) => entity.source_type === "person"),
       );
-      await applyCompanyHardGroups(db, state);
       await queueAliasOnlyCompanyGroups(db, state);
+      await applyCompanyHardGroups(db, state);
       await applyProductGroups(db, entities, state);
       await applyPersonTokenSetGroups(db, entities, emails, state);
       await applyPersonStrictGroups(db, entities, emails, state);


### PR DESCRIPTION
Follows #507. Two fixes to the duplicate drain, both found by running the merged pass against a
real canvas-ai clone (3,801 files, 1,529 entities).

Plan: `.planning/knowledge/implemented/PR6A_DRAIN_FOLLOWUP.md`

## 1. The drain was losing an alias-only pair

The pass deliberately does not auto-merge company pairs joined only by a `name_alias` edge —
aliases are model output, so those go to the review queue for a human. On the real run one never
arrived: `Redseerconsulting`, 115 mention-files, holder of `redseerconsulting.com`. The pass then
wrote `status: complete`, so it would never revisit.

Three causes, all needed:

- `normalizeName` lowercases and trims but **keeps spaces**, so `Redseer` and `Red Seer` are
  different keys.
- The `name_alias` edge matches an entity's **name** key against other entities' **alias** keys,
  never alias-to-alias.
- M1's spaced-form rename ran **before** the alias-only queueing. Renaming `Redseer` to
  `Red Seer` destroyed the edge to `Redseerconsulting` before anything looked for it.

A second, independent bug in the same function would have dropped it anyway: the
`!hardMembers.has(...)` filter plus the `aliasOnlyMembers.length < 2` guard made an
(alias-only member, hard-group member) pair impossible to express.

**Fix:** queue before merging, and resolve each alias-only member's candidate to the survivor its
hard-group partner *will* elect — not to whoever the full alias group elects, which on this shape
picks `Redseerconsulting` itself because it holds a domain.

Also skips the survivor rename for own-org groups. `Canvasx` (2,374 mentions, holds `canvasx.ai`)
was being renamed to `Canvas X`, an extraction artefact with one mention. Exactly one of the nine
real groups carries the `ownOrg` flag. An earlier draft used a mention-count rule instead; it was
measured and would have left `Oliverwyman`, `Sugarfit`, `Redseer` and `Greenmentor` de-spaced.

Bumped to version 2 so the pass re-runs where version 1 wrote `complete` — in the pass, in the
route's `duplicate-drain:v1` lookups, and in the snapshot type. Missing any one ships the fix
without it ever running.

## 2. M5 merged the people M3 and M4 refuse

Found while verifying the above. **This is a defect in what shipped as #507**, not something this
PR introduces.

M3 vetoes a person group when two members hold emails and the sets are disjoint. M4 refuses any
group with more than one emailed member. M5 checked nothing — it merged on name identity alone.

On a clean run all three of M5's merges fused two entities that each held an email, and one fused
two different people: an entity named `Abhishek Sharma` holding `abhishek.sharma@onestop.ai` with
another holding `abhinav.sharma@moonshotcom.com`. In that same run `m3EmailVetoes: 1` — M3 had
already looked at that group and correctly refused it.

**It cannot wait for a later PR.** The version bump above makes the pass re-run over graphs that
completed v1, and M5's output is what makes the next run's M3 match. Replaying v2 over a
v1-drained clone fused a third `Abhishek Sharma` in, leaving one entity holding three addresses
across three companies. The drain also runs at boot via `startDuplicateDrain`, so this fires on
deploy rather than waiting for anyone to press a button.

**Fix:** extract M3's disjoint-email check into one helper and call it from M5. No new rule.
Vetoed rows stay `pending` for a human instead of being auto-confirmed.

Effect, measured:

| M5 merge | outcome | why |
|---|---|---|
| Himanshu Kalra | merges | both entities list **both** addresses in `aliases`, so the sets are equal, not disjoint |
| Vishal Sharma | vetoed | `vishal@autopilot.black` vs `vishal@autopilot.design` — genuinely disjoint, a correct merge given up |
| Abhishek Sharma | vetoed | the one that fused two different people |

The Himanshu case is why the rule discriminates rather than just blocking. `emailsFromEntity`
reads emails out of `aliases` as well as metadata, so an entity ever seen under two addresses
carries both. Genuine same-person duplicates usually do; different people do not.

One correct merge is lost to block one wrong one. A wrong person merge is silent, corrupts every
downstream edge, and needs an unmerge to undo. A blocked correct merge is a queue row someone
clicks. This is already M3's accepted behaviour on the same shape, so M5 stops being the one
class with a different standard.

Rejected: a local-part rule (`abhishek.sharma` ≠ `abhinav.sharma`) would also keep the Vishal
merge, but it is tuned to three data points on one tenant.

## Verified against real data

Fresh clone, migrations replayed, driven through `POST /api/graph-passes/duplicate-drain-runs`.

| Check | Result |
|---|---|
| `Redseerconsulting ~ Red Seer` queued | yes — **6** alias-only pairs, up from v1's 5 |
| Own-org rename skipped | survivor kept `Canvasx`, not `Canvas X` |
| The Abhishek shape | all 5 entities live and separate, the pair sits `pending` |
| Class counts | m1=9 m2=2 m3=11 m4=7 m5=1, 30 merges total |
| Counters | `m3EmailVetoes: 1` `m5EmailVetoes: 2` `aliasOnlyQueued: 9` `aliasOnlyDropped: 0` |
| Second run | converged — applied nothing |

## Tests

Four new integration tests through the HTTP route. **Each was run with its change reverted and
observed to fail**, since this series has shipped headline tests that passed either way:

1. An alias-only member survives its partner being merged — `Error: no result`
2. The queued candidate is the hard-group survivor — `expected 'redseerconsulting' to be 'red-seer'`
3. Version 2 re-runs where version 1 completed — `expected undefined to match object { status: 'pending' }`
4. M5 does not merge two people whose emails disagree — `expected 1 to be 2` on the live-entity count

Test 2 matters: a weaker "candidate is live" assertion would have passed unfixed, because the
hard survivor and `Redseerconsulting` are both live after the run.

No migration. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
