### PR TITLE
SKE-411: Surface foreign-owner builder chat lock

### DIFF
--- a/packages/web/src/routes/automation-builder.isolated.test.tsx
+++ b/packages/web/src/routes/automation-builder.isolated.test.tsx
@@ -1473,6 +1473,43 @@ describe("AutomationBuilderPage", () => {
     );
   });
 
+  it("makes a foreign owner's active builder lock visible and blocks new chats", async () => {
+    mocks.search = {};
+    mocks.listConversations.mockResolvedValue({
+      taskId: "task-123",
+      conversations: [
+        {
+          conversationId: "owner-builder-chat",
+          kinds: ["builder"],
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+          lastActiveAt: "2026-06-01T00:00:00.000Z",
+          archivedAt: null,
+          state: "active",
+          transcriptUserName: "Alice Member",
+        },
+      ],
+      builderLock: {
+        state: "held",
+        conversationId: "owner-builder-chat",
+        owner: "other",
+        expiresAt: "2026-06-01T00:05:00.000Z",
+      },
+      transcriptAccess: "admin",
+    });
+    mocks.webChatConversations.mockResolvedValue({ conversations: [] });
+
+    renderBuilder();
+
+    const lockNotice = await screen.findByTestId("automation-builder-chat-lock-notice");
+    expect(lockNotice).toHaveTextContent("You can still inspect and edit this automation");
+    const newChatButton = screen.getByRole("button", { name: "New chat" });
+    expect(newChatButton).toBeDisabled();
+
+    await userEvent.setup().click(newChatButton);
+    expect(mocks.createConversation).not.toHaveBeenCalled();
+  });
+
   it("uses viewer-scoped transcript summaries for builder chat labels and hides source chats", async () => {
     mocks.search = {};
     mocks.listConversations.mockResolvedValue({

--- a/packages/web/src/routes/automation-builder.tsx
+++ b/packages/web/src/routes/automation-builder.tsx
@@ -1681,7 +1681,12 @@ function BuilderChatSidecar({
       replaceBuilderConversationCache(queryClient, conversationsQueryKey, conversation);
       openConversation(conversation.conversationId);
     },
-    onError: (error) => toast.error(builderChatMutationError(error, "Could not start a chat")),
+    onError: (error) => {
+      toast.error(builderChatMutationError(error, "Could not start a chat"));
+      if (error instanceof ApiRequestError && error.code === "BUILDER_CHAT_LOCKED") {
+        void conversationsQuery.refetch();
+      }
+    },
   });
   const selectMutation = useMutation({
     mutationFn: (conversation: ScheduledTaskConversationSummary) =>
@@ -1727,6 +1732,7 @@ function BuilderChatSidecar({
         onBackToAutomations={onBackToAutomations}
         onNew={() => createMutation.mutate()}
         newPending={createMutation.isPending}
+        newDisabled={conversationsQuery.data?.builderLock?.state === "held"}
         onArchive={
           selectedConversation && !selectedIsArchived
             ? () => archiveMutation.mutate(selectedConversation.conversationId)
@@ -1792,6 +1798,7 @@ function BuilderChatHeader({
   onBackToAutomations,
   onNew,
   newPending,
+  newDisabled,
   onArchive,
   archivePending,
 }: {
@@ -1802,6 +1809,7 @@ function BuilderChatHeader({
   onBackToAutomations: () => void;
   onNew: () => void;
   newPending: boolean;
+  newDisabled?: boolean;
   onArchive?: () => void;
   archivePending: boolean;
 }) {
@@ -1883,7 +1891,7 @@ function BuilderChatHeader({
             variant="outline"
             className="h-8 shrink-0 gap-1.5 rounded-[8px] border-border/80 bg-background px-2.5 text-[12px] shadow-none hover:bg-muted/70 focus-visible:ring-brand-accent/50"
             onClick={onNew}
-            disabled={newPending}
+            disabled={newPending || newDisabled}
           >
             {newPending ? <SpinnerGapIcon size={14} className="animate-spin" /> : <PlusIcon size={14} />}
             New chat


### PR DESCRIPTION
## Summary

- disable Builder Chat New chat while another user holds the automation-wide builder lock
- refresh the conversation/lock query when a create request loses a race and returns BUILDER_CHAT_LOCKED
- add an admin regression test covering a foreign owner lock and the preserved ability to inspect/edit the automation

## Linear Scope

- [SKE-411: Surface foreign-owner builder chat lock in the automation builder](https://linear.app/sketch-ai/issue/SKE-411/surface-foreign-owner-builder-chat-lock-in-the-automation-builder)

## Root Cause

The server correctly serializes Builder Chats with a task-wide lock and returns a typed BUILDER_CHAT_LOCKED conflict when another user owns the active chat. The automation builder already received that lock state and rendered a notice, but the header left New chat enabled. An admin opening a foreign-owned automation could therefore click an action that was guaranteed to fail, while a race between the initial query and the create request could leave the stale UI enabled after the 409 response.

## Implementation Details

- Pass the task conversation query lock state into BuilderChatHeader and disable New chat while the lock is held.
- On a typed BUILDER_CHAT_LOCKED create error, keep the existing user-facing error toast and refetch the conversation list so the lock notice is authoritative.
- Add regression coverage that asserts the lock is visible, New chat is disabled, and no create request is sent, while the existing admin task-edit path remains available.

## Verification

- Node 24 `pnpm exec biome check .` — passed
- Node 24 `pnpm typecheck` — passed
- Node 24 `pnpm test` — server 507 test files passed, 2 skipped; 5,915 tests passed, 22 skipped; web 56 test files passed, 555 tests passed
- Node 24 `pnpm build` — passed
- Node 24 pre-push checks — passed
- `git diff --check` — passed

## Risk / Rollout

- Web-only behavior change; no schema, API, or migration changes.
- Existing task-wide lock and admin automation-edit semantics are unchanged.
- The change prevents a known conflict before the request and reconciles the UI if a concurrent request wins the race.
