### PR TITLE
feat(whatsapp): resolve participant phones, propose entity names, and index group history in inprocess mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .env
+.env.bak-*
 data
 data/
 tmp/
@@ -22,3 +23,4 @@ docs/superpowers/specs/
 .claude/skills/implement-story
 .claude/skills/remote-tenant-debugging
 .claude/skills/run-canvas-sketch
+.claude/skills/worktree-dev-setup

--- a/packages/server/src/agent/tools/chat-search.integration.test.ts
+++ b/packages/server/src/agent/tools/chat-search.integration.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { type Kysely, sql } from "kysely";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { reconcileWhatsAppGroupAcls } from "../../connectors/whatsapp-salience";
+import { reconcileWhatsAppGroupAcls } from "../../connectors/whatsapp-emission";
 import { createConnectorRepository } from "../../db/repositories/connectors";
 import { createConversationSlicesRepository } from "../../db/repositories/conversation-slices";
 import { createConversationRepository } from "../../db/repositories/conversations";

--- a/packages/server/src/api/connectors-whatsapp-scope.test.ts
+++ b/packages/server/src/api/connectors-whatsapp-scope.test.ts
@@ -8,6 +8,7 @@ import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-group
 import type { DB } from "../db/schema";
 import { createApp } from "../http";
 import { createTestConfig, createTestDb, createTestLogger } from "../test-utils";
+import type { WhatsAppSocketFacade } from "../whatsapp/facade-contract";
 
 const ADMIN_EMAIL = "admin@test.com";
 const MEMBER_EMAIL = "member@test.com";
@@ -83,10 +84,20 @@ describe("WhatsApp connector scope API", () => {
   let app: ReturnType<typeof createApp>;
   let cookie: string;
   let adminId: string;
+  let refreshedGroups: string[];
 
   beforeEach(async () => {
     db = await createTestDb();
-    app = createApp(db, createTestConfig(), { logger });
+    refreshedGroups = [];
+    app = createApp(db, createTestConfig(), {
+      logger,
+      whatsapp: {
+        groupMetadata: async (jid: string) => {
+          refreshedGroups.push(jid);
+          return null;
+        },
+      } as unknown as WhatsAppSocketFacade,
+    });
     adminId = await seedAdmin(db);
     cookie = await login(app);
   });
@@ -117,11 +128,13 @@ describe("WhatsApp connector scope API", () => {
       "beta@g.us": 0,
       "gamma@g.us": 1,
     });
+    expect(refreshedGroups).toEqual(["alpha@g.us"]);
 
     const second = await patchScope(app, cookie, connector.id, {
       groupIndexing: { "alpha@g.us": true, "beta@g.us": false },
     });
     expect(second.status).toBe(200);
+    expect(refreshedGroups).toEqual(["alpha@g.us"]);
     await expect(indexFlags(db)).resolves.toEqual({
       "alpha@g.us": 1,
       "beta@g.us": 0,

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -71,6 +71,7 @@ import {
 import type { DB } from "../db/schema";
 import { HIDDEN_ENTITY_SOURCE_TYPES } from "../entities/profile-facts";
 import { createSettingsBackedSlackIndexingFacade } from "../slack/indexing-facade";
+import type { WhatsAppSocketFacade } from "../whatsapp/facade-contract";
 import {
   type ConnectorPermissions,
   connectorPermissions,
@@ -243,6 +244,7 @@ export async function pruneGoogleCalendarFilesOutsideScope(params: {
 export async function applyWhatsAppGroupScope(params: {
   db: Kysely<DB>;
   scopeConfig: Record<string, unknown>;
+  newlyEnabled?: string[];
 }): Promise<Record<string, unknown>> {
   if (hasOwn(params.scopeConfig, "groupJids")) {
     throw new WhatsAppGroupScopeValidationError("groupJids is no longer supported");
@@ -267,7 +269,7 @@ export async function applyWhatsAppGroupScope(params: {
     throw new WhatsAppGroupScopeValidationError(`Unknown WhatsApp group jid: ${unknownJids[0]}`);
   }
 
-  await applyIndexSelection(params.db, parsed.data);
+  params.newlyEnabled?.push(...(await applyIndexSelection(params.db, parsed.data)));
   return scopeConfig;
 }
 
@@ -430,6 +432,7 @@ export function connectorRoutes(
     /** Overrides the settings-derived model, so tests can drive the per-file enrich route. */
     enrichmentGenerator?: GeminiGenerator;
     taskMintingGenerator?: GeminiGenerator;
+    whatsapp?: Pick<WhatsAppSocketFacade, "groupMetadata">;
   },
 ) {
   const routes = new Hono();
@@ -2365,12 +2368,17 @@ export function connectorRoutes(
     }
 
     let requestedScope: Record<string, unknown>;
+    const newlyEnabledWhatsAppGroups: string[] = [];
     try {
       requestedScope = await db.transaction().execute(async (trx) => {
         const txConnectorRepo = createConnectorRepository(trx, appConfig?.ENCRYPTION_KEY);
         const scope =
           config.connector_type === "whatsapp"
-            ? await applyWhatsAppGroupScope({ db: trx, scopeConfig: parsed.data.scopeConfig })
+            ? await applyWhatsAppGroupScope({
+                db: trx,
+                scopeConfig: parsed.data.scopeConfig,
+                newlyEnabled: newlyEnabledWhatsAppGroups,
+              })
             : parsed.data.scopeConfig;
         const existingScope =
           config.scope_config && typeof config.scope_config === "string"
@@ -2391,6 +2399,14 @@ export function connectorRoutes(
         return c.json({ error: { code: "VALIDATION_ERROR", message: err.message } }, 400);
       }
       throw err;
+    }
+
+    for (const groupJid of newlyEnabledWhatsAppGroups) {
+      try {
+        await deps?.whatsapp?.groupMetadata(groupJid, { refresh: true });
+      } catch (err) {
+        logger.warn({ err, groupJid }, "Failed to refresh newly enabled WhatsApp group metadata");
+      }
     }
 
     if (config.connector_type === "google_calendar" || config.connector_type === "outlook_calendar") {

--- a/packages/server/src/api/connectors.ts
+++ b/packages/server/src/api/connectors.ts
@@ -433,6 +433,15 @@ export function connectorRoutes(
     enrichmentGenerator?: GeminiGenerator;
     taskMintingGenerator?: GeminiGenerator;
     whatsapp?: Pick<WhatsAppSocketFacade, "groupMetadata">;
+    /**
+     * Wakes the WhatsApp backfill worker after groups are newly enabled.
+     * Without it the worker only notices on its 5-minute reconcile sweep, so a
+     * user who pairs and then enables a group — the normal order — watches an
+     * empty Files page until the sweep happens to run. "Sync now" does not help
+     * either: sync drives the chunker, and the chunker has nothing to chunk
+     * until the worker adopts the captured history into a range.
+     */
+    wakeWhatsAppBackfill?: () => Promise<void> | void;
   },
 ) {
   const routes = new Hono();
@@ -2409,6 +2418,14 @@ export function connectorRoutes(
       }
     }
 
+    if (newlyEnabledWhatsAppGroups.length > 0) {
+      try {
+        await deps?.wakeWhatsAppBackfill?.();
+      } catch (err) {
+        logger.warn({ err }, "Failed to wake the WhatsApp backfill worker after enabling groups");
+      }
+    }
+
     if (config.connector_type === "google_calendar" || config.connector_type === "outlook_calendar") {
       await pruneCalendarFilesOutsideScope({
         db,
@@ -2451,6 +2468,21 @@ export function connectorRoutes(
       // Reset stale "syncing" status — the previous sync likely crashed
       await connectorRepo.updateConfig(config.id, { syncStatus: "active", errorMessage: null });
       logger.warn({ connectorId: config.id }, "Reset stale syncing status via manual trigger");
+    }
+
+    /**
+     * Adopt any captured-but-unowned WhatsApp history before the sync runs.
+     * Sync drives the chunker, and the chunker can only see messages that a
+     * backfill range already owns — so without this a manual "Sync now" on a
+     * group whose history has not been adopted yet completes with every counter
+     * at zero and looks like the button did nothing.
+     */
+    if (config.connector_type === "whatsapp") {
+      try {
+        await deps?.wakeWhatsAppBackfill?.();
+      } catch (err) {
+        logger.warn({ err }, "Failed to wake the WhatsApp backfill worker before a manual sync");
+      }
     }
 
     // Run sync then enrichment in background

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -420,6 +420,12 @@ export async function createServer(config: Config, options?: CreateServerOptions
   let inProcessWhatsAppLease: InProcessWhatsAppLease | null = null;
   let whatsappBot: WhatsAppBot | null = null;
   let whatsapp: WhatsAppSocketFacade;
+  /**
+   * The worker is constructed further down, after the facade exists, but the
+   * in-process socket callback below is defined before that point and has to
+   * reach it on connect. Same indirection the inbound consumer already uses.
+   */
+  const whatsappBackfillWorkerRef: { current: WhatsAppBackfillWorker | null } = { current: null };
   const observeInProcessBaileysSocketState = async (
     socketState: "connected" | "disconnected" | "logged-out",
     socketGeneration: number,
@@ -434,6 +440,29 @@ export async function createServer(config: Config, options?: CreateServerOptions
       ...(statusCode === undefined ? {} : { statusCode }),
       reason: `inprocess_${socketState}`,
     });
+    /**
+     * Gateway mode reaches `handleConnected` through the supervisor's socket
+     * state hook. In-process has no supervisor, so without this the worker
+     * never sees a connection: ranges are never rearmed and captured history
+     * stays orphaned, which is why enabling a group indexed nothing.
+     *
+     * Deliberately not awaited. This runs inside the Baileys connection-open
+     * path, which is already writing (credentials, group metadata); awaiting a
+     * further write here contends for SQLite's single writer and raised
+     * SQLITE_BUSY, and because nothing upstream catches it the whole process
+     * died on connect. The worker's own 5-minute reconcile sweep repeats this
+     * work, so a failure here costs promptness, never correctness.
+     */
+    if (socketState === "connected") {
+      void whatsappBackfillWorkerRef.current
+        ?.handleConnected({ leaseGeneration: identity.generation, socketGeneration })
+        .catch((error) => {
+          logger.warn(
+            { ...safeWhatsAppErrorFields(error), socketGeneration },
+            "WhatsApp backfill connect handling failed; reconcile sweep will retry",
+          );
+        });
+    }
   };
   if (config.WHATSAPP_RUNTIME_MODE === "gateway" && usesBaileys) {
     whatsappSupervisor = new WhatsAppGatewaySupervisor({
@@ -1033,18 +1062,26 @@ export async function createServer(config: Config, options?: CreateServerOptions
   };
   const whatsappHandlers = wireWhatsAppHandlers(whatsappRuntime, whatsappAdapterDeps);
   const whatsappInboundConsumerRef: { current: WhatsAppInboundConsumer | null } = { current: null };
-  const whatsappBackfillWorker =
-    whatsapp instanceof GatewayClientFacade
-      ? new WhatsAppBackfillWorker({
-          db,
-          config,
-          logger,
-          facade: whatsapp,
-          handlers: whatsappHandlers,
-          shouldHandleInboundMessage: whatsappRuntime.shouldHandleInboundMessage,
-          onRequestAccepted: () => whatsappInboundConsumerRef.current?.wake(),
-        })
-      : null;
+  /**
+   * Gated on the provider, not on the facade class. The worker only ever needs
+   * `WhatsAppSocketFacade.fetchMessageHistory`, which the in-process facade
+   * implements just as the gateway client does; narrowing to
+   * `GatewayClientFacade` meant every deployment on the default
+   * `WHATSAPP_RUNTIME_MODE=inprocess` silently built no worker, so group
+   * history was captured but never adopted into a backfill range — never
+   * sliced, chunked, or minted.
+   */
+  const whatsappBackfillWorker = usesBaileys
+    ? new WhatsAppBackfillWorker({
+        db,
+        config,
+        logger,
+        facade: whatsapp,
+        handlers: whatsappHandlers,
+        shouldHandleInboundMessage: whatsappRuntime.shouldHandleInboundMessage,
+        onRequestAccepted: () => whatsappInboundConsumerRef.current?.wake(),
+      })
+    : null;
   const whatsappInboundConsumer = new WhatsAppInboundConsumer({
     db,
     logger,
@@ -1055,6 +1092,7 @@ export async function createServer(config: Config, options?: CreateServerOptions
     backfillWorker: whatsappBackfillWorker ?? undefined,
   });
   whatsappInboundConsumerRef.current = whatsappInboundConsumer;
+  whatsappBackfillWorkerRef.current = whatsappBackfillWorker;
   if (backgroundWork) {
     await createWhatsAppInboundEventsRepository(db).resetDispatched();
     whatsappInboundConsumer.start();
@@ -1108,6 +1146,12 @@ export async function createServer(config: Config, options?: CreateServerOptions
   const app = createApp(db, config, {
     whatsapp,
     whatsappRuntime,
+    /**
+     * `forceSweep` bypasses the 5-minute interval so a group enabled seconds
+     * after the socket connected does not wait for the next scheduled sweep to
+     * have its captured history adopted.
+     */
+    wakeWhatsAppBackfill: () => whatsappBackfillWorker?.reconcile(true),
     captureWhatsAppLid: (userId, phoneE164) => {
       void whatsappUserLidRefresh.capture(userId, phoneE164).catch((error) => {
         logger.warn(

--- a/packages/server/src/connectors/slack-salience.ts
+++ b/packages/server/src/connectors/slack-salience.ts
@@ -13,7 +13,7 @@ import {
 import type { SlackIndexingFacade } from "../slack/indexing-facade";
 import type { GeminiGenerator } from "./gemini-generate";
 import { SLACK_CONVERSATION_SLICE_FILE_TYPE, type SyncedItem } from "./types";
-import { type WhatsAppSalienceVerdict, parseWhatsAppSalienceResponse } from "./whatsapp-salience";
+import { type WhatsAppSalienceVerdict, parseWhatsAppSalienceResponse } from "./whatsapp-emission";
 
 export const DEFAULT_SLACK_SALIENCE_BATCH_LIMIT = 50;
 export const SLACK_EMISSION_REFRESH_DAYS = 7;

--- a/packages/server/src/connectors/whatsapp-chunker.ts
+++ b/packages/server/src/connectors/whatsapp-chunker.ts
@@ -1186,6 +1186,58 @@ async function admitWhatsAppBackfillGraphPages(options: ChunkWhatsAppGroupsOptio
     if (result.rangeCompleted) rangesCompleted += 1;
   }
 
+  /**
+   * `chatsServed: 0` is ambiguous across five different predicates in
+   * `findNextGraphCandidate`, and reading the counter alone cannot tell you
+   * which one held. Probe the disqualifying conditions only when nothing was
+   * served, so the normal path pays nothing and a dead-looking pipeline still
+   * names its own cause.
+   *
+   * `groupsByJid.size > 0` is load-bearing, not defensive: an empty list renders
+   * as `IN ()`, which SQLite accepts and Postgres rejects as a syntax error —
+   * the error would escape this function and fail the whole sync. It is also the
+   * one case needing no explanation, since having no enabled groups is itself
+   * the reason nothing was served.
+   */
+  if (servedGroupJids.length === 0 && !skippedForPressure && groupsByJid.size > 0) {
+    const groupJids = [...groupsByJid.keys()];
+    const [ranges, halted] = await Promise.all([
+      options.db
+        .selectFrom("whatsapp_backfill_ranges")
+        .select(({ fn, eb }) => [
+          fn.countAll<number>().as("total"),
+          fn
+            .sum<number>(eb.case().when("status", "in", ["complete", "exhausted"]).then(1).else(0).end())
+            .as("terminal"),
+          fn.sum<number>(eb.case().when("graph_completed_at", "is", null).then(1).else(0).end()).as("ungraphed"),
+        ])
+        .where("group_jid", "in", groupJids)
+        .executeTakeFirst(),
+      options.db
+        .selectFrom("whatsapp_backfill_checkpoints")
+        .select(({ fn }) => fn.countAll<number>().as("halted"))
+        .where("group_jid", "in", groupJids)
+        .where("graph_halted_at", "is not", null)
+        .executeTakeFirst(),
+    ]);
+    const ungraphed = Number(ranges?.ungraphed ?? 0);
+    const fields = {
+      enabledGroups: groupJids.length,
+      ranges: Number(ranges?.total ?? 0),
+      rangesTerminal: Number(ranges?.terminal ?? 0),
+      rangesUngraphed: ungraphed,
+      checkpointsHalted: Number(halted?.halted ?? 0),
+    };
+    /**
+     * Once a group is fully backfilled every range is graph-completed and
+     * serving nothing is the correct steady state, which would otherwise emit
+     * this line at info on every sync forever. Reserve info for the case worth
+     * looking at: ranges still waiting to be graphed while none could be served.
+     */
+    if (ungraphed > 0) options.logger.info(fields, "WhatsApp backfill graph admission served no chat");
+    else options.logger.debug(fields, "WhatsApp backfill graph admission served no chat");
+  }
+
   return {
     chatsServed: servedGroupJids.length,
     messagesRead,

--- a/packages/server/src/connectors/whatsapp-emission.integration.test.ts
+++ b/packages/server/src/connectors/whatsapp-emission.integration.test.ts
@@ -12,7 +12,7 @@ import { createTestDb, createTestLogger, createTestPgDb } from "../test-utils";
 import { runEnrichment } from "./enrichment";
 import type { GeminiGenerator } from "./gemini-generate";
 import { runConnectorSync } from "./sync";
-import { emitWhatsAppSyncedItems, reconcileWhatsAppGroupAcls } from "./whatsapp-salience";
+import { emitWhatsAppSyncedItems, reconcileWhatsAppGroupAcls } from "./whatsapp-emission";
 
 const RAW_IDENTIFIER_PATTERN = /(?:\+?[1-9]\d{9,14}\b|@s\.whatsapp\.net|@lid)/iu;
 const SALIENCE_SIGNALS = JSON.stringify({ signals: ["decision"], entities: [] });

--- a/packages/server/src/connectors/whatsapp-emission.test.ts
+++ b/packages/server/src/connectors/whatsapp-emission.test.ts
@@ -15,7 +15,7 @@ import {
   parseWhatsAppSalienceResponse,
   processWhatsAppSalience,
   renderWhatsAppTranscript,
-} from "./whatsapp-salience";
+} from "./whatsapp-emission";
 
 function fakeLogger(): Logger {
   return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() } as unknown as Logger;

--- a/packages/server/src/connectors/whatsapp-emission.ts
+++ b/packages/server/src/connectors/whatsapp-emission.ts
@@ -32,7 +32,7 @@ import {
 export const DEFAULT_WHATSAPP_SALIENCE_BATCH_LIMIT = 50;
 export const WHATSAPP_EMISSION_REFRESH_DAYS = 7;
 
-const PROMPT_VERSION = "whatsapp-salience-v1";
+const PROMPT_VERSION = "whatsapp-emission-v1";
 const DAY_MS = 24 * 60 * 60 * 1000;
 const SALIENCE_CLAIM_STALE_MS = 10 * 60 * 1000;
 const SALIENCE_SIGNALS = new Set(["decision", "commitment", "question", "named_entity"]);
@@ -552,11 +552,25 @@ function renderedMessageCount(content: string | null): number {
   return transcript ? transcript.split("\n").length : 0;
 }
 
+/**
+ * Why a kept slice produced no synced item. Emission previously reported a bare
+ * `emitted: 0` with a single `skippedNoScope` counter, so the far more common
+ * skips — an open slice under the message threshold, or content that has not
+ * changed since the last file — were indistinguishable from "there was nothing
+ * to do". Debugging a pipeline that looks dead always asks "why not", and a
+ * count alone cannot answer it.
+ */
+export type WhatsAppEmissionSkipReason =
+  | "no_access_scope"
+  | "below_min_messages"
+  | "unchanged_content"
+  | "below_refresh_threshold";
+
 async function syncedItemForKeptSlice(
   db: Kysely<DB>,
   context: SliceContext,
   logger: Logger,
-): Promise<{ item: SyncedItem | null; skippedNoScope: boolean }> {
+): Promise<{ item: SyncedItem | null; skippedNoScope: boolean; skipReason: WhatsAppEmissionSkipReason | null }> {
   const rendered = await renderSlice(db, context, logger);
   if (rendered.serializedRosterSnapshot !== context.slice.roster_snapshot) {
     await db
@@ -571,14 +585,25 @@ async function syncedItemForKeptSlice(
       { sliceId: context.slice.id, conversationId: context.conversationId, groupJid: context.groupJid },
       "Skipped WhatsApp slice indexing because no teammate access scope resolved",
     );
-    return { item: null, skippedNoScope: true };
+    return { item: null, skippedNoScope: true, skipReason: "no_access_scope" };
   }
   const titleGroup = sanitizeWhatsAppDisplayText(context.groupName) || "WhatsApp group";
   const content = rendered.content;
   const contentHash = stableContentHash(content);
   if (context.slice.status === "open") {
     const minMessages = context.chunkMinMessages ?? DEFAULT_WHATSAPP_LLM_CHUNK_MIN_MESSAGES;
-    if (context.slice.message_count < minMessages) return { item: null, skippedNoScope: false };
+    if (context.slice.message_count < minMessages) {
+      logger.debug(
+        {
+          sliceId: context.slice.id,
+          groupJid: context.groupJid,
+          messageCount: context.slice.message_count,
+          minMessages,
+        },
+        "Skipped WhatsApp open slice below the minimum message threshold",
+      );
+      return { item: null, skippedNoScope: false, skipReason: "below_min_messages" };
+    }
     const indexedFileId = context.slice.indexed_file_id ?? (await findSliceFileId(db, context.slice.id));
     if (indexedFileId) {
       const existing = await db
@@ -586,7 +611,8 @@ async function syncedItemForKeptSlice(
         .select(["content_hash", "content"])
         .where("id", "=", indexedFileId)
         .executeTakeFirst();
-      if (existing?.content_hash === contentHash) return { item: null, skippedNoScope: false };
+      if (existing?.content_hash === contentHash)
+        return { item: null, skippedNoScope: false, skipReason: "unchanged_content" };
       const previousMessageCount = renderedMessageCount(existing?.content ?? null);
       const refreshMessages =
         context.chunkProvisionalRefreshMessages ?? DEFAULT_WHATSAPP_LLM_CHUNK_PROVISIONAL_REFRESH_MESSAGES;
@@ -594,12 +620,13 @@ async function syncedItemForKeptSlice(
         context.slice.message_count >= previousMessageCount &&
         context.slice.message_count - previousMessageCount < refreshMessages
       ) {
-        return { item: null, skippedNoScope: false };
+        return { item: null, skippedNoScope: false, skipReason: "below_refresh_threshold" };
       }
     }
   }
   return {
     skippedNoScope: false,
+    skipReason: null,
     item: {
       providerFileId: context.slice.id,
       providerUrl: null,
@@ -704,11 +731,18 @@ export async function* emitWhatsAppSyncedItems(options: {
   emissionRefreshDays?: number;
   now?: Date;
   onSkippedNoScope?: () => void;
+  /**
+   * Receives one tally per run so the caller can fold the reasons into its own
+   * summary line rather than emitting a log per skipped slice — a busy group
+   * skips many slices per sync, and per-slice lines would bury the signal.
+   */
+  onSkipReason?: (reason: WhatsAppEmissionSkipReason) => void;
 }): AsyncGenerator<SyncedItem> {
   const kept = await listKeptSliceContexts(options.db, options.emissionRefreshDays, options.now);
   for (const context of kept) {
-    const { item, skippedNoScope } = await syncedItemForKeptSlice(options.db, context, options.logger);
+    const { item, skippedNoScope, skipReason } = await syncedItemForKeptSlice(options.db, context, options.logger);
     if (skippedNoScope) options.onSkippedNoScope?.();
+    if (skipReason) options.onSkipReason?.(skipReason);
     if (item) yield item;
   }
 }

--- a/packages/server/src/connectors/whatsapp.ts
+++ b/packages/server/src/connectors/whatsapp.ts
@@ -11,7 +11,7 @@ import {
   WHATSAPP_EMISSION_REFRESH_DAYS,
   emitWhatsAppSyncedItems,
   reconcileWhatsAppGroupAcls,
-} from "./whatsapp-salience";
+} from "./whatsapp-emission";
 
 function assertSystemCredentials(credentials: ConnectorCredentials): void {
   if (credentials.type !== "system") {
@@ -130,6 +130,7 @@ export function createWhatsAppConnector(): Connector {
       });
       let skippedNoScope = 0;
       let emitted = 0;
+      const skipReasons: Record<string, number> = {};
       for await (const item of emitWhatsAppSyncedItems({
         db,
         logger,
@@ -137,11 +138,27 @@ export function createWhatsAppConnector(): Connector {
         onSkippedNoScope: () => {
           skippedNoScope += 1;
         },
+        onSkipReason: (reason) => {
+          skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
+        },
       })) {
         emitted += 1;
         yield item;
       }
-      logger.info({ emitted, skippedNoScope }, "Completed WhatsApp synced item emission");
+      /**
+       * `skipReasons` is what makes an `emitted: 0` actionable: it names which
+       * gate held every candidate back instead of leaving zero ambiguous
+       * between "nothing to emit" and "everything was blocked".
+       */
+      logger.info(
+        {
+          emitted,
+          skippedNoScope,
+          candidates: emitted + Object.values(skipReasons).reduce((a, b) => a + b, 0),
+          skipReasons,
+        },
+        "Completed WhatsApp synced item emission",
+      );
       if (connectorConfigId) {
         await reconcileWhatsAppGroupAcls({ db, logger, connectorConfigId });
       }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -186,6 +186,7 @@ import * as m183 from "./migrations/183-graph-pass-runs";
 import * as m184 from "./migrations/184-person-contact-point-cutover";
 import * as m185 from "./migrations/185-queue-pass-reason";
 import * as m186 from "./migrations/186-entity-merge-groups";
+import * as m187 from "./migrations/187-entity-name-proposals";
 import type { DB } from "./schema";
 
 /**
@@ -381,6 +382,7 @@ export function createMigrator(db: Kysely<DB>): Migrator {
           "184-person-contact-point-cutover": m184,
           "185-queue-pass-reason": m185,
           "186-entity-merge-groups": m186,
+          "187-entity-name-proposals": m187,
         };
       },
     },

--- a/packages/server/src/db/migrations/187-entity-name-proposals.ts
+++ b/packages/server/src/db/migrations/187-entity-name-proposals.ts
@@ -1,0 +1,41 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("entities")
+    .addColumn("name_status", "text", (col) => col.notNull().defaultTo("confirmed"))
+    .execute();
+  await db.schema
+    .createTable("entity_name_proposals")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("entity_id", "text", (col) => col.notNull().references("entities.id").onDelete("cascade"))
+    .addColumn("source", "text", (col) => col.notNull())
+    .addColumn("value", "text", (col) => col.notNull())
+    .addColumn("normalized_value", "text", (col) => col.notNull())
+    .addColumn("observed_count", "integer", (col) => col.notNull().defaultTo(1))
+    .addColumn("first_seen_at", "text", (col) => col.notNull())
+    .addColumn("last_seen_at", "text", (col) => col.notNull())
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("pending"))
+    .addColumn("resolved_by_user_id", "text", (col) => col.references("users.id"))
+    .addColumn("resolved_at", "text")
+    .addUniqueConstraint("entity_name_proposals_entity_source_value_uidx", ["entity_id", "source", "normalized_value"])
+    .execute();
+  await sql`
+    UPDATE entities
+    SET name_status = 'placeholder'
+    WHERE source_type = 'person'
+      AND EXISTS (
+        SELECT 1
+        FROM entity_contact_points
+        WHERE entity_contact_points.entity_id = entities.id
+          AND entity_contact_points.source = 'whatsapp_identity'
+          AND entity_contact_points.kind IN ('phone', 'whatsapp_lid')
+          AND entity_contact_points.value = entities.name
+      )
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("entity_name_proposals").execute();
+  await db.schema.alterTable("entities").dropColumn("name_status").execute();
+}

--- a/packages/server/src/db/migrations/migrate-pg.integration.test.ts
+++ b/packages/server/src/db/migrations/migrate-pg.integration.test.ts
@@ -23,7 +23,7 @@ import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as slackFileAccessBackfillCleanupMigration from "./163-slack-file-access-backfill-cleanup";
 import * as typedAccessPrincipalsMigration from "./165-typed-access-principals";
 
-const EXPECTED_MIGRATION_COUNT = 182;
+const EXPECTED_MIGRATION_COUNT = 183;
 
 describe("runMigrations on Postgres — full sequence", () => {
   let db!: Kysely<DB>;

--- a/packages/server/src/db/migrations/migrate.test.ts
+++ b/packages/server/src/db/migrations/migrate.test.ts
@@ -29,7 +29,7 @@ import * as slackRosterEvidenceMigration from "./161-slack-roster-evidence";
 import * as outlookCalendarProviderFileScopeMigration from "./164-outlook-calendar-provider-file-scope";
 import * as entityMergeGroupsMigration from "./186-entity-merge-groups";
 
-const EXPECTED_MIGRATION_COUNT = 182;
+const EXPECTED_MIGRATION_COUNT = 183;
 
 function createBlankDb(): Kysely<DB> {
   return new Kysely<DB>({
@@ -50,6 +50,54 @@ describe("runMigrations — full sequence", () => {
 
   it("runs all migrations on a fresh database without error", async () => {
     await expect(runMigrations(db, { quiet: true })).resolves.not.toThrow();
+  });
+
+  it("backfills placeholder status only for WhatsApp identity names", async () => {
+    const migrator = createMigrator(db);
+    await migrator.migrateTo("180-whatsapp-chunk-conversion-state");
+    await db
+      .insertInto("entities")
+      .values([
+        {
+          id: "whatsapp-phone",
+          name: "+919969577769",
+          source_type: "person",
+          status: "confirmed",
+          hotness: 0,
+          created_at: "2026-08-13T00:00:00.000Z",
+          updated_at: "2026-08-13T00:00:00.000Z",
+        },
+        {
+          id: "email-phone",
+          name: "+919891688787",
+          source_type: "person",
+          status: "confirmed",
+          hotness: 0,
+          created_at: "2026-08-13T00:00:00.000Z",
+          updated_at: "2026-08-13T00:00:00.000Z",
+        },
+      ])
+      .execute();
+    await db
+      .insertInto("entity_contact_points")
+      .values({
+        id: "whatsapp-phone-point",
+        entity_id: "whatsapp-phone",
+        kind: "phone",
+        value: "+919969577769",
+        source: "whatsapp_identity",
+      })
+      .execute();
+
+    await migrator.migrateToLatest();
+
+    const rows = await sql<{ id: string; name_status: string }>`
+      SELECT id, name_status FROM entities ORDER BY id
+    `.execute(db);
+    expect(rows.rows).toEqual([
+      { id: "email-phone", name_status: "confirmed" },
+      { id: "whatsapp-phone", name_status: "placeholder" },
+    ]);
   });
 
   it("logs each applied migration by default and stays silent when quiet is set", async () => {

--- a/packages/server/src/db/repositories/entities.ts
+++ b/packages/server/src/db/repositories/entities.ts
@@ -178,6 +178,7 @@ export interface UpsertPersonEntityData {
   source: string;
   sourceId: string;
   provenanceTier?: ProvenanceTier;
+  nameStatus?: "confirmed" | "placeholder";
 }
 
 export function isHumanSubtypeOverride(provenanceTier: string | null | undefined): boolean {
@@ -1779,6 +1780,7 @@ export function createEntityRepository(db: Kysely<DB>) {
           metadata: JSON.stringify(metadata),
           source_ref_id: null,
           status: "confirmed",
+          name_status: data.nameStatus ?? "confirmed",
           provenance_tier: data.provenanceTier ?? "inferred",
           hotness: 0,
           created_at: now,

--- a/packages/server/src/db/repositories/entity-aliases.ts
+++ b/packages/server/src/db/repositories/entity-aliases.ts
@@ -1,8 +1,42 @@
-import type { Kysely } from "kysely";
+import { randomUUID } from "node:crypto";
+import { type Kysely, sql } from "kysely";
+import { normalizeName } from "../../connectors/name-normalize";
 import { parseAliasesString } from "../../entities/materialize-json";
 import type { DB } from "../schema";
 
 const MAX_ALIAS_MERGE_ATTEMPTS = 8;
+
+export async function upsertEntityNameProposal(
+  db: Kysely<DB>,
+  entityId: string,
+  source: string,
+  value: string,
+  observedAt = new Date().toISOString(),
+): Promise<void> {
+  const normalizedValue = normalizeName(value);
+  if (!normalizedValue) return;
+  await db
+    .insertInto("entity_name_proposals")
+    .values({
+      id: randomUUID(),
+      entity_id: entityId,
+      source,
+      value,
+      normalized_value: normalizedValue,
+      first_seen_at: observedAt,
+      last_seen_at: observedAt,
+      resolved_by_user_id: null,
+      resolved_at: null,
+    })
+    .onConflict((oc) =>
+      oc.columns(["entity_id", "source", "normalized_value"]).doUpdateSet({
+        value,
+        observed_count: sql`entity_name_proposals.observed_count + 1`,
+        last_seen_at: observedAt,
+      }),
+    )
+    .execute();
+}
 
 export async function mergeEntityAliases(
   db: Kysely<DB>,
@@ -51,47 +85,17 @@ export async function enrichWhatsAppRosterPersonName(
   db: Kysely<DB>,
   entityId: string,
   candidates: Array<string | null | undefined>,
-  identityValues: Array<string | null | undefined>,
+  proposalCandidates: Array<string | null | undefined> = candidates,
   now = new Date().toISOString(),
 ): Promise<void> {
   const names = candidates
     .map((candidate) => candidate?.trim())
     .filter((candidate): candidate is string => Boolean(candidate));
   if (names.length === 0) return;
-  const fallbackNames = new Set(
-    identityValues.map((value) => value?.trim().toLowerCase()).filter((value): value is string => Boolean(value)),
-  );
-  for (let attempt = 0; attempt < MAX_ALIAS_MERGE_ATTEMPTS; attempt += 1) {
-    const entity = await db
-      .selectFrom("entities")
-      .select(["id", "name", "aliases"])
-      .where("id", "=", entityId)
-      .where("source_type", "=", "person")
-      .where("status", "!=", "archived")
-      .where("deleted_at", "is", null)
-      .where("merged_into_entity_id", "is", null)
-      .executeTakeFirst();
-    if (!entity) return;
-    if (!fallbackNames.has(entity.name.trim().toLowerCase())) {
-      await mergeEntityAliases(db, entityId, names, now);
-      return;
-    }
-
-    const aliases = parseAliasesString(entity.aliases);
-    const seen = new Set(aliases.map((alias) => alias.trim().toLowerCase()));
-    if (!seen.has(entity.name.trim().toLowerCase())) aliases.push(entity.name);
-    const update = await db
-      .updateTable("entities")
-      .set({ name: names[0], aliases: JSON.stringify(aliases), updated_at: now })
-      .where("id", "=", entity.id)
-      .where("name", "=", entity.name)
-      .$if(entity.aliases === null, (query) => query.where("aliases", "is", null))
-      .$if(entity.aliases !== null, (query) => query.where("aliases", "=", entity.aliases))
-      .executeTakeFirst();
-    if (Number(update.numUpdatedRows) > 0) {
-      await mergeEntityAliases(db, entityId, names.slice(1), now);
-      return;
-    }
+  await mergeEntityAliases(db, entityId, names, now);
+  for (const name of proposalCandidates
+    .map((candidate) => candidate?.trim())
+    .filter((candidate): candidate is string => Boolean(candidate))) {
+    await upsertEntityNameProposal(db, entityId, "whatsapp_pushname", name, now);
   }
-  throw new Error(`WhatsApp roster name enrichment remained contended for ${entityId}`);
 }

--- a/packages/server/src/db/repositories/whatsapp-group-observations.integration.test.ts
+++ b/packages/server/src/db/repositories/whatsapp-group-observations.integration.test.ts
@@ -6,6 +6,7 @@ import type { DB } from "../schema";
 import { createEntityRepository } from "./entities";
 import { createUserRepository } from "./users";
 import { createWhatsAppGroupRepository } from "./whatsapp-groups";
+import { projectWhatsAppRosterPerson } from "./whatsapp-roster-person-projection";
 
 type DbFactory = () => Promise<Kysely<DB>>;
 
@@ -260,6 +261,86 @@ function observationSuite(label: string, createDb: DbFactory) {
         .where("entity_contact_points.value", "=", lid)
         .executeTakeFirstOrThrow();
       expect(person).toEqual({ name: lid, subtype: "external", kind: "whatsapp_lid", value: lid });
+    }, 30_000);
+
+    it("keeps a WhatsApp placeholder name while accumulating one proposal", async () => {
+      const groupJid = `proposal-${randomUUID()}@g.us`;
+      const phone = "+919891688787";
+      const lid = "3878523285582@lid";
+      await createWhatsAppGroupRepository(db).upsert({
+        jid: groupJid,
+        name: "sketch-whatsapp-test",
+        description: null,
+        updated_at: "2026-08-13T00:00:00.000Z",
+      });
+
+      await projectWhatsAppRosterPerson(db, {
+        groupJid,
+        phoneE164: phone,
+        lid,
+        displayName: "Tanush Yadav",
+        observedAt: "2026-08-13T06:02:47.000Z",
+      });
+      await projectWhatsAppRosterPerson(db, {
+        groupJid,
+        phoneE164: phone,
+        lid,
+        displayName: "Tanush Yadav",
+        observedAt: "2026-08-13T06:03:47.000Z",
+      });
+
+      const entity = await db
+        .selectFrom("entities")
+        .select(["id", "name", "name_status", "aliases"])
+        .where("name", "=", phone)
+        .executeTakeFirstOrThrow();
+      expect(entity).toMatchObject({ name: phone, name_status: "placeholder" });
+      expect(JSON.parse(entity.aliases ?? "[]")).toEqual(["Tanush Yadav"]);
+      await expect(
+        db
+          .selectFrom("entity_name_proposals")
+          .select(["entity_id", "source", "value", "normalized_value", "observed_count", "status"])
+          .where("entity_id", "=", entity.id)
+          .execute(),
+      ).resolves.toEqual([
+        {
+          entity_id: entity.id,
+          source: "whatsapp_pushname",
+          value: "Tanush Yadav",
+          normalized_value: "tanush yadav",
+          observed_count: 2,
+          status: "pending",
+        },
+      ]);
+    }, 30_000);
+
+    it("keeps an existing numeric-name Person confirmed", async () => {
+      const groupJid = `confirmed-${randomUUID()}@g.us`;
+      const phone = "+919891688788";
+      await createWhatsAppGroupRepository(db).upsert({
+        jid: groupJid,
+        name: "Confirmed",
+        description: null,
+        updated_at: "2026-08-13T00:00:00.000Z",
+      });
+      const existing = await createEntityRepository(db).upsertPersonEntity({
+        name: phone,
+        email: "confirmed@example.com",
+        subtype: "external",
+        source: "email",
+        sourceId: "confirmed@example.com",
+      });
+
+      await projectWhatsAppRosterPerson(db, {
+        groupJid,
+        phoneE164: phone,
+        lid: null,
+        observedAt: "2026-08-13T06:02:47.000Z",
+      });
+
+      await expect(
+        db.selectFrom("entities").select("name_status").where("id", "=", existing.id).executeTakeFirstOrThrow(),
+      ).resolves.toEqual({ name_status: "confirmed" });
     }, 30_000);
 
     it("projects a retained participant after its group becomes enabled", async () => {

--- a/packages/server/src/db/repositories/whatsapp-groups.test.ts
+++ b/packages/server/src/db/repositories/whatsapp-groups.test.ts
@@ -177,6 +177,36 @@ describe("createWhatsAppGroupRepository", () => {
     ]);
   });
 
+  it("projects retained participants when applyIndexSelection enables a group", async () => {
+    await repo.upsert({
+      jid: "120363409999039961@g.us",
+      name: "sketch-whatsapp-test",
+      description: null,
+      updated_at: "2026-08-13T00:00:00.000Z",
+      index_enabled: 0,
+    });
+    await repo.refreshParticipants("120363409999039961@g.us", [
+      {
+        participantJid: "149916051591191@lid",
+        phoneE164: "+919969577769",
+        lid: "149916051591191@lid",
+      },
+    ]);
+
+    await expect(applyIndexSelection(db, { "120363409999039961@g.us": true })).resolves.toEqual([
+      "120363409999039961@g.us",
+    ]);
+    await expect(
+      db
+        .selectFrom("entities")
+        .innerJoin("entity_contact_points", "entity_contact_points.entity_id", "entities.id")
+        .select(["entities.name", "entity_contact_points.kind", "entity_contact_points.value"])
+        .where("entity_contact_points.kind", "=", "phone")
+        .where("entity_contact_points.value", "=", "+919969577769")
+        .execute(),
+    ).resolves.toEqual([{ name: "+919969577769", kind: "phone", value: "+919969577769" }]);
+  });
+
   it("requeues kept linked slices when a group flips from disabled to enabled", async () => {
     const seedGroupWithLinkedSlice = async (jid: string, suffix: string) => {
       await repo.upsert({

--- a/packages/server/src/db/repositories/whatsapp-groups.ts
+++ b/packages/server/src/db/repositories/whatsapp-groups.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { type Insertable, type Kysely, type Selectable, type Transaction, sql } from "kysely";
+import { type Insertable, type Kysely, type Selectable, sql } from "kysely";
 import { normalizeWhatsAppIdentityLid } from "../../identity-normalization";
 import type {
   DB,
@@ -95,7 +95,7 @@ function normalizedParticipant(participant: WhatsAppGroupParticipantInput) {
 }
 
 async function projectCompleteParticipantIdentity(
-  db: Transaction<DB>,
+  db: Kysely<DB>,
   phoneE164: string,
   lid: string,
   observedAt: string,
@@ -152,7 +152,7 @@ async function projectCompleteParticipantIdentity(
 }
 
 async function projectParticipantIdentity(
-  db: Transaction<DB>,
+  db: Kysely<DB>,
   groupJid: string,
   participant: ReturnType<typeof normalizedParticipant>,
   observedAt: string,
@@ -216,24 +216,41 @@ function enabledJidsFromSelection(selection: WhatsAppGroupIndexSelection): strin
 }
 
 /** Applies only JIDs present in the delta without opening a transaction. */
-export async function applyIndexSelection(db: Kysely<DB>, selection: WhatsAppGroupIndexSelection): Promise<void> {
+export async function applyIndexSelection(db: Kysely<DB>, selection: WhatsAppGroupIndexSelection): Promise<string[]> {
   const enable = enabledJidsFromSelection(selection);
   const disable = Object.entries(selection)
     .filter(([, enabled]) => !enabled)
     .map(([jid]) => jid);
 
+  let newlyEnabled: string[] = [];
   if (enable.length > 0) {
-    const previouslyEnabled = await db
+    const current = await db
       .selectFrom("whatsapp_groups")
-      .select("jid")
-      .where("index_enabled", "=", 1)
+      .select(["jid", "index_enabled"])
       .where("jid", "in", enable)
       .execute();
-    const previous = new Set(previouslyEnabled.map((row) => row.jid));
-    const newlyEnabled = enable.filter((jid) => !previous.has(jid));
+    newlyEnabled = current.filter((row) => row.index_enabled !== 1).map((row) => row.jid);
     if (newlyEnabled.length > 0) {
       await requeueKeptSlicesCore(db, newlyEnabled);
       await db.updateTable("whatsapp_groups").set({ index_enabled: 1 }).where("jid", "in", newlyEnabled).execute();
+      const participants = await db
+        .selectFrom("whatsapp_group_participants")
+        .select(["group_jid", "participant_jid", "phone_e164", "lid", "admin_role", "last_seen_at"])
+        .where("group_jid", "in", newlyEnabled)
+        .execute();
+      for (const participant of participants) {
+        await projectParticipantIdentity(
+          db,
+          participant.group_jid,
+          normalizedParticipant({
+            participantJid: participant.participant_jid,
+            phoneE164: participant.phone_e164,
+            lid: participant.lid,
+            adminRole: participant.admin_role as WhatsAppGroupParticipantAdminRole | null,
+          }),
+          participant.last_seen_at,
+        );
+      }
     }
   }
 
@@ -245,6 +262,7 @@ export async function applyIndexSelection(db: Kysely<DB>, selection: WhatsAppGro
       .where("jid", "in", disable)
       .execute();
   }
+  return newlyEnabled;
 }
 
 export const WHATSAPP_GROUP_INDEXING_KEY = "groupIndexing";

--- a/packages/server/src/db/repositories/whatsapp-roster-person-projection.ts
+++ b/packages/server/src/db/repositories/whatsapp-roster-person-projection.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { type Transaction, sql } from "kysely";
+import { type Kysely, sql } from "kysely";
 import type { DB } from "../schema";
 import { createEntityRepository, whereLiveEntity } from "./entities";
+import { mergeEntityAliases, upsertEntityNameProposal } from "./entity-aliases";
 
 export type WhatsAppRosterProjectionResult = "created" | "linked" | "disabled" | "ambiguous" | "missing-identity";
 
@@ -9,10 +10,11 @@ export interface WhatsAppRosterProjectionInput {
   groupJid: string;
   phoneE164: string | null;
   lid: string | null;
+  displayName?: string | null;
   observedAt: string;
 }
 
-async function matchingPersonIds(db: Transaction<DB>, input: WhatsAppRosterProjectionInput): Promise<Set<string>> {
+async function matchingPersonIds(db: Kysely<DB>, input: WhatsAppRosterProjectionInput): Promise<Set<string>> {
   const ids = new Set<string>();
   const contactConditions: Array<{ kind: "phone" | "whatsapp_lid"; value: string }> = [];
   if (input.phoneE164) contactConditions.push({ kind: "phone", value: input.phoneE164 });
@@ -57,7 +59,7 @@ async function matchingPersonIds(db: Transaction<DB>, input: WhatsAppRosterProje
 }
 
 async function upsertIdentityContactPoint(
-  db: Transaction<DB>,
+  db: Kysely<DB>,
   entityId: string,
   kind: "phone" | "whatsapp_lid",
   value: string,
@@ -117,7 +119,7 @@ async function upsertIdentityContactPoint(
 }
 
 export async function projectWhatsAppRosterPerson(
-  db: Transaction<DB>,
+  db: Kysely<DB>,
   input: WhatsAppRosterProjectionInput,
 ): Promise<WhatsAppRosterProjectionResult> {
   if (!input.phoneE164 && !input.lid) return "missing-identity";
@@ -139,6 +141,7 @@ export async function projectWhatsAppRosterPerson(
         source: "whatsapp_identity",
         sourceId: input.phoneE164 ? `phone:${input.phoneE164}` : `lid:${input.lid}`,
         provenanceTier: "inferred",
+        nameStatus: "placeholder",
       })
     : await db
         .selectFrom("entities")
@@ -161,6 +164,11 @@ export async function projectWhatsAppRosterPerson(
       source: "whatsapp_identity",
       sourceId: `lid:${input.lid}`,
     });
+  }
+  const displayName = input.displayName?.trim();
+  if (displayName) {
+    await mergeEntityAliases(db, entity.id, [displayName]);
+    await upsertEntityNameProposal(db, entity.id, "whatsapp_pushname", displayName, input.observedAt);
   }
   return created ? "created" : "linked";
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1068,6 +1068,7 @@ export interface InboxMessagesTable {
 export interface EntitiesTable {
   id: string;
   name: string;
+  name_status: Generated<string>;
   source_type: string;
   subtype: string | null;
   aliases: string | null;
@@ -1082,6 +1083,20 @@ export interface EntitiesTable {
   share_with_everyone: Generated<number>;
   deleted_at: string | null;
   merged_into_entity_id: string | null;
+}
+
+export interface EntityNameProposalsTable {
+  id: string;
+  entity_id: string;
+  source: string;
+  value: string;
+  normalized_value: string;
+  observed_count: Generated<number>;
+  first_seen_at: string;
+  last_seen_at: string;
+  status: Generated<string>;
+  resolved_by_user_id: string | null;
+  resolved_at: string | null;
 }
 
 export interface EntityMergesTable {
@@ -1778,6 +1793,7 @@ export interface DB {
   agent_user_configs: AgentUserConfigsTable;
   inbox_messages: InboxMessagesTable;
   entities: EntitiesTable;
+  entity_name_proposals: EntityNameProposalsTable;
   entity_merges: EntityMergesTable;
   entity_share_emails: EntityShareEmailsTable;
   entity_source_refs: EntitySourceRefsTable;

--- a/packages/server/src/entities/rank.test.ts
+++ b/packages/server/src/entities/rank.test.ts
@@ -6,6 +6,7 @@ function person(id: string, name: string): Entity {
   return {
     id,
     name,
+    name_status: "confirmed",
     source_type: "person",
     subtype: "external",
     aliases: null,

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -110,6 +110,8 @@ import type { WhatsAppTemplateRequest } from "./whatsapp/templates";
 
 interface AppDeps {
   whatsapp?: WhatsAppSocketFacade;
+  /** Adopts captured-but-unowned WhatsApp history: on group enable and before a manual sync. */
+  wakeWhatsAppBackfill?: () => Promise<void> | void;
   whatsappRuntime?: WhatsAppRuntime;
   watiWebhook?: WatiWhatsAppProvider;
   managedWhatsapp?: ManagedWhatsAppProvider;
@@ -649,6 +651,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
         taskMintingGenerator: deps.taskMintingGenerator,
         enrichmentGenerator: deps.enrichmentGenerator,
         whatsapp: deps.whatsapp,
+        wakeWhatsAppBackfill: deps.wakeWhatsAppBackfill,
       }),
     );
   }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -648,6 +648,7 @@ export function createApp(db: Kysely<DB>, config: Config, deps?: AppDeps) {
       connectorRoutes(connectors, db, deps.logger, users, config, {
         taskMintingGenerator: deps.taskMintingGenerator,
         enrichmentGenerator: deps.enrichmentGenerator,
+        whatsapp: deps.whatsapp,
       }),
     );
   }

--- a/packages/server/src/whatsapp/bot.isolated.test.ts
+++ b/packages/server/src/whatsapp/bot.isolated.test.ts
@@ -1,7 +1,7 @@
 import { DisconnectReason, type GroupMetadata, proto } from "@whiskeysockets/baileys";
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
+import { applyIndexSelection, createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";
 import type { DB } from "../db/schema";
 import { createTestDb, createTestLogger } from "../test-utils";
 import {
@@ -1042,6 +1042,120 @@ describe("WhatsAppBot handleGroupMessage LID resolution", () => {
       pushName: "Charlie",
     } as proto.IWebMessageInfo;
   }
+
+  function capturedIdentityMessage(input: {
+    remoteJid: string;
+    id: string;
+    fromMe?: boolean;
+  }): proto.IWebMessageInfo {
+    return {
+      key: {
+        remoteJid: input.remoteJid,
+        fromMe: input.fromMe ?? false,
+        id: input.id,
+        participant: "3878523285582@lid",
+        participantAlt: "919891688787@s.whatsapp.net",
+        addressingMode: "lid",
+      },
+      messageTimestamp: 1786600967,
+      pushName: "Tanush Yadav",
+      broadcast: false,
+      message: { conversation: "What is the context graph" },
+    } as proto.IWebMessageInfo;
+  }
+
+  it("projects identity from a captured group upsert", async () => {
+    await createWhatsAppGroupRepository(db).upsert({
+      jid: "120363409999039961@g.us",
+      name: "sketch-whatsapp-test",
+      description: null,
+      updated_at: "2026-08-13T00:00:00.000Z",
+    });
+    const { fire } = createBotWithMockSocket(async () => null);
+
+    await fire({
+      type: "notify",
+      messages: [capturedIdentityMessage({ remoteJid: "120363409999039961@g.us", id: "3B644913E27A9A2424C8" })],
+    });
+
+    const points = await db
+      .selectFrom("entity_contact_points")
+      .innerJoin("entities", "entities.id", "entity_contact_points.entity_id")
+      .select(["entities.id", "entity_contact_points.kind", "entity_contact_points.value"])
+      .where("entity_contact_points.kind", "in", ["phone", "whatsapp_lid"])
+      .orderBy("entity_contact_points.kind")
+      .execute();
+    expect(new Set(points.map((row) => row.id)).size).toBe(1);
+    expect(points.map(({ kind, value }) => ({ kind, value }))).toEqual([
+      { kind: "phone", value: "+919891688787" },
+      { kind: "whatsapp_lid", value: "3878523285582@lid" },
+    ]);
+    await expect(
+      db
+        .selectFrom("entities")
+        .select(["name", "name_status", "aliases"])
+        .where("id", "=", points[0].id)
+        .executeTakeFirst(),
+    ).resolves.toEqual({ name: "+919891688787", name_status: "placeholder", aliases: '["Tanush Yadav"]' });
+    await expect(
+      db
+        .selectFrom("entity_name_proposals")
+        .select(["source", "value", "observed_count", "status"])
+        .where("entity_id", "=", points[0].id)
+        .execute(),
+    ).resolves.toEqual([{ source: "whatsapp_pushname", value: "Tanush Yadav", observed_count: 1, status: "pending" }]);
+  });
+
+  it("contains identity projection to inbound messages in index-enabled groups", async () => {
+    const groups = createWhatsAppGroupRepository(db);
+    await groups.upsert({
+      jid: "disabled@g.us",
+      name: "Disabled",
+      description: null,
+      updated_at: "2026-08-13T00:00:00.000Z",
+      index_enabled: 0,
+    });
+    await groups.upsert({
+      jid: "enabled@g.us",
+      name: "Enabled",
+      description: null,
+      updated_at: "2026-08-13T00:00:00.000Z",
+    });
+    const { fire } = createBotWithMockSocket(async () => null);
+
+    await fire({
+      type: "notify",
+      messages: [capturedIdentityMessage({ remoteJid: "disabled@g.us", id: "disabled-1" })],
+    });
+    await fire({
+      type: "notify",
+      messages: [capturedIdentityMessage({ remoteJid: "919891688787@s.whatsapp.net", id: "dm-1" })],
+    });
+    await fire({
+      type: "notify",
+      messages: [capturedIdentityMessage({ remoteJid: "enabled@g.us", id: "from-me-1", fromMe: true })],
+    });
+    await expect(db.selectFrom("entities").select("id").where("source_type", "=", "person").execute()).resolves.toEqual(
+      [],
+    );
+
+    await applyIndexSelection(db, { "disabled@g.us": true });
+    await fire({
+      type: "append",
+      messages: [capturedIdentityMessage({ remoteJid: "disabled@g.us", id: "disabled-2" })],
+    });
+    await expect(
+      db.selectFrom("entities").select("id").where("source_type", "=", "person").execute(),
+    ).resolves.toHaveLength(1);
+
+    await fire({
+      type: "append",
+      messages: [capturedIdentityMessage({ remoteJid: "enabled@g.us", id: "enabled-1" })],
+    });
+    await expect(
+      db.selectFrom("entities").select("id").where("source_type", "=", "person").execute(),
+    ).resolves.toHaveLength(1);
+  });
 
   it("resolves LID senderJid to phone number via resolveLidToPhone", async () => {
     const { fire, captured } = createBotWithMockSocket(async () => "+15550001111");

--- a/packages/server/src/whatsapp/bot.ts
+++ b/packages/server/src/whatsapp/bot.ts
@@ -31,6 +31,7 @@ import type {
   WhatsAppGroupParticipantInput,
   WhatsAppGroupParticipantRefreshLogger,
 } from "../db/repositories/whatsapp-groups";
+import { projectWhatsAppRosterPerson } from "../db/repositories/whatsapp-roster-person-projection";
 import type { DB } from "../db/schema";
 import { normalizeWhatsAppIdentityLid, normalizeWhatsAppIdentityPhone } from "../identity-normalization";
 import type { Logger } from "../logger";
@@ -62,6 +63,7 @@ const RECONNECT_FACTOR = 1.8;
 const RECONNECT_JITTER = 0.25;
 const GROUP_META_TTL_MS = 5 * 60_000;
 const GROUP_SYNC_THROTTLE_MS = 5 * 60_000;
+const IDENTITY_PROJECTION_CACHE_SIZE = 1_000;
 
 /** Cached WA version — fetched once from GitHub, reused for all subsequent connections. */
 let cachedVersion: WAVersion | null = null;
@@ -232,6 +234,7 @@ export class WhatsAppBot {
     { interval: ReturnType<typeof setInterval>; ttl: ReturnType<typeof setTimeout> }
   >();
   private groupMetaCache = new Map<string, { meta: GroupMetadata; expires: number }>();
+  private projectedIdentities = new Map<string, true>();
 
   constructor(config: WhatsAppBotConfig) {
     this.db = config.db;
@@ -887,6 +890,14 @@ export class WhatsAppBot {
 
         if (msg.key.id && this.recentlySent.has(msg.key.id)) continue;
 
+        if (isGroup) {
+          try {
+            await this.observeGroupMessageIdentity(msg, jid);
+          } catch (err) {
+            this.logger.warn({ err, groupJid: jid }, "Failed to project WhatsApp message identity");
+          }
+        }
+
         const messageType = getContentType(msg.message);
         const text = extractText(msg);
         const hasMedia = hasMediaContent(messageType);
@@ -900,6 +911,43 @@ export class WhatsAppBot {
         }
       }
     });
+  }
+
+  private async observeGroupMessageIdentity(msg: proto.IWebMessageInfo, groupJid: string): Promise<void> {
+    const senderJid = msg.key?.participant ?? msg.participant;
+    if (!senderJid) return;
+    if (
+      (this.sock?.user?.id && areJidsSameUser(senderJid, this.sock.user.id)) ||
+      (this.sock?.user?.lid && areJidsSameUser(senderJid, this.sock.user.lid))
+    ) {
+      return;
+    }
+    const lid = normalizeWhatsAppIdentityLid(senderJid);
+    const participantAlt = (msg.key as proto.IMessageKey & { participantAlt?: string }).participantAlt;
+    const phoneE164 = participantAlt?.endsWith("@s.whatsapp.net")
+      ? jidToPhoneNumber(participantAlt)
+      : senderJid.endsWith("@s.whatsapp.net")
+        ? jidToPhoneNumber(senderJid)
+        : await this.resolveLidToPhone(senderJid);
+    const displayName = msg.pushName?.trim() || null;
+    const key = [groupJid, lid ?? "", phoneE164 ?? "", displayName ?? ""].join("|");
+    if (this.projectedIdentities.delete(key)) {
+      this.projectedIdentities.set(key, true);
+      return;
+    }
+    const timestamp = Number(msg.messageTimestamp);
+    const result = await projectWhatsAppRosterPerson(this.db, {
+      groupJid,
+      phoneE164,
+      lid,
+      displayName,
+      observedAt: Number.isFinite(timestamp) ? new Date(timestamp * 1_000).toISOString() : new Date().toISOString(),
+    });
+    if (result !== "created" && result !== "linked") return;
+    this.projectedIdentities.set(key, true);
+    if (this.projectedIdentities.size > IDENTITY_PROJECTION_CACHE_SIZE) {
+      this.projectedIdentities.delete(this.projectedIdentities.keys().next().value as string);
+    }
   }
 
   private async handleDmMessage(

--- a/packages/server/src/whatsapp/group-participants.test.ts
+++ b/packages/server/src/whatsapp/group-participants.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { collectWhatsAppGroupParticipants } from "./group-participants";
+
+/**
+ * Fixtures below are copied verbatim from a live `groupMetadata()` response for
+ * a lid-addressed group. WhatsApp returns the phone as a PN JID and supplies no
+ * name field of any kind — no `name`, `notify`, or `verifiedName`.
+ */
+const LIVE_LID_GROUP_PARTICIPANTS = [
+  { id: "149916051591191@lid", phoneNumber: "919969577769@s.whatsapp.net", admin: "superadmin" },
+  { id: "3878523285582@lid", phoneNumber: "919891688787@s.whatsapp.net", admin: null },
+  { id: "27596070871045@lid", phoneNumber: "917977430265@s.whatsapp.net", admin: null },
+];
+
+describe("collectWhatsAppGroupParticipants", () => {
+  it("extracts the phone from a PN JID without consulting the LID resolver", async () => {
+    const resolveLidToPhone = vi.fn().mockResolvedValue(null);
+
+    const collected = await collectWhatsAppGroupParticipants(
+      { participants: LIVE_LID_GROUP_PARTICIPANTS },
+      resolveLidToPhone,
+    );
+
+    expect(collected.skippedCount).toBe(0);
+    expect(collected.participants).toEqual([
+      { jid: "149916051591191@lid", phoneE164: "+919969577769", lid: "149916051591191@lid", admin: "superadmin" },
+      { jid: "3878523285582@lid", phoneE164: "+919891688787", lid: "3878523285582@lid", admin: null },
+      { jid: "27596070871045@lid", phoneE164: "+917977430265", lid: "27596070871045@lid", admin: null },
+    ]);
+    expect(resolveLidToPhone).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the LID resolver only when no phoneNumber is supplied", async () => {
+    const resolveLidToPhone = vi.fn().mockResolvedValue("+15555000123");
+
+    const collected = await collectWhatsAppGroupParticipants(
+      { participants: [{ id: "44445555@lid", admin: null }] },
+      resolveLidToPhone,
+    );
+
+    expect(collected.participants[0].phoneE164).toBe("+15555000123");
+    expect(resolveLidToPhone).toHaveBeenCalledWith("44445555@lid");
+  });
+
+  it("keeps a lid-only participant when the resolver cache misses", async () => {
+    const resolveLidToPhone = vi.fn().mockResolvedValue(null);
+
+    const collected = await collectWhatsAppGroupParticipants(
+      { participants: [{ id: "44445555@lid", admin: null }] },
+      resolveLidToPhone,
+    );
+
+    expect(collected.participants).toEqual([
+      { jid: "44445555@lid", phoneE164: null, lid: "44445555@lid", admin: null },
+    ]);
+  });
+
+  it("never treats a LID as a phone number", async () => {
+    const resolveLidToPhone = vi.fn().mockResolvedValue(null);
+
+    const collected = await collectWhatsAppGroupParticipants(
+      { participants: [{ id: "3878523285582@lid", phoneNumber: "149916051591191@lid", admin: null }] },
+      resolveLidToPhone,
+    );
+
+    expect(collected.participants[0].phoneE164).toBeNull();
+  });
+
+  it("strips a device suffix from the PN JID", async () => {
+    const resolveLidToPhone = vi.fn().mockResolvedValue(null);
+
+    const collected = await collectWhatsAppGroupParticipants(
+      { participants: [{ id: "3878523285582@lid", phoneNumber: "919891688787:12@s.whatsapp.net", admin: null }] },
+      resolveLidToPhone,
+    );
+
+    expect(collected.participants[0].phoneE164).toBe("+919891688787");
+  });
+
+  it("still accepts an already-normalized E.164 phoneNumber", async () => {
+    const resolveLidToPhone = vi.fn().mockResolvedValue(null);
+
+    const collected = await collectWhatsAppGroupParticipants(
+      { participants: [{ id: "3878523285582@lid", phoneNumber: "+919891688787", admin: null }] },
+      resolveLidToPhone,
+    );
+
+    expect(collected.participants[0].phoneE164).toBe("+919891688787");
+  });
+});

--- a/packages/server/src/whatsapp/group-participants.ts
+++ b/packages/server/src/whatsapp/group-participants.ts
@@ -31,10 +31,26 @@ function participantLid(row: Record<string, unknown>, jid: string): string | nul
   return asString(row.lid) ?? (jid.endsWith("@lid") ? jid : null);
 }
 
+/**
+ * In lid-addressed groups — now WhatsApp's default — the participant phone
+ * arrives as a PN JID (`919969577769@s.whatsapp.net`), not bare E.164. Prefixing
+ * that with `+` produces a value `normalizeContactPointValue` rejects, so the
+ * number WhatsApp handed us was discarded and resolution fell through to the
+ * cache-dependent LID lookup. Strip the server and device suffix first.
+ *
+ * A `@lid` value is an opaque identifier that happens to be numeric: stripping
+ * its suffix yields something that passes an E.164 shape check while being a
+ * phone number nobody owns. Reject it outright rather than mint a fake.
+ */
 function explicitPhoneNumber(value: unknown): string | null {
   const phoneNumber = asString(value);
-  if (!phoneNumber) return null;
-  const candidate = phoneNumber.startsWith("+") || phoneNumber.startsWith("00") ? phoneNumber : `+${phoneNumber}`;
+  if (!phoneNumber || /@lid$/i.test(phoneNumber)) return null;
+  const bare = phoneNumber
+    .replace(/@s\.whatsapp\.net$/i, "")
+    .split(":")[0]
+    .trim();
+  if (!bare) return null;
+  const candidate = bare.startsWith("+") || bare.startsWith("00") ? bare : `+${bare}`;
   try {
     const normalized = normalizeContactPointValue("whatsapp", candidate);
     return isWhatsAppDmPhoneE164(normalized) ? normalized : null;

--- a/packages/server/src/whatsapp/identity-resolution.test.ts
+++ b/packages/server/src/whatsapp/identity-resolution.test.ts
@@ -286,6 +286,14 @@ describe("WhatsApp roster snapshot", () => {
     });
     await createConversationRepository(db).insertMessage({
       conversationId: conversation.id,
+      providerMessageId: "entity-alias-real-push-name",
+      senderJid: "15550000901@s.whatsapp.net",
+      senderName: "First Push Name",
+      text: "hello first",
+      receivedAt: "2026-07-07T08:59:00.000Z",
+    });
+    await createConversationRepository(db).insertMessage({
+      conversationId: conversation.id,
       providerMessageId: "entity-alias-push-name",
       senderJid: "15550000901@s.whatsapp.net",
       senderName: "Unknown",
@@ -341,6 +349,7 @@ describe("WhatsApp roster snapshot", () => {
     expect(JSON.parse(entity.aliases ?? "[]")).toEqual([
       "Existing Alias",
       "PUSH NAME",
+      "First Push Name",
       "Group Label",
       "Second Push Name",
     ]);
@@ -349,13 +358,26 @@ describe("WhatsApp roster snapshot", () => {
     expect(entity.aliases).not.toContain("@lid");
     expect(entity.aliases).not.toContain("12345");
     expect(entity.aliases).not.toContain("Unknown");
+    await expect(
+      db
+        .selectFrom("entity_name_proposals")
+        .select("value")
+        .where("entity_id", "=", "entity-aliases")
+        .orderBy("value")
+        .execute(),
+    ).resolves.toEqual([{ value: "First Push Name" }, { value: "Second Push Name" }]);
   });
 
-  it("promotes a safe push name over a phone fallback canonical name", async () => {
+  it("proposes a safe push name without changing a phone fallback canonical name", async () => {
     const groupJid = "120363000000010@g.us";
     const groups = await seedGroup(groupJid);
     const phone = "+15550000910";
     await seedEntity({ id: "phone-fallback-person", name: phone });
+    await db
+      .updateTable("entities")
+      .set({ name_status: "placeholder" })
+      .where("id", "=", "phone-fallback-person")
+      .execute();
     await seedContactPoint("phone-fallback-person", phone);
     await groups.refreshParticipants(groupJid, [
       { participantJid: "15550000910@s.whatsapp.net", phoneE164: phone, adminRole: null },
@@ -384,11 +406,18 @@ describe("WhatsApp roster snapshot", () => {
 
     const entity = await db
       .selectFrom("entities")
-      .select(["name", "aliases"])
+      .select(["name", "name_status", "aliases"])
       .where("id", "=", "phone-fallback-person")
       .executeTakeFirstOrThrow();
-    expect(entity.name).toBe("Asha Mehta");
-    expect(JSON.parse(entity.aliases ?? "[]")).toContain(phone);
+    expect(entity).toMatchObject({ name: phone, name_status: "placeholder" });
+    expect(JSON.parse(entity.aliases ?? "[]")).toEqual(["Asha Mehta"]);
+    await expect(
+      db
+        .selectFrom("entity_name_proposals")
+        .select(["source", "value", "observed_count", "status"])
+        .where("entity_id", "=", "phone-fallback-person")
+        .execute(),
+    ).resolves.toEqual([{ source: "whatsapp_pushname", value: "Asha Mehta", observed_count: 1, status: "pending" }]);
   });
 
   it("serializes display context without raw phone numbers or phone JIDs", async () => {

--- a/packages/server/src/whatsapp/identity-resolution.test.ts
+++ b/packages/server/src/whatsapp/identity-resolution.test.ts
@@ -6,7 +6,7 @@ import {
   assertNoRawWhatsAppIdentifiers,
   renderWhatsAppRosterBlock,
   renderWhatsAppTranscript,
-} from "../connectors/whatsapp-salience";
+} from "../connectors/whatsapp-emission";
 import { createConversationRepository } from "../db/repositories/conversations";
 import { createUserRepository } from "../db/repositories/users";
 import { createWhatsAppGroupRepository } from "../db/repositories/whatsapp-groups";

--- a/packages/server/src/whatsapp/identity-resolution.ts
+++ b/packages/server/src/whatsapp/identity-resolution.ts
@@ -159,7 +159,7 @@ async function enrichResolvedEntityAliases(
     phone_e164: string | null;
     lid: string | null;
     resolution: WhatsAppIdentityResolution;
-    aliasName?: string;
+    aliasNames: string[];
   }>,
 ): Promise<void> {
   const candidates = participants.filter(
@@ -175,19 +175,19 @@ async function enrichResolvedEntityAliases(
     labels.map((label) => [normalizeWhatsAppIdentityPhone(label.phone_e164), safeEntityAlias(label.display_name)]),
   );
   const additionsByEntityId = new Map<string, string[]>();
-  const identityValuesByEntityId = new Map<string, string[]>();
+  const pushNamesByEntityId = new Map<string, string[]>();
   for (const candidate of candidates) {
     const phone = normalizeWhatsAppIdentityPhone(candidate.phone_e164);
     const additions = additionsByEntityId.get(candidate.resolution.entityId) ?? [];
-    additions.push(candidate.aliasName ?? "", phone ? (labelByPhone.get(phone) ?? "") : "");
+    additions.push(...candidate.aliasNames, phone ? (labelByPhone.get(phone) ?? "") : "");
     additionsByEntityId.set(candidate.resolution.entityId, additions);
-    const identityValues = identityValuesByEntityId.get(candidate.resolution.entityId) ?? [];
-    identityValues.push(phone ?? "", normalizeWhatsAppIdentityLid(candidate.lid) ?? "");
-    identityValuesByEntityId.set(candidate.resolution.entityId, identityValues);
+    const pushNames = pushNamesByEntityId.get(candidate.resolution.entityId) ?? [];
+    pushNames.push(...candidate.aliasNames);
+    pushNamesByEntityId.set(candidate.resolution.entityId, pushNames);
   }
 
   for (const [entityId, additions] of additionsByEntityId) {
-    await enrichWhatsAppRosterPersonName(db, entityId, additions, identityValuesByEntityId.get(entityId) ?? []);
+    await enrichWhatsAppRosterPersonName(db, entityId, additions, pushNamesByEntityId.get(entityId) ?? []);
   }
 }
 
@@ -485,40 +485,53 @@ export function createWhatsAppIdentityResolutionService(db: Kysely<DB>) {
   return { resolve, resolveRoster };
 }
 
-async function loadPushNamesBySenderJid(db: Kysely<DB>, conversationId: number): Promise<Map<string, string>> {
+const MAX_PUSH_NAMES_PER_SENDER = 10;
+
+async function loadPushNamesBySenderJid(db: Kysely<DB>, conversationId: number): Promise<Map<string, string[]>> {
   const ranked = db
     .selectFrom("conversation_messages")
     .select(["sender_jid", "sender_name", "received_at", "id"])
     .select(
-      sql<number>`row_number() over (partition by sender_jid order by received_at desc, id desc)`.as("sender_rank"),
+      sql<number>`row_number() over (
+        partition by sender_jid, lower(trim(sender_name))
+        order by received_at desc, id desc
+      )`.as("name_rank"),
     )
     .where("conversation_id", "=", conversationId)
-    .where("is_bot", "=", 0);
+    .where("is_bot", "=", 0)
+    .where(sql<boolean>`lower(trim(sender_name)) <> 'unknown'`);
   const rows = await db
     .selectFrom(ranked.as("ranked_messages"))
-    .select(["sender_jid", "sender_name"])
-    .where("sender_rank", "=", 1)
+    .select(["sender_jid", "sender_name", "received_at", "id"])
+    .where("name_rank", "=", 1)
+    .orderBy("sender_jid", "asc")
+    .orderBy("received_at", "desc")
+    .orderBy("id", "desc")
     .execute();
 
-  const out = new Map<string, string>();
+  const out = new Map<string, string[]>();
   for (const row of rows) {
     const senderJid = row.sender_jid.trim();
     const senderName = row.sender_name.trim();
-    if (senderJid && senderName) out.set(senderJid, senderName);
+    if (!senderJid || !senderName) continue;
+    const names = out.get(senderJid) ?? [];
+    if (names.length >= MAX_PUSH_NAMES_PER_SENDER) continue;
+    names.push(senderName);
+    out.set(senderJid, names);
   }
   return out;
 }
 
-function rawPushNameForParticipant(
-  pushNamesBySenderJid: Map<string, string>,
+function rawPushNamesForParticipant(
+  pushNamesBySenderJid: Map<string, string[]>,
   participantJid: string,
   phoneE164: string | null,
-): string | undefined {
+): string[] {
   const direct = pushNamesBySenderJid.get(participantJid);
   if (direct) return direct;
   const normalizedPhone = normalizeWhatsAppIdentityPhone(phoneE164);
-  if (!normalizedPhone) return undefined;
-  return pushNamesBySenderJid.get(phoneE164ToWhatsAppJid(normalizedPhone));
+  if (!normalizedPhone) return [];
+  return pushNamesBySenderJid.get(phoneE164ToWhatsAppJid(normalizedPhone)) ?? [];
 }
 
 export async function buildWhatsAppRosterSnapshot({
@@ -544,23 +557,28 @@ export async function buildWhatsAppRosterSnapshot({
 
   const snapshotInputs = participants.map((participant) => {
     const resolution = resolutions.get(participant.participant_jid) ?? { kind: "unresolved" };
-    const rawPushName = rawPushNameForParticipant(
+    const rawPushNames = rawPushNamesForParticipant(
       pushNamesBySenderJid,
       participant.participant_jid,
       participant.phone_e164,
     );
-    return { participant, resolution, pushName: safePushName(rawPushName), aliasName: safeEntityAlias(rawPushName) };
+    return {
+      participant,
+      resolution,
+      pushName: safePushName(rawPushNames[0]),
+      aliasNames: rawPushNames.map(safeEntityAlias).filter((name): name is string => Boolean(name)),
+    };
   });
   if (enrichEntityAliases) {
     try {
       await enrichResolvedEntityAliases(
         db,
         groupJid,
-        snapshotInputs.map(({ participant, resolution, aliasName }) => ({
+        snapshotInputs.map(({ participant, resolution, aliasNames }) => ({
           phone_e164: participant.phone_e164,
           lid: participant.lid,
           resolution,
-          aliasName,
+          aliasNames,
         })),
       );
     } catch (err) {

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -34,10 +34,18 @@ const maxWorkers = process.env.VITEST_MAX_WORKERS
  * Pool is "threads": for this suite (many small files) thread workers spawn far
  * cheaper than forked processes.
  */
+/**
+ * `testTimeout` is raised above vitest's 5s default because the migration suite
+ * runs the full chain against a fresh database ~49 times in one file. Each test
+ * takes ~300ms alone but crosses 5s under full-suite worker contention, and
+ * every migration added lengthens all of them. The work is correct, just slow —
+ * a longer ceiling costs nothing when tests pass.
+ */
 const shared = {
   environment: "node" as const,
   globalSetup: ["src/test-global-setup.ts"],
   setupFiles: ["src/test-setup.ts"],
+  testTimeout: 30_000,
   env: {
     DATA_DIR: "/tmp/sketch-test-data",
   },


### PR DESCRIPTION
## Problem

Enabling indexing on a WhatsApp group minted person entities named `+9198…` or `123@lid`, and they stayed that way.

Verified against a live Baileys socket (raw captures in the plan appendix):

| Signal | Roster (`groupMetadata`) | `messages.upsert` | `messaging-history.set` |
| --- | --- | --- | --- |
| LID | `id` | `key.participant` | `key.participant` |
| Phone | `phoneNumber` | `key.participantAlt` | absent |
| **Name** | **never** | `pushName` | absent |

Two phone sources were being thrown away, and `pushName` — the only name source that exists — was consumed on the indexing path only.

## Root cause

`groupMetadata` returns the phone as a PN JID (`919969577769@s.whatsapp.net`). Prefixing that with `+` produced a value `normalizeContactPointValue` rejects; the throw was swallowed and resolution fell through to the LID mapping cache, which has no server fallback and returns `null` on a miss. Cache miss meant `phone_e164 = null`, an entity named after the LID, no teammate match, and a missing phone principal in the group ACL — in every lid-addressed group, which is now all of them.

It survived because the covering test asserted `phoneNumber: "+1 (555) 500-0002"`, a shape WhatsApp has never sent. New fixtures are copied verbatim from live captures.

## Changes

- **Phone extraction** — strip the `@s.whatsapp.net` and `:device` suffixes before normalizing. `@lid` values are rejected outright: a LID is numeric, so stripping its suffix yields a plausible E.164 belonging to a stranger.
- **`key.participantAlt`** — consumed on every inbound group message, guarded by an LRU keyed on `groupJid` that caches only successful projections, so a disabled-group result can't block minting elsewhere.
- **Enable hook** — `applyIndexSelection` re-projects stored participants in the same operation that flips `index_enabled`, so entities appear immediately rather than waiting for the next reconnect. Works with the socket down.
- **`entity_name_proposals`** — observed names are recorded for confirmation and merged into `aliases`.
- **`testTimeout: 30_000`** — `migrate.test.ts` runs the full chain ~49 times and already flaked at 7.8s on `main`; each migration added lengthens all of them.

## Behaviour change worth reviewing

**Nothing automated writes `entities.name` anymore.** The roster enricher no longer renames, and `name_status` marks WhatsApp placeholders. Until the confirmation UI ships, WhatsApp entities display their phone number where they were previously auto-renamed. This is deliberate — the old behaviour renamed on a string heuristic with no provenance and no way to correct it — but it is a visible regression in that window, and the UI should follow close behind.

Migration defaults `name_status` to `confirmed` (preserving today's semantics for every existing row, including email entities) and backfills `placeholder` only where an entity's name equals one of its own `whatsapp_identity` contact points.

## Known ceiling

A group member who has never sent a message can never be named — no source exists. Named if they've ever spoken while we were connected or catching up; phone-and-LID only otherwise.

## Out of scope

Removed members keep group access because participant rows are never deleted — pre-existing, tracked in [SKE-402](https://linear.app/sketch-ai/issue/SKE-402/whatsapp-removed-group-members-keep-access-participant-rows-are-never).

## Testing

5548 server tests + 508 web tests green via the pre-push hook. New coverage for PN JID extraction, the LID-as-phone trap, device-suffix stripping, enable-time re-projection, and the `name_status` backfill.

Plan: `.planning/connectors/implemented/WHATSAPP_ENTITY_IDENTITY_PROJECTION.md` (submodule pointer bumped in this PR)
---

# Second fix: group history was never indexed in `inprocess` mode

Found while verifying the identity work end to end on a live socket — the entities minted correctly, but no files ever appeared from the group.

## Problem

WhatsApp group history reaches the index through one chain:

```
captured messages → adopted into a whatsapp_backfill_ranges row → graph admission
  → conversation_slices → LLM chunking → emission → indexed_files
```

`WhatsAppBackfillWorker` owns the first hop. It was constructed only when `whatsapp instanceof GatewayClientFacade`, which holds only for `WHATSAPP_RUNTIME_MODE=gateway`. But `inprocess` is the zod default (`config.ts:119`), and `WHATSAPP_RUNTIME_MODE` **does not exist anywhere in sketch-platform** — not in the tenant env catalog, not in the live task definition, not in the tenant secret blob (checked canvas-ai directly: 24 keys, not one of them this).

So every managed tenant runs `inprocess`, the worker was never built, and messages sat with `backfill_range_id IS NULL` — invisible to the entire pipeline. Silently: every counter logged `0`, no error anywhere.

## Changes

**1. Ungate the worker** — gate on the provider, not the facade class. The worker's option type is already `facade: WhatsAppSocketFacade` and it only calls `fetchMessageHistory` and `pairing.status()`, both of which the in-process facade implements.

**2. Wire `handleConnected` for in-process** — gateway mode reaches it via the supervisor's socket-state hook; in-process has no supervisor. Called from `observeInProcessBaileysSocketState` through a ref, deliberately **not awaited** with a `.catch`: awaiting it inside the Baileys connection-open path (already writing creds and group metadata) produced `SQLITE_BUSY`, and the unhandled rejection killed the process on every connect. A failure here is not lost — the 5-minute reconcile sweep retries.

**3. `wakeWhatsAppBackfill`** — new optional dep threaded `bootstrap → createApp → connectorRoutes`, implemented as `whatsappBackfillWorker?.reconcile(true)`. Called after groups are newly enabled, and at the start of `POST /:id/syncs`. Both wrapped in try/catch that only warns. Without it the worker notices nothing until its next 5-minute sweep, so enabling a group left the UI empty, and "Sync now" genuinely did nothing — sync drives the chunker, and the chunker has nothing to chunk until the worker has adopted history into a range.

**4. Diagnostics** — this class of failure logged nothing but zeroes, so:
- Emission now returns a typed skip reason per slice (`no_access_scope` / `below_min_messages` / `unchanged_content` / `below_refresh_threshold`), tallied onto the existing completion line alongside a `candidates` count.
- When graph admission serves no chat and it wasn't backpressure, two aggregate probes name which of the five predicates held. `info` only while ranges remain ungraphed, `debug` once fully backfilled — otherwise it would log forever as the correct steady state.

**5. Rename** — `whatsapp-salience.ts` → `whatsapp-emission.ts` (+ its two test files, via `git mv`, all 7 importers updated). The WhatsApp salience judge is dead; the file does emission and ACL reconciliation. `processWhatsAppSalience` is left in place for now — still referenced by its own test, removal is a separate cleanup.

## Verified live

In-process, real paired WhatsApp: 41 messages → 1 range → settled `exhausted` → 3 slices (17 closed, 7 closed, 8 open) → **2 indexed_files**. Before these changes this chain produced 0 of everything.

## Follow-ups (not in this PR)

- A range settling to `exhausted` doesn't trigger a sync — it waits up to 30 min for the scheduler.
- `disconnected_at` is never set in-process, so gap repair is inert.
- Delete the dead `processWhatsAppSalience` and its test.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
