### PR TITLE
fix(whatsapp): index history for groups that never got a live message

### DIFF
--- a/packages/server/src/whatsapp/backfill-worker.test.ts
+++ b/packages/server/src/whatsapp/backfill-worker.test.ts
@@ -248,6 +248,138 @@ describe("WhatsAppBackfillWorker", () => {
     ]);
   });
 
+  it("bootstraps an initial range for an enabled group whose history never saw a live message", async () => {
+    const conversation = await seedGroup(db);
+    await db.updateTable("whatsapp_groups").set({ index_enabled: 1 }).where("jid", "=", "group@g.us").execute();
+    const conversations = createConversationRepository(db);
+    await db
+      .insertInto("whatsapp_backfill_checkpoints")
+      .values({
+        group_jid: "group@g.us",
+        last_fetched_key: null,
+        status: "complete",
+        live_start_effective_at: null,
+        live_start_message_id: null,
+      })
+      .execute();
+    for (const [id, connectionKey, providerTimestamp] of [
+      ["history-older-higher-key", KEY_3, "2026-07-17T09:00:00.000Z"],
+      ["history-newest-lower-key", KEY_1, "2026-07-17T10:00:00.000Z"],
+    ] as const) {
+      await conversations.insertMessage({
+        conversationId: conversation.id,
+        providerMessageId: id,
+        eventKey: `event-${id}`,
+        senderName: "History Sender",
+        providerTimestamp,
+        source: "history",
+        connectionKey,
+      });
+    }
+
+    await worker(db).reconcile(true);
+
+    const initial = await db
+      .selectFrom("whatsapp_backfill_ranges")
+      .select(["id", "connection_key", "upper_bound_at"])
+      .where("group_jid", "=", "group@g.us")
+      .where("kind", "=", "initial")
+      .executeTakeFirstOrThrow();
+    expect(initial.connection_key).toBe(KEY_3);
+    /**
+     * Strictly past the newest stranded row so materialization keeps the siblings
+     * that share its second, which `timestamp >= upper_bound_at` would drop.
+     */
+    expect(initial.upper_bound_at).toBe("2026-07-17T10:00:00.001Z");
+    const rows = await db
+      .selectFrom("conversation_messages")
+      .select(["provider_message_id", "backfill_range_id"])
+      .where("source", "=", "history")
+      .orderBy("provider_message_id")
+      .execute();
+    expect(rows).toEqual([
+      { provider_message_id: "history-newest-lower-key", backfill_range_id: initial.id },
+      { provider_message_id: "history-older-higher-key", backfill_range_id: initial.id },
+    ]);
+    const checkpoint = await db
+      .selectFrom("whatsapp_backfill_checkpoints")
+      .select(["live_start_effective_at", "live_start_message_id"])
+      .where("group_jid", "=", "group@g.us")
+      .executeTakeFirstOrThrow();
+    expect(checkpoint).toEqual({ live_start_effective_at: null, live_start_message_id: null });
+  });
+
+  it("skips bootstrapping when every stranded row lacks a connection key", async () => {
+    const conversation = await seedGroup(db);
+    await db.updateTable("whatsapp_groups").set({ index_enabled: 1 }).where("jid", "=", "group@g.us").execute();
+    const conversations = createConversationRepository(db);
+    await db
+      .insertInto("whatsapp_backfill_checkpoints")
+      .values({
+        group_jid: "group@g.us",
+        last_fetched_key: null,
+        status: "complete",
+        live_start_effective_at: null,
+        live_start_message_id: null,
+      })
+      .execute();
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "history-null-key",
+      eventKey: "event-history-null-key",
+      senderName: "History Sender",
+      providerTimestamp: "2026-07-17T10:00:00.000Z",
+      source: "history",
+      connectionKey: null,
+    });
+
+    await worker(db).reconcile(true);
+
+    await expect(
+      db
+        .selectFrom("whatsapp_backfill_ranges")
+        .select("id")
+        .where("group_jid", "=", "group@g.us")
+        .where("kind", "=", "initial")
+        .executeTakeFirst(),
+    ).resolves.toBeUndefined();
+  });
+
+  it("leaves history stranded when the group is not enabled for indexing", async () => {
+    const conversation = await seedGroup(db);
+    const conversations = createConversationRepository(db);
+    await db
+      .insertInto("whatsapp_backfill_checkpoints")
+      .values({
+        group_jid: "group@g.us",
+        last_fetched_key: null,
+        status: "complete",
+        live_start_effective_at: null,
+        live_start_message_id: null,
+      })
+      .execute();
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "history-disabled",
+      eventKey: "event-history-disabled",
+      senderName: "History Sender",
+      providerTimestamp: "2026-07-17T10:00:00.000Z",
+      source: "history",
+      connectionKey: KEY_1,
+    });
+
+    await worker(db).reconcile(true);
+
+    await expect(
+      db
+        .selectFrom("whatsapp_backfill_ranges")
+        .select("id")
+        .where("group_jid", "=", "group@g.us")
+        .where("kind", "=", "initial")
+        .executeTakeFirst(),
+    ).resolves.toBeUndefined();
+  });
+
   it("creates a gap on an accepted connected transition and sweep-recovers an orphaned key", async () => {
     const conversation = await seedGroup(db);
     await seedLease(db);

--- a/packages/server/src/whatsapp/backfill-worker.test.ts
+++ b/packages/server/src/whatsapp/backfill-worker.test.ts
@@ -309,6 +309,88 @@ describe("WhatsAppBackfillWorker", () => {
     expect(checkpoint).toEqual({ live_start_effective_at: null, live_start_message_id: null });
   });
 
+  it("rescues later history on a newer connection key for a bootstrapped group with no live start", async () => {
+    const conversation = await seedGroup(db);
+    await db.updateTable("whatsapp_groups").set({ index_enabled: 1 }).where("jid", "=", "group@g.us").execute();
+    const conversations = createConversationRepository(db);
+    await db
+      .insertInto("whatsapp_backfill_checkpoints")
+      .values({
+        group_jid: "group@g.us",
+        last_fetched_key: null,
+        status: "complete",
+        live_start_effective_at: null,
+        live_start_message_id: null,
+      })
+      .execute();
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "history-bootstrap",
+      eventKey: "event-history-bootstrap",
+      senderName: "History Sender",
+      providerTimestamp: "2026-07-17T09:00:00.000Z",
+      source: "history",
+      connectionKey: KEY_1,
+    });
+
+    await worker(db).reconcile(true);
+
+    const straggler = await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "history-straggler",
+      eventKey: "event-history-straggler",
+      senderName: "History Sender",
+      providerTimestamp: "2026-07-17T10:00:00.000Z",
+      source: "history",
+      connectionKey: KEY_3,
+    });
+
+    await worker(db).reconcile(true);
+
+    const rescued = await db
+      .selectFrom("conversation_messages")
+      .select("backfill_range_id")
+      .where("id", "=", straggler.row.id)
+      .executeTakeFirstOrThrow();
+    expect(rescued.backfill_range_id).not.toBeNull();
+    const checkpoint = await db
+      .selectFrom("whatsapp_backfill_checkpoints")
+      .select("live_start_message_id")
+      .where("group_jid", "=", "group@g.us")
+      .executeTakeFirstOrThrow();
+    expect(checkpoint.live_start_message_id).toBeNull();
+  });
+
+  it("leaves a disabled group without a live start out of the orphan rescue sweep", async () => {
+    const conversation = await seedGroup(db);
+    const conversations = createConversationRepository(db);
+    await db
+      .insertInto("whatsapp_backfill_checkpoints")
+      .values({
+        group_jid: "group@g.us",
+        last_fetched_key: null,
+        status: "complete",
+        live_start_effective_at: null,
+        live_start_message_id: null,
+      })
+      .execute();
+    await conversations.insertMessage({
+      conversationId: conversation.id,
+      providerMessageId: "history-disabled-orphan",
+      eventKey: "event-history-disabled-orphan",
+      senderName: "History Sender",
+      providerTimestamp: "2026-07-17T10:00:00.000Z",
+      source: "history",
+      connectionKey: KEY_1,
+    });
+
+    await worker(db).reconcile(true);
+
+    await expect(
+      db.selectFrom("whatsapp_backfill_ranges").select("id").where("group_jid", "=", "group@g.us").execute(),
+    ).resolves.toEqual([]);
+  });
+
   it("skips bootstrapping when every stranded row lacks a connection key", async () => {
     const conversation = await seedGroup(db);
     await db.updateTable("whatsapp_groups").set({ index_enabled: 1 }).where("jid", "=", "group@g.us").execute();

--- a/packages/server/src/whatsapp/backfill-worker.test.ts
+++ b/packages/server/src/whatsapp/backfill-worker.test.ts
@@ -309,6 +309,79 @@ describe("WhatsAppBackfillWorker", () => {
     expect(checkpoint).toEqual({ live_start_effective_at: null, live_start_message_id: null });
   });
 
+  it("repairs downtime for an enabled group that has never seen a live message", async () => {
+    await seedGroup(db);
+    await db.updateTable("whatsapp_groups").set({ index_enabled: 1 }).where("jid", "=", "group@g.us").execute();
+    await seedLease(db);
+    await db
+      .insertInto("whatsapp_backfill_checkpoints")
+      .values({
+        group_jid: "group@g.us",
+        last_fetched_key: null,
+        status: "complete",
+        live_start_effective_at: null,
+        live_start_message_id: null,
+      })
+      .execute();
+    await db
+      .insertInto("whatsapp_connection_transitions")
+      .values({
+        connection_key: KEY_3,
+        lease_generation: 1,
+        socket_generation: 3,
+        disconnected_at: "2026-07-17T10:30:00.000Z",
+        connected_at: "2026-07-17T10:45:00.000Z",
+      })
+      .execute();
+
+    await worker(db).reconcile(true);
+
+    await expect(
+      db
+        .selectFrom("whatsapp_backfill_ranges")
+        .select(["range_key", "lower_bound_at", "upper_bound_at"])
+        .where("group_jid", "=", "group@g.us")
+        .execute(),
+    ).resolves.toEqual([
+      {
+        range_key: `gap:${KEY_3}`,
+        lower_bound_at: "2026-07-17T10:30:00.000Z",
+        upper_bound_at: "2026-07-17T10:45:00.000Z",
+      },
+    ]);
+  });
+
+  it("does not repair downtime for a disabled group", async () => {
+    await seedGroup(db);
+    await seedLease(db);
+    await db
+      .insertInto("whatsapp_backfill_checkpoints")
+      .values({
+        group_jid: "group@g.us",
+        last_fetched_key: null,
+        status: "complete",
+        live_start_effective_at: null,
+        live_start_message_id: null,
+      })
+      .execute();
+    await db
+      .insertInto("whatsapp_connection_transitions")
+      .values({
+        connection_key: KEY_3,
+        lease_generation: 1,
+        socket_generation: 3,
+        disconnected_at: "2026-07-17T10:30:00.000Z",
+        connected_at: "2026-07-17T10:45:00.000Z",
+      })
+      .execute();
+
+    await worker(db).reconcile(true);
+
+    await expect(
+      db.selectFrom("whatsapp_backfill_ranges").select("id").where("group_jid", "=", "group@g.us").execute(),
+    ).resolves.toEqual([]);
+  });
+
   it("rescues later history on a newer connection key for a bootstrapped group with no live start", async () => {
     const conversation = await seedGroup(db);
     await db.updateTable("whatsapp_groups").set({ index_enabled: 1 }).where("jid", "=", "group@g.us").execute();

--- a/packages/server/src/whatsapp/backfill-worker.ts
+++ b/packages/server/src/whatsapp/backfill-worker.ts
@@ -558,7 +558,19 @@ export class WhatsAppBackfillWorker {
       .where("message.source", "=", "history")
       .where("message.backfill_range_id", "is", null)
       .where("message.connection_key", "is not", null)
-      .where("checkpoint.live_start_message_id", "is not", null);
+      /**
+       * `live_start` alone used to be a fair proxy for "this group has ranges to
+       * adopt into", because a group without it had none. Bootstrapping stranded
+       * history breaks that: those groups now hold an initial range while
+       * `live_start` stays NULL by design, and without them here the rescue sweep
+       * — supplemental ranges for rows behind an advanced graph cursor, gap ranges
+       * for rows on a newer connection key — can never reach them. Enabled groups
+       * qualify on their own. Disabled ones without `live_start` stay out, so no
+       * range is opened, and no history fetched, for a group nobody asked to index.
+       */
+      .where((eb) =>
+        eb.or([eb("checkpoint.live_start_message_id", "is not", null), eb("group.index_enabled", "=", 1)]),
+      );
     if (groupJids && groupJids.length > 0)
       query = query.where("conversation.provider_conversation_id", "in", groupJids);
     const orphans = await query.execute();

--- a/packages/server/src/whatsapp/backfill-worker.ts
+++ b/packages/server/src/whatsapp/backfill-worker.ts
@@ -442,6 +442,92 @@ export class WhatsAppBackfillWorker {
         );
       }
     }
+    await this.bootstrapStrandedHistoryRanges(nowMs, now, account);
+  }
+
+  /**
+   * A group backfilled before any live message never establishes `live_start`,
+   * so the live-message path that adopts captured history into an initial range
+   * never fires. Its history stays orphaned (`backfill_range_id IS NULL`) and is
+   * never sliced, chunked, or minted. Bootstrap the initial range for enabled
+   * groups in that state by synthesizing the boundary from the newest captured
+   * history row: adoption is not gated on the upper bound, so every stranded row
+   * is pulled in, and the graph slicer keys on the range rather than
+   * `live_start`, so the history indexes as soon as the range materializes.
+   * Deliberately does not write `live_start` to the checkpoint — a real live
+   * message stays the only writer of the true live boundary.
+   */
+  private async bootstrapStrandedHistoryRanges(
+    nowMs: number,
+    now: string,
+    account: WhatsAppAccountIdentity,
+  ): Promise<void> {
+    const stranded = await this.options.db
+      .selectFrom("whatsapp_backfill_checkpoints as checkpoint")
+      .innerJoin("whatsapp_groups as group", "group.jid", "checkpoint.group_jid")
+      .select("checkpoint.group_jid")
+      .where("group.index_enabled", "=", 1)
+      .where("checkpoint.live_start_message_id", "is", null)
+      .execute();
+    for (const { group_jid: groupJid } of stranded) {
+      const orphaned = this.options.db
+        .selectFrom("conversation_messages as message")
+        .innerJoin("conversations as conversation", "conversation.id", "message.conversation_id")
+        .where("conversation.platform", "=", "whatsapp")
+        .where("conversation.kind", "=", "group")
+        .where("conversation.provider_conversation_id", "=", groupJid)
+        .where("message.source", "=", "history")
+        .where("message.backfill_range_id", "is", null);
+      const newest = await orphaned
+        .select(["message.id", "message.effective_at"])
+        .where("message.effective_at", "is not", null)
+        .orderBy("message.effective_at", "desc")
+        .orderBy("message.id", "desc")
+        .executeTakeFirst();
+      if (!newest?.effective_at) continue;
+      /**
+       * Initial-range adoption matches `connection_key <= range.connection_key`,
+       * so the range has to carry the highest key among the stranded rows or the
+       * newer ones stay orphaned. That key need not belong to the newest row by
+       * time, so it is read separately.
+       */
+      const highestUnownedKey = await orphaned
+        .select("message.connection_key")
+        .where("message.connection_key", "is not", null)
+        .orderBy("message.connection_key", "desc")
+        .executeTakeFirst();
+      /**
+       * Adoption compares `connection_key <= range.connection_key`, which no NULL
+       * key can satisfy. Without a real key the range could never adopt anything,
+       * so skip rather than leave an empty range behind that only blocks ordering.
+       */
+      if (!highestUnownedKey?.connection_key) continue;
+      /**
+       * Provider timestamps are second-granularity, so the newest stranded row
+       * routinely shares its `effective_at` with siblings. Materialization drops
+       * fetched messages at `timestamp >= upper_bound_at`, so an exclusive bound
+       * placed exactly on that row would discard every sibling in the same second.
+       * Push the synthetic bound one millisecond past it; the row itself is
+       * already captured and re-materialization dedups.
+       */
+      const syntheticBoundary = new Date(Date.parse(newest.effective_at) + 1).toISOString();
+      const result = await this.ranges.ensureInitialRange({
+        groupJid,
+        connectionKey: highestUnownedKey.connection_key,
+        liveStartEffectiveAt: syntheticBoundary,
+        liveStartMessageId: newest.id,
+        lowerBoundAt: new Date(nowMs - this.options.config.WHATSAPP_HISTORY_LOOKBACK_DAYS * DAY_MS).toISOString(),
+        now,
+        accountJid: account.jid,
+        accountLid: account.lid,
+      });
+      if (result.created || result.adopted > 0) {
+        this.options.logger.info(
+          { rangeId: result.row.id, rowsAdopted: result.adopted, groupJid },
+          "WhatsApp initial backfill range bootstrapped from stranded history",
+        );
+      }
+    }
   }
 
   private async reconcileState(nowMs: number, now: string): Promise<void> {

--- a/packages/server/src/whatsapp/backfill-worker.ts
+++ b/packages/server/src/whatsapp/backfill-worker.ts
@@ -695,7 +695,16 @@ export class WhatsAppBackfillWorker {
       .selectFrom("whatsapp_backfill_checkpoints as checkpoint")
       .innerJoin("whatsapp_groups as group", "group.jid", "checkpoint.group_jid")
       .select("checkpoint.group_jid")
-      .where("checkpoint.live_start_message_id", "is not", null)
+      /**
+       * Gap ranges are how downtime is repaired, and a transition is consumed
+       * once — `reconciled_at` is stamped below whether or not a given group was
+       * covered, so a group missing from this list loses that window for good.
+       * Keying only on `live_start` silently excluded enabled groups that had yet
+       * to see a live message, which is exactly the state bootstrapped groups sit
+       * in permanently. Disabled groups stay out: repairing downtime for them
+       * would mean fetching history nobody asked to index.
+       */
+      .where((eb) => eb.or([eb("checkpoint.live_start_message_id", "is not", null), eb("group.index_enabled", "=", 1)]))
       .execute();
     for (const transition of transitions) {
       if (transition.disconnected_at) {


### PR DESCRIPTION
## What broke

Enable a WhatsApp group for indexing, and its history is backfilled but never indexed — 0 slices, 0 chunks, 0 entities — as long as no *live* message arrives in that group. Observed on `sketch-whatsapp-test`: 33 history rows ingested, checkpoint already `status=complete`, and nothing downstream ever ran. Not slowness; the pipeline never started.

## Why

The entire history-indexing pipeline was bootstrapped only by the arrival of the first live message.

1. The graph slicer only touches messages that belong to a backfill range (`backfill_range_id = <range>`).
2. That initial range was created **only** on the live path — [`inbound-consumer.ts:239`](packages/server/src/whatsapp/inbound-consumer.ts#L239) (`recordLiveStartOnce` → `ensureInitialRange` → adopts orphaned history).
3. The periodic reconciler that would otherwise adopt orphaned history was **itself gated** on `live_start` being set — [`backfill-worker.ts:408`](packages/server/src/whatsapp/backfill-worker.ts#L408).

No live message → no `live_start` → no range → history stays orphaned → never sliced, chunked, or minted.

The slicer never needed `live_start` ([`whatsapp-chunker.ts:874`](packages/server/src/connectors/whatsapp-chunker.ts#L874) gates on checkpoint + `index_enabled=1` + `graph_halted_at IS NULL`); it keys purely on the range. The only missing link was **range creation**.

## The fix

One new pass, `bootstrapStrandedHistoryRanges`, called at the end of `reconcileInitialRanges`. For enabled groups with `live_start IS NULL` that still have orphaned history, it creates the initial range using a synthetic boundary from the newest captured history row. Adoption is not gated on the upper bound, so every stranded row is pulled in; the slicer indexes them as soon as the range materializes.

No schema change, no migration. Reuses the exact `ensureInitialRange` + adoption mechanism the live path already runs in production. Idempotent and self-healing — once rows are adopted the query returns nothing.

Three details that would otherwise strand or lose rows:

- **Never writes `live_start`.** A real live message stays the only writer of the true live boundary; the synthetic value is passed to range creation only.
- **Carries the highest connection key among the stranded rows**, not the newest-by-time row's key. Initial-range adoption matches `connection_key <= range.connection_key`, so a lower key would silently leave the newer rows orphaned — the same bug in a new place.
- **The synthetic upper bound sits 1ms past the newest row.** Provider timestamps are second-granularity and materialization drops fetched messages at `timestamp >= upper_bound_at`, so a bound placed exactly on that row would discard every sibling sharing its second. Verified against the dev DB: 76 same-timestamp sibling groups exist in real history.

Groups whose stranded rows all lack a connection key are skipped — no NULL key can satisfy the adoption predicate, so such a range could never adopt anything.

## Second commit: the same gate, one method further down

Review surfaced that `reconcileOwnership` — the safety net for history the initial range structurally cannot take (rows behind an advanced graph cursor, which need a supplemental range; rows on a newer connection key, which need a gap range) — carried the **same** `live_start IS NOT NULL` filter. Bootstrapped groups keep `live_start` NULL by design, so they could never enter that net, and any history arriving after the first indexing pass would stay orphaned for good.

Fixed by admitting enabled groups on their own. Worth noting the naive fix would have been wrong: that query has **no `index_enabled` filter of its own**, so simply dropping the gate would have pulled in every disabled group holding orphaned history and started fetching history for groups nobody asked to index. Disabled groups without `live_start` stay out.

## Third commit: the same gate again, and this one loses data

`reconcileConnectionTransitions` creates the gap ranges that recover messages sent while the socket was down. It carried the same filter — and unlike the first two, this one destroys rather than delays. A transition is consumed exactly once: `reconciled_at` is stamped after the pass whether or not a given group was covered. A group absent from that list never gets its downtime window fetched, and nothing replays it later.

Enabled groups now qualify on their own. That covers bootstrapped groups (permanently `live_start`-less by design) and any enabled group yet to see a live message. Disabled groups stay out.

**Known limit:** a group disabled while the socket was down and enabled afterwards still loses that window — its transition was already consumed. Replaying spent transitions on enable needs its own design and is not attempted here.

## All three in one view

| # | Site | What the gate cost |
|---|---|---|
| 1 | `reconcileInitialRanges` | history never indexed — the reported bug |
| 2 | `reconcileOwnership` | leftovers never swept up |
| 3 | `reconcileConnectionTransitions` | downtime never repaired — real message loss |

## Tests

Seven added to `backfill-worker.test.ts`:

1. **The regression.** Enabled group, checkpoint with `live_start = NULL`, two orphaned history rows where the newest-by-time row carries the *lower* connection key. Asserts the `initial` range is created with the max key, an upper bound strictly past the newest row, both rows adopted, and `live_start` still NULL. Confirmed to fail with the new call commented out.
2. **Disabled-group guard** — `index_enabled=0` creates no range.
3. **Null-key guard** — all-NULL connection keys create no range.
4. **The rescue.** A bootstrapped group receives later history on a *newer* connection key; asserts it gets adopted and `live_start` stays NULL. Confirmed to fail with the gate change reverted.
5. **Rescue guard** — a disabled group with no `live_start` gets no ranges at all, so the sweep opens nothing for groups nobody asked to index.
6. **Downtime repair.** An enabled group that has never seen a live message gets a `gap:` range spanning exactly the disconnect window. Confirmed to fail with the gate change reverted.
7. **Downtime guard** — a disabled group gets no range from the same transition.

## Verification

- `pnpm biome check`, `pnpm typecheck` — clean
- `pnpm test:unit` — server 416 files / 4828 tests, web 52 files / 509 tests, all green
- Root cause validated against the live dev DB, not just the RCA writeup

## Reviewed

Reviewed by Codex `gpt-5.6-sol` (medium effort). It raised four issues; **three are fixed here** — the same-timestamp boundary, the NULL-key range, and the orphan-rescue gate (second commit).

Its claims were checked against the live dev DB rather than taken on trust. Two are worth recording:

- The **NULL connection key** case is not reachable in practice — all 45 groups, zero NULL keys. A guard was added regardless, since it costs one line and prevents a range that could never adopt anything.
- The suggestion to **gate bootstrap on `checkpoint.status = 'complete'`** was declined: 18 of 45 checkpoints sit at `in_progress`, so that gate could permanently suppress the fix — the worse failure mode for a bug whose symptom is "never indexes."

One issue is knowingly left open, as it is narrow and not a regression:

- **A later live message leaves a fetch gap.** The `initial` range key is constant and `onConflict` does nothing, so the anchor stays at the bootstrap row and the window between it and the first live message is never fetched backwards. Connection-transition gap ranges already cover the disconnect case, so this only bites when there is no connection transition across that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
