### PR TITLE
feat(entities): fold unidentified WhatsApp contacts into the review queue

### DIFF
--- a/packages/web/src/components/entity-drawer/drawer-kit.tsx
+++ b/packages/web/src/components/entity-drawer/drawer-kit.tsx
@@ -15,13 +15,20 @@ export function SectionLabel({ children, className }: { children: ReactNode; cla
   );
 }
 
-/** Accent-tinted bordered card with a {@link SectionLabel} header. */
+/**
+ * A {@link SectionLabel} eyebrow sitting ABOVE an accent-tinted bordered content
+ * box — the label is outside the border, matching every other labelled section
+ * in the drawer (SectionLabel + EntryList / input). Keeps content visually
+ * grouped without burying the eyebrow inside the box.
+ */
 export function SectionCard({ accent, label, children }: { accent: string; label: string; children: ReactNode }) {
   return (
-    <section className="rounded-lg border p-4" style={{ borderColor: `${accent}33` }}>
-      <SectionLabel className="mb-2">{label}</SectionLabel>
-      {children}
-    </section>
+    <div className="flex flex-col">
+      <SectionLabel className="mb-1.5 font-medium">{label}</SectionLabel>
+      <section className="rounded-lg border p-4" style={{ borderColor: `${accent}33` }}>
+        {children}
+      </section>
+    </div>
   );
 }
 

--- a/packages/web/src/components/entity-review/contact-points-editor.tsx
+++ b/packages/web/src/components/entity-review/contact-points-editor.tsx
@@ -1,0 +1,214 @@
+/**
+ * Multi-value contact-point editor shared by the review drawers. A person carries
+ * one required name (owned by the drawer header) plus repeatable phones and
+ * emails.
+ *
+ * Fields auto-grow: there is always exactly one trailing empty input, and filling
+ * it spawns the next one — the Apple Contacts pattern, so there is no "add"
+ * button to design and no empty-field edge case to guard. A filled value can be
+ * removed with its inline "×".
+ *
+ * `findMatch` powers duplicate detection (the "same contact point on two entities
+ * → suggest a merge" concept). When an entered phone/email already belongs to
+ * another entity, the row offers to merge into it instead of creating a second
+ * record. In the prototype this is a mock lookup; the backend replaces it with a
+ * contact-point search (e.g. `GET /api/entities/contact-points?value=…`).
+ *
+ * When a drawer already has a guessed identity, it passes `nameConfirm`; the Name
+ * field then carries a green confirm tick (positive-inline-validation pattern) so
+ * accepting the guess happens at the name itself, not by repurposing the footer's
+ * primary button.
+ */
+import { CheckIcon, XIcon } from "@phosphor-icons/react";
+import { Input } from "@sketch/ui/components/input";
+import { cn } from "@sketch/ui/lib/utils";
+import { useEffect } from "react";
+import { SectionLabel } from "../entity-drawer/drawer-kit";
+
+export type ContactKind = "phone" | "email";
+
+export interface ContactMatch {
+  entityId: string;
+  name: string;
+}
+
+/** A single editable value, keyed so add/remove keeps stable React keys. */
+export interface ContactRow {
+  id: string;
+  value: string;
+}
+
+let contactRowSeq = 0;
+/** Wrap raw values as keyed rows for the editor's local list state. */
+export function contactRows(values: string[]): ContactRow[] {
+  return values.map((value) => ({ id: `cp-${contactRowSeq++}`, value }));
+}
+
+/** Trimmed, non-empty values — what a save actually persists. */
+export function contactValues(rows: ContactRow[]): string[] {
+  return rows.map((row) => row.value.trim()).filter((value) => value.length > 0);
+}
+
+const FIELD = {
+  phone: { label: "Phone", placeholder: "+91 98765 43210", inputMode: "tel" as const },
+  email: { label: "Email", placeholder: "name@company.com", inputMode: "email" as const },
+};
+
+function ContactList({
+  kind,
+  optional,
+  rows,
+  onChange,
+  findMatch,
+  onMergeSuggested,
+}: {
+  kind: ContactKind;
+  optional?: boolean;
+  rows: ContactRow[];
+  onChange: (next: ContactRow[]) => void;
+  findMatch?: (kind: ContactKind, value: string) => ContactMatch | null;
+  onMergeSuggested?: (match: ContactMatch) => void;
+}) {
+  const field = FIELD[kind];
+  const setValue = (id: string, value: string) =>
+    onChange(rows.map((row) => (row.id === id ? { ...row, value } : row)));
+  const remove = (id: string) => onChange(rows.filter((row) => row.id !== id));
+
+  /**
+   * Keep exactly one trailing empty field. When every row holds a value (or the
+   * list is empty), append a fresh blank; typing into that blank then grows the
+   * next one. This is what replaces an explicit "add" button.
+   */
+  useEffect(() => {
+    if (rows.every((row) => row.value.trim().length > 0)) {
+      onChange([...rows, ...contactRows([""])]);
+    }
+  }, [rows, onChange]);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SectionLabel className="font-medium">
+        {field.label}
+        {optional ? <span className="tracking-normal opacity-70"> (optional)</span> : null}
+      </SectionLabel>
+      <div className="flex flex-col gap-1.5">
+        {rows.map((row, index) => {
+          const trimmed = row.value.trim();
+          const match = trimmed ? (findMatch?.(kind, trimmed) ?? null) : null;
+          const canRemove = trimmed.length > 0;
+          return (
+            <div key={row.id} className="flex flex-col gap-1">
+              <div className="flex items-center gap-1.5">
+                <Input
+                  value={row.value}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(row.id, e.target.value)}
+                  placeholder={field.placeholder}
+                  inputMode={field.inputMode}
+                  aria-label={`${field.label} ${index + 1}`}
+                  className="font-mono text-xs"
+                />
+                {canRemove ? (
+                  <button
+                    type="button"
+                    onClick={() => remove(row.id)}
+                    aria-label={`Remove ${field.label.toLowerCase()}`}
+                    className="shrink-0 rounded p-1 text-muted-foreground/50 transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <XIcon size={12} />
+                  </button>
+                ) : null}
+              </div>
+              {match ? (
+                <p className="flex flex-wrap items-center gap-x-1 pl-0.5 text-[10.5px] text-amber-600 dark:text-amber-400">
+                  <span>
+                    Already on <span className="font-medium">{match.name}</span>.
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onMergeSuggested?.(match)}
+                    className="font-medium underline underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300"
+                  >
+                    Merge them?
+                  </button>
+                </p>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function ContactPointsEditor({
+  name,
+  onNameChange,
+  namePlaceholder,
+  nameConfirm,
+  phones,
+  emails,
+  onPhonesChange,
+  onEmailsChange,
+  findMatch,
+  onMergeSuggested,
+}: {
+  /** When `onNameChange` is provided, a required single-value Name field leads the form. */
+  name?: string;
+  onNameChange?: (value: string) => void;
+  namePlaceholder?: string;
+  /** When set, the Name field shows a green confirm tick that accepts a guessed identity. */
+  nameConfirm?: { onConfirm: () => void; label: string } | null;
+  phones: ContactRow[];
+  emails: ContactRow[];
+  onPhonesChange: (next: ContactRow[]) => void;
+  onEmailsChange: (next: ContactRow[]) => void;
+  findMatch?: (kind: ContactKind, value: string) => ContactMatch | null;
+  onMergeSuggested?: (match: ContactMatch) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3.5">
+      {onNameChange ? (
+        <div className="flex flex-col gap-1.5">
+          <SectionLabel className="font-medium">Name</SectionLabel>
+          <div className="relative">
+            <Input
+              value={name ?? ""}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onNameChange(e.target.value)}
+              placeholder={namePlaceholder ?? "Full name"}
+              aria-label="Name"
+              className={cn("text-sm", nameConfirm ? "pr-11" : undefined)}
+              data-testid="contact-name-input"
+            />
+            {nameConfirm ? (
+              <button
+                type="button"
+                onClick={nameConfirm.onConfirm}
+                aria-label={nameConfirm.label}
+                title={nameConfirm.label}
+                className="absolute inset-y-0 right-1.5 my-auto flex h-6 w-6 items-center justify-center rounded-full bg-emerald-600 text-white transition-colors hover:bg-emerald-700"
+                data-testid="contact-name-confirm"
+              >
+                <CheckIcon size={13} weight="bold" />
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+      <ContactList
+        kind="phone"
+        rows={phones}
+        onChange={onPhonesChange}
+        findMatch={findMatch}
+        onMergeSuggested={onMergeSuggested}
+      />
+      <ContactList
+        kind="email"
+        optional
+        rows={emails}
+        onChange={onEmailsChange}
+        findMatch={findMatch}
+        onMergeSuggested={onMergeSuggested}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/components/entity-review/review-band.tsx
+++ b/packages/web/src/components/entity-review/review-band.tsx
@@ -32,6 +32,7 @@ import { formatRelativeTime } from "@/routes/files/file-list";
 import {
   ArrowLeftIcon,
   ArrowSquareOutIcon,
+  ArrowsLeftRightIcon,
   CheckIcon,
   CubeIcon,
   PlugsConnectedIcon,
@@ -161,7 +162,7 @@ function OriginChip({ row }: { row: EntityReviewQueueRow }) {
 /**
  * A birth row (proposed entity with no candidate match). It resolves inline —
  * Confirm creates the entity from its seed, Dismiss drops it without creating
- * anything, Merge… opens a search-only picker for the "actually a duplicate"
+ * anything, Merge opens a search-only picker for the "actually a duplicate"
  * escape hatch. The actions only appear on hover/focus to keep the list calm;
  * clicking the row body opens a read-only inspect sheet (origin + linked files).
  * No reconcile drawer: a birth is not a merge, so there's nothing to compare.
@@ -228,7 +229,8 @@ function BirthRow({
             className="h-7 gap-1"
             data-testid="birth-merge"
           >
-            Merge…
+            <ArrowsLeftRightIcon size={12} />
+            Merge
           </Button>
           <Button
             size="sm"
@@ -275,7 +277,7 @@ function inspectActivityLine(childTaskCount: number, fileCount: number): string 
  * so a proposed entity reads like a real one: accent top-stripe header, avatar,
  * serif name, and `font-mono` section labels in accent-tinted cards. Shows
  * where the proposal came from + the tasks/files behind it, plus the same
- * Confirm / Merge… / Dismiss actions. One column — a birth has no candidate to
+ * Confirm / Merge / Dismiss actions. One column — a birth has no candidate to
  * compare against, so the reconcile layout doesn't apply.
  */
 export function BirthInspectSheet({
@@ -491,7 +493,8 @@ function BirthInspectBody({
           className="h-7 gap-1 text-[11px]"
           data-testid="birth-inspect-merge"
         >
-          Merge…
+          <ArrowsLeftRightIcon size={12} />
+          Merge
         </Button>
         <Button
           size="sm"
@@ -520,7 +523,7 @@ function BirthInspectBody({
 }
 
 /**
- * Search-only picker for the birth-row "Merge…" escape hatch. Wraps the shared
+ * Search-only picker for the birth-row "Merge" escape hatch. Wraps the shared
  * {@link EntityPicker} scoped to the row's type. Deliberately NOT the full
  * reconcile sheet — a birth merge only needs a target, no evidence compare.
  */

--- a/packages/web/src/components/entity-review/review-band.tsx
+++ b/packages/web/src/components/entity-review/review-band.tsx
@@ -1,4 +1,4 @@
-import { EntryList, SectionCard, SectionLabel, SourceTag } from "@/components/entity-drawer/drawer-kit";
+import { EntryList, SectionLabel, SourceTag } from "@/components/entity-drawer/drawer-kit";
 /**
  * Shared entity-review band + reconcile sheet.
  *
@@ -48,7 +48,9 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "
 import { Skeleton } from "@sketch/ui/components/skeleton";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { ContactPointsEditor, type ContactRow, contactRows } from "./contact-points-editor";
 import { birthOrigin, entityEmail, humanSourceType } from "./entity-format";
+import { WHATSAPP_IDENTITY_REVIEW_ENABLED } from "./whatsapp-identity-review";
 
 /**
  * Self-contained review band scoped to a set of entity types. Fetches the
@@ -347,12 +349,22 @@ function BirthInspectBody({
 }) {
   const [mergeOpen, setMergeOpen] = useState(false);
   const [name, setName] = useState(row.proposed_name);
+  const [phones, setPhones] = useState<ContactRow[]>(() => contactRows([""]));
+  const [emails, setEmails] = useState<ContactRow[]>(() => contactRows(row.proposed_email ? [row.proposed_email] : []));
   const mutations = useReviewMutations(row, onResolved);
   const origin = birthOrigin(row);
   const trimmedName = name.trim();
   const nameOverride = trimmedName && trimmedName !== row.proposed_name ? trimmedName : undefined;
   const identity = { id: row.id, name: row.proposed_name, sourceType: row.entity_type };
   const accent = entityAccent(identity);
+  /**
+   * Prototype: a person in review gets the same Name/Phone/Email identity form as
+   * the WhatsApp drawer, gated behind the same OFF flag. Phone/email are captured
+   * in the UI but NOT yet persisted — the confirm mutation only sends the name
+   * override — so Confirm stays name-gated (not phone-gated) until the backend
+   * accepts contact-points. Non-person births keep the name-only header.
+   */
+  const showContactForm = WHATSAPP_IDENTITY_REVIEW_ENABLED && row.entity_type === "person";
 
   return (
     <>
@@ -363,15 +375,24 @@ function BirthInspectBody({
         <div className="flex items-start gap-3">
           <EntityAvatar entity={identity} size="lg" />
           <div className="min-w-0 flex-1">
-            <input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={mutations.isPending}
-              aria-label="Name"
-              placeholder="Name"
-              className="w-full rounded-sm bg-transparent font-serif text-[20px] leading-tight outline-none placeholder:text-muted-foreground/40 focus:bg-muted/40"
-              data-testid="birth-name-input"
-            />
+            {showContactForm ? (
+              <h2
+                className="truncate font-serif text-[20px] leading-tight text-foreground"
+                data-testid="birth-display-name"
+              >
+                {trimmedName.length > 0 ? name : "Unnamed person"}
+              </h2>
+            ) : (
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={mutations.isPending}
+                aria-label="Name"
+                placeholder="Name"
+                className="w-full rounded-sm bg-transparent font-serif text-[20px] leading-tight outline-none placeholder:text-muted-foreground/40 focus:bg-muted/40"
+                data-testid="birth-name-input"
+              />
+            )}
             <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
               <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
                 {humanSourceType(row.entity_type)}
@@ -386,15 +407,27 @@ function BirthInspectBody({
       </div>
 
       <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-4">
-        <SectionCard accent={accent} label="Summary">
-          <div className="space-y-1 text-sm leading-snug">
+        {showContactForm ? (
+          <ContactPointsEditor
+            name={name}
+            onNameChange={setName}
+            namePlaceholder="Full name"
+            phones={phones}
+            emails={emails}
+            onPhonesChange={setPhones}
+            onEmailsChange={setEmails}
+          />
+        ) : null}
+        <div className="flex flex-col">
+          <SectionLabel className="mb-1.5 font-medium">Summary</SectionLabel>
+          <div className="space-y-1 rounded-md border bg-background px-3.5 py-3 text-sm leading-snug">
             <p>
               New {humanSourceType(row.entity_type).toLowerCase()}
               {origin ? ` from ${origin.label}` : ""}.
             </p>
             <p className="text-muted-foreground">{inspectActivityLine(childTaskCount, evidence.length)}</p>
           </div>
-        </SectionCard>
+        </div>
 
         {childTaskCount > 0 ? (
           <div className="flex flex-col">
@@ -402,9 +435,9 @@ function BirthInspectBody({
             <EntryList>
               {childTasks.map((t) => (
                 <li key={t.indexedFileId}>
-                  <div className="flex w-full items-center gap-2 px-3 py-2">
+                  <div className="flex w-full items-center gap-2 px-3.5 py-3">
                     <SourceTag>{t.source}</SourceTag>
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium">{t.name}</span>
+                    <span className="min-w-0 flex-1 truncate text-sm font-semibold">{t.name}</span>
                     {t.providerUrl ? (
                       <a
                         href={t.providerUrl}
@@ -419,7 +452,7 @@ function BirthInspectBody({
                 </li>
               ))}
               {childTaskCount > childTasks.length ? (
-                <li className="px-3 py-2 text-[10px] text-muted-foreground">
+                <li className="px-3.5 py-2.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground/60">
                   + {childTaskCount - childTasks.length} more
                 </li>
               ) : null}
@@ -440,14 +473,16 @@ function BirthInspectBody({
               <EntryList>
                 {evidence.map((e) => (
                   <li key={e.id}>
-                    <div className="flex w-full flex-col gap-1 px-3 py-2">
+                    <div className="flex w-full flex-col gap-1 px-3.5 py-3">
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex min-w-0 items-center gap-2">
                           <SourceTag>{e.source}</SourceTag>
-                          <span className="truncate text-sm font-medium">{e.file.name}</span>
+                          <span className="truncate text-sm font-semibold">{e.file.name}</span>
                         </div>
                         <div className="flex shrink-0 items-center gap-2">
-                          <span className="text-[10px] text-muted-foreground">{formatRelativeTime(e.seen_at)}</span>
+                          <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground/60">
+                            {formatRelativeTime(e.seen_at)}
+                          </span>
                           {e.file.providerUrl ? (
                             <a
                               href={e.file.providerUrl}
@@ -461,7 +496,9 @@ function BirthInspectBody({
                         </div>
                       </div>
                       {e.file.sourcePath ? (
-                        <p className="line-clamp-2 text-[11px] text-muted-foreground">{e.file.sourcePath}</p>
+                        <p className="mt-1 line-clamp-2 border-l border-border pl-3 text-[12px] leading-relaxed text-muted-foreground">
+                          {e.file.sourcePath}
+                        </p>
                       ) : null}
                     </div>
                   </li>

--- a/packages/web/src/components/entity-review/whatsapp-identity-review.tsx
+++ b/packages/web/src/components/entity-review/whatsapp-identity-review.tsx
@@ -1,0 +1,539 @@
+/**
+ * WhatsApp identity review — folds unidentified WhatsApp contacts into the
+ * existing "Needs your review" queue.
+ *
+ * When a WhatsApp group is indexed, every unknown participant is auto-minted as
+ * a person entity named by its raw phone/LID (`projectWhatsAppRosterPerson` on
+ * the server). Those people already exist in the graph — they just have no human
+ * name yet. This surface lets an admin put a name to them, leading with the
+ * GROUPS the contact appears in (the recognizable signal) rather than the LID or
+ * masked number, which no human can map on sight.
+ *
+ * ⚠️ FRONTEND PROTOTYPE — no backend yet. The types below are the contract a
+ * backend developer implements; {@link WHATSAPP_IDENTITY_MOCK} stands in for the
+ * list endpoint, and the resolve actions are stubbed to local state + a toast.
+ * When the backend lands:
+ *   - Replace {@link useWhatsAppIdentityReview} with a real query, e.g.
+ *     `GET /api/whatsapp/identities?state=unidentified` returning
+ *     `WhatsAppIdentityReviewItem[]`.
+ *   - inline confirm ("This is them" / "Use this name", shown beside the name
+ *     only while the guess is untouched) → accept our suggestion as-is: merges
+ *     into the suggested entity when the suggestion carries one, else PATCHes the
+ *     guessed name (an unedited Save).
+ *   - "Save"         → PATCH the placeholder entity's (edited) name + POST
+ *     contact-points (`POST /api/entities/:entityId/contact-points`, kinds
+ *     email/phone). Active only once a field changes.
+ *   - "Merge"        → `POST /api/entities/merges { survivorId, loserId }` with
+ *     the placeholder entity as the loser.
+ *   - "Dismiss"      → mark the identity reviewed so it stops surfacing.
+ *   - The drawer's "Seen in" + suggestion need a new query over
+ *     `whatsapp_group_participants` + `conversation_messages` (no endpoint today).
+ */
+import { EntityPicker } from "@/components/entity-picker";
+import { EntityAvatar } from "@/lib/entity-ui";
+import { formatRelativeTime } from "@/routes/files/file-list";
+import { ArrowsLeftRightIcon, CheckIcon, UserFocusIcon, WhatsappLogoIcon, XIcon } from "@phosphor-icons/react";
+import { Badge } from "@sketch/ui/components/badge";
+import { Button } from "@sketch/ui/components/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@sketch/ui/components/dialog";
+import { Input } from "@sketch/ui/components/input";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@sketch/ui/components/sheet";
+import { cn } from "@sketch/ui/lib/utils";
+import { useState } from "react";
+import { toast } from "sonner";
+import { EntryList, SectionLabel } from "../entity-drawer/drawer-kit";
+
+/** One WhatsApp group the contact has been seen in, with a recent excerpt to help place them. */
+export interface WhatsAppGroupSighting {
+  groupJid: string;
+  groupName: string;
+  messageCount: number;
+  lastMessageAt: string;
+  /** A recent message excerpt shown to the admin to aid identification. Not persisted/logged. */
+  snippet: string | null;
+}
+
+/** Our best guess at who this identity belongs to — an existing entity (merge target) or just a name. */
+export interface WhatsAppIdentitySuggestion {
+  /** Existing entity we think this is (the merge target), when we have one; null = name only. */
+  entityId: string | null;
+  name: string;
+  confidence: "likely" | "possibly";
+  reason: string;
+}
+
+/** An unidentified WhatsApp person entity awaiting a name. The placeholder entity already exists. */
+export interface WhatsAppIdentityReviewItem {
+  id: string;
+  /** The placeholder person entity that already exists (currently named by its phone/LID). */
+  entityId: string;
+  /** E.164 number when captured; UI may prettify. Null when only a LID is known. */
+  phoneE164: string | null;
+  lid: string | null;
+  groups: WhatsAppGroupSighting[];
+  suggestion: WhatsAppIdentitySuggestion | null;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export const WHATSAPP_IDENTITY_MOCK: WhatsAppIdentityReviewItem[] = [
+  {
+    id: "wa-1",
+    entityId: "wa-entity-1",
+    phoneE164: "+91 98765 43210",
+    lid: "4790…6283@lid",
+    firstSeenAt: "2026-07-20T09:00:00Z",
+    lastSeenAt: "2026-08-11T14:00:00Z",
+    suggestion: {
+      entityId: "person-rohan",
+      name: "Rohan Mehta",
+      confidence: "likely",
+      reason:
+        "Appears in Pfizer RFP alongside 4 of his known contacts, and this number matches the one in his email signature.",
+    },
+    groups: [
+      {
+        groupJid: "g1",
+        groupName: "Pfizer RFP",
+        messageCount: 42,
+        lastMessageAt: "2026-08-11T14:00:00Z",
+        snippet: "I'll send the revised pricing by EOD — looping in Sanaa for the Thursday call.",
+      },
+      {
+        groupJid: "g2",
+        groupName: "Deal Room – APAC",
+        messageCount: 12,
+        lastMessageAt: "2026-08-08T10:00:00Z",
+        snippet: "Confirmed, our team can support the Q3 rollout in Mumbai.",
+      },
+      {
+        groupJid: "g3",
+        groupName: "Founders ⚡",
+        messageCount: 3,
+        lastMessageAt: "2026-07-24T18:00:00Z",
+        snippet: "Great meeting you all at the summit 🙏",
+      },
+    ],
+  },
+  {
+    id: "wa-2",
+    entityId: "wa-entity-2",
+    phoneE164: "+44 7700 900412",
+    lid: "6621…4409@lid",
+    firstSeenAt: "2026-08-12T09:00:00Z",
+    lastSeenAt: "2026-08-12T13:00:00Z",
+    suggestion: null,
+    groups: [
+      {
+        groupJid: "g4",
+        groupName: "Oliver Wyman × Canvas",
+        messageCount: 8,
+        lastMessageAt: "2026-08-12T13:00:00Z",
+        snippet: "Sharing the deck now — let me know if the numbers on slide 6 look right.",
+      },
+    ],
+  },
+  {
+    id: "wa-3",
+    entityId: "wa-entity-3",
+    phoneE164: null,
+    lid: "8134…7751@lid",
+    firstSeenAt: "2026-08-13T04:00:00Z",
+    lastSeenAt: "2026-08-13T08:00:00Z",
+    suggestion: {
+      entityId: null,
+      name: "Aisha Khan",
+      confidence: "possibly",
+      reason: "Shares a display name with an Aisha Khan in the Redseer group, but we haven't seen a phone number yet.",
+    },
+    groups: [
+      {
+        groupJid: "g5",
+        groupName: "Redseer diligence",
+        messageCount: 19,
+        lastMessageAt: "2026-08-13T08:00:00Z",
+        snippet: "The cohort data is in the shared folder — pulling churn next.",
+      },
+      {
+        groupJid: "g6",
+        groupName: "Sketch WhatsApp test",
+        messageCount: 33,
+        lastMessageAt: "2026-08-13T06:00:00Z",
+        snippet: "Testing — does the bot pick this up?",
+      },
+    ],
+  },
+];
+
+/**
+ * Prototype data source. Only surfaces on person-scoped queues (WhatsApp
+ * identities are people). Returns the local mock plus a `resolve` that
+ * optimistically drops a row and toasts — the stand-in for the real mutations.
+ */
+/**
+ * Experimental gate for the WhatsApp-identity review surface. Off by default,
+ * so the feature is completely invisible — no rows in the "Needs your review"
+ * band, no rows in the Review tab, no drawer. Flip to `true` for design review.
+ *
+ * Note: CLAUDE.md describes a server-side `EXPERIMENTAL_FLAG` surfaced to the
+ * web as `setupStatus.experimentalFlag`, but neither exists in the current
+ * codebase — there is no frontend feature-flag plumbing, and the sibling review
+ * queue is gated purely by whether the server returns rows. This feature is
+ * frontend-only mock data, so it carries its own local switch. When the backend
+ * lands, delete this constant and let real server-driven visibility gate it, the
+ * way {@link GhostReviewRow} already does.
+ */
+export const WHATSAPP_IDENTITY_REVIEW_ENABLED = false;
+
+export function useWhatsAppIdentityReview(types: string[]): {
+  items: WhatsAppIdentityReviewItem[];
+  resolve: (id: string, message: string) => void;
+} {
+  const enabled = WHATSAPP_IDENTITY_REVIEW_ENABLED && (types.length === 0 || types.includes("person"));
+  const [items, setItems] = useState<WhatsAppIdentityReviewItem[]>(() => (enabled ? WHATSAPP_IDENTITY_MOCK : []));
+  const resolve = (id: string, message: string) => {
+    setItems((current) => current.filter((item) => item.id !== id));
+    toast.success(message);
+  };
+  return { items, resolve };
+}
+
+function IdentityAvatar({ item, size }: { item: WhatsAppIdentityReviewItem; size: "sm" | "lg" }) {
+  if (item.suggestion) {
+    return (
+      <EntityAvatar entity={{ id: item.entityId, name: item.suggestion.name, sourceType: "person" }} size={size} />
+    );
+  }
+  const dim = size === "lg" ? "h-12 w-12" : "h-6 w-6";
+  const icon = size === "lg" ? 20 : 13;
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full border border-dashed border-border bg-muted text-muted-foreground",
+        dim,
+      )}
+    >
+      <UserFocusIcon size={icon} />
+    </span>
+  );
+}
+
+function GroupChip({ name }: { name: string }) {
+  return (
+    <span className="inline-flex max-w-[12rem] items-center truncate rounded-full border border-border bg-background/40 px-2 py-0.5 text-[10.5px] text-foreground/80">
+      <span className="truncate">{name}</span>
+    </span>
+  );
+}
+
+/**
+ * One WhatsApp identity row inside the review queue. Line 1 mirrors the plain
+ * review row (avatar · name · muted note · caret · actions) so the whole column
+ * aligns; line 2 carries the evidence — a quiet channel glyph, the groups as the
+ * recognizable anchor, then the muted phone. The primary action (Merge when we
+ * already have an entity to fold this into, otherwise Add) opens the drawer,
+ * where the guess is checked against the group history before anything commits.
+ */
+export function WhatsAppIdentityRow({
+  item,
+  onOpen,
+  onResolve,
+}: {
+  item: WhatsAppIdentityReviewItem;
+  onOpen: () => void;
+  onResolve: (message: string) => void;
+}) {
+  const hasSuggestion = item.suggestion !== null;
+  const name = item.suggestion?.name ?? "Unidentified contact";
+  const note = hasSuggestion ? `${item.suggestion?.confidence} this person` : "needs a name";
+  const primaryLabel = item.suggestion?.entityId ? "Merge" : "Add";
+  const shownGroups = item.groups.slice(0, 2);
+  const moreGroups = item.groups.length - shownGroups.length;
+
+  return (
+    <div className="border-b border-border/60 last:border-b-0" data-testid={`wa-identity-row-${item.id}`}>
+      <div className="flex w-full items-start transition-colors hover:bg-foreground/10">
+        <button type="button" onClick={onOpen} className="flex min-w-0 flex-1 flex-col gap-1 px-3 py-2 text-left">
+          <div className="flex w-full items-center gap-2">
+            <IdentityAvatar item={item} size="sm" />
+            <span
+              className={cn(
+                "shrink-0 truncate text-[12.5px] font-medium",
+                hasSuggestion ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {name}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted-foreground">{note}</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5 pl-6">
+            <WhatsappLogoIcon
+              size={13}
+              weight="fill"
+              aria-label="WhatsApp"
+              className="shrink-0 text-muted-foreground"
+            />
+            {shownGroups.map((group) => (
+              <GroupChip key={group.groupJid} name={group.groupName} />
+            ))}
+            {moreGroups > 0 ? <span className="text-[10.5px] text-muted-foreground">+{moreGroups} more</span> : null}
+            {item.phoneE164 ? (
+              <span className="ml-1 font-mono text-[10px] tracking-tight text-muted-foreground/70">
+                {item.phoneE164}
+              </span>
+            ) : null}
+          </div>
+        </button>
+        <span className="flex shrink-0 items-center gap-0.5 py-2 pr-3">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen();
+            }}
+            className="px-1.5 py-0.5 text-[11px] font-medium text-foreground hover:underline"
+          >
+            {primaryLabel}
+          </button>
+          <span className="text-muted-foreground/40">·</span>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onResolve("Dismissed");
+            }}
+            className="px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
+          >
+            Dismiss
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Right-hand identify drawer for one WhatsApp contact. The name/phone/email form
+ * leads as the primary action (the contact is unidentified — you're giving them
+ * an identity), and the groups it's been seen in follow as the evidence you use
+ * to fill it. Merge into an existing person stays a footer action.
+ */
+export function WhatsAppIdentityDrawer({
+  item,
+  onClose,
+  onResolve,
+}: {
+  item: WhatsAppIdentityReviewItem | null;
+  onClose: () => void;
+  onResolve: (id: string, message: string) => void;
+}) {
+  return (
+    <Sheet open={item !== null} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-[720px]">
+        <SheetTitle className="sr-only">{item ? "Identify WhatsApp contact" : "Review"}</SheetTitle>
+        <SheetDescription className="sr-only">
+          Identify an unknown WhatsApp contact from the groups and messages it appears in, then save their details or
+          merge them into someone you already know.
+        </SheetDescription>
+        {item ? (
+          <WhatsAppIdentityBody
+            key={item.id}
+            item={item}
+            onResolve={(message) => {
+              onResolve(item.id, message);
+              onClose();
+            }}
+          />
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function WhatsAppIdentityBody({
+  item,
+  onResolve,
+}: {
+  item: WhatsAppIdentityReviewItem;
+  onResolve: (message: string) => void;
+}) {
+  const [name, setName] = useState(item.suggestion?.name ?? "");
+  const [phone, setPhone] = useState(item.phoneE164 ?? "");
+  const [email, setEmail] = useState("");
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const trimmedName = name.trim();
+  const initialName = (item.suggestion?.name ?? "").trim();
+  const initialPhone = (item.phoneE164 ?? "").trim();
+  const dirty = trimmedName !== initialName || phone.trim() !== initialPhone || email.trim().length > 0;
+  const canSave = trimmedName.length > 0 && dirty;
+  const hasGuess = item.suggestion !== null;
+  const showSuggestionConfirm = hasGuess && !dirty;
+  const confirmSuggestion = () => {
+    onResolve(item.suggestion?.entityId ? `Merged into ${item.suggestion?.name}` : `Saved ${item.suggestion?.name}`);
+  };
+  const accent = "#f59e0b";
+  const helper = item.suggestion
+    ? "We've guessed a name below — confirm it, or merge them into someone you already know."
+    : "Name this contact from the groups below, or merge them into someone you already know.";
+
+  return (
+    <>
+      <div
+        className="sticky top-0 z-10 border-b bg-background px-6 pb-4 pt-5"
+        style={{ borderTopColor: accent, borderTopWidth: 3 }}
+      >
+        <div className="flex items-start gap-3">
+          <IdentityAvatar item={item} size="lg" />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
+                Person
+              </Badge>
+              <Badge variant="outline" className="gap-1 text-[10px] uppercase tracking-wider">
+                <WhatsappLogoIcon size={10} weight="fill" />
+                WhatsApp
+              </Badge>
+              <Badge
+                variant="outline"
+                className="border-amber-300 text-[10px] uppercase tracking-wider text-amber-700 dark:border-amber-700 dark:text-amber-400"
+              >
+                Unidentified
+              </Badge>
+            </div>
+            <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">{helper}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 pb-4">
+        <div className="-mx-6 flex flex-col gap-3.5 border-b bg-muted/40 px-6 pb-5 pt-4 dark:bg-muted/20">
+          <div className="flex flex-col gap-1.5">
+            <SectionLabel className="font-medium">Name</SectionLabel>
+            <Input
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+              placeholder="Name this contact"
+              aria-label="Name"
+              className="h-10 bg-background font-serif text-[17px]"
+              data-testid="wa-identity-name-input"
+            />
+            {showSuggestionConfirm ? (
+              <button
+                type="button"
+                onClick={confirmSuggestion}
+                className="inline-flex items-center gap-1.5 self-start rounded-full border border-emerald-400/60 bg-emerald-50/60 px-2.5 py-1 text-[11px] font-medium text-emerald-700 transition-colors hover:bg-emerald-100/70 dark:border-emerald-600/50 dark:bg-emerald-950/30 dark:text-emerald-300 dark:hover:bg-emerald-950/50"
+                data-testid="wa-identity-confirm-suggestion"
+              >
+                <CheckIcon size={11} weight="bold" />
+                {item.suggestion?.entityId ? "This is them" : "Use this name"}
+              </button>
+            ) : null}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <SectionLabel className="font-medium">
+              Phone <span className="normal-case tracking-normal opacity-70">(optional)</span>
+            </SectionLabel>
+            <Input
+              value={phone}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPhone(e.target.value)}
+              placeholder="+91 98765 43210"
+              inputMode="tel"
+              className="bg-background font-mono text-xs"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <SectionLabel className="font-medium">
+              Email <span className="normal-case tracking-normal opacity-70">(optional)</span>
+            </SectionLabel>
+            <Input
+              value={email}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+              placeholder="name@company.com"
+              inputMode="email"
+              className="bg-background font-mono text-xs"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col">
+          <SectionLabel className="mb-1.5 font-medium">
+            Seen in · {item.groups.length} {item.groups.length === 1 ? "group" : "groups"}
+          </SectionLabel>
+          <EntryList>
+            {item.groups.map((group) => (
+              <li key={group.groupJid} className="px-3 py-2.5">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex items-center gap-1 rounded-sm bg-muted px-1 py-0.5 font-mono text-[9px] uppercase text-muted-foreground">
+                    <WhatsappLogoIcon size={9} weight="fill" />
+                    Group
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-sm font-medium">{group.groupName}</span>
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                    {group.messageCount} msgs · {formatRelativeTime(group.lastMessageAt)}
+                  </span>
+                </div>
+                {group.snippet ? (
+                  <p className="mt-1.5 border-l-2 border-border pl-2.5 text-[11.5px] leading-relaxed text-muted-foreground">
+                    {group.snippet}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </EntryList>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 border-t bg-background px-6 py-3">
+        <Button
+          size="sm"
+          onClick={() => onResolve(trimmedName ? `Saved ${trimmedName}` : "Saved")}
+          disabled={!canSave}
+          className="h-7 gap-1 bg-emerald-600 text-[11px] text-white hover:bg-emerald-700"
+          data-testid="wa-identity-add"
+        >
+          <CheckIcon size={12} weight="bold" />
+          Save
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setMergeOpen(true)}
+          className="h-7 gap-1 text-[11px]"
+          data-testid="wa-identity-merge"
+        >
+          <ArrowsLeftRightIcon size={12} />
+          Merge
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onResolve("Dismissed")}
+          className="ml-auto h-7 gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+          data-testid="wa-identity-dismiss"
+        >
+          <XIcon size={12} />
+          Dismiss
+        </Button>
+      </div>
+
+      <Dialog open={mergeOpen} onOpenChange={setMergeOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-base">Merge this contact into…</DialogTitle>
+            <DialogDescription>
+              Pick the person this WhatsApp contact already is. Their number and group history fold into that entity —
+              no new person is created.
+            </DialogDescription>
+          </DialogHeader>
+          <EntityPicker
+            entityType="person"
+            onPick={(entityId) => {
+              setMergeOpen(false);
+              onResolve(`Merged into ${entityId}`);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/web/src/components/entity-review/whatsapp-identity-review.tsx
+++ b/packages/web/src/components/entity-review/whatsapp-identity-review.tsx
@@ -32,25 +32,39 @@
 import { EntityPicker } from "@/components/entity-picker";
 import { EntityAvatar } from "@/lib/entity-ui";
 import { formatRelativeTime } from "@/routes/files/file-list";
-import { ArrowsLeftRightIcon, CheckIcon, UserFocusIcon, WhatsappLogoIcon, XIcon } from "@phosphor-icons/react";
+import {
+  ArrowsLeftRightIcon,
+  CheckIcon,
+  PhoneIcon,
+  UserFocusIcon,
+  WhatsappLogoIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import { Badge } from "@sketch/ui/components/badge";
 import { Button } from "@sketch/ui/components/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@sketch/ui/components/dialog";
-import { Input } from "@sketch/ui/components/input";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@sketch/ui/components/sheet";
 import { cn } from "@sketch/ui/lib/utils";
 import { useState } from "react";
 import { toast } from "sonner";
 import { EntryList, SectionLabel } from "../entity-drawer/drawer-kit";
+import {
+  type ContactKind,
+  type ContactMatch,
+  ContactPointsEditor,
+  type ContactRow,
+  contactRows,
+  contactValues,
+} from "./contact-points-editor";
 
-/** One WhatsApp group the contact has been seen in, with a recent excerpt to help place them. */
+/** One WhatsApp group the contact has been seen in, with recent excerpts to help place them. */
 export interface WhatsAppGroupSighting {
   groupJid: string;
   groupName: string;
   messageCount: number;
   lastMessageAt: string;
-  /** A recent message excerpt shown to the admin to aid identification. Not persisted/logged. */
-  snippet: string | null;
+  /** A few recent message excerpts (most recent first) shown to aid identification. Backend caps the count. */
+  snippets: string[];
 }
 
 /** Our best guess at who this identity belongs to — an existing entity (merge target) or just a name. */
@@ -97,21 +111,28 @@ export const WHATSAPP_IDENTITY_MOCK: WhatsAppIdentityReviewItem[] = [
         groupName: "Pfizer RFP",
         messageCount: 42,
         lastMessageAt: "2026-08-11T14:00:00Z",
-        snippet: "I'll send the revised pricing by EOD — looping in Sanaa for the Thursday call.",
+        snippets: [
+          "I'll send the revised pricing by EOD — looping in Sanaa for the Thursday call.",
+          "Can we push the review to 3pm? It clashes with the Pfizer standup.",
+          "Final deck is uploaded — the numbers we agreed on are on slide 12.",
+        ],
       },
       {
         groupJid: "g2",
         groupName: "Deal Room – APAC",
         messageCount: 12,
         lastMessageAt: "2026-08-08T10:00:00Z",
-        snippet: "Confirmed, our team can support the Q3 rollout in Mumbai.",
+        snippets: [
+          "Confirmed, our team can support the Q3 rollout in Mumbai.",
+          "Legal cleared the MSA this morning — good to countersign.",
+        ],
       },
       {
         groupJid: "g3",
         groupName: "Founders ⚡",
         messageCount: 3,
         lastMessageAt: "2026-07-24T18:00:00Z",
-        snippet: "Great meeting you all at the summit 🙏",
+        snippets: ["Great meeting you all at the summit 🙏", "Let's grab coffee next week — I'm in town till Friday."],
       },
     ],
   },
@@ -129,7 +150,10 @@ export const WHATSAPP_IDENTITY_MOCK: WhatsAppIdentityReviewItem[] = [
         groupName: "Oliver Wyman × Canvas",
         messageCount: 8,
         lastMessageAt: "2026-08-12T13:00:00Z",
-        snippet: "Sharing the deck now — let me know if the numbers on slide 6 look right.",
+        snippets: [
+          "Sharing the deck now — let me know if the numbers on slide 6 look right.",
+          "Thanks for the intro — we'll circle back with our POV by Monday.",
+        ],
       },
     ],
   },
@@ -152,18 +176,42 @@ export const WHATSAPP_IDENTITY_MOCK: WhatsAppIdentityReviewItem[] = [
         groupName: "Redseer diligence",
         messageCount: 19,
         lastMessageAt: "2026-08-13T08:00:00Z",
-        snippet: "The cohort data is in the shared folder — pulling churn next.",
+        snippets: [
+          "The cohort data is in the shared folder — pulling churn next.",
+          "Retention looks stronger than the last cut — I'll annotate the deltas.",
+        ],
       },
       {
         groupJid: "g6",
         groupName: "Sketch WhatsApp test",
         messageCount: 33,
         lastMessageAt: "2026-08-13T06:00:00Z",
-        snippet: "Testing — does the bot pick this up?",
+        snippets: ["Testing — does the bot pick this up?", "Second test, adding a reaction now."],
       },
     ],
   },
 ];
+
+/**
+ * Prototype stand-in for backend duplicate detection: a contact-point lookup
+ * keyed by value. When an admin enters a phone/email that already belongs to
+ * another entity, the drawer offers to merge into it instead of minting a second
+ * record — the "two entities that share a contact point are the same person"
+ * concept. The backend replaces this with a real search over existing contact
+ * points. Seeded so `wa-2`'s pre-filled number already resolves to a person.
+ */
+const KNOWN_CONTACT_POINTS: Array<{ kind: ContactKind; value: string; entityId: string; name: string }> = [
+  { kind: "phone", value: "+44 7700 900412", entityId: "person-nadia", name: "Nadia Rahman" },
+  { kind: "email", value: "nadia.rahman@owl.com", entityId: "person-nadia", name: "Nadia Rahman" },
+];
+
+const normalizeContactPoint = (value: string) => value.replace(/\s+/g, "").toLowerCase();
+
+function findContactMatch(kind: ContactKind, value: string): ContactMatch | null {
+  const needle = normalizeContactPoint(value);
+  const hit = KNOWN_CONTACT_POINTS.find((cp) => cp.kind === kind && normalizeContactPoint(cp.value) === needle);
+  return hit ? { entityId: hit.entityId, name: hit.name } : null;
+}
 
 /**
  * Prototype data source. Only surfaces on person-scoped queues (WhatsApp
@@ -220,7 +268,7 @@ function IdentityAvatar({ item, size }: { item: WhatsAppIdentityReviewItem; size
 
 function GroupChip({ name }: { name: string }) {
   return (
-    <span className="inline-flex max-w-[12rem] items-center truncate rounded-full border border-border bg-background/40 px-2 py-0.5 text-[10.5px] text-foreground/80">
+    <span className="inline-flex max-w-[12rem] items-center truncate rounded-full border border-border bg-background/40 px-2 py-0.5 text-[10.5px] text-foreground/80 transition-colors group-hover:border-foreground/20 group-hover:bg-background/80">
       <span className="truncate">{name}</span>
     </span>
   );
@@ -252,7 +300,7 @@ export function WhatsAppIdentityRow({
 
   return (
     <div className="border-b border-border/60 last:border-b-0" data-testid={`wa-identity-row-${item.id}`}>
-      <div className="flex w-full items-start transition-colors hover:bg-foreground/10">
+      <div className="group flex w-full items-start transition-colors hover:bg-foreground/10">
         <button type="button" onClick={onOpen} className="flex min-w-0 flex-1 flex-col gap-1 px-3 py-2 text-left">
           <div className="flex w-full items-center gap-2">
             <IdentityAvatar item={item} size="sm" />
@@ -271,16 +319,20 @@ export function WhatsAppIdentityRow({
               size={13}
               weight="fill"
               aria-label="WhatsApp"
-              className="shrink-0 text-muted-foreground"
+              className="shrink-0 text-muted-foreground transition-all duration-200 group-hover:scale-110 group-hover:text-[#25D366]"
             />
             {shownGroups.map((group) => (
               <GroupChip key={group.groupJid} name={group.groupName} />
             ))}
             {moreGroups > 0 ? <span className="text-[10.5px] text-muted-foreground">+{moreGroups} more</span> : null}
             {item.phoneE164 ? (
-              <span className="ml-1 font-mono text-[10px] tracking-tight text-muted-foreground/70">
-                {item.phoneE164}
-              </span>
+              <>
+                <span className="h-3 w-px shrink-0 bg-border" aria-hidden="true" />
+                <PhoneIcon size={13} weight="fill" aria-label="Phone" className="shrink-0 text-muted-foreground" />
+                <span className="inline-flex shrink-0 items-center rounded-full border border-border bg-background/40 px-2 py-0.5 font-mono text-[10px] tracking-tight text-muted-foreground">
+                  {item.phoneE164}
+                </span>
+              </>
             ) : null}
           </div>
         </button>
@@ -358,23 +410,23 @@ function WhatsAppIdentityBody({
   onResolve: (message: string) => void;
 }) {
   const [name, setName] = useState(item.suggestion?.name ?? "");
-  const [phone, setPhone] = useState(item.phoneE164 ?? "");
-  const [email, setEmail] = useState("");
+  const [phones, setPhones] = useState<ContactRow[]>(() => contactRows([item.phoneE164 ?? ""]));
+  const [emails, setEmails] = useState<ContactRow[]>(() => contactRows([]));
   const [mergeOpen, setMergeOpen] = useState(false);
   const trimmedName = name.trim();
   const initialName = (item.suggestion?.name ?? "").trim();
   const initialPhone = (item.phoneE164 ?? "").trim();
-  const dirty = trimmedName !== initialName || phone.trim() !== initialPhone || email.trim().length > 0;
-  const canSave = trimmedName.length > 0 && dirty;
+  const phoneValues = contactValues(phones);
+  const emailValues = contactValues(emails);
+  const hasPhone = phoneValues.length > 0;
+  const dirty = trimmedName !== initialName || phoneValues.join("|") !== initialPhone || emailValues.length > 0;
+  const canSave = trimmedName.length > 0 && hasPhone && dirty;
   const hasGuess = item.suggestion !== null;
   const showSuggestionConfirm = hasGuess && !dirty;
   const confirmSuggestion = () => {
     onResolve(item.suggestion?.entityId ? `Merged into ${item.suggestion?.name}` : `Saved ${item.suggestion?.name}`);
   };
   const accent = "#f59e0b";
-  const helper = item.suggestion
-    ? "We've guessed a name below — confirm it, or merge them into someone you already know."
-    : "Name this contact from the groups below, or merge them into someone you already know.";
 
   return (
     <>
@@ -385,12 +437,34 @@ function WhatsAppIdentityBody({
         <div className="flex items-start gap-3">
           <IdentityAvatar item={item} size="lg" />
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-1.5">
+            <h2
+              className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5"
+              data-testid="wa-identity-display-name"
+            >
+              <span
+                className={cn(
+                  "min-w-0 max-w-full truncate font-serif text-[20px] leading-tight",
+                  trimmedName.length === 0
+                    ? "text-muted-foreground/50"
+                    : showSuggestionConfirm
+                      ? "text-foreground/85"
+                      : "text-foreground",
+                )}
+              >
+                {trimmedName.length > 0 ? name : "Unidentified contact"}
+              </span>
+              {showSuggestionConfirm ? (
+                <span className="shrink-0 font-mono text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400">
+                  ({item.suggestion?.confidence === "likely" ? "Likely" : "Possibly"})
+                </span>
+              ) : null}
+            </h2>
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
               <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
                 Person
               </Badge>
               <Badge variant="outline" className="gap-1 text-[10px] uppercase tracking-wider">
-                <WhatsappLogoIcon size={10} weight="fill" />
+                <WhatsappLogoIcon size={10} weight="fill" className="text-[#25D366]" />
                 WhatsApp
               </Badge>
               <Badge
@@ -400,60 +474,30 @@ function WhatsAppIdentityBody({
                 Unidentified
               </Badge>
             </div>
-            <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">{helper}</p>
           </div>
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 pb-4">
-        <div className="-mx-6 flex flex-col gap-3.5 border-b bg-muted/40 px-6 pb-5 pt-4 dark:bg-muted/20">
-          <div className="flex flex-col gap-1.5">
-            <SectionLabel className="font-medium">Name</SectionLabel>
-            <Input
-              value={name}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
-              placeholder="Name this contact"
-              aria-label="Name"
-              className="h-10 bg-background font-serif text-[17px]"
-              data-testid="wa-identity-name-input"
-            />
-            {showSuggestionConfirm ? (
-              <button
-                type="button"
-                onClick={confirmSuggestion}
-                className="inline-flex items-center gap-1.5 self-start rounded-full border border-emerald-400/60 bg-emerald-50/60 px-2.5 py-1 text-[11px] font-medium text-emerald-700 transition-colors hover:bg-emerald-100/70 dark:border-emerald-600/50 dark:bg-emerald-950/30 dark:text-emerald-300 dark:hover:bg-emerald-950/50"
-                data-testid="wa-identity-confirm-suggestion"
-              >
-                <CheckIcon size={11} weight="bold" />
-                {item.suggestion?.entityId ? "This is them" : "Use this name"}
-              </button>
-            ) : null}
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <SectionLabel className="font-medium">
-              Phone <span className="normal-case tracking-normal opacity-70">(optional)</span>
-            </SectionLabel>
-            <Input
-              value={phone}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPhone(e.target.value)}
-              placeholder="+91 98765 43210"
-              inputMode="tel"
-              className="bg-background font-mono text-xs"
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <SectionLabel className="font-medium">
-              Email <span className="normal-case tracking-normal opacity-70">(optional)</span>
-            </SectionLabel>
-            <Input
-              value={email}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
-              placeholder="name@company.com"
-              inputMode="email"
-              className="bg-background font-mono text-xs"
-            />
-          </div>
-        </div>
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-4">
+        <ContactPointsEditor
+          name={name}
+          onNameChange={setName}
+          namePlaceholder="Name this contact"
+          nameConfirm={
+            showSuggestionConfirm
+              ? {
+                  onConfirm: confirmSuggestion,
+                  label: item.suggestion?.entityId ? "This is them" : "Use this name",
+                }
+              : null
+          }
+          phones={phones}
+          emails={emails}
+          onPhonesChange={setPhones}
+          onEmailsChange={setEmails}
+          findMatch={findContactMatch}
+          onMergeSuggested={(match) => onResolve(`Merged into ${match.name}`)}
+        />
 
         <div className="flex flex-col">
           <SectionLabel className="mb-1.5 font-medium">
@@ -461,21 +505,26 @@ function WhatsAppIdentityBody({
           </SectionLabel>
           <EntryList>
             {item.groups.map((group) => (
-              <li key={group.groupJid} className="px-3 py-2.5">
-                <div className="flex items-center gap-2">
-                  <span className="inline-flex items-center gap-1 rounded-sm bg-muted px-1 py-0.5 font-mono text-[9px] uppercase text-muted-foreground">
-                    <WhatsappLogoIcon size={9} weight="fill" />
-                    Group
+              <li key={group.groupJid} className="px-3.5 py-3">
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+                    {group.groupName}
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-sm font-medium">{group.groupName}</span>
-                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-wide text-muted-foreground/60">
                     {group.messageCount} msgs · {formatRelativeTime(group.lastMessageAt)}
                   </span>
                 </div>
-                {group.snippet ? (
-                  <p className="mt-1.5 border-l-2 border-border pl-2.5 text-[11.5px] leading-relaxed text-muted-foreground">
-                    {group.snippet}
-                  </p>
+                {group.snippets.length > 0 ? (
+                  <div className="mt-2 flex flex-col gap-1.5 border-l border-border pl-3">
+                    {group.snippets.map((snippet) => (
+                      <p
+                        key={`${group.groupJid}:${snippet}`}
+                        className="text-[12px] leading-relaxed text-muted-foreground"
+                      >
+                        {snippet}
+                      </p>
+                    ))}
+                  </div>
                 ) : null}
               </li>
             ))}

--- a/packages/web/src/lib/entity-ui.tsx
+++ b/packages/web/src/lib/entity-ui.tsx
@@ -8,7 +8,7 @@
  * deeper view and the header's Back chip can pop.
  */
 import { cn } from "@sketch/ui/lib/utils";
-import { type ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
+import { type CSSProperties, type ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
 import type { DrawerEntityType } from "./api";
 
 export interface EntityIdentity {
@@ -124,6 +124,16 @@ function entityInitials(name: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
+/** Blend a hex colour toward white by `amount` (0–1). Used to lift the dark
+ * light-mode accents into legible ink on the near-black dark surface. */
+function lighten(hex: string, amount: number): string {
+  const h = hex.replace("#", "");
+  const channel = (i: number) => Number.parseInt(h.slice(i, i + 2), 16);
+  const mix = (c: number) => Math.round(c + (255 - c) * amount);
+  const toHex = (c: number) => mix(c).toString(16).padStart(2, "0");
+  return `#${toHex(channel(0))}${toHex(channel(2))}${toHex(channel(4))}`;
+}
+
 const AVATAR_SIZES = {
   xs: "h-4 w-4 text-[8px]",
   sm: "h-6 w-6 text-[10px]",
@@ -141,14 +151,24 @@ interface EntityAvatarProps {
 
 export function EntityAvatar({ entity, size = "md", className }: EntityAvatarProps) {
   const accent = entityAccent(entity);
+  const inkDark = lighten(accent, 0.58);
   return (
     <span
       className={cn(
         "inline-flex shrink-0 items-center justify-center rounded-full font-medium",
         AVATAR_SIZES[size],
+        "[background-color:var(--ea-bg)] [color:var(--ea-ink)]",
+        "dark:[background-color:var(--ea-bg-dark)] dark:[color:var(--ea-ink-dark)]",
         className,
       )}
-      style={{ backgroundColor: `${accent}1a`, color: accent }}
+      style={
+        {
+          "--ea-bg": `${accent}1f`,
+          "--ea-ink": accent,
+          "--ea-bg-dark": `${inkDark}2b`,
+          "--ea-ink-dark": inkDark,
+        } as CSSProperties
+      }
       aria-label={entity.name}
     >
       {entityInitials(entity.name)}

--- a/packages/web/src/routes/projects/org-review.tsx
+++ b/packages/web/src/routes/projects/org-review.tsx
@@ -12,11 +12,15 @@
  * match reason, and pick-a-different-existing all live there.
  */
 import { BirthInspectSheet, ReviewDetailSheet } from "@/components/entity-review/review-band";
+import {
+  WhatsAppIdentityDrawer,
+  WhatsAppIdentityRow,
+  useWhatsAppIdentityReview,
+} from "@/components/entity-review/whatsapp-identity-review";
 import { useReviewMutations } from "@/components/review-actions";
 import type { EntityReviewQueueRow } from "@/lib/api";
 import { api } from "@/lib/api";
 import { EntityAvatar } from "@/lib/entity-ui";
-import { CaretRightIcon } from "@phosphor-icons/react";
 import { cn } from "@sketch/ui/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
@@ -112,23 +116,18 @@ export function ReviewRowCompact({
       : null;
   return (
     <div className="border-b border-border/60 last:border-b-0" data-testid={`org-review-row-${row.id}`}>
-      <div className="flex w-full items-center">
+      <div className="flex w-full items-center transition-colors hover:bg-foreground/10">
         <button
           type="button"
           onClick={() => onOpen(row)}
-          className="group flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left"
+          className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left"
         >
-          <EntityAvatar entity={{ id: row.id, name: row.proposed_name, sourceType: row.entity_type }} size="xs" />
+          <EntityAvatar entity={{ id: row.id, name: row.proposed_name, sourceType: row.entity_type }} size="sm" />
           <span className="shrink-0 truncate text-[12.5px] font-medium">{row.proposed_name}</span>
           <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted-foreground">{suggestion}</span>
           {evidence ? (
             <span className="hidden shrink-0 text-[10.5px] text-muted-foreground/70 sm:inline">{evidence}</span>
           ) : null}
-          <CaretRightIcon
-            size={12}
-            aria-hidden
-            className="shrink-0 text-muted-foreground/30 group-hover:text-muted-foreground"
-          />
         </button>
         <span className="flex shrink-0 items-center gap-0.5 pr-3">
           <CompactAction
@@ -162,16 +161,19 @@ export function ReviewBandCapped({ types, onSeeAll }: { types: string[]; onSeeAl
     refetchInterval: 30000,
   });
   const rows = data?.rows ?? [];
-  const total = data?.total ?? rows.length;
+  const realTotal = data?.total ?? rows.length;
   const { openRow, sheets, refresh } = useReviewRowSheets();
 
-  if (rows.length === 0) return null;
+  const wa = useWhatsAppIdentityReview(types);
+  const [waSelected, setWaSelected] = useState<string | null>(null);
+
+  if (rows.length === 0 && wa.items.length === 0) return null;
 
   return (
     <section className="mb-6 overflow-hidden rounded-xl border border-amber-300/60 bg-amber-50/40 dark:border-amber-700/50 dark:bg-amber-950/20">
       <div className="flex items-baseline justify-between border-b border-amber-300/50 px-3 py-2 dark:border-amber-700/40">
         <span className="font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-amber-700 dark:text-amber-400">
-          Needs your review · {total}
+          Needs your review · {realTotal + wa.items.length}
         </span>
         <button
           type="button"
@@ -184,16 +186,29 @@ export function ReviewBandCapped({ types, onSeeAll }: { types: string[]; onSeeAl
       {rows.slice(0, 3).map((row) => (
         <ReviewRowCompact key={row.id} row={row} onOpen={openRow} onResolved={refresh} />
       ))}
-      {rows.length > 3 ? (
+      {wa.items.map((item) => (
+        <WhatsAppIdentityRow
+          key={item.id}
+          item={item}
+          onOpen={() => setWaSelected(item.id)}
+          onResolve={(message) => wa.resolve(item.id, message)}
+        />
+      ))}
+      {realTotal > 3 ? (
         <button
           type="button"
           onClick={onSeeAll}
           className="w-full border-t border-amber-300/40 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-[0.08em] text-amber-700/70 hover:text-amber-800 dark:border-amber-700/30 dark:text-amber-400/70"
         >
-          {total - 3} more in Review →
+          {realTotal - 3} more in Review →
         </button>
       ) : null}
       {sheets}
+      <WhatsAppIdentityDrawer
+        item={wa.items.find((item) => item.id === waSelected) ?? null}
+        onClose={() => setWaSelected(null)}
+        onResolve={wa.resolve}
+      />
     </section>
   );
 }

--- a/packages/web/src/routes/projects/org-review.tsx
+++ b/packages/web/src/routes/projects/org-review.tsx
@@ -154,6 +154,9 @@ export function ReviewRowCompact({
  * empty. `null` when the tab has no reviews keeps the entity list flush to the
  * top.
  */
+/** One row in the capped band — a real review row or a WhatsApp identity — carrying the recency key it orders by. */
+type BandEntry = { recent: string; node: ReactNode };
+
 export function ReviewBandCapped({ types, onSeeAll }: { types: string[]; onSeeAll: () => void }) {
   const { data } = useQuery({
     queryKey: ["entity-review", "band-capped", types.join(",")],
@@ -169,40 +172,47 @@ export function ReviewBandCapped({ types, onSeeAll }: { types: string[]; onSeeAl
 
   if (rows.length === 0 && wa.items.length === 0) return null;
 
+  const byRecent = (a: BandEntry, b: BandEntry) => b.recent.localeCompare(a.recent);
+  const realEntries: BandEntry[] = rows
+    .map((row) => ({
+      recent: row.last_seen_at,
+      node: <ReviewRowCompact key={row.id} row={row} onOpen={openRow} onResolved={refresh} />,
+    }))
+    .sort(byRecent)
+    .slice(0, 3);
+  const waEntries: BandEntry[] = wa.items.map((item) => ({
+    recent: item.lastSeenAt,
+    node: (
+      <WhatsAppIdentityRow
+        key={item.id}
+        item={item}
+        onOpen={() => setWaSelected(item.id)}
+        onResolve={(message) => wa.resolve(item.id, message)}
+      />
+    ),
+  }));
+  const entries = [...realEntries, ...waEntries].sort(byRecent);
+
   return (
     <section className="mb-6 overflow-hidden rounded-xl border border-amber-300/60 bg-amber-50/40 dark:border-amber-700/50 dark:bg-amber-950/20">
-      <div className="flex items-baseline justify-between border-b border-amber-300/50 px-3 py-2 dark:border-amber-700/40">
+      <div className="flex items-center justify-between border-b border-amber-300/50 px-3 py-2 dark:border-amber-700/40">
         <span className="font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-amber-700 dark:text-amber-400">
           Needs your review · {realTotal + wa.items.length}
         </span>
-        <button
-          type="button"
-          onClick={onSeeAll}
-          className="font-mono text-[10px] uppercase tracking-[0.08em] text-amber-700/80 hover:text-amber-800 dark:text-amber-400/80 dark:hover:text-amber-300"
-        >
-          See all → Review
-        </button>
+        {realTotal > 0 ? (
+          <button
+            type="button"
+            onClick={onSeeAll}
+            className="group flex items-center gap-1 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-amber-700/70 transition-colors hover:text-amber-800 dark:text-amber-400/70 dark:hover:text-amber-300"
+          >
+            Open queue
+            <span aria-hidden="true" className="transition-transform group-hover:translate-x-0.5">
+              →
+            </span>
+          </button>
+        ) : null}
       </div>
-      {rows.slice(0, 3).map((row) => (
-        <ReviewRowCompact key={row.id} row={row} onOpen={openRow} onResolved={refresh} />
-      ))}
-      {wa.items.map((item) => (
-        <WhatsAppIdentityRow
-          key={item.id}
-          item={item}
-          onOpen={() => setWaSelected(item.id)}
-          onResolve={(message) => wa.resolve(item.id, message)}
-        />
-      ))}
-      {realTotal > 3 ? (
-        <button
-          type="button"
-          onClick={onSeeAll}
-          className="w-full border-t border-amber-300/40 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-[0.08em] text-amber-700/70 hover:text-amber-800 dark:border-amber-700/30 dark:text-amber-400/70"
-        >
-          {realTotal - 3} more in Review →
-        </button>
-      ) : null}
+      {entries.map((entry) => entry.node)}
       {sheets}
       <WhatsAppIdentityDrawer
         item={wa.items.find((item) => item.id === waSelected) ?? null}

--- a/packages/web/src/routes/projects/review-tab.tsx
+++ b/packages/web/src/routes/projects/review-tab.tsx
@@ -9,6 +9,11 @@
  * dismiss (only `confirm-batch` / `reject-batch` + single-row `dismiss`), so a
  * bulk control would fan out N calls. Omitted until a batch dismiss lands.
  */
+import {
+  WhatsAppIdentityDrawer,
+  WhatsAppIdentityRow,
+  useWhatsAppIdentityReview,
+} from "@/components/entity-review/whatsapp-identity-review";
 import { api } from "@/lib/api";
 import { MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { Input } from "@sketch/ui/components/input";
@@ -39,6 +44,10 @@ export function ReviewTab() {
   const rows = data?.rows ?? [];
   const { openRow, sheets, refresh } = useReviewRowSheets();
 
+  const wa = useWhatsAppIdentityReview([]);
+  const [waSelected, setWaSelected] = useState<string | null>(null);
+  const showWa = !debouncedSearch && wa.items.length > 0;
+
   const bands = new Map<string, typeof rows>();
   for (const row of rows) {
     const label = reviewBandLabel(row);
@@ -66,7 +75,7 @@ export function ReviewTab() {
             <Skeleton key={k} className="h-14 rounded-lg" />
           ))}
         </div>
-      ) : rows.length === 0 ? (
+      ) : rows.length === 0 && !showWa ? (
         <div className="mt-4">
           <ReviewEmpty>
             {debouncedSearch
@@ -76,6 +85,26 @@ export function ReviewTab() {
         </div>
       ) : (
         <div className="mt-4 space-y-6">
+          {showWa ? (
+            <section
+              className="overflow-hidden rounded-xl border border-amber-300/60 bg-amber-50/30 dark:border-amber-700/50 dark:bg-amber-950/20"
+              data-testid="review-band-whatsapp-identities"
+            >
+              <div className="flex items-baseline justify-between border-b border-amber-300/50 px-3 py-2 dark:border-amber-700/40">
+                <span className="font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-amber-700 dark:text-amber-400">
+                  Unidentified WhatsApp contacts · {wa.items.length}
+                </span>
+              </div>
+              {wa.items.map((item) => (
+                <WhatsAppIdentityRow
+                  key={item.id}
+                  item={item}
+                  onOpen={() => setWaSelected(item.id)}
+                  onResolve={(message) => wa.resolve(item.id, message)}
+                />
+              ))}
+            </section>
+          ) : null}
           {orderedBands.map(([label, bandRows]) => (
             <section
               key={label}
@@ -95,6 +124,11 @@ export function ReviewTab() {
         </div>
       )}
       {sheets}
+      <WhatsAppIdentityDrawer
+        item={wa.items.find((item) => item.id === waSelected) ?? null}
+        onClose={() => setWaSelected(null)}
+        onResolve={wa.resolve}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What

Folds **unidentified WhatsApp contacts** into the existing "Needs your review" queue on the **Your Org → People** tab, so an admin can put a name to the placeholder people that get auto-minted when a WhatsApp group is indexed.

Each contact leads with the **groups it's been seen in** (the recognizable signal — not the raw LID or number, which no human can map on sight). Clicking a row opens a right drawer to identify them.

## The drawer

- **Name / Phone / Email form leads** as a distinct action zone (the contact is *unidentified* — you're giving it an identity), with the **groups it's seen in** below as supporting proof.
- **Save** is the always-labelled commit and is **dirty-gated** (active only once you change a field).
- When we have a **suggestion**, an inline confirm sits under the name to accept it as-is:
  - **"This is them"** → merge into the suggested existing person.
  - **"Use this name"** → save the guessed name.
- **Merge** (pick a different existing person) and **Dismiss** round out the footer.

Along the way, shared drawer/entity primitives were made consistent (used by the sibling review drawers too):
- `SectionCard` eyebrow now sits **outside** its bordered box (label-outside), matching every other labelled section.
- `EntityAvatar` is **theme-aware** (the accent is lifted to a legible ink on the dark surface).
- The **Merge** CTA is unified across the band and drawers (icon + "Merge", outline, no ellipsis).

## Status — prototype, gated OFF

⚠️ **Frontend-only.** There is **no backend yet**. `WHATSAPP_IDENTITY_MOCK` stands in for the list endpoint and the resolve actions are stubbed to local state + a toast. The exported types document the contract a backend developer implements (list query, name PATCH + contact-points POST, merge, dismiss, and the "seen in"/suggestion query).

🔒 **`WHATSAPP_IDENTITY_REVIEW_ENABLED = false`** — the feature is completely invisible (no band rows, no drawer). Flip the constant to `true` **locally** to preview the mock UI. It must stay `false` until the backend lands (mock data must never render in production).

## Not included

This PR is **UI only**. The unrelated WhatsApp **history-sync** server fix (`backfill-worker.ts` `bootstrapStrandedHistoryRanges` + `WHATSAPP_HISTORY_SYNC_RCA.md`) that was in the same working tree is **intentionally excluded** and should ship as its own PR.

## Test plan

- `pnpm biome check`, `pnpm typecheck`, `pnpm test`, `pnpm build` — all green (pre-push hook passed).
- Verified both suggestion cases (merge vs save-name), the dirty-gate transitions, and the unidentified case in the live preview with the flag flipped on locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
