### PR TITLE
fix(entities): make queue pass verdicts survive the next run, and wire the passes to boot

### DIFF
--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -60,11 +60,11 @@ import { createWhatsAppInboundEventsRepository } from "./db/repositories/whatsap
 import { createWhatsAppProviderEventRepository } from "./db/repositories/whatsapp-provider-events";
 import { createWhatsAppTemplateMappingRepository } from "./db/repositories/whatsapp-template-mappings";
 import type { DB } from "./db/schema";
-import { startDuplicateDrain } from "./entities/duplicate-drain";
 import { configureMaterializeDefaults } from "./entities/materialize";
 import { startNormalizationBackfill } from "./entities/normalization-backfill";
 import { isPersonalOrSharedDomain } from "./entities/personal-domains";
 import type { ProposeEntityType } from "./entities/propose";
+import { startQueueDrainSequence } from "./entities/queue-run";
 import { createApp } from "./http";
 import { buildMcpConfig, createProvider } from "./integrations/factory";
 import type { IntegrationProvider, IntegrationStatus } from "./integrations/types";
@@ -879,7 +879,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
   // for pre-migration rows in the background; readers stay on the legacy path
   // until it completes, so this must not block startup readiness.
   const normalizationBackfill = backgroundWork ? startNormalizationBackfill(db, logger) : null;
-  const duplicateDrain = backgroundWork ? startDuplicateDrain(db, logger) : null;
+  const queueDrainSequence = backgroundWork ? startQueueDrainSequence(db, logger) : null;
   const whatsappWindowKeepAliveJob =
     backgroundWork && config.WHATSAPP_WINDOW_KEEPALIVE_ENABLED
       ? startWhatsAppWindowKeepAliveJob({
@@ -1264,7 +1264,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     }
     whatsappInboundRetention?.stop();
     normalizationBackfill?.stop();
-    duplicateDrain?.stop();
+    queueDrainSequence?.stop();
     await managedMemberReconciliationPromise?.catch(() => undefined);
     await telemetry.shutdown();
     await syncScheduler?.stop();

--- a/packages/server/src/entities/queue-passes.integration.test.ts
+++ b/packages/server/src/entities/queue-passes.integration.test.ts
@@ -7,8 +7,10 @@ import { createUserRepository } from "../db/repositories/users";
 import type { DB } from "../db/schema";
 import { createApp } from "../http";
 import { createTestConfig, createTestLogger, createTestPgDb } from "../test-utils";
+import { duplicateDrainStateRowId } from "./duplicate-drain";
 import { applyProjection } from "./queue-projection";
 import { liveEntitiesForNames, loadQueueRows } from "./queue-reconcile";
+import { startQueueDrainSequence } from "./queue-run";
 import { structuralPass, withAttendeeFactChunkSizeForTest } from "./queue-structural";
 
 const ADMIN_EMAIL = "admin@test.com";
@@ -226,6 +228,14 @@ async function queueState(db: Kysely<DB>, ids: string[]) {
     .execute();
 }
 
+async function mergeCount(db: Kysely<DB>): Promise<number> {
+  const row = await db
+    .selectFrom("entity_merges")
+    .select((eb) => eb.fn.countAll<number>().as("count"))
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+}
+
 /**
  * Aliases are not a table — they live in `entities.aliases`, so `selectAll` on
  * entities already carries them.
@@ -318,7 +328,7 @@ describe("queue graph passes", () => {
 
     const row = await readRow(h.db, rowId);
     expect(row?.status).toBe("deferred");
-    expect(row?.pass_reason).toBe("superseded_by_entity");
+    expect(row?.pass_reason).toBe("name_already_resolved");
     expect(row?.candidate_entity_id).toBe(supersedes);
     expect(row?.candidate_entity_ids).toBeNull();
     expect(row?.candidate_score).toBeNull();
@@ -329,7 +339,38 @@ describe("queue graph passes", () => {
 
     const processed = await readRow(h.db, nullSourceRow);
     expect(processed?.candidate_entity_id).toBe(nullSourceLive);
-    expect(processed?.pass_reason).toBe("superseded_by_entity");
+    expect(processed?.pass_reason).toBe("name_already_resolved");
+  });
+
+  it("keeps a re-pointed row verdict stable across queue runs", async () => {
+    const candidate = await seedEntity(h.db, { name: "N. Rahman" });
+    const resolved = await seedEntity(h.db, { name: "Nadia Rahman" });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Nadia Rahman",
+      candidateEntityId: candidate,
+      candidateEntityIds: [candidate],
+      candidateScore: 0.8,
+    });
+
+    await runPasses(h);
+    const run1 = await readRow(h.db, rowId);
+    await runPasses(h);
+    const run2 = await readRow(h.db, rowId);
+
+    expect(run1).toMatchObject({
+      status: "deferred",
+      pass_reason: "name_already_resolved",
+      candidate_entity_id: resolved,
+    });
+    expect({
+      status: run2?.status,
+      pass_reason: run2?.pass_reason,
+      candidate_entity_id: run2?.candidate_entity_id,
+    }).toEqual({
+      status: run1?.status,
+      pass_reason: run1?.pass_reason,
+      candidate_entity_id: run1?.candidate_entity_id,
+    });
   });
 
   it("T3 leaves no stale candidate fields after the merge and delete repairs", async () => {
@@ -354,7 +395,7 @@ describe("queue graph passes", () => {
 
     const repointed = await readRow(h.db, mergedRow);
     expect(repointed?.candidate_entity_id).toBe(survivor);
-    expect(repointed?.pass_reason).toBe("candidate_merged_away");
+    expect(repointed?.pass_reason).toBe("no_shared_file");
     expect(repointed?.candidate_score).toBeNull();
     expect(repointed?.candidate_entity_ids).toBeNull();
     expect(repointed?.candidate_generated_at).not.toBe("2020-01-01T00:00:00.000Z");
@@ -364,6 +405,51 @@ describe("queue graph passes", () => {
     expect(cleared?.candidate_score).toBeNull();
     expect(cleared?.candidate_entity_ids).toBeNull();
     expect(cleared?.candidate_generated_at).not.toBe("2020-01-01T00:00:00.000Z");
+  });
+
+  it("keeps a repaired merged-away row stable and does not auto-merge it", async () => {
+    const survivor = await seedEntity(h.db, { name: "Survivor Entity" });
+    const merged = await seedEntity(h.db, { name: "Merged Entity", mergedInto: survivor });
+    const rowId = await seedQueueRow(h.db, h.ownerId, {
+      name: "Merged Proposal",
+      candidateEntityId: merged,
+      candidateEntityIds: [merged, survivor],
+      candidateScore: 0.9,
+    });
+    const [fileId] = await seedIndexedFiles(h.db, h.ownerId, "merged-stability", 1);
+    await seedReviewEvidence(h.db, rowId, [fileId]);
+    await seedMention(h.db, survivor, fileId);
+
+    await runPasses(h);
+    const run1 = await readRow(h.db, rowId);
+    await runPasses(h);
+    const run2 = await readRow(h.db, rowId);
+
+    expect({
+      status: run2?.status,
+      pass_reason: run2?.pass_reason,
+      candidate_entity_id: run2?.candidate_entity_id,
+    }).toEqual({
+      status: run1?.status,
+      pass_reason: run1?.pass_reason,
+      candidate_entity_id: run1?.candidate_entity_id,
+    });
+    expect(run1).toMatchObject({
+      status: "pending",
+      pass_reason: null,
+      candidate_entity_id: survivor,
+    });
+
+    const mergesBeforeDrain = await mergeCount(h.db);
+    const drain = await h.app.request("/api/graph-passes/duplicate-drain-runs", {
+      method: "POST",
+      headers: { Cookie: h.cookie },
+    });
+    expect(drain.status).toBe(201);
+    expect(await mergeCount(h.db)).toBe(mergesBeforeDrain);
+    const afterDrain = await readRow(h.db, rowId);
+    expect(afterDrain?.status).toBe("pending");
+    expect(afterDrain?.resolved_entity_id).toBeNull();
   });
 
   /**
@@ -534,7 +620,7 @@ describe("queue graph passes", () => {
     expect((await readRow(h.db, vetoRow))?.pass_reason).toBe("different_emails");
   });
 
-  it("F1 the veto fires when the proposal's name resolves to the candidate", async () => {
+  it("F1 the register wins when the proposal's name resolves to the candidate", async () => {
     const candidate = await seedEntity(h.db, { name: "Admin", metadata: { email: "admin@one.test" } });
     const rowId = await seedQueueRow(h.db, h.ownerId, {
       name: "Admin",
@@ -546,7 +632,7 @@ describe("queue graph passes", () => {
 
     const row = await readRow(h.db, rowId);
     expect(row?.status).toBe("deferred");
-    expect(row?.pass_reason).toBe("different_emails");
+    expect(row?.pass_reason).toBe("name_already_resolved");
   });
 
   /**
@@ -938,5 +1024,26 @@ describe("queue graph passes", () => {
     expect(snapshot.kind).toBe("queue");
     expect(snapshot.scannedRows).toBe(1);
     expect((snapshot.set as Record<string, number>).name_already_resolved).toBe(1);
+  });
+
+  it("runs queue passes before the boot duplicate drain", async () => {
+    const candidate = await seedEntity(h.db, { name: "Alpha Tool", type: "tool" });
+    await seedQueueRow(h.db, h.ownerId, {
+      name: "Tool Alpha",
+      type: "tool",
+      candidateEntityId: candidate,
+      candidateScore: 1,
+    });
+
+    const handle = startQueueDrainSequence(h.db, createTestLogger());
+    await handle.done;
+
+    const state = await h.db
+      .selectFrom("graph_pass_runs")
+      .select(["input_snapshot_json"])
+      .where("id", "=", duplicateDrainStateRowId)
+      .executeTakeFirstOrThrow();
+    const snapshot = JSON.parse(state.input_snapshot_json) as { m5SkippedPassReason?: number };
+    expect(snapshot.m5SkippedPassReason).toBeGreaterThan(0);
   });
 });

--- a/packages/server/src/entities/queue-projection.ts
+++ b/packages/server/src/entities/queue-projection.ts
@@ -4,8 +4,6 @@ import type { DB } from "../db/schema";
 
 export type PassReason =
   | "name_already_resolved"
-  | "superseded_by_entity"
-  | "candidate_merged_away"
   | "different_emails"
   | "co_listed_participants"
   | "type_mismatch"
@@ -22,8 +20,6 @@ export type PassReason =
  */
 export const REASON_PRIORITY: Record<PassReason, number> = {
   name_already_resolved: 1,
-  superseded_by_entity: 1,
-  candidate_merged_away: 1,
   different_emails: 2,
   co_listed_participants: 2,
   type_mismatch: 2,

--- a/packages/server/src/entities/queue-reconcile.ts
+++ b/packages/server/src/entities/queue-reconcile.ts
@@ -1,6 +1,6 @@
 import type { Kysely } from "kysely";
 import type { DB } from "../db/schema";
-import { type PassReason, type ReasonHit, reviewFreezeBoundary } from "./queue-projection";
+import { type ReasonHit, reviewFreezeBoundary } from "./queue-projection";
 import { inScope, nonTerminal } from "./queue-scope";
 
 export type QueueRowForPasses = {
@@ -208,8 +208,7 @@ export async function reconcileQueue(
 
       if (usable) {
         group(row.id, candidateId, usable.id);
-        const reason: PassReason = live && live.id === usable.id ? "name_already_resolved" : "candidate_merged_away";
-        hits.push({ rowId: row.id, reason });
+        if (live && live.id === usable.id) hits.push({ rowId: row.id, reason: "name_already_resolved" });
         continue;
       }
 
@@ -220,8 +219,11 @@ export async function reconcileQueue(
 
     if (live && live.id !== candidateId) {
       group(row.id, candidateId, live.id);
-      hits.push({ rowId: row.id, reason: "superseded_by_entity" });
+      hits.push({ rowId: row.id, reason: "name_already_resolved" });
+      continue;
     }
+
+    if (live && live.id === candidateId) hits.push({ rowId: row.id, reason: "name_already_resolved" });
   }
 
   let repointed = 0;

--- a/packages/server/src/entities/queue-run.ts
+++ b/packages/server/src/entities/queue-run.ts
@@ -1,18 +1,25 @@
 import type { Kysely } from "kysely";
+import type { Logger } from "pino";
 import type { QueueRunSnapshot } from "../db/repositories/graph-pass-runs";
 import type { DB } from "../db/schema";
+import { runDuplicateDrain } from "./duplicate-drain";
 import { applyProjection, resolveReasons } from "./queue-projection";
 import { liveEntitiesForNames, loadQueueRows, reconcileQueue } from "./queue-reconcile";
 import { structuralPass } from "./queue-structural";
+
+export interface QueueDrainSequenceHandle {
+  done: Promise<void>;
+  stop: () => void;
+}
 
 /**
  * One queue graph pass: reconcile, then structure, then one projection.
  *
  * The rows are re-read between the two passes because phase A re-points and
  * clears candidates, and phase B's rules are all about the candidate. Neither
- * pass writes to the graph, and the projection recomputes `(status,
- * pass_reason)` from scratch, so a run that overlaps another converges rather
- * than corrupting anything.
+ * pass writes to the graph. The projection recomputes `(status, pass_reason)`
+ * from scratch, so overlapping runs converge once every emitted reason still
+ * describes the post-reconcile row.
  */
 export async function runQueuePasses(db: Kysely<DB>): Promise<QueueRunSnapshot> {
   const initialRows = await loadQueueRows(db);
@@ -37,5 +44,33 @@ export async function runQueuePasses(db: Kysely<DB>): Promise<QueueRunSnapshot> 
     frozen: counts.frozen,
     candidatesRepointed: reconciled.repointed,
     candidatesCleared: reconciled.cleared,
+  };
+}
+
+/**
+ * Runs boot graph maintenance in the measured order: queue, duplicate drain,
+ * queue. The sequence is intentionally in-memory and assumes a single server
+ * process; there is no durable lock preventing two booting processes from
+ * interleaving their drains.
+ */
+export function startQueueDrainSequence(db: Kysely<DB>, logger?: Logger): QueueDrainSequenceHandle {
+  let stopped = false;
+  const done = (async () => {
+    await runQueuePasses(db);
+    try {
+      await runDuplicateDrain(db, { logger, shouldStop: () => stopped });
+    } finally {
+      await runQueuePasses(db);
+    }
+  })()
+    .then(() => undefined)
+    .catch((err) => {
+      logger?.error({ err }, "queue/drain startup sequence failed");
+    });
+  return {
+    done,
+    stop: () => {
+      stopped = true;
+    },
   };
 }


### PR DESCRIPTION
Follows #506. Two defects in the queue passes, both found by running the merged code against a
real canvas-ai clone.

Plan: `.planning/knowledge/to-be-developed/PR5A_QUEUE_PASS_STABILITY.md`

## 1. The pass names the problem it just repaired

`queue-reconcile.ts` re-points a stale candidate — a repair — and then emits a reason describing
the state it just left behind. On the next run that condition is false, no hit is emitted, and
there is **no branch at all** for "the candidate is already correct", so the row falls through and
the stateless projection clears it.

Measured: four consecutive calls to `POST /api/graph-passes/queue-runs` against a clean clone
(3,801 files, 1,529 entities, 531 open rows) with **nothing else touching the database**.

| Run | Rows changed | `repointed` |
|---|---|---|
| 1 | 200 | 26 |
| 2 | **26** | 0 |
| 3 | 0 | 0 |

Every one of the 26 was `superseded_by_entity`, and all 26 were reversed:

```
17  deferred/superseded_by_entity  ->  pending/(none)
 9  deferred/superseded_by_entity  ->  pending/bare_name_only
```

Seventeen rows were hidden from the reviewer on run 1 and came back on run 2 with **no reason
recorded**. Real examples: `Citibank N.A. ~ JP Morgan Chase Bank`, `Expedia ~ Booking.com`,
`Ministry of Defense ~ Ministry of Tourism`. All correctly deferred, then un-deferred.

The projection is not at fault — it correctly recomputes from scratch every run. It was only
unstable because the hits were.

**Fix, in one rule:** a reason may only describe a condition that is still true after reconcile
has finished. So the re-point branch emits `name_already_resolved`, the missing already-correct
branch emits it too, and `superseded_by_entity` and `candidate_merged_away` lose their only
emitters and are removed.

### Removing a reason is not cosmetic

No production code reads either *string* and nothing in `packages/web` reads `pass_reason` at all
— but the drain reads it **generically**: any non-null reason means M5 skips the row. So a row
deferred behind one of these becomes a row M5 will consider merging, and M5 is the class that
just fused two different people in #508.

Accepted, on three grounds: zero rows carried `candidate_merged_away` on the measured corpus; it
restores pre-#506 behaviour rather than inventing new; and #508 gives M5 the disjoint-email veto
it was missing. Pinned by a test that runs the drain and asserts no merge happens.

## 2. The queue passes never ran

`runQueuePasses` had exactly one caller — the HTTP route — and nothing called that route. The
drain was started at boot; the queue passes were not. **#506 shipped and had never run against any
graph.** Everything above required invoking the route by hand.

Boot now starts the measured sequence: **queue → drain → queue**. Queue first because the drain
consumes the reasons; queue again after because the drain merges entities and invalidates
candidates.

Four constraints, all load-bearing:

- **Not wrapped in `withMaterializeReplayQueue`** — `runDuplicateDrain` already takes that lock, so
  wrapping the outer sequence would deadlock on the drain step.
- A failed first queue pass **does not start the drain** — running it over un-annotated rows is the
  exact path this PR closes.
- A drain that throws after partial merges **still runs the trailing pass**, because partial merges
  are when stale candidates matter most.
- Does not block startup readiness.

The sequence assumes a single process. There is no durable lock — but that is already true of
`startDuplicateDrain` on main today, so this widens the exposure rather than creating it. Recorded
in the starter's docstring; the lock is deliberately its own PR, since it is equally needed by the
drain alone.

## Measured after building it

Fresh clone, same corpus, driven through the HTTP route.

| | before | after |
|---|---|---|
| runs to settle, queue alone | 3 | **1** |
| rows reversed on run 2 | 26 | **0** |
| rows ending with a reason erased | 17 | **0** |
| runs to settle after a drain | 3 | 1 |

The full sequence: drain reports `m5SkippedPassReason: 62`, `merged: 30`, `m5EmailVetoes: 2`, and
the Abhishek/Abhinav people stay separate. The queue pass after the drain moves 8 rows once then
goes quiet — the drain changing the graph underneath, not the pass disagreeing with itself.

### Two consequences the plan did not predict

**`name_already_resolved` fires more widely** — 101 rows before, 153 after, so deferred rows go
110 → 157. This is inherent: a reason emitted only for rows that were just re-pointed is exactly
the non-re-derivable pattern being removed, so it must fire on state. The 47 newly hidden rows
were listed, not assumed — all self-pairs like `Admin ~ Admin`, `Munaf ~ Munaf`,
`Turkmen, Serdar ~ Turkmen, Serdar`, where the proposed name is the candidate's own name and there
is no merge question.

**It outranks more specific reasons** — `different_emails` drops 8 → 4, `co_listed_participants`
1 → 0, since priority 1 beats priority 2. The four that keep `different_emails` are the genuine
cross-name pairs (`Montessoro, Cecilia ~ Cecilia Montessoro`, `Sahil ~ Sahil Mokaddam`) where the
reason carries information; the ones that lost it are self-pairs.

Accepted because both reasons defer, so no row changes visibility, and nothing reads `pass_reason`
today. **Worth revisiting when a reader exists** — a UI, or PR 5c — because a row whose name
resolves to its candidate *and* whose emails disagree is a real conflict that
`name_already_resolved` does not describe.

This changes an existing test's meaning: `F1` asserted the email veto fires when the name resolves
to the candidate; it now asserts the register wins. Renamed rather than deleted, and the veto is
still covered by the test above it where the name does not resolve.

## Tests

Three new, end to end through the HTTP route. **Each was run with its change reverted and observed
to fail**, since this series has shipped headline tests that passed either way:

1. A re-pointed row holds its verdict — `Expected "name_already_resolved"; Received "superseded_by_entity"`
2. A repaired merged-away row is stable **and is not auto-merged** — run 1 `deferred/candidate_merged_away`, run 2 `pending/null`
3. Boot runs the queue passes before the drain — `expected 0 to be greater than 0`

Test 2 runs the drain and asserts the merge count is unchanged; that is what pins the un-gating
above. Tests assert `run1 == run2` rather than a specific second value, because the run-2 value on
unfixed code is fixture-dependent.

Three existing tests that asserted the removed strings were updated.

No migration. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
