### PR TITLE
feat(entities): show the proposed name beside a placeholder

### DIFF
--- a/packages/server/src/api/entities/profile-routes.ts
+++ b/packages/server/src/api/entities/profile-routes.ts
@@ -10,6 +10,7 @@ import {
   normalizeContactPointValue,
   whereLiveEntity,
 } from "../../db/repositories/entities";
+import { listPendingNameProposalsByEntity } from "../../db/repositories/entity-aliases";
 import {
   type RelationListEntry,
   createEntityRelationshipsRepository,
@@ -109,15 +110,18 @@ async function loadEntityFactsForId(
   const relRepo = createEntityRelationshipsRepository(db);
   const entity = await repo.getEntity(entityId, viewer);
   if (!entity) return null;
-  const [aggregates, relations] = await Promise.all([
+  const [aggregates, relations, proposals] = await Promise.all([
     repo.getEntityProfileAggregates(entity.id, viewer),
     relRepo.listRelationsForEntity(entity.id, { limit: 50 }),
+    listPendingNameProposalsByEntity(db, [entity.id]),
   ]);
   const parsedMetadata = entity.metadata ? (JSON.parse(entity.metadata) as Record<string, unknown>) : null;
   const topRelationships = [...relations.outgoing, ...relations.incoming].sort(relationCompare).slice(0, 10);
   return {
     entityId: entity.id,
     name: entity.name,
+    nameStatus: entity.name_status,
+    proposedName: proposals.get(entity.id) ?? null,
     sourceType: entity.source_type,
     entityType: mapSourceTypeToEntityType(entity.source_type),
     metadata: parsedMetadata,
@@ -507,11 +511,17 @@ export function createEntityProfileRoutes(db: Kysely<DB>, _deps: EntityRoutesDep
       countQuery = countQuery.where(entityVisibilityPredicate(viewer));
     }
     const countResult = await countQuery.executeTakeFirst();
+    const proposalsByEntity = await listPendingNameProposalsByEntity(
+      db,
+      entities.map((e) => e.id),
+    );
 
     return c.json({
       entities: entities.map((e) => ({
         id: e.id,
         name: e.name,
+        nameStatus: e.name_status,
+        proposedName: proposalsByEntity.get(e.id) ?? null,
         sourceType: e.source_type,
         subtype: e.subtype,
         aliases: e.aliases ? JSON.parse(e.aliases) : [],
@@ -682,11 +692,14 @@ export function createEntityProfileRoutes(db: Kysely<DB>, _deps: EntityRoutesDep
     const parsedAliases = entity.aliases ? (JSON.parse(entity.aliases) as string[]) : [];
     const activity = await loadActivityStats(db, entity.id, viewer);
     const summary = buildSummary(facts, activity);
+    const proposals = await listPendingNameProposalsByEntity(db, [entity.id]);
 
     return c.json({
       entity: {
         id: entity.id,
         name: entity.name,
+        nameStatus: entity.name_status,
+        proposedName: proposals.get(entity.id) ?? null,
         sourceType: entity.source_type,
         subtype: entity.subtype,
         aliases: parsedAliases,

--- a/packages/server/src/db/repositories/entity-aliases.test.ts
+++ b/packages/server/src/db/repositories/entity-aliases.test.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from "node:crypto";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestDb } from "../../test-utils";
+import type { DB } from "../schema";
+import { listPendingNameProposalsByEntity, upsertEntityNameProposal } from "./entity-aliases";
+
+describe("listPendingNameProposalsByEntity", () => {
+  let db: Kysely<DB>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function seedEntity(id: string, name: string, nameStatus: string): Promise<void> {
+    const now = new Date().toISOString();
+    await db
+      .insertInto("entities")
+      .values({
+        id,
+        name,
+        source_type: "person",
+        subtype: "external",
+        aliases: null,
+        metadata: null,
+        source_ref_id: null,
+        status: "confirmed",
+        provenance_tier: "inferred",
+        hotness: 0,
+        name_status: nameStatus,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
+  }
+
+  async function seedProposal(
+    entityId: string,
+    value: string,
+    observedCount: number,
+    lastSeenAt: string,
+    status = "pending",
+  ): Promise<void> {
+    await db
+      .insertInto("entity_name_proposals")
+      .values({
+        id: randomUUID(),
+        entity_id: entityId,
+        source: "whatsapp_pushname",
+        value,
+        normalized_value: value.toLowerCase(),
+        observed_count: observedCount,
+        first_seen_at: lastSeenAt,
+        last_seen_at: lastSeenAt,
+        status,
+        resolved_by_user_id: null,
+        resolved_at: null,
+      })
+      .execute();
+  }
+
+  it("returns the pending proposal for a placeholder entity", async () => {
+    await seedEntity("e1", "+919891688787", "placeholder");
+    await seedProposal("e1", "Tanush Yadav", 10, "2026-08-13T00:00:00.000Z");
+
+    const result = await listPendingNameProposalsByEntity(db, ["e1"]);
+
+    expect(result.get("e1")).toBe("Tanush Yadav");
+  });
+
+  it("returns nothing for a placeholder entity with no proposal", async () => {
+    await seedEntity("e1", "+919891688787", "placeholder");
+
+    const result = await listPendingNameProposalsByEntity(db, ["e1"]);
+
+    expect(result.has("e1")).toBe(false);
+  });
+
+  it("returns nothing for a confirmed entity even when a proposal is pending", async () => {
+    await seedEntity("e1", "Tanush Yadav", "confirmed");
+    await seedProposal("e1", "Tanush", 4, "2026-08-13T00:00:00.000Z");
+
+    const result = await listPendingNameProposalsByEntity(db, ["e1"]);
+
+    expect(result.has("e1")).toBe(false);
+  });
+
+  it("ignores proposals that are no longer pending", async () => {
+    await seedEntity("e1", "+919891688787", "placeholder");
+    await seedProposal("e1", "Tanush Yadav", 10, "2026-08-13T00:00:00.000Z", "rejected");
+
+    const result = await listPendingNameProposalsByEntity(db, ["e1"]);
+
+    expect(result.has("e1")).toBe(false);
+  });
+
+  it("prefers the most observed proposal, then the most recent", async () => {
+    await seedEntity("e1", "+919891688787", "placeholder");
+    await seedProposal("e1", "Rarely Seen", 2, "2026-08-13T09:00:00.000Z");
+    await seedProposal("e1", "Tanush Yadav", 9, "2026-08-13T01:00:00.000Z");
+    await seedEntity("e2", "+919650805188", "placeholder");
+    await seedProposal("e2", "Older Tie", 3, "2026-08-13T01:00:00.000Z");
+    await seedProposal("e2", "Newer Tie", 3, "2026-08-13T08:00:00.000Z");
+
+    const result = await listPendingNameProposalsByEntity(db, ["e1", "e2"]);
+
+    expect(result.get("e1")).toBe("Tanush Yadav");
+    expect(result.get("e2")).toBe("Newer Tie");
+  });
+
+  /**
+   * An empty list renders as `IN ()`, which SQLite tolerates and Postgres
+   * rejects as a syntax error, so the guard has to short-circuit before the
+   * query is built rather than rely on the dialect being forgiving.
+   */
+  it("returns an empty map without querying when given no entity ids", async () => {
+    const result = await listPendingNameProposalsByEntity(db, []);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("keeps proposals scoped to their own entity", async () => {
+    await seedEntity("e1", "+919891688787", "placeholder");
+    await seedEntity("e2", "+919650805188", "placeholder");
+    await seedProposal("e1", "Tanush Yadav", 10, "2026-08-13T00:00:00.000Z");
+
+    const result = await listPendingNameProposalsByEntity(db, ["e1", "e2"]);
+
+    expect(result.get("e1")).toBe("Tanush Yadav");
+    expect(result.has("e2")).toBe(false);
+  });
+
+  it("surfaces a proposal recorded through upsertEntityNameProposal", async () => {
+    await seedEntity("e1", "+919891688787", "placeholder");
+    await upsertEntityNameProposal(db, "e1", "whatsapp_pushname", "Tanush Yadav");
+
+    const result = await listPendingNameProposalsByEntity(db, ["e1"]);
+
+    expect(result.get("e1")).toBe("Tanush Yadav");
+  });
+});

--- a/packages/server/src/db/repositories/entity-aliases.ts
+++ b/packages/server/src/db/repositories/entity-aliases.ts
@@ -6,6 +6,57 @@ import type { DB } from "../schema";
 
 const MAX_ALIAS_MERGE_ATTEMPTS = 8;
 
+/**
+ * The best pending name proposal per entity, for entities still carrying a
+ * placeholder name. A WhatsApp-minted person is named after its own phone number
+ * until a pushName confirms a real one, so this is what lets a surface render
+ * "Tanush Yadav (+919891688787)" instead of the bare digits.
+ *
+ * Ranking happens in memory rather than via DISTINCT ON or a window function so
+ * the query stays portable across SQLite and Postgres. Callers pass at most a
+ * page of entity ids, so the row count is bounded by the page size.
+ *
+ * The empty-input guard is load-bearing, not defensive: an empty list renders as
+ * `IN ()`, which SQLite accepts and Postgres rejects as a syntax error.
+ */
+export async function listPendingNameProposalsByEntity(
+  db: Kysely<DB>,
+  entityIds: string[],
+): Promise<Map<string, string>> {
+  const best = new Map<string, string>();
+  if (entityIds.length === 0) return best;
+  const rows = await db
+    .selectFrom("entity_name_proposals")
+    .innerJoin("entities", "entities.id", "entity_name_proposals.entity_id")
+    .select([
+      "entity_name_proposals.entity_id",
+      "entity_name_proposals.value",
+      "entity_name_proposals.observed_count",
+      "entity_name_proposals.last_seen_at",
+    ])
+    .where("entity_name_proposals.entity_id", "in", entityIds)
+    .where("entity_name_proposals.status", "=", "pending")
+    .where("entities.name_status", "=", "placeholder")
+    .execute();
+
+  const ranked = new Map<string, { value: string; observedCount: number; lastSeenAt: string }>();
+  for (const row of rows) {
+    const value = row.value.trim();
+    if (!value) continue;
+    const current = ranked.get(row.entity_id);
+    const candidate = { value, observedCount: row.observed_count, lastSeenAt: row.last_seen_at };
+    if (
+      !current ||
+      candidate.observedCount > current.observedCount ||
+      (candidate.observedCount === current.observedCount && candidate.lastSeenAt > current.lastSeenAt)
+    ) {
+      ranked.set(row.entity_id, candidate);
+    }
+  }
+  for (const [entityId, candidate] of ranked) best.set(entityId, candidate.value);
+  return best;
+}
+
 export async function upsertEntityNameProposal(
   db: Kysely<DB>,
   entityId: string,

--- a/packages/server/src/entities/profile-facts.ts
+++ b/packages/server/src/entities/profile-facts.ts
@@ -39,6 +39,13 @@ export interface CompanyDomainFact {
 export interface EntityProfileFacts {
   entityId: string;
   name: string;
+  nameStatus: string;
+  /**
+   * Best pending name proposal, populated only while `nameStatus` is
+   * "placeholder" so a surface can render the real name beside the identifier
+   * the entity is currently named after.
+   */
+  proposedName: string | null;
   sourceType: string;
   entityType: DrawerEntityType;
   metadata: Record<string, unknown> | null;

--- a/packages/web/src/components/entity-drawer/entity-drawer.tsx
+++ b/packages/web/src/components/entity-drawer/entity-drawer.tsx
@@ -25,7 +25,7 @@ import type {
   TaskStatus,
 } from "@/lib/api";
 import { api } from "@/lib/api";
-import { EntityAvatar, EntityChip, entityAccent, useEntityUi } from "@/lib/entity-ui";
+import { EntityAvatar, EntityChip, entityAccent, entityDisplayLabel, useEntityUi } from "@/lib/entity-ui";
 import {
   ArrowLeftIcon,
   ArrowsLeftRightIcon,
@@ -237,7 +237,9 @@ function DrawerHeader({ entity, stackDepth, previousName, onBack, accent, onOpen
         <EntityAvatar entity={entity} size="lg" />
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-3">
-            <h2 className="min-w-0 flex-1 truncate font-serif text-[20px] leading-tight">{entity.name}</h2>
+            <h2 className="min-w-0 flex-1 truncate font-serif text-[20px] leading-tight">
+              {entityDisplayLabel(entity)}
+            </h2>
             <div className="flex shrink-0 items-center gap-2">
               {entity.shareWithEveryone ? (
                 <Badge variant="outline" className="gap-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">

--- a/packages/web/src/components/entity-drawer/entity-popover.tsx
+++ b/packages/web/src/components/entity-drawer/entity-popover.tsx
@@ -10,7 +10,7 @@
  * Mounted globally by EntityUiProvider; opened via openEntity(id, { mode: "popover" }).
  */
 import { type EntityRelationView, api } from "@/lib/api";
-import { EntityAvatar, entityAccent, useEntityUi } from "@/lib/entity-ui";
+import { EntityAvatar, entityAccent, entityDisplayLabel, useEntityUi } from "@/lib/entity-ui";
 import { Badge } from "@sketch/ui/components/badge";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@sketch/ui/components/dialog";
 import { Skeleton } from "@sketch/ui/components/skeleton";
@@ -99,7 +99,7 @@ function PopoverBody({ entityId }: { entityId: string }) {
       <div className="flex items-center gap-2">
         <EntityAvatar entity={entity} size="md" />
         <div className="min-w-0 flex-1">
-          <p className="truncate font-serif text-base">{entity.name}</p>
+          <p className="truncate font-serif text-base">{entityDisplayLabel(entity)}</p>
           <Badge variant="outline" className="mt-0.5 text-[10px] uppercase tracking-wider">
             {entity.profile.entityType}
           </Badge>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -547,6 +547,9 @@ export function isEntityReviewErrorCode(code: string | undefined): code is Entit
 export interface EntityListItem {
   id: string;
   name: string;
+  nameStatus: string;
+  /** Best pending name proposal; set only while `nameStatus` is "placeholder". */
+  proposedName: string | null;
   sourceType: string;
   subtype: string | null;
   aliases: string[];

--- a/packages/web/src/lib/entity-ui.test.tsx
+++ b/packages/web/src/lib/entity-ui.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { entityDisplayLabel } from "./entity-ui";
+
+describe("entityDisplayLabel", () => {
+  it("brackets the placeholder identifier behind the proposed name", () => {
+    expect(entityDisplayLabel({ name: "+919891688787", proposedName: "Tanush Yadav" })).toBe(
+      "Tanush Yadav (+919891688787)",
+    );
+  });
+
+  it("renders the stored name alone when no proposal exists", () => {
+    expect(entityDisplayLabel({ name: "+919891688787", proposedName: null })).toBe("+919891688787");
+    expect(entityDisplayLabel({ name: "Tanush Yadav" })).toBe("Tanush Yadav");
+  });
+
+  it("treats a blank proposal as no proposal", () => {
+    expect(entityDisplayLabel({ name: "+919891688787", proposedName: "   " })).toBe("+919891688787");
+  });
+});

--- a/packages/web/src/lib/entity-ui.tsx
+++ b/packages/web/src/lib/entity-ui.tsx
@@ -19,6 +19,21 @@ export interface EntityIdentity {
   entityType?: DrawerEntityType;
 }
 
+/**
+ * Label for an entity still named after its own phone number or LID. A
+ * WhatsApp-minted person keeps that identifier as its name until a pushName is
+ * confirmed, so rendering "Tanush Yadav (+919891688787)" surfaces the name we
+ * already know while keeping it visibly unconfirmed beside the identifier it
+ * came from.
+ *
+ * The raw `name` stays the label wherever a user acts on it rather than reads
+ * it — renaming and picking a merge survivor both need the stored value.
+ */
+export function entityDisplayLabel(entity: { name: string; proposedName?: string | null }): string {
+  const proposed = entity.proposedName?.trim();
+  return proposed ? `${proposed} (${entity.name})` : entity.name;
+}
+
 type DrawerMode = "drawer" | "popover";
 
 interface EntityUiContextValue {

--- a/packages/web/src/routes/projects/index.test.tsx
+++ b/packages/web/src/routes/projects/index.test.tsx
@@ -12,6 +12,8 @@ function entity(
   overrides: Partial<EntityListItem> & Pick<EntityListItem, "id" | "name" | "sourceType">,
 ): EntityListItem {
   return {
+    nameStatus: "confirmed",
+    proposedName: null,
     subtype: null,
     aliases: [],
     contactPoints: [],

--- a/packages/web/src/routes/projects/people-tab.tsx
+++ b/packages/web/src/routes/projects/people-tab.tsx
@@ -14,7 +14,7 @@
  */
 import type { EntityListItem } from "@/lib/api";
 import { api } from "@/lib/api";
-import { EntityAvatar, useEntityUi } from "@/lib/entity-ui";
+import { EntityAvatar, entityDisplayLabel, useEntityUi } from "@/lib/entity-ui";
 import { formatRelativeTime } from "@/routes/files/file-list";
 import { CaretDownIcon, MagnifyingGlassIcon, SparkleIcon } from "@phosphor-icons/react";
 import { Badge } from "@sketch/ui/components/badge";
@@ -275,7 +275,7 @@ function PersonRow({ person }: { person: EntityListItem }) {
       testId={`org-person-${person.id}`}
       onOpen={() => openEntity(person.id)}
       avatar={<EntityAvatar entity={{ id: person.id, name: person.name, sourceType: "person" }} size="sm" />}
-      primary={person.name}
+      primary={entityDisplayLabel(person)}
       primaryChips={
         isAi ? (
           <Badge


### PR DESCRIPTION
## Problem

A WhatsApp-minted person keeps its own phone number or LID as its display name until a pushName is confirmed. We often already know the real name:

```
entity    name            name_status   proposed       observed  status
dc6b18f2  +919891688787   placeholder   Tanush Yadav   10        pending
```

The group transcript renders "Tanush Yadav" because `displayNameForResolution` substitutes the pushName at render time. Every other surface — People, the entity drawer, the popover — shows the digits.

## Change

Display only. When an entity's `name_status` is `placeholder` and a pending name proposal exists, surface it as:

```
Tanush Yadav (+919891688787)
```

No write path is touched: the stored `name` and `name_status` are unchanged and the proposal stays `pending`. The name is shown without being silently trusted — it reads as a proposal sitting next to the identifier it came from.

- `listPendingNameProposalsByEntity` returns the best pending proposal per entity, ranked by `observed_count` then `last_seen_at`, scoped to placeholder entities. Ranking happens in memory so the query stays portable across SQLite and Postgres, and the empty-input guard short-circuits before `IN ()` can reach Postgres.
- Entity list and detail serializers gain `nameStatus` and `proposedName`.
- `entityDisplayLabel` composes the label for the drawer header, popover, and People list.

`name` deliberately keeps returning the stored value. The rename dialog prefills from it and the merge dialog labels its survivor toggle with it, and both would be wrong if `name` carried the bracketed string.

This is the first read of `entity_name_proposals` — the table has had writers and no readers since migration 187.

## Not in scope

The larger design — a third `name_status` value that adopts the pushName as the entity's real name, a `placeholder < proposed < confirmed` rank in `rescuedSurvivorName`, and a review-and-confirm surface — is being handled separately. This change touches no write path, so it neither blocks nor conflicts with that work and can be removed cleanly once names are adopted for real.

Two findings from reviewing that design are recorded in the plan and stay true regardless: `renameSurvivor` hardcoding `confirmed` becomes a way to promote an unreviewed name through a merge, and adopting self-set pushNames as entity names creates a collision in `upsertPersonEntity`'s exact-name match.

## Tests

8 repository tests (placeholder with and without a proposal, confirmed entity, non-pending proposal, `observed_count` and recency ranking, empty-input guard, cross-entity scoping) and 3 label tests. Full unit tier green: 4855 tests.

## Plan

`.planning/connectors/implemented/ENTITY_NAME_PROPOSED_STATUS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)