### PR TITLE
fix(entities): keep the real name when merging into a placeholder

### DIFF
--- a/packages/server/src/entities/merge.test.ts
+++ b/packages/server/src/entities/merge.test.ts
@@ -173,6 +173,79 @@ describe("entity merge core", () => {
     ).resolves.toEqual({ provenance_tier: "declared" });
   });
 
+  it("adopts the loser's confirmed name when the survivor is only a placeholder", async () => {
+    await seedEntity(db, "survivor", "+919891688787");
+    await seedEntity(db, "loser", "Tanush");
+    await db.updateTable("entities").set({ name_status: "placeholder" }).where("id", "=", "survivor").execute();
+
+    await mergeEntities(db, { survivorId: "survivor", loserId: "loser", userId: USER_ID });
+
+    const survivor = await db
+      .selectFrom("entities")
+      .select(["name", "name_status", "aliases"])
+      .where("id", "=", "survivor")
+      .executeTakeFirstOrThrow();
+    expect(survivor.name).toBe("Tanush");
+    expect(survivor.name_status).toBe("confirmed");
+    expect(JSON.parse(survivor.aliases ?? "[]")).toContain("+919891688787");
+  });
+
+  it("keeps the rescued name when a second confirmed entity is merged in later", async () => {
+    await seedEntity(db, "survivor", "+919891688787");
+    await seedEntity(db, "loser", "Tanush");
+    await seedEntity(db, "later", "Bob");
+    await db.updateTable("entities").set({ name_status: "placeholder" }).where("id", "=", "survivor").execute();
+
+    await mergeEntities(db, { survivorId: "survivor", loserId: "loser", userId: USER_ID });
+    await mergeEntities(db, { survivorId: "survivor", loserId: "later", userId: USER_ID });
+
+    await expect(
+      db.selectFrom("entities").select("name").where("id", "=", "survivor").executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ name: "Tanush" });
+  });
+
+  it("keeps a confirmed survivor name when the loser is the placeholder", async () => {
+    await seedEntity(db, "survivor", "Tanush");
+    await seedEntity(db, "loser", "+919891688787");
+    await db.updateTable("entities").set({ name_status: "placeholder" }).where("id", "=", "loser").execute();
+
+    await mergeEntities(db, { survivorId: "survivor", loserId: "loser", userId: USER_ID });
+
+    await expect(
+      db.selectFrom("entities").select("name").where("id", "=", "survivor").executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ name: "Tanush" });
+  });
+
+  it("lets an explicit survivor name win over the placeholder rescue", async () => {
+    await seedEntity(db, "survivor", "+919891688787");
+    await seedEntity(db, "loser", "Tanush");
+    await db.updateTable("entities").set({ name_status: "placeholder" }).where("id", "=", "survivor").execute();
+
+    await mergeEntities(db, {
+      survivorId: "survivor",
+      loserId: "loser",
+      userId: USER_ID,
+      survivorName: "Tanush Sharma",
+    });
+
+    await expect(
+      db.selectFrom("entities").select("name").where("id", "=", "survivor").executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ name: "Tanush Sharma" });
+  });
+
+  it("restores the placeholder name and status when the rescue merge is undone", async () => {
+    await seedEntity(db, "survivor", "+919891688787");
+    await seedEntity(db, "loser", "Tanush");
+    await db.updateTable("entities").set({ name_status: "placeholder" }).where("id", "=", "survivor").execute();
+
+    const merge = await mergeEntities(db, { survivorId: "survivor", loserId: "loser", userId: USER_ID });
+    await unmergeEntities(db, { mergeId: merge.mergeId, userId: USER_ID });
+
+    await expect(
+      db.selectFrom("entities").select(["name", "name_status"]).where("id", "=", "survivor").executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ name: "+919891688787", name_status: "placeholder" });
+  });
+
   it.each([
     ["external", "internal"],
     ["internal", "external"],

--- a/packages/server/src/entities/merge.ts
+++ b/packages/server/src/entities/merge.ts
@@ -50,6 +50,7 @@ export type EntityMergeMove =
       colChanges: Partial<{
         subtype: { before: string | null; after: string | null };
         name: { before: string | null; after: string | null };
+        name_status: { before: string | null; after: string | null };
       }>;
     }
   | { kind: "alias_added"; value: string; normalizedKey: string };
@@ -787,28 +788,47 @@ async function addAliasIfAbsent(
   return next;
 }
 
-async function renameSurvivorIfRequested(
+/**
+ * A WhatsApp-minted person is named after its own phone number or LID until a
+ * pushName confirms a real one, which makes the survivor's name a poor default
+ * when the other side already has a confirmed one: merging a Slack "Tanush"
+ * into `+919891688787` would otherwise keep the digits and demote the readable
+ * name to an alias. Survivor choice stays the caller's — only the name moves.
+ */
+function rescuedSurvivorName(survivor: Entity, loser: Entity | undefined): string | undefined {
+  if (!loser) return undefined;
+  if (survivor.name_status !== "placeholder" || loser.name_status === "placeholder") return undefined;
+  return loser.name;
+}
+
+async function renameSurvivor(
   db: Kysely<DB>,
   survivor: Entity,
-  input: MergeEntitiesInput,
+  requestedName: string | undefined,
   moves: EntityMergeMove[],
 ): Promise<Entity> {
-  const name = input.survivorName?.trim();
+  const name = requestedName?.trim();
   if (!name || name === survivor.name) return survivor;
   const aliases = await addAliasIfAbsent(db, survivor.id, survivor.aliases, survivor.name, moves);
+  const nameStatus = "confirmed";
   moves.push({
     table: "entities",
     rowId: survivor.id,
-    colChanges: { name: { before: survivor.name, after: name } },
+    colChanges: {
+      name: { before: survivor.name, after: name },
+      ...(survivor.name_status === nameStatus
+        ? {}
+        : { name_status: { before: survivor.name_status, after: nameStatus } }),
+    },
   });
   await db
     .updateTable("entities")
-    .set({ name, aliases, updated_at: new Date().toISOString() })
+    .set({ name, aliases, name_status: nameStatus, updated_at: new Date().toISOString() })
     .where("id", "=", survivor.id)
     .where("deleted_at", "is", null)
     .where("merged_into_entity_id", "is", null)
     .execute();
-  return { ...survivor, name, aliases };
+  return { ...survivor, name, aliases, name_status: nameStatus };
 }
 
 function emptyMergePreview(
@@ -1114,7 +1134,8 @@ export async function mergeEntitiesInTransaction(
   assertMergeable(survivor, loser, input);
 
   const moves: EntityMergeMove[] = [];
-  if (survivor) survivor = await renameSurvivorIfRequested(db, survivor, input, moves);
+  if (survivor)
+    survivor = await renameSurvivor(db, survivor, input.survivorName ?? rescuedSurvivorName(survivor, loser), moves);
   if (survivor?.source_type === "person" && loser?.source_type === "person") {
     const internalSubtype = survivor.subtype === "internal" || loser.subtype === "internal";
     if (internalSubtype && survivor.subtype !== "internal") {


### PR DESCRIPTION
## Symptom

Merging a Slack person into a WhatsApp person kept the phone number as the display name.

An entity showing `+919891688787` carried both `tanush@canvasx.ai` and the phone. The identifiers merged correctly — only the name was wrong. "Tanush Yadav" survived as an alias.

## Cause

WhatsApp mints a person named after their own phone number or LID until a pushName confirms a real one (`name_status = 'placeholder'`, migration 187).

Merge always preserved `survivor.name` verbatim — there was no name-quality comparison in `merge.ts`. The merge dialog defaults the survivor to whichever drawer you opened (`entity-merge-dialog.tsx:55`), so opening the WhatsApp entity made the phone number win.

## Fix

When no explicit `survivorName` is given, default the survivor's name to the loser's if the survivor's `name_status` is `placeholder` and the loser's is not, and mark it `confirmed`.

The `confirmed` write is load-bearing, not cosmetic: without it, merging a second confirmed entity into the same survivor would fire the rescue again and overwrite the rescued name.

Survivor choice is unchanged — the surviving entity id, its relationships, and its provenance all stay as the caller specified. Only the display name moves, and the old placeholder name is kept as an alias. Undo restores both name and status.

The backend already had the `survivorName` plumbing; this computes a sensible default for it.

## Tests

Five cases in `merge.test.ts`: placeholder survivor adopts the confirmed name; confirmed survivor keeps its name when the loser is the placeholder; explicit `survivorName` still wins; a chained merge does not overwrite a rescued name; undo restores the placeholder name and status.

Verified end to end on a live paired WhatsApp: re-merging the pair produced "Tanush Yadav" with the phone as an alias, and the name now flows through to transcripts, AI summaries, and linked entities.

## Follow-up (deliberately deferred)

UI work to let the user pick the surviving name explicitly — a "Keep name" toggle separate from "Keep as survivor", sent as `survivorName`. The web client never sends that field today.

Closes SKE-407

🤖 Generated with [Claude Code](https://claude.com/claude-code)